### PR TITLE
feat(oauth): request read-only Gmail access with --readonly

### DIFF
--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -174,7 +174,8 @@ func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager,
 // grantDecided is true only in the daemon subprocess after an authenticated
 // frontend preflight minted the token. That token can be registered even when
 // the provider returned wider scopes than requested; the frontend already
-// warned about the grant, and reauthorizing cannot narrow it.
+// warned about the grant, and reauthorizing cannot narrow it. The current token
+// must still contain the Gmail read scope the frontend requested.
 func addAccountTokenReusable(
 	mgr *oauth.Manager,
 	email string,
@@ -189,7 +190,10 @@ func addAccountTokenReusable(
 	if needsClientCheck && !mgr.TokenMatchesClient(email) {
 		return false
 	}
-	return grantDecided || addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
+	if grantDecided {
+		return mgr.HasScope(email, oauth.ScopeGmailReadonly)
+	}
+	return addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
 }
 
 // addAccountAuthorizeError decorates an authorization failure with the

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/oauth"
@@ -17,10 +20,19 @@ var (
 	forceReauth                 bool
 	oauthAppName                string
 	noDefaultIdentityAddAccount bool
+	readonlyGrant               bool
 )
 
 // addAccountUse is the usage string for the add-account command.
 const addAccountUse = "add-account <email>"
+
+// addAccountGrantDecidedFlag records that the grant decision was already made
+// by the frontend CLI before it proxied to the daemon. The daemon appends this
+// flag only after authenticating the frontend's proof with its private runtime
+// token. The decision gates authorization, so re-running it in the subprocess
+// after the frontend has already authorized would refuse a token this run just
+// minted.
+const addAccountGrantDecidedFlag = "grant-decided"
 
 // errGmailSourceNotFound is returned by findGmailSource when no Gmail
 // source is registered for the given identifier. Wrapped via fmt.Errorf
@@ -39,6 +51,15 @@ for authorizing on headless servers (Google does not support Gmail in device flo
 If a token already exists, the command skips authorization. Use --force to delete
 the existing token and start a fresh OAuth flow.
 
+By default msgvault requests Gmail read and modify access. Use --readonly to
+request read access only.
+
+Access already granted cannot be narrowed. Re-authorizing does not revoke it,
+and revoking applies to the whole grant, so --readonly refuses an account that
+already holds Gmail write access. To make such an account read-only, revoke
+msgvault at https://myaccount.google.com/permissions, delete its token file,
+then add it again with --readonly.
+
 For Google Workspace orgs that require their own OAuth app, use --oauth-app to
 specify a named app from config.toml.
 
@@ -46,6 +67,7 @@ Examples:
   msgvault add-account you@gmail.com
   msgvault add-account you@gmail.com --headless
  msgvault add-account you@gmail.com --force
+  msgvault add-account you@gmail.com --readonly
   msgvault add-account you@acme.com --oauth-app acme
   msgvault add-account you@gmail.com --display-name "Work Account"`,
 	Args: cobra.ExactArgs(1),
@@ -70,6 +92,24 @@ func newAddAccountCmd() *cobra.Command {
 	}
 	registerAddAccountFlags(cmd)
 	return cmd
+}
+
+// addAccountGrantDecided reports whether the daemon authenticated a completed
+// frontend grant decision before starting this subprocess.
+//
+// The flag is absent when a caller builds its own command without registering
+// the internal flags, which several tests and embedders do. Absent means
+// undecided — the conservative default, since it keeps the gate rather than
+// skipping it.
+func addAccountGrantDecided(cmd *cobra.Command) bool {
+	// Only honored inside the daemon's CLI subprocess. Direct CLI use rejects
+	// it, the generic CLI-run API rejects it, and the daemon appends it only
+	// after validating its private runtime token.
+	if !isDaemonCLISubprocess() {
+		return false
+	}
+	flag := cmd.Flags().Lookup(addAccountGrantDecidedFlag)
+	return flag != nil && flag.Value.String() == "true"
 }
 
 // addAccountBinding is the resolved OAuth app for an add-account run.
@@ -103,6 +143,11 @@ func resolveAddAccountBinding(flagApp string, flagExplicit bool, storedApp sql.N
 // newAddAccountOAuthManager builds the Gmail OAuth manager for email,
 // preserving any already-granted scopes so Google's replacement consent
 // does not drop Calendar/Drive scopes from the shared token file.
+//
+// Callers MUST build the manager before --force deletes the token. The scope
+// list is derived from the grant on disk, so probing after deletion would find
+// nothing to preserve and quietly discard the account's Calendar/Drive access
+// along with the Gmail scopes --force meant to reset.
 func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager, error) {
 	scopeProbe, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
 	if err != nil {
@@ -111,6 +156,7 @@ func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager,
 	oauthScopes := addAccountOAuthScopesForToken(
 		scopeProbe.HasScopeMetadata(email),
 		scopeProbe.GrantedScopes(email),
+		readonlyGrant,
 	)
 	mgr, err := oauth.NewManagerWithScopes(clientSecretsPath, cfg.TokensDir(), logger, oauthScopes)
 	if err != nil {
@@ -129,22 +175,73 @@ func addAccountTokenReusable(mgr *oauth.Manager, email string, binding addAccoun
 		binding.resolvedApp != ""
 	return mgr.HasToken(email) &&
 		(!needsClientCheck || mgr.TokenMatchesClient(email)) &&
-		addAccountTokenHasGmailScopes(mgr, email)
+		addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
 }
 
 // addAccountAuthorizeError decorates an authorization failure with the
 // re-add hint when the consent screen authenticated a different address
 // than the one being added.
+//
+// The hint repeats the flags that determine the grant. Printing a bare
+// add-account to someone who ran --readonly would have them request write
+// access on the retry, silently undoing the narrowing they asked for.
 func addAccountAuthorizeError(err error, sourceExists bool) error {
 	var mismatch *oauth.TokenMismatchError
 	if errors.As(err, &mismatch) && !sourceExists {
 		return fmt.Errorf(
 			"%w\nIf %s is the primary address, re-add with:\n"+
-				"  msgvault add-account %s",
-			err, mismatch.Actual, mismatch.Actual,
+				"  msgvault add-account %s%s",
+			err, mismatch.Actual, mismatch.Actual, addAccountGrantFlagSuffix(),
 		)
 	}
 	return fmt.Errorf("authorization failed: %w", err)
+}
+
+// readonlyGrantWarning checks what actually came back after a --readonly
+// authorization. Requesting read-only does not by itself guarantee a read-only
+// grant: the authorization server decides what to issue, and a response can
+// carry scopes that were not requested. Rather than trust the request, read the
+// recorded grant and say so if any write scope survived.
+//
+// It warns rather than failing, for two reasons. The token is already written
+// and is the account's only credential, so deleting it would trade a too-wide
+// grant for no access at all. And aborting here would stop short of registering
+// the source, leaving a token on disk that no other command can see — while the
+// obvious retry is refused, because the grant now carries the very write access
+// the refusal exists to catch. Warning keeps the account working and puts the
+// remedy in the operator's hands.
+func readonlyGrantWarning(mgr *oauth.Manager, email string) string {
+	granted := oauth.GrantedGmailWriteScopes(mgr.GrantedScopes(email))
+	if len(granted) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Warning: authorization for %s returned Gmail write access (%s) despite --readonly.\n"+
+			"The grant is wider than requested. Removing it takes the same steps as any\n"+
+			"other narrowing — revoking alone will not do it, because the refusal reads the\n"+
+			"scopes recorded in the token file:\n%s",
+		email, strings.Join(granted, ", "),
+		narrowingSteps(email, mgr.TokenPath(email)),
+	)
+}
+
+// warnOnWiderThanRequestedGrant prints the readonly grant warning, if any.
+func warnOnWiderThanRequestedGrant(out io.Writer, mgr *oauth.Manager, email string) {
+	if !readonlyGrant {
+		return
+	}
+	if warning := readonlyGrantWarning(mgr, email); warning != "" {
+		_, _ = fmt.Fprintln(out, warning)
+	}
+}
+
+// addAccountGrantFlagSuffix renders the grant-affecting flags of the current
+// run for inclusion in remediation commands.
+func addAccountGrantFlagSuffix() string {
+	if readonlyGrant {
+		return " --readonly"
+	}
+	return ""
 }
 
 // runAddAccountHTTP completes any needed browser authorization in this
@@ -152,49 +249,58 @@ func addAccountAuthorizeError(err error, sourceExists bool) error {
 // the daemon. The subprocess then finds a fresh reusable token, so it never
 // opens a browser (or waits on a human) while holding the operation gate.
 func runAddAccountHTTP(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed(addAccountGrantDecidedFlag) {
+		return usageErr(cmd, fmt.Errorf("--%s is internal and cannot be supplied", addAccountGrantDecidedFlag))
+	}
+	grantDecided := false
 	if !headless {
-		if err := preflightAddAccountAuthorize(cmd, args[0]); err != nil {
+		var err error
+		grantDecided, err = preflightAddAccountAuthorize(cmd, args[0])
+		if err != nil {
 			return err
 		}
 	}
-	return runDaemonCLICommandHTTPFromCobra(cmd, args)
+	return runDaemonCLICommandHTTPFromCobraWithGrantDecision(cmd, args, grantDecided)
 }
 
-func preflightAddAccountAuthorize(cmd *cobra.Command, email string) error {
+func preflightAddAccountAuthorize(cmd *cobra.Command, email string) (bool, error) {
 	if IsRemoteMode() {
 		// Tokens live on the remote host; authorization must happen there.
-		return nil
+		return false, nil
 	}
 	storedApp, sourceExists, err := lookupGmailAccountBinding(cmd.Context(), email)
 	if err != nil {
-		return err
+		return false, err
 	}
 	binding := resolveAddAccountBinding(oauthAppName, cmd.Flags().Changed("oauth-app"), storedApp, sourceExists)
 	if cfg.OAuth.ServiceAccountKeyFor(binding.resolvedApp) != "" {
 		// Service accounts mint tokens on demand; no browser involved.
-		return nil
+		return false, nil
 	}
 	clientSecretsPath, err := cfg.OAuth.ClientSecretsFor(binding.resolvedApp)
 	if err != nil {
 		// Let the subprocess report the configuration error.
-		return nil //nolint:nilerr // deliberate: config errors surface daemon-side
+		return false, nil //nolint:nilerr // deliberate: config errors surface daemon-side
 	}
 	mgr, err := newAddAccountOAuthManager(clientSecretsPath, email)
 	if err != nil {
-		return err
+		return false, err
+	}
+	if err := applyAddAccountGrantDecision(cmd.OutOrStdout(), mgr, email, binding.resolvedApp); err != nil {
+		return false, err
 	}
 	if forceReauth {
 		if mgr.HasToken(email) {
 			fmt.Printf("Removing existing token for %s...\n", email)
 			if err := mgr.DeleteToken(email); err != nil {
-				return fmt.Errorf("delete existing token: %w", err)
+				return false, fmt.Errorf("delete existing token: %w", err)
 			}
 		} else {
 			fmt.Printf("No existing token found for %s, proceeding with authorization.\n", email)
 		}
 	}
 	if addAccountTokenReusable(mgr, email, binding) {
-		return nil
+		return false, nil
 	}
 
 	if binding.bindingChanged {
@@ -203,15 +309,23 @@ func preflightAddAccountAuthorize(cmd *cobra.Command, email string) error {
 		fmt.Println("Starting browser authorization...")
 	}
 	if err := mgr.Authorize(cmd.Context(), email); err != nil {
-		return addAccountAuthorizeError(err, sourceExists)
+		return false, addAccountAuthorizeError(err, sourceExists)
 	}
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), mgr, email)
+	// The grant decision is a pre-authorization gate, and it has now been made
+	// for this run. The daemon request carries a runtime-token-authenticated
+	// proof so its subprocess registers the account instead of
+	// re-litigating the grant: if the authorization above came back wider than
+	// requested, the subprocess would otherwise refuse the very token this
+	// process just minted, leaving it on disk with no source row and the
+	// obvious retry blocked by the same refusal.
 	// The subprocess must not force-delete the token minted above.
 	if forceReauth {
 		if err := cmd.Flags().Set("force", "false"); err != nil {
-			return fmt.Errorf("clear --force after authorization: %w", err)
+			return false, fmt.Errorf("clear --force after authorization: %w", err)
 		}
 	}
-	return nil
+	return true, nil
 }
 
 // lookupGmailAccountBinding fetches the stored oauth_app binding for email
@@ -271,7 +385,15 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 		if saKeyPath != "" {
 			return usageErr(cmd, errors.New("service accounts do not use --headless; run add-account without --headless"))
 		}
-		oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp)
+		// The grant decision applies here too. --headless only prints
+		// instructions, but those instructions are what the operator then runs
+		// on the browser machine: telling someone to widen a narrowed account,
+		// or handing them a --readonly recipe that will be refused when they
+		// get there, is the same failure as doing it directly.
+		if err := applyHeadlessGrantDecision(cmd, email, resolvedApp); err != nil {
+			return err
+		}
+		oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp, readonlyGrant)
 		return nil
 	}
 
@@ -279,6 +401,9 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	if saKeyPath != "" {
 		if forceReauth {
 			return usageErr(cmd, errors.New("service accounts do not use --force; tokens are minted on demand from the configured service account key"))
+		}
+		if readonlyGrant {
+			return usageErr(cmd, errors.New("service accounts do not use --readonly; scopes come from the domain-wide delegation grant configured in the Workspace admin console"))
 		}
 		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
 		if saErr != nil {
@@ -356,6 +481,16 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Refuse or warn about the grant change while the existing token is still
+	// on disk — --force below removes the evidence this decision needs.
+	// Skipped when the frontend CLI already decided and authorized; see
+	// addAccountGrantDecidedFlag.
+	if !addAccountGrantDecided(cmd) {
+		if err := applyAddAccountGrantDecision(cmd.OutOrStdout(), oauthMgr, email, resolvedApp); err != nil {
+			return err
+		}
+	}
+
 	// If --force, delete existing token so we re-authorize
 	if forceReauth {
 		if oauthMgr.HasToken(email) {
@@ -420,6 +555,7 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	if err := oauthMgr.Authorize(cmd.Context(), email); err != nil {
 		return addAccountAuthorizeError(err, existingSource != nil)
 	}
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email)
 
 	// Authorization succeeded — now persist the binding and source.
 	source, err := s.GetOrCreateSource(sourceTypeGmail, email)
@@ -460,20 +596,52 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func addAccountOAuthScopesForToken(hasScopeMetadata bool, existingScopes []string) []string {
+// addAccountOAuthScopesForToken builds the scope list to request. Existing
+// grants are carried forward because Google's replacement consent would
+// otherwise drop Calendar/Drive from the shared token file.
+//
+// Under readonly the Gmail write scopes are subtracted from those carried-over
+// grants and only gmail.readonly is required, which is what makes narrowing
+// actually narrow. Everything non-Gmail passes through untouched.
+func addAccountOAuthScopesForToken(hasScopeMetadata bool, existingScopes []string, readonly bool) []string {
+	required := oauth.Scopes
+	if readonly {
+		required = oauth.ScopesGmailReadonly
+	}
 	if !hasScopeMetadata {
-		return append([]string(nil), oauth.Scopes...)
+		return append([]string(nil), required...)
 	}
 	scopes := append([]string(nil), existingScopes...)
-	for _, scope := range oauth.Scopes {
+	if readonly {
+		scopes = oauth.WithoutGmailWriteScopes(scopes)
+	}
+	for _, scope := range required {
 		scopes = appendScopeIfMissing(scopes, scope)
 	}
 	return scopes
 }
 
-func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string) bool {
+// addAccountTokenHasGmailScopes reports whether the stored token already
+// covers what this run needs, so the token can be reused without a fresh
+// consent. Under readonly, gmail.readonly on its own is enough — re-authorizing
+// an account that is already narrowed would be a pointless browser round trip.
+func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string, readonly bool) bool {
 	if !mgr.HasScopeMetadata(email) {
-		return true
+		// A token predating scope recording satisfies a default run, whose
+		// scope set it almost certainly already matches. It cannot satisfy a
+		// readonly run: reusing an unverifiable grant would treat "unknown" as
+		// "already narrow". decideAddAccountGrant refuses this case before it
+		// reaches here, so this is a guard rather than the primary check.
+		return !readonly
+	}
+	if readonly {
+		// Read access is necessary but not sufficient: gmail.readonly is part
+		// of the default scope set, so an ordinary write-capable token has it
+		// too. Reusing one would report success over a grant --readonly exists
+		// to avoid. decideAddAccountGrant refuses that case first, but this
+		// must not depend on the gate upstream staying in place.
+		return mgr.HasScope(email, oauth.ScopeGmailReadonly) &&
+			!oauth.HasGmailWriteScope(mgr.GrantedScopes(email))
 	}
 	for _, scope := range oauth.ScopesDeletion {
 		if mgr.HasScope(email, scope) {
@@ -486,6 +654,273 @@ func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string) bool {
 		}
 	}
 	return true
+}
+
+// addAccountGrantDecision is the verdict on an account's current grant versus
+// what this run is about to request.
+type addAccountGrantDecision struct {
+	// Err refuses the run outright.
+	Err error
+	// Warning is printed before authorization proceeds.
+	Warning string
+}
+
+// decideAddAccountGrant compares the account's current grant against the
+// requested one. It is pure so both the local command and the daemon preflight
+// reach the same verdict from the same inputs.
+//
+// Refusal (readonly over an existing write grant) is unconditional. Neither
+// --force nor --headless is consulted, because neither changes the outcome:
+// re-authorizing does not revoke the previous grant, and revoking it would
+// invalidate the replacement, so there is no flag combination that narrows
+// access already granted.
+//
+// The widening warning fires only when there is an existing narrower Gmail
+// grant to widen. A brand-new account is the common case and a warning there
+// would be noise; an account holding only Calendar/Drive is likewise getting
+// its first Gmail grant, not losing a narrowed one.
+//
+// A token predating scope metadata is refused under readonly for the same
+// reason a known write grant is: msgvault cannot tell what it holds, and such
+// tokens were minted when read plus modify was the only scope set, so treating
+// "unknown" as "narrow enough" would report success over a still-write-capable
+// grant. Only readonly is affected; every other path keeps its existing
+// tolerance for legacy tokens.
+func decideAddAccountGrant(
+	email string,
+	hasToken bool,
+	hasScopeMetadata bool,
+	grantedScopes []string,
+	readonly bool,
+	freshClient bool,
+	tokenPath string,
+) addAccountGrantDecision {
+	if !hasToken {
+		return addAccountGrantDecision{}
+	}
+	if readonly {
+		// Consenting to a genuinely different OAuth client means a grant that
+		// does not exist yet, so nothing is carried forward and this is not
+		// narrowing in place. The caller must confirm the client really is
+		// different — two app names can resolve to the same client_secret.json,
+		// and treating that as fresh would wave the existing write grant
+		// through untouched.
+		//
+		// --force deliberately does NOT waive the refusal. It deletes the local
+		// token and obtains a narrower one, but the grant it replaces stays
+		// live at Google: a refresh token issued beforehand keeps working with
+		// its original write scopes. Allowing --force here would hand back a
+		// read-only token while write access remained in existence, which is
+		// the appearance of narrowing rather than narrowing.
+		if freshClient {
+			return addAccountGrantDecision{}
+		}
+		if !hasScopeMetadata {
+			return addAccountGrantDecision{Err: fmt.Errorf(
+				"%s has a token that predates scope recording, so its Gmail access cannot be verified\n"+
+					"Tokens this old were issued with read and modify access, which --readonly "+
+					"cannot take away on its own.\n%s",
+				email, narrowingRemedy(email, tokenPath),
+			)}
+		}
+		if granted := oauth.GrantedGmailWriteScopes(grantedScopes); len(granted) > 0 {
+			return addAccountGrantDecision{Err: fmt.Errorf(
+				"%s already has Gmail write access (%s)\n"+
+					"Re-authorizing preserves scopes the account already holds, so --readonly "+
+					"alone cannot take write access away.\n"+
+					"Non-Gmail grants such as Calendar are preserved either way.\n%s",
+				email, strings.Join(granted, ", "), narrowingRemedy(email, tokenPath),
+			)}
+		}
+		return addAccountGrantDecision{}
+	}
+	if oauth.IsNarrowedGmailGrant(grantedScopes) {
+		return addAccountGrantDecision{Warning: fmt.Sprintf(
+			"Warning: %s currently has read-only Gmail access (%s).\n"+
+				"Continuing will request write access (%s).\n"+
+				"Re-run with --readonly to keep the narrower grant.",
+			email,
+			strings.Join(gmailScopesIn(grantedScopes), ", "),
+			strings.Join(oauth.Scopes, ", "),
+		)}
+	}
+	return addAccountGrantDecision{}
+}
+
+// refuseReadonlyUnderAliasSpelling fails a read-only run when a token is
+// stored under a Gmail alias spelling of email. Proceeding would mint or
+// reuse a read-only token for this spelling while the other spelling's
+// credential kept whatever access it has — reported as a successful
+// read-only setup.
+//
+// With no token under this spelling the remedy is simply to use the stored
+// one, where the normal grant decision applies. When both spellings hold
+// tokens, that redirect would bounce off the mirror-image refusal, so the
+// remedy is the same revoke-and-re-add procedure as any other narrowing —
+// revocation at Google clears the account's grant for the client, so both
+// credentials die together — with every duplicate file removed before the
+// single re-add.
+func refuseReadonlyUnderAliasSpelling(mgr *oauth.Manager, email, resolvedApp string) error {
+	equivalents := mgr.FindEquivalentTokenEmails(email)
+	equivalents = slices.DeleteFunc(equivalents, mgr.TokenIssuedByDifferentClient)
+	if len(equivalents) == 0 {
+		return nil
+	}
+	flags := addAccountReadonlyRemediationFlagSuffix(resolvedApp)
+	if !mgr.HasToken(email) || mgr.TokenIssuedByDifferentClient(email) {
+		return fmt.Errorf(
+			"%s refers to the same Google account as %s, which has a stored token\n"+
+				"A read-only setup under a second spelling would leave that token's "+
+				"access in place, unnarrowed.\n"+
+				"Use the stored spelling instead:\n"+
+				"  msgvault add-account %s%s",
+			email, equivalents[0], equivalents[0], flags)
+	}
+	removals := []string{"  2. rm " + oauth.ShellQuote(mgr.TokenPath(email))}
+	for _, equivalent := range equivalents {
+		removals = append(removals, "     rm "+oauth.ShellQuote(mgr.TokenPath(equivalent)))
+	}
+	return fmt.Errorf(
+		"%s and %s hold stored tokens for the same Google account\n"+
+			"A read-only decision cannot be made while both exist.\n"+
+			"To make this account read-only, remove its access and grant it again:\n"+
+			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
+			"%s\n"+
+			"  3. msgvault add-account %s%s\n"+
+			"Revoking clears every other Google scope for this account, so re-run the\n"+
+			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"%s",
+		email, strings.Join(equivalents, ", "), strings.Join(removals, "\n"), email, flags,
+		"Archived mail is not affected.")
+}
+
+func addAccountReadonlyRemediationFlagSuffix(resolvedApp string) string {
+	var suffix string
+	if resolvedApp != "" {
+		suffix = " --oauth-app " + oauth.ShellQuote(resolvedApp)
+	}
+	return suffix + " --readonly"
+}
+
+// narrowingRemedy renders the way out of a refusal.
+//
+// Access already granted cannot be narrowed in place, and no flag changes that.
+// Re-authorizing does not revoke the previous grant — a refresh token issued
+// beforehand keeps working with its original scopes — and revoking is
+// all-or-nothing for the client, so revoking the old credential would destroy
+// the replacement too. The only sequence that produces a genuinely read-only
+// account is to remove the grant at Google and create it again.
+//
+// The procedure is identical on a headless host, so there is no variant: the
+// authorization flow prints a URL and waits on its loopback callback, which can
+// be completed from any browser.
+//
+// tokenPath is passed in rather than derived from the global config, so this
+// and decideAddAccountGrant stay pure and testable.
+func narrowingRemedy(email, tokenPath string) string {
+	return "Access already granted cannot be narrowed: re-authorizing does not revoke it,\n" +
+		"and revoking applies to the whole grant.\n" +
+		narrowingSteps(email, tokenPath)
+}
+
+// narrowingSteps is the procedure itself, shared by the refusal and by the
+// wider-than-requested warning so the two cannot drift. Step 2 is not optional
+// and revoking alone will not do: the refusal reads the scopes recorded in the
+// token file, which revoking at Google does not touch.
+//
+// The path is shell-quoted because the tokens directory comes from
+// MSGVAULT_HOME, --home, or [data].data_dir, any of which may contain a space —
+// and an unquoted rm would then take two operands and silently do nothing.
+func narrowingSteps(email, tokenPath string) string {
+	return fmt.Sprintf(
+		"To make this account read-only, remove its access and grant it again:\n"+
+			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
+			"  2. rm %s\n"+
+			"  3. msgvault add-account %s --readonly\n"+
+			"Revoking clears every other Google scope for this account, so re-run the\n"+
+			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"Archived mail is not affected.",
+		oauth.ShellQuote(tokenPath), email,
+	)
+}
+
+// gmailScopesIn returns the Gmail scopes present in scopes, so the widening
+// warning can name the current grant precisely instead of describing it.
+func gmailScopesIn(scopes []string) []string {
+	var gmail []string
+	for _, scope := range scopes {
+		if oauth.HasAnyGmailScope([]string{scope}) {
+			gmail = append(gmail, scope)
+		}
+	}
+	return gmail
+}
+
+// applyHeadlessGrantDecision runs the grant decision for a --headless run,
+// which prints instructions rather than authorizing and so never reaches the
+// usual decision point.
+//
+// It is best-effort by design: --headless has always worked as a pure
+// instruction-printer, including on a host with no OAuth credentials
+// configured, and requiring credentials here would regress that. When the
+// manager cannot be built there is no recorded grant to inspect, so the
+// instructions print as before.
+func applyHeadlessGrantDecision(cmd *cobra.Command, email, resolvedApp string) error {
+	clientSecretsPath, err := cfg.OAuth.ClientSecretsFor(resolvedApp)
+	if err != nil {
+		return nil //nolint:nilerr // deliberate: --headless works without configured credentials
+	}
+	mgr, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
+	if err != nil {
+		// Unreadable or malformed credentials are a real problem, not the
+		// "no credentials configured" case above, and silently skipping the
+		// gate would print instructions that widen a narrowed account. Say so
+		// and print nothing rather than guess.
+		return wrapOAuthError(fmt.Errorf("create oauth manager: %w", err))
+	}
+	return applyAddAccountGrantDecision(cmd.OutOrStdout(), mgr, email, resolvedApp)
+}
+
+// applyAddAccountGrantDecision reports the verdict, returning an error when
+// the run must stop. It must run before any authorization and, critically,
+// before --force deletes the token: once the token is gone there is no grant
+// left to compare against.
+func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email, resolvedApp string) error {
+	// Authorization accepts Gmail alias spellings (dots, plus-addresses,
+	// case, googlemail.com) as the same account, so a read-only decision
+	// must not treat an exact-match miss as a fresh account while an
+	// equivalent spelling holds a credential. Refused for --readonly only;
+	// default runs keep their existing behavior.
+	if readonlyGrant {
+		if err := refuseReadonlyUnderAliasSpelling(mgr, email, resolvedApp); err != nil {
+			return err
+		}
+	}
+	// The token's own client_id is the whole question: a grant belonging to a
+	// different client is not one --readonly could narrow. Deliberately not
+	// gated on bindingChanged, which requires an existing source row and so
+	// missed both a copied token with no row yet and an inherited binding.
+	// TokenIssuedByDifferentClient already answers conservatively, returning
+	// false when provenance is unknown.
+	freshClient := mgr.TokenIssuedByDifferentClient(email)
+	decision := decideAddAccountGrant(
+		email,
+		mgr.HasToken(email),
+		mgr.HasScopeMetadata(email),
+		mgr.GrantedScopes(email),
+		readonlyGrant,
+		freshClient,
+		mgr.TokenPath(email),
+	)
+	if decision.Err != nil {
+		return decision.Err
+	}
+	if decision.Warning != "" {
+		if _, err := fmt.Fprintln(out, decision.Warning); err != nil {
+			return fmt.Errorf("write grant warning: %w", err)
+		}
+	}
+	return nil
 }
 
 func findGmailSource(
@@ -509,6 +944,11 @@ func registerAddAccountFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&accountDisplayName, "display-name", "", "Display name for the account (e.g., \"Work\", \"Personal\")")
 	cmd.Flags().StringVar(&oauthAppName, "oauth-app", "", "Named OAuth app from config (for Google Workspace orgs)")
 	cmd.Flags().BoolVar(&noDefaultIdentityAddAccount, "no-default-identity", false, noDefaultIdentityHelp)
+	cmd.Flags().BoolVar(&readonlyGrant, "readonly", false, "Request Gmail read-only access instead of read+write (refused if the account already holds write access)")
+	cmd.Flags().Bool(addAccountGrantDecidedFlag, false, "Internal: the grant decision was already applied by the frontend CLI")
+	if err := cmd.Flags().MarkHidden(addAccountGrantDecidedFlag); err != nil {
+		panic(fmt.Sprintf("mark --%s hidden: %v", addAccountGrantDecidedFlag, err))
+	}
 }
 
 func init() {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -806,8 +806,8 @@ func refuseReadonlyUnderAliasSpelling(mgr *oauth.Manager, email, resolvedApp str
 			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
 			"%s\n"+
 			"  3. msgvault add-account %s%s\n"+
-			"Revoking clears every other Google scope for this account, so re-run the\n"+
-			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"Revoking also clears other Google scopes for this OAuth app, including\n"+
+			"Calendar and Drive. Re-authorize those integrations separately.\n"+
 			"%s",
 		email, strings.Join(equivalents, ", "), strings.Join(removals, "\n"), email, flags,
 		"Archived mail is not affected.")
@@ -857,8 +857,8 @@ func narrowingSteps(email, tokenPath, resolvedApp string) string {
 			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
 			"  2. rm %s\n"+
 			"  3. msgvault add-account %s%s\n"+
-			"Revoking clears every other Google scope for this account, so re-run the\n"+
-			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"Revoking also clears other Google scopes for this OAuth app, including\n"+
+			"Calendar and Drive. Re-authorize those integrations separately.\n"+
 			"Archived mail is not affected.",
 		oauth.ShellQuote(tokenPath), email, flags,
 	)

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -224,7 +224,7 @@ func addAccountAuthorizeError(err error, sourceExists bool) error {
 // obvious retry is refused, because the grant now carries the very write access
 // the refusal exists to catch. Warning keeps the account working and puts the
 // remedy in the operator's hands.
-func readonlyGrantWarning(mgr *oauth.Manager, email string) string {
+func readonlyGrantWarning(mgr *oauth.Manager, email, resolvedApp string) string {
 	granted := oauth.GrantedGmailWriteScopes(mgr.GrantedScopes(email))
 	if len(granted) == 0 {
 		return ""
@@ -235,16 +235,16 @@ func readonlyGrantWarning(mgr *oauth.Manager, email string) string {
 			"other narrowing — revoking alone will not do it, because the refusal reads the\n"+
 			"scopes recorded in the token file:\n%s",
 		email, strings.Join(granted, ", "),
-		narrowingSteps(email, mgr.TokenPath(email)),
+		narrowingSteps(email, mgr.TokenPath(email), resolvedApp),
 	)
 }
 
 // warnOnWiderThanRequestedGrant prints the readonly grant warning, if any.
-func warnOnWiderThanRequestedGrant(out io.Writer, mgr *oauth.Manager, email string) {
+func warnOnWiderThanRequestedGrant(out io.Writer, mgr *oauth.Manager, email, resolvedApp string) {
 	if !readonlyGrant {
 		return
 	}
-	if warning := readonlyGrantWarning(mgr, email); warning != "" {
+	if warning := readonlyGrantWarning(mgr, email, resolvedApp); warning != "" {
 		_, _ = fmt.Fprintln(out, warning)
 	}
 }
@@ -325,7 +325,7 @@ func preflightAddAccountAuthorize(cmd *cobra.Command, email string) (bool, error
 	if err := mgr.Authorize(cmd.Context(), email); err != nil {
 		return false, addAccountAuthorizeError(err, sourceExists)
 	}
-	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), mgr, email)
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), mgr, email, binding.resolvedApp)
 	// The grant decision is a pre-authorization gate, and it has now been made
 	// for this run. The daemon request carries a runtime-token-authenticated
 	// proof so its subprocess registers the account instead of
@@ -570,7 +570,7 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	if err := oauthMgr.Authorize(cmd.Context(), email); err != nil {
 		return addAccountAuthorizeError(err, existingSource != nil)
 	}
-	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email)
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email, resolvedApp)
 
 	// Authorization succeeded — now persist the binding and source.
 	source, err := s.GetOrCreateSource(sourceTypeGmail, email)
@@ -709,6 +709,7 @@ func decideAddAccountGrant(
 	readonly bool,
 	freshClient bool,
 	tokenPath string,
+	resolvedApp string,
 ) addAccountGrantDecision {
 	if !hasToken {
 		return addAccountGrantDecision{}
@@ -735,7 +736,7 @@ func decideAddAccountGrant(
 				"%s has a token that predates scope recording, so its Gmail access cannot be verified\n"+
 					"Tokens this old were issued with read and modify access, which --readonly "+
 					"cannot take away on its own.\n%s",
-				email, narrowingRemedy(email, tokenPath),
+				email, narrowingRemedy(email, tokenPath, resolvedApp),
 			)}
 		}
 		if granted := oauth.GrantedGmailWriteScopes(grantedScopes); len(granted) > 0 {
@@ -744,7 +745,7 @@ func decideAddAccountGrant(
 					"Re-authorizing preserves scopes the account already holds, so --readonly "+
 					"alone cannot take write access away.\n"+
 					"Non-Gmail grants such as Calendar are preserved either way.\n%s",
-				email, strings.Join(granted, ", "), narrowingRemedy(email, tokenPath),
+				email, strings.Join(granted, ", "), narrowingRemedy(email, tokenPath, resolvedApp),
 			)}
 		}
 		return addAccountGrantDecision{}
@@ -832,10 +833,10 @@ func addAccountReadonlyRemediationFlagSuffix(resolvedApp string) string {
 //
 // tokenPath is passed in rather than derived from the global config, so this
 // and decideAddAccountGrant stay pure and testable.
-func narrowingRemedy(email, tokenPath string) string {
+func narrowingRemedy(email, tokenPath, resolvedApp string) string {
 	return "Access already granted cannot be narrowed: re-authorizing does not revoke it,\n" +
 		"and revoking applies to the whole grant.\n" +
-		narrowingSteps(email, tokenPath)
+		narrowingSteps(email, tokenPath, resolvedApp)
 }
 
 // narrowingSteps is the procedure itself, shared by the refusal and by the
@@ -846,16 +847,17 @@ func narrowingRemedy(email, tokenPath string) string {
 // The path is shell-quoted because the tokens directory comes from
 // MSGVAULT_HOME, --home, or [data].data_dir, any of which may contain a space —
 // and an unquoted rm would then take two operands and silently do nothing.
-func narrowingSteps(email, tokenPath string) string {
+func narrowingSteps(email, tokenPath, resolvedApp string) string {
+	flags := addAccountReadonlyRemediationFlagSuffix(resolvedApp)
 	return fmt.Sprintf(
 		"To make this account read-only, remove its access and grant it again:\n"+
 			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
 			"  2. rm %s\n"+
-			"  3. msgvault add-account %s --readonly\n"+
+			"  3. msgvault add-account %s%s\n"+
 			"Revoking clears every other Google scope for this account, so re-run the\n"+
 			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
 			"Archived mail is not affected.",
-		oauth.ShellQuote(tokenPath), email,
+		oauth.ShellQuote(tokenPath), email, flags,
 	)
 }
 
@@ -875,15 +877,22 @@ func gmailScopesIn(scopes []string) []string {
 // which prints instructions rather than authorizing and so never reaches the
 // usual decision point.
 //
-// It is best-effort by design: --headless has always worked as a pure
-// instruction-printer, including on a host with no OAuth credentials
-// configured, and requiring credentials here would regress that. When the
-// manager cannot be built there is no recorded grant to inspect, so the
-// instructions print as before.
+// It is best-effort by design: --headless still prints for a new account when
+// OAuth credentials are not configured. A read-only run with an exact or
+// equivalent stored token fails closed, because its client cannot be verified.
 func applyHeadlessGrantDecision(cmd *cobra.Command, email, resolvedApp string) error {
 	clientSecretsPath, err := cfg.OAuth.ClientSecretsFor(resolvedApp)
 	if err != nil {
-		return nil //nolint:nilerr // deliberate: --headless works without configured credentials
+		if !readonlyGrant {
+			return nil // --headless still prints without configured credentials
+		}
+		if oauth.StoredTokenOrEquivalentExists(cfg.TokensDir(), email) {
+			return fmt.Errorf(
+				"%s has a stored token, but its Gmail access cannot be verified without OAuth client credentials: %w",
+				email, err,
+			)
+		}
+		return nil // --headless works without configured credentials for a new account
 	}
 	mgr, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
 	if err != nil {
@@ -926,6 +935,7 @@ func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email, reso
 		readonlyGrant,
 		freshClient,
 		mgr.TokenPath(email),
+		resolvedApp,
 	)
 	if decision.Err != nil {
 		return decision.Err

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -520,6 +520,9 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 
 	tokenReusable := !forceReauth && addAccountTokenReusable(oauthMgr, email, binding, grantDecided)
 	if tokenReusable {
+		if grantDecided {
+			warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email, resolvedApp)
+		}
 		source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 		if err != nil {
 			return fmt.Errorf("create source: %w", err)

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/oauth"
@@ -17,10 +19,17 @@ var (
 	forceReauth                 bool
 	oauthAppName                string
 	noDefaultIdentityAddAccount bool
+	readonlyGrant               bool
 )
 
 // addAccountUse is the usage string for the add-account command.
 const addAccountUse = "add-account <email>"
+
+// addAccountGrantDecidedFlag records that the grant decision was already made
+// by the frontend CLI before it proxied to the daemon. The decision gates
+// authorization, so re-running it in the subprocess — after the frontend has
+// already authorized — would refuse a token this run just minted.
+const addAccountGrantDecidedFlag = "grant-decided"
 
 // errGmailSourceNotFound is returned by findGmailSource when no Gmail
 // source is registered for the given identifier. Wrapped via fmt.Errorf
@@ -39,6 +48,15 @@ for authorizing on headless servers (Google does not support Gmail in device flo
 If a token already exists, the command skips authorization. Use --force to delete
 the existing token and start a fresh OAuth flow.
 
+By default msgvault requests Gmail read and modify access. Use --readonly to
+request read access only.
+
+Access already granted cannot be narrowed. Re-authorizing does not revoke it,
+and revoking applies to the whole grant, so --readonly refuses an account that
+already holds Gmail write access. To make such an account read-only, revoke
+msgvault at https://myaccount.google.com/permissions, delete its token file,
+then add it again with --readonly.
+
 For Google Workspace orgs that require their own OAuth app, use --oauth-app to
 specify a named app from config.toml.
 
@@ -46,6 +64,7 @@ Examples:
   msgvault add-account you@gmail.com
   msgvault add-account you@gmail.com --headless
  msgvault add-account you@gmail.com --force
+  msgvault add-account you@gmail.com --readonly
   msgvault add-account you@acme.com --oauth-app acme
   msgvault add-account you@gmail.com --display-name "Work Account"`,
 	Args: cobra.ExactArgs(1),
@@ -70,6 +89,27 @@ func newAddAccountCmd() *cobra.Command {
 	}
 	registerAddAccountFlags(cmd)
 	return cmd
+}
+
+// addAccountGrantDecided reports whether the frontend CLI already applied the
+// grant decision before proxying to the daemon.
+//
+// The flag is absent when a caller builds its own command without registering
+// the internal flags, which several tests and embedders do. Absent means
+// undecided — the conservative default, since it keeps the gate rather than
+// skipping it.
+func addAccountGrantDecided(cmd *cobra.Command) bool {
+	// Only honored inside the daemon's CLI subprocess. MarkHidden removes the
+	// flag from help output but pflag still parses it, so without this a user —
+	// or anything able to POST args to the daemon's CLI-run API — could pass
+	// --grant-decided directly and skip the write-access refusal entirely. The
+	// frontend applies the decision itself and never consults this flag, so
+	// restricting it to the subprocess costs nothing.
+	if !isDaemonCLISubprocess() {
+		return false
+	}
+	flag := cmd.Flags().Lookup(addAccountGrantDecidedFlag)
+	return flag != nil && flag.Value.String() == "true"
 }
 
 // addAccountBinding is the resolved OAuth app for an add-account run.
@@ -103,6 +143,11 @@ func resolveAddAccountBinding(flagApp string, flagExplicit bool, storedApp sql.N
 // newAddAccountOAuthManager builds the Gmail OAuth manager for email,
 // preserving any already-granted scopes so Google's replacement consent
 // does not drop Calendar/Drive scopes from the shared token file.
+//
+// Callers MUST build the manager before --force deletes the token. The scope
+// list is derived from the grant on disk, so probing after deletion would find
+// nothing to preserve and quietly discard the account's Calendar/Drive access
+// along with the Gmail scopes --force meant to reset.
 func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager, error) {
 	scopeProbe, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
 	if err != nil {
@@ -111,6 +156,7 @@ func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager,
 	oauthScopes := addAccountOAuthScopesForToken(
 		scopeProbe.HasScopeMetadata(email),
 		scopeProbe.GrantedScopes(email),
+		readonlyGrant,
 	)
 	mgr, err := oauth.NewManagerWithScopes(clientSecretsPath, cfg.TokensDir(), logger, oauthScopes)
 	if err != nil {
@@ -129,22 +175,73 @@ func addAccountTokenReusable(mgr *oauth.Manager, email string, binding addAccoun
 		binding.resolvedApp != ""
 	return mgr.HasToken(email) &&
 		(!needsClientCheck || mgr.TokenMatchesClient(email)) &&
-		addAccountTokenHasGmailScopes(mgr, email)
+		addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
 }
 
 // addAccountAuthorizeError decorates an authorization failure with the
 // re-add hint when the consent screen authenticated a different address
 // than the one being added.
+//
+// The hint repeats the flags that determine the grant. Printing a bare
+// add-account to someone who ran --readonly would have them request write
+// access on the retry, silently undoing the narrowing they asked for.
 func addAccountAuthorizeError(err error, sourceExists bool) error {
 	var mismatch *oauth.TokenMismatchError
 	if errors.As(err, &mismatch) && !sourceExists {
 		return fmt.Errorf(
 			"%w\nIf %s is the primary address, re-add with:\n"+
-				"  msgvault add-account %s",
-			err, mismatch.Actual, mismatch.Actual,
+				"  msgvault add-account %s%s",
+			err, mismatch.Actual, mismatch.Actual, addAccountGrantFlagSuffix(),
 		)
 	}
 	return fmt.Errorf("authorization failed: %w", err)
+}
+
+// readonlyGrantWarning checks what actually came back after a --readonly
+// authorization. Requesting read-only does not by itself guarantee a read-only
+// grant: the authorization server decides what to issue, and a response can
+// carry scopes that were not requested. Rather than trust the request, read the
+// recorded grant and say so if any write scope survived.
+//
+// It warns rather than failing, for two reasons. The token is already written
+// and is the account's only credential, so deleting it would trade a too-wide
+// grant for no access at all. And aborting here would stop short of registering
+// the source, leaving a token on disk that no other command can see — while the
+// obvious retry is refused, because the grant now carries the very write access
+// the refusal exists to catch. Warning keeps the account working and puts the
+// remedy in the operator's hands.
+func readonlyGrantWarning(mgr *oauth.Manager, email string) string {
+	granted := oauth.GrantedGmailWriteScopes(mgr.GrantedScopes(email))
+	if len(granted) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Warning: authorization for %s returned Gmail write access (%s) despite --readonly.\n"+
+			"The grant is wider than requested. Removing it takes the same steps as any\n"+
+			"other narrowing — revoking alone will not do it, because the refusal reads the\n"+
+			"scopes recorded in the token file:\n%s",
+		email, strings.Join(granted, ", "),
+		narrowingSteps(email, mgr.TokenPath(email)),
+	)
+}
+
+// warnOnWiderThanRequestedGrant prints the readonly grant warning, if any.
+func warnOnWiderThanRequestedGrant(out io.Writer, mgr *oauth.Manager, email string) {
+	if !readonlyGrant {
+		return
+	}
+	if warning := readonlyGrantWarning(mgr, email); warning != "" {
+		_, _ = fmt.Fprintln(out, warning)
+	}
+}
+
+// addAccountGrantFlagSuffix renders the grant-affecting flags of the current
+// run for inclusion in remediation commands.
+func addAccountGrantFlagSuffix() string {
+	if readonlyGrant {
+		return " --readonly"
+	}
+	return ""
 }
 
 // runAddAccountHTTP completes any needed browser authorization in this
@@ -183,6 +280,9 @@ func preflightAddAccountAuthorize(cmd *cobra.Command, email string) error {
 	if err != nil {
 		return err
 	}
+	if err := applyAddAccountGrantDecision(cmd.OutOrStdout(), mgr, email); err != nil {
+		return err
+	}
 	if forceReauth {
 		if mgr.HasToken(email) {
 			fmt.Printf("Removing existing token for %s...\n", email)
@@ -204,6 +304,18 @@ func preflightAddAccountAuthorize(cmd *cobra.Command, email string) error {
 	}
 	if err := mgr.Authorize(cmd.Context(), email); err != nil {
 		return addAccountAuthorizeError(err, sourceExists)
+	}
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), mgr, email)
+	// The grant decision is a pre-authorization gate, and it has now been made
+	// for this run. Tell the subprocess so it registers the account instead of
+	// re-litigating the grant: if the authorization above came back wider than
+	// requested, the subprocess would otherwise refuse the very token this
+	// process just minted, leaving it on disk with no source row and the
+	// obvious retry blocked by the same refusal.
+	if cmd.Flags().Lookup(addAccountGrantDecidedFlag) != nil {
+		if err := cmd.Flags().Set(addAccountGrantDecidedFlag, "true"); err != nil {
+			return fmt.Errorf("set --%s after authorization: %w", addAccountGrantDecidedFlag, err)
+		}
 	}
 	// The subprocess must not force-delete the token minted above.
 	if forceReauth {
@@ -271,7 +383,15 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 		if saKeyPath != "" {
 			return usageErr(cmd, errors.New("service accounts do not use --headless; run add-account without --headless"))
 		}
-		oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp)
+		// The grant decision applies here too. --headless only prints
+		// instructions, but those instructions are what the operator then runs
+		// on the browser machine: telling someone to widen a narrowed account,
+		// or handing them a --readonly recipe that will be refused when they
+		// get there, is the same failure as doing it directly.
+		if err := applyHeadlessGrantDecision(cmd, email, resolvedApp); err != nil {
+			return err
+		}
+		oauth.PrintHeadlessInstructions(email, cfg.TokensDir(), resolvedApp, readonlyGrant)
 		return nil
 	}
 
@@ -279,6 +399,9 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	if saKeyPath != "" {
 		if forceReauth {
 			return usageErr(cmd, errors.New("service accounts do not use --force; tokens are minted on demand from the configured service account key"))
+		}
+		if readonlyGrant {
+			return usageErr(cmd, errors.New("service accounts do not use --readonly; scopes come from the domain-wide delegation grant configured in the Workspace admin console"))
 		}
 		saMgr, saErr := oauth.NewServiceAccountManager(saKeyPath, oauth.Scopes)
 		if saErr != nil {
@@ -356,6 +479,16 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Refuse or warn about the grant change while the existing token is still
+	// on disk — --force below removes the evidence this decision needs.
+	// Skipped when the frontend CLI already decided and authorized; see
+	// addAccountGrantDecidedFlag.
+	if !addAccountGrantDecided(cmd) {
+		if err := applyAddAccountGrantDecision(cmd.OutOrStdout(), oauthMgr, email); err != nil {
+			return err
+		}
+	}
+
 	// If --force, delete existing token so we re-authorize
 	if forceReauth {
 		if oauthMgr.HasToken(email) {
@@ -420,6 +553,7 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	if err := oauthMgr.Authorize(cmd.Context(), email); err != nil {
 		return addAccountAuthorizeError(err, existingSource != nil)
 	}
+	warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email)
 
 	// Authorization succeeded — now persist the binding and source.
 	source, err := s.GetOrCreateSource(sourceTypeGmail, email)
@@ -460,20 +594,52 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func addAccountOAuthScopesForToken(hasScopeMetadata bool, existingScopes []string) []string {
+// addAccountOAuthScopesForToken builds the scope list to request. Existing
+// grants are carried forward because Google's replacement consent would
+// otherwise drop Calendar/Drive from the shared token file.
+//
+// Under readonly the Gmail write scopes are subtracted from those carried-over
+// grants and only gmail.readonly is required, which is what makes narrowing
+// actually narrow. Everything non-Gmail passes through untouched.
+func addAccountOAuthScopesForToken(hasScopeMetadata bool, existingScopes []string, readonly bool) []string {
+	required := oauth.Scopes
+	if readonly {
+		required = oauth.ScopesGmailReadonly
+	}
 	if !hasScopeMetadata {
-		return append([]string(nil), oauth.Scopes...)
+		return append([]string(nil), required...)
 	}
 	scopes := append([]string(nil), existingScopes...)
-	for _, scope := range oauth.Scopes {
+	if readonly {
+		scopes = oauth.WithoutGmailWriteScopes(scopes)
+	}
+	for _, scope := range required {
 		scopes = appendScopeIfMissing(scopes, scope)
 	}
 	return scopes
 }
 
-func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string) bool {
+// addAccountTokenHasGmailScopes reports whether the stored token already
+// covers what this run needs, so the token can be reused without a fresh
+// consent. Under readonly, gmail.readonly on its own is enough — re-authorizing
+// an account that is already narrowed would be a pointless browser round trip.
+func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string, readonly bool) bool {
 	if !mgr.HasScopeMetadata(email) {
-		return true
+		// A token predating scope recording satisfies a default run, whose
+		// scope set it almost certainly already matches. It cannot satisfy a
+		// readonly run: reusing an unverifiable grant would treat "unknown" as
+		// "already narrow". decideAddAccountGrant refuses this case before it
+		// reaches here, so this is a guard rather than the primary check.
+		return !readonly
+	}
+	if readonly {
+		// Read access is necessary but not sufficient: gmail.readonly is part
+		// of the default scope set, so an ordinary write-capable token has it
+		// too. Reusing one would report success over a grant --readonly exists
+		// to avoid. decideAddAccountGrant refuses that case first, but this
+		// must not depend on the gate upstream staying in place.
+		return mgr.HasScope(email, oauth.ScopeGmailReadonly) &&
+			!oauth.HasGmailWriteScope(mgr.GrantedScopes(email))
 	}
 	for _, scope := range oauth.ScopesDeletion {
 		if mgr.HasScope(email, scope) {
@@ -486,6 +652,208 @@ func addAccountTokenHasGmailScopes(mgr *oauth.Manager, email string) bool {
 		}
 	}
 	return true
+}
+
+// addAccountGrantDecision is the verdict on an account's current grant versus
+// what this run is about to request.
+type addAccountGrantDecision struct {
+	// Err refuses the run outright.
+	Err error
+	// Warning is printed before authorization proceeds.
+	Warning string
+}
+
+// decideAddAccountGrant compares the account's current grant against the
+// requested one. It is pure so both the local command and the daemon preflight
+// reach the same verdict from the same inputs.
+//
+// Refusal (readonly over an existing write grant) is unconditional. Neither
+// --force nor --headless is consulted, because neither changes the outcome:
+// re-authorizing does not revoke the previous grant, and revoking it would
+// invalidate the replacement, so there is no flag combination that narrows
+// access already granted.
+//
+// The widening warning fires only when there is an existing narrower Gmail
+// grant to widen. A brand-new account is the common case and a warning there
+// would be noise; an account holding only Calendar/Drive is likewise getting
+// its first Gmail grant, not losing a narrowed one.
+//
+// A token predating scope metadata is refused under readonly for the same
+// reason a known write grant is: msgvault cannot tell what it holds, and such
+// tokens were minted when read plus modify was the only scope set, so treating
+// "unknown" as "narrow enough" would report success over a still-write-capable
+// grant. Only readonly is affected; every other path keeps its existing
+// tolerance for legacy tokens.
+func decideAddAccountGrant(
+	email string,
+	hasToken bool,
+	hasScopeMetadata bool,
+	grantedScopes []string,
+	readonly bool,
+	freshClient bool,
+	tokenPath string,
+) addAccountGrantDecision {
+	if !hasToken {
+		return addAccountGrantDecision{}
+	}
+	if readonly {
+		// Consenting to a genuinely different OAuth client means a grant that
+		// does not exist yet, so nothing is carried forward and this is not
+		// narrowing in place. The caller must confirm the client really is
+		// different — two app names can resolve to the same client_secret.json,
+		// and treating that as fresh would wave the existing write grant
+		// through untouched.
+		//
+		// --force deliberately does NOT waive the refusal. It deletes the local
+		// token and obtains a narrower one, but the grant it replaces stays
+		// live at Google: a refresh token issued beforehand keeps working with
+		// its original write scopes. Allowing --force here would hand back a
+		// read-only token while write access remained in existence, which is
+		// the appearance of narrowing rather than narrowing.
+		if freshClient {
+			return addAccountGrantDecision{}
+		}
+		if !hasScopeMetadata {
+			return addAccountGrantDecision{Err: fmt.Errorf(
+				"%s has a token that predates scope recording, so its Gmail access cannot be verified\n"+
+					"Tokens this old were issued with read and modify access, which --readonly "+
+					"cannot take away on its own.\n%s",
+				email, narrowingRemedy(email, tokenPath),
+			)}
+		}
+		if granted := oauth.GrantedGmailWriteScopes(grantedScopes); len(granted) > 0 {
+			return addAccountGrantDecision{Err: fmt.Errorf(
+				"%s already has Gmail write access (%s)\n"+
+					"Re-authorizing preserves scopes the account already holds, so --readonly "+
+					"alone cannot take write access away.\n"+
+					"Non-Gmail grants such as Calendar are preserved either way.\n%s",
+				email, strings.Join(granted, ", "), narrowingRemedy(email, tokenPath),
+			)}
+		}
+		return addAccountGrantDecision{}
+	}
+	if oauth.IsNarrowedGmailGrant(grantedScopes) {
+		return addAccountGrantDecision{Warning: fmt.Sprintf(
+			"Warning: %s currently has read-only Gmail access (%s).\n"+
+				"Continuing will request write access (%s).\n"+
+				"Re-run with --readonly to keep the narrower grant.",
+			email,
+			strings.Join(gmailScopesIn(grantedScopes), ", "),
+			strings.Join(oauth.Scopes, ", "),
+		)}
+	}
+	return addAccountGrantDecision{}
+}
+
+// narrowingRemedy renders the way out of a refusal.
+//
+// Access already granted cannot be narrowed in place, and no flag changes that.
+// Re-authorizing does not revoke the previous grant — a refresh token issued
+// beforehand keeps working with its original scopes — and revoking is
+// all-or-nothing for the client, so revoking the old credential would destroy
+// the replacement too. The only sequence that produces a genuinely read-only
+// account is to remove the grant at Google and create it again.
+//
+// The procedure is identical on a headless host, so there is no variant: the
+// authorization flow prints a URL and waits on its loopback callback, which can
+// be completed from any browser.
+//
+// tokenPath is passed in rather than derived from the global config, so this
+// and decideAddAccountGrant stay pure and testable.
+func narrowingRemedy(email, tokenPath string) string {
+	return "Access already granted cannot be narrowed: re-authorizing does not revoke it,\n" +
+		"and revoking applies to the whole grant.\n" +
+		narrowingSteps(email, tokenPath)
+}
+
+// narrowingSteps is the procedure itself, shared by the refusal and by the
+// wider-than-requested warning so the two cannot drift. Step 2 is not optional
+// and revoking alone will not do: the refusal reads the scopes recorded in the
+// token file, which revoking at Google does not touch.
+//
+// The path is shell-quoted because the tokens directory comes from
+// MSGVAULT_HOME, --home, or [data].data_dir, any of which may contain a space —
+// and an unquoted rm would then take two operands and silently do nothing.
+func narrowingSteps(email, tokenPath string) string {
+	return fmt.Sprintf(
+		"To make this account read-only, remove its access and grant it again:\n"+
+			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
+			"  2. rm %s\n"+
+			"  3. msgvault add-account %s --readonly\n"+
+			"Revoking clears every other Google scope for this account, so re-run the\n"+
+			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"Archived mail is not affected.",
+		oauth.ShellQuote(tokenPath), email,
+	)
+}
+
+// gmailScopesIn returns the Gmail scopes present in scopes, so the widening
+// warning can name the current grant precisely instead of describing it.
+func gmailScopesIn(scopes []string) []string {
+	var gmail []string
+	for _, scope := range scopes {
+		if oauth.HasAnyGmailScope([]string{scope}) {
+			gmail = append(gmail, scope)
+		}
+	}
+	return gmail
+}
+
+// applyHeadlessGrantDecision runs the grant decision for a --headless run,
+// which prints instructions rather than authorizing and so never reaches the
+// usual decision point.
+//
+// It is best-effort by design: --headless has always worked as a pure
+// instruction-printer, including on a host with no OAuth credentials
+// configured, and requiring credentials here would regress that. When the
+// manager cannot be built there is no recorded grant to inspect, so the
+// instructions print as before.
+func applyHeadlessGrantDecision(cmd *cobra.Command, email, resolvedApp string) error {
+	clientSecretsPath, err := cfg.OAuth.ClientSecretsFor(resolvedApp)
+	if err != nil {
+		return nil //nolint:nilerr // deliberate: --headless works without configured credentials
+	}
+	mgr, err := oauth.NewManager(clientSecretsPath, cfg.TokensDir(), logger)
+	if err != nil {
+		// Unreadable or malformed credentials are a real problem, not the
+		// "no credentials configured" case above, and silently skipping the
+		// gate would print instructions that widen a narrowed account. Say so
+		// and print nothing rather than guess.
+		return wrapOAuthError(fmt.Errorf("create oauth manager: %w", err))
+	}
+	return applyAddAccountGrantDecision(cmd.OutOrStdout(), mgr, email)
+}
+
+// applyAddAccountGrantDecision reports the verdict, returning an error when
+// the run must stop. It must run before any authorization and, critically,
+// before --force deletes the token: once the token is gone there is no grant
+// left to compare against.
+func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email string) error {
+	// The token's own client_id is the whole question: a grant belonging to a
+	// different client is not one --readonly could narrow. Deliberately not
+	// gated on bindingChanged, which requires an existing source row and so
+	// missed both a copied token with no row yet and an inherited binding.
+	// TokenIssuedByDifferentClient already answers conservatively, returning
+	// false when provenance is unknown.
+	freshClient := mgr.TokenIssuedByDifferentClient(email)
+	decision := decideAddAccountGrant(
+		email,
+		mgr.HasToken(email),
+		mgr.HasScopeMetadata(email),
+		mgr.GrantedScopes(email),
+		readonlyGrant,
+		freshClient,
+		mgr.TokenPath(email),
+	)
+	if decision.Err != nil {
+		return decision.Err
+	}
+	if decision.Warning != "" {
+		if _, err := fmt.Fprintln(out, decision.Warning); err != nil {
+			return fmt.Errorf("write grant warning: %w", err)
+		}
+	}
+	return nil
 }
 
 func findGmailSource(
@@ -509,6 +877,11 @@ func registerAddAccountFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&accountDisplayName, "display-name", "", "Display name for the account (e.g., \"Work\", \"Personal\")")
 	cmd.Flags().StringVar(&oauthAppName, "oauth-app", "", "Named OAuth app from config (for Google Workspace orgs)")
 	cmd.Flags().BoolVar(&noDefaultIdentityAddAccount, "no-default-identity", false, noDefaultIdentityHelp)
+	cmd.Flags().BoolVar(&readonlyGrant, "readonly", false, "Request Gmail read-only access instead of read+write (refused if the account already holds write access)")
+	cmd.Flags().Bool(addAccountGrantDecidedFlag, false, "Internal: the grant decision was already applied by the frontend CLI")
+	if err := cmd.Flags().MarkHidden(addAccountGrantDecidedFlag); err != nil {
+		panic(fmt.Sprintf("mark --%s hidden: %v", addAccountGrantDecidedFlag, err))
+	}
 }
 
 func init() {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -166,16 +166,30 @@ func newAddAccountOAuthManager(clientSecretsPath, email string) (*oauth.Manager,
 }
 
 // addAccountTokenReusable reports whether the stored token can be reused
-// without a fresh authorization. The token's client identity is validated
-// whenever any named app is involved — from an explicit flag, a binding
-// change, or a stored binding — because a mismatched token would fail on
-// its next refresh.
-func addAccountTokenReusable(mgr *oauth.Manager, email string, binding addAccountBinding) bool {
-	needsClientCheck := binding.bindingChanged || binding.explicit ||
+// without a fresh authorization. A known client mismatch is never reusable.
+// Named-app and authenticated-preflight paths also reject unknown client
+// provenance, while the ordinary implicit-default path retains its legacy
+// tolerance for tokens without client metadata.
+//
+// grantDecided is true only in the daemon subprocess after an authenticated
+// frontend preflight minted the token. That token can be registered even when
+// the provider returned wider scopes than requested; the frontend already
+// warned about the grant, and reauthorizing cannot narrow it.
+func addAccountTokenReusable(
+	mgr *oauth.Manager,
+	email string,
+	binding addAccountBinding,
+	grantDecided bool,
+) bool {
+	if !mgr.HasToken(email) || mgr.TokenIssuedByDifferentClient(email) {
+		return false
+	}
+	needsClientCheck := grantDecided || binding.bindingChanged || binding.explicit ||
 		binding.resolvedApp != ""
-	return mgr.HasToken(email) &&
-		(!needsClientCheck || mgr.TokenMatchesClient(email)) &&
-		addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
+	if needsClientCheck && !mgr.TokenMatchesClient(email) {
+		return false
+	}
+	return grantDecided || addAccountTokenHasGmailScopes(mgr, email, readonlyGrant)
 }
 
 // addAccountAuthorizeError decorates an authorization failure with the
@@ -299,7 +313,7 @@ func preflightAddAccountAuthorize(cmd *cobra.Command, email string) (bool, error
 			fmt.Printf("No existing token found for %s, proceeding with authorization.\n", email)
 		}
 	}
-	if addAccountTokenReusable(mgr, email, binding) {
+	if addAccountTokenReusable(mgr, email, binding, false) {
 		return false, nil
 	}
 
@@ -485,7 +499,8 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 	// on disk — --force below removes the evidence this decision needs.
 	// Skipped when the frontend CLI already decided and authorized; see
 	// addAccountGrantDecidedFlag.
-	if !addAccountGrantDecided(cmd) {
+	grantDecided := addAccountGrantDecided(cmd)
+	if !grantDecided {
 		if err := applyAddAccountGrantDecision(cmd.OutOrStdout(), oauthMgr, email, resolvedApp); err != nil {
 			return err
 		}
@@ -503,7 +518,7 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	tokenReusable := !forceReauth && addAccountTokenReusable(oauthMgr, email, binding)
+	tokenReusable := !forceReauth && addAccountTokenReusable(oauthMgr, email, binding, grantDecided)
 	if tokenReusable {
 		source, err := s.GetOrCreateSource(sourceTypeGmail, email)
 		if err != nil {

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 	"strings"
 
@@ -927,6 +928,16 @@ func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email, reso
 			return err
 		}
 	}
+	hasToken := mgr.HasToken(email)
+	if readonlyGrant && !hasToken {
+		tokenPath := mgr.TokenPath(email)
+		if _, err := os.Lstat(tokenPath); err == nil || !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf(
+				"%s has a stored token file that cannot be read, so its Gmail access cannot be verified\n%s",
+				email, narrowingRemedy(email, tokenPath, resolvedApp),
+			)
+		}
+	}
 	// The token's own client_id is the whole question: a grant belonging to a
 	// different client is not one --readonly could narrow. Deliberately not
 	// gated on bindingChanged, which requires an existing source row and so
@@ -936,7 +947,7 @@ func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email, reso
 	freshClient := mgr.TokenIssuedByDifferentClient(email)
 	decision := decideAddAccountGrant(
 		email,
-		mgr.HasToken(email),
+		hasToken,
 		mgr.HasScopeMetadata(email),
 		mgr.GrantedScopes(email),
 		readonlyGrant,

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -745,6 +745,51 @@ func decideAddAccountGrant(
 	return addAccountGrantDecision{}
 }
 
+// refuseReadonlyUnderAliasSpelling fails a read-only run when a token is
+// stored under a Gmail alias spelling of email. Proceeding would mint or
+// reuse a read-only token for this spelling while the other spelling's
+// credential kept whatever access it has — reported as a successful
+// read-only setup.
+//
+// With no token under this spelling the remedy is simply to use the stored
+// one, where the normal grant decision applies. When both spellings hold
+// tokens, that redirect would bounce off the mirror-image refusal, so the
+// remedy is the same revoke-and-re-add procedure as any other narrowing —
+// revocation at Google clears the account's grant for the client, so both
+// credentials die together — with every duplicate file removed before the
+// single re-add.
+func refuseReadonlyUnderAliasSpelling(mgr *oauth.Manager, email string) error {
+	equivalents := mgr.FindEquivalentTokenEmails(email)
+	if len(equivalents) == 0 {
+		return nil
+	}
+	if !mgr.HasToken(email) {
+		return fmt.Errorf(
+			"%s refers to the same Google account as %s, which has a stored token\n"+
+				"A read-only setup under a second spelling would leave that token's "+
+				"access in place, unnarrowed.\n"+
+				"Use the stored spelling instead:\n"+
+				"  msgvault add-account %s --readonly",
+			email, equivalents[0], equivalents[0])
+	}
+	removals := []string{"  2. rm " + oauth.ShellQuote(mgr.TokenPath(email))}
+	for _, equivalent := range equivalents {
+		removals = append(removals, "     rm "+oauth.ShellQuote(mgr.TokenPath(equivalent)))
+	}
+	return fmt.Errorf(
+		"%s and %s hold stored tokens for the same Google account\n"+
+			"A read-only decision cannot be made while both exist.\n"+
+			"To make this account read-only, remove its access and grant it again:\n"+
+			"  1. Revoke msgvault at https://myaccount.google.com/permissions\n"+
+			"%s\n"+
+			"  3. msgvault add-account %s --readonly\n"+
+			"Revoking clears every other Google scope for this account, so re-run the\n"+
+			"commands that granted them (msgvault add-calendar, add-synctech-sms-drive).\n"+
+			"%s",
+		email, strings.Join(equivalents, ", "), strings.Join(removals, "\n"), email,
+		"Archived mail is not affected.")
+}
+
 // narrowingRemedy renders the way out of a refusal.
 //
 // Access already granted cannot be narrowed in place, and no flag changes that.
@@ -829,6 +874,16 @@ func applyHeadlessGrantDecision(cmd *cobra.Command, email, resolvedApp string) e
 // before --force deletes the token: once the token is gone there is no grant
 // left to compare against.
 func applyAddAccountGrantDecision(out io.Writer, mgr *oauth.Manager, email string) error {
+	// Authorization accepts Gmail alias spellings (dots, plus-addresses,
+	// case, googlemail.com) as the same account, so a read-only decision
+	// must not treat an exact-match miss as a fresh account while an
+	// equivalent spelling holds a credential. Refused for --readonly only;
+	// default runs keep their existing behavior.
+	if readonlyGrant {
+		if err := refuseReadonlyUnderAliasSpelling(mgr, email); err != nil {
+			return err
+		}
+	}
 	// The token's own client_id is the whole question: a grant belonging to a
 	// different client is not one --readonly could narrow. Deliberately not
 	// gated on bindingChanged, which requires an existing source row and so

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -454,6 +454,23 @@ func TestAddAccount_ReadonlyRefusesWriteCapableAccount(t *testing.T) {
 	assert.Equal(before, after, "refusal must not touch the existing token")
 }
 
+func TestAddAccount_ReadonlyRefusesMalformedStoredToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+	defer restore()
+	require.NoError(os.WriteFile(tokenPath, []byte("{not valid json"), 0600))
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "cannot be verified")
+	assert.NotContains(out, "Starting browser authorization")
+}
+
 func TestAddAccount_ReadonlyRemediationPreservesNamedOAuthApp(t *testing.T) {
 	saveAddAccountFlags(t)
 	_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -1,0 +1,834 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/oauth"
+)
+
+// Token fixtures for the grants that only become reachable once read-only
+// accounts exist. No real credentials are present.
+
+const gmailReadonlyTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+const gmailReadonlyCalendarTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/calendar.readonly"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+// gmailFullOnlyTokenJSON holds the broad full-access scope and NOT
+// gmail.modify. Produced by narrowing an account to read-only and later
+// escalating it for permanent deletion. Any write check that looks only at
+// gmail.modify gets this account wrong.
+const gmailFullOnlyTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://mail.google.com/"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+// saveAddAccountFlags snapshots the package-level add-account flag globals so
+// a test can set them without leaking into the rest of the package.
+func saveAddAccountFlags(t *testing.T) {
+	t.Helper()
+	savedHeadless, savedForce, savedReadonly := headless, forceReauth, readonlyGrant
+	savedApp, savedName, savedNoDefault := oauthAppName, accountDisplayName, noDefaultIdentityAddAccount
+	t.Cleanup(func() {
+		headless, forceReauth, readonlyGrant = savedHeadless, savedForce, savedReadonly
+		oauthAppName, accountDisplayName, noDefaultIdentityAddAccount = savedApp, savedName, savedNoDefault
+	})
+}
+
+// runAddAccountForTest drives the real add-account command against the seeded
+// environment and returns everything it printed. os.Stdout is captured rather
+// than a cobra buffer because the command reports progress with fmt.Printf, so
+// a buffer alone would miss most of what an operator actually sees.
+//
+// The context is pre-cancelled, so a run that reaches the browser flow fails
+// immediately instead of hanging. Tests that expect no authorization assert on
+// the absence of that failure.
+func runAddAccountForTest(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	testCmd := &cobra.Command{
+		Use:  addAccountUse,
+		Args: cobra.ExactArgs(1),
+		RunE: runAddAccountLocal,
+	}
+	registerAddAccountFlags(testCmd)
+
+	root := newTestRootCmd()
+	root.AddCommand(testCmd)
+	root.SetArgs(append([]string{"add-account"}, args...))
+
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err, "create stdout pipe")
+	savedStdout := os.Stdout
+	os.Stdout = writer
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, reader)
+		captured <- buf.String()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runErr := root.ExecuteContext(ctx)
+
+	os.Stdout = savedStdout
+	require.NoError(t, writer.Close(), "close stdout pipe")
+	out := <-captured
+	require.NoError(t, reader.Close(), "close stdout reader")
+
+	t.Log(out)
+	if runErr != nil {
+		return out, fmt.Errorf("run add-account: %w", runErr)
+	}
+	return out, nil
+}
+
+func TestAddAccountOAuthScopesForToken_Readonly(t *testing.T) {
+	tests := []struct {
+		name             string
+		hasScopeMetadata bool
+		existing         []string
+		readonly         bool
+		want             []string
+	}{
+		{
+			name:     "fresh account requests read and write by default",
+			readonly: false,
+			want:     oauth.Scopes,
+		},
+		{
+			name:     "fresh account with readonly requests read only",
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "narrowing drops every write scope and keeps calendar",
+			hasScopeMetadata: true,
+			existing: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailModify,
+				oauth.ScopeGmailFull,
+				oauth.ScopeCalendarReadonly,
+			},
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+		},
+		{
+			// Write scopes msgvault never requests still have to be stripped;
+			// a grant is read-only when nothing in it can write.
+			name:             "narrowing drops write scopes msgvault never requests",
+			hasScopeMetadata: true,
+			existing: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailSend,
+				oauth.ScopeGmailCompose,
+				oauth.ScopeGmailInsert,
+				oauth.ScopeGmailLabels,
+				oauth.ScopeGmailSettingsBasic,
+				oauth.ScopeGmailSettingsSharing,
+				oauth.ScopeCalendarReadonly,
+			},
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+		},
+		{
+			// gmail.metadata is read-only and must survive narrowing.
+			name:             "narrowing keeps the read-only metadata scope",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailMetadata, oauth.ScopeGmailModify},
+			readonly:         true,
+			want:             []string{oauth.ScopeGmailMetadata, oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "narrowing an account that only holds full access still yields read only",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailFull},
+			readonly:         true,
+			want:             []string{oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "default request over an existing grant is unchanged",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			readonly:         false,
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeCalendarReadonly,
+				oauth.ScopeGmailModify,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addAccountOAuthScopesForToken(tt.hasScopeMetadata, tt.existing, tt.readonly)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecideAddAccountGrant(t *testing.T) {
+	const email = "user@example.com"
+
+	tests := []struct {
+		name             string
+		hasToken         bool
+		hasScopeMetadata bool
+		granted          []string
+		readonly         bool
+		freshClient      bool
+		wantErr          bool
+		wantErrContains  string
+		wantWarn         bool
+	}{
+		{
+			name:             "refusal names the revoke-and-re-add procedure",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "myaccount.google.com/permissions",
+		},
+		{
+			// gmail.send is write-capable but never requested by msgvault, so
+			// a set that stops at modify and full would wave it through.
+			name:             "readonly over a send-only grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailSend},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailSend,
+		},
+		{
+			name:             "readonly over a settings grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailSettingsBasic},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailSettingsBasic,
+		},
+		{
+			// Metadata is read-only, so this grant is genuinely narrow and
+			// must not be refused.
+			name:             "readonly over a metadata grant is a no-op",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailMetadata},
+			readonly:         true,
+		},
+		{
+			name:     "brand new account never warns",
+			readonly: false,
+		},
+		{
+			name:     "brand new account accepts readonly",
+			readonly: true,
+		},
+		{
+			// A token predating scope recording holds an unverifiable grant,
+			// and tokens that old were minted with read + modify. Treating
+			// "unknown" as "already narrow" would report success over a still
+			// write-capable account.
+			name:             "legacy token without scope metadata is refused under readonly",
+			hasToken:         true,
+			hasScopeMetadata: false,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "predates scope recording",
+		},
+		{
+			name:             "legacy token is left alone on a default run",
+			hasToken:         true,
+			hasScopeMetadata: false,
+			readonly:         false,
+		},
+		{
+			name:             "readonly over a modify grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "cannot be narrowed",
+		},
+		{
+			// The full-access scope is the write scope a check that only
+			// knows gmail.modify would miss.
+			name:             "readonly over a full access grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailFull},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailFull,
+		},
+		{
+			// A genuinely different OAuth client has no prior grant, so this
+			// is a first authorization rather than narrowing in place. The
+			// caller sets this only when the token's recorded client_id
+			// differs — unknown provenance does not qualify.
+			name:             "readonly proceeds for a genuinely different oauth client",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			freshClient:      true,
+		},
+		{
+			name:             "readonly over an already narrow grant is a silent no-op",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			readonly:         true,
+		},
+		{
+			name:             "default run over a narrow grant warns before widening",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly},
+			readonly:         false,
+			wantWarn:         true,
+		},
+		{
+			name:             "default run over a write grant does not warn",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         false,
+		},
+		{
+			// Adding Gmail to a Calendar-only token is a first Gmail grant,
+			// not a widening of a narrowed one.
+			name:             "calendar only token does not warn",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeCalendarReadonly},
+			readonly:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			got := decideAddAccountGrant(
+				email, tt.hasToken, tt.hasScopeMetadata, tt.granted, tt.readonly,
+				tt.freshClient, "/tmp/tokens/user@example.com.json")
+
+			if tt.wantErr {
+				require.Error(got.Err)
+				assert.Contains(got.Err.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(got.Err)
+			}
+			if tt.wantWarn {
+				assert.Contains(got.Warning, "read-only Gmail access")
+			} else {
+				assert.Empty(got.Warning)
+			}
+		})
+	}
+}
+
+func TestAddAccountTokenHasGmailScopes_Readonly(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenJSON string
+		readonly  bool
+		want      bool
+	}{
+		{
+			name:      "readonly run accepts a read-only token",
+			tokenJSON: gmailReadonlyTokenJSON,
+			readonly:  true,
+			want:      true,
+		},
+		{
+			name:      "default run rejects a read-only token",
+			tokenJSON: gmailReadonlyTokenJSON,
+			readonly:  false,
+			want:      false,
+		},
+		{
+			name:      "default run accepts a full gmail token",
+			tokenJSON: gmailOnlyTokenJSON,
+			readonly:  false,
+			want:      true,
+		},
+		{
+			name:      "default run tolerates a legacy token with no recorded scopes",
+			tokenJSON: legacyTokenJSON,
+			readonly:  false,
+			want:      true,
+		},
+		{
+			// Never reuse an unverifiable grant as though it were narrow.
+			name:      "readonly run rejects a legacy token with no recorded scopes",
+			tokenJSON: legacyTokenJSON,
+			readonly:  true,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, restore := seedTokenEnv(t, tt.tokenJSON)
+			defer restore()
+
+			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want,
+				addAccountTokenHasGmailScopes(mgr, scopeEscalationAccount, tt.readonly))
+		})
+	}
+}
+
+// TestAddAccount_ReadonlyRefusesWriteCapableAccount covers requirement 4: the
+// run must fail rather than report success while leaving write access in
+// place, and it must leave the token untouched so nothing is lost.
+func TestAddAccount_ReadonlyRefusesWriteCapableAccount(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailCalendarTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "already has Gmail write access")
+	assert.Contains(err.Error(), oauth.ScopeGmailModify)
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "refusal must not touch the existing token")
+}
+
+// TestAddAccount_ReadonlyForceIsStillRefused is the regression for the change
+// that matters most here. --force used to waive the refusal and re-authorize
+// narrow, which measured out badly against a live account: msgvault's token
+// narrowed, but a refresh token issued beforehand kept returning write-scoped
+// access tokens, and revoking it invalidated the replacement too. There is no
+// flag combination that narrows access already granted, so --force must not
+// look like one.
+func TestAddAccount_ReadonlyForceIsStillRefused(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--force", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "already has Gmail write access")
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "Removing existing token")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after,
+		"the refusal must run before --force deletes anything")
+}
+
+// TestAddAccount_ReadonlyRefusesFullAccessAccount is the same refusal for an
+// account whose only write scope is the broad full-access one. A check written
+// against gmail.modify alone would silently downgrade nothing here and report
+// success.
+func TestAddAccount_ReadonlyRefusesFullAccessAccount(t *testing.T) {
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailFullOnlyTokenJSON)
+	defer restore()
+
+	_, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), oauth.ScopeGmailFull)
+}
+
+// TestAddAccount_ReadonlyRefusesLegacyTokenWithoutScopeMetadata is the
+// regression for a hole in the refusal contract: a token predating scope
+// recording has no scopes array, so the write-access check found nothing to
+// object to, the token was reused, and the command reported success over an
+// account that still held gmail.modify.
+//
+// Tokens that old were minted when read + modify was the only scope set, so
+// "no recorded scopes" must be treated as "possibly write-capable", not as
+// "already narrow".
+func TestAddAccount_ReadonlyRefusesLegacyTokenWithoutScopeMetadata(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, legacyTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "predates scope recording")
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "already authorized")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "refusal must not touch the existing token")
+}
+
+// TestAddAccount_LegacyTokenStillReusableWithoutReadonly pins the other half:
+// only --readonly is affected. A default run keeps its existing tolerance for
+// tokens with no recorded scopes.
+func TestAddAccount_LegacyTokenStillReusableWithoutReadonly(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, legacyTokenJSON)
+	defer restore()
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--no-default-identity")
+
+	require.NoError(err)
+	assert.Contains(out, "already authorized")
+	assert.NotContains(out, "Warning")
+}
+
+// TestAddAccount_HeadlessAppliesGrantDecision is the regression for a bypass:
+// the --headless branch returned before the grant decision ran, so it printed
+// instructions for widening a narrowed account with no warning, and accepted
+// --readonly against a write-capable account that would be refused anywhere
+// else. --headless only prints, but what it prints is what the operator then
+// runs on a machine with a browser.
+func TestAddAccount_HeadlessAppliesGrantDecision(t *testing.T) {
+	t.Run("refuses readonly against a write-capable account", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--readonly", "--no-default-identity")
+
+		require.Error(err)
+		assert.Contains(err.Error(), "already has Gmail write access")
+		// The remedy is identical on every host: revoke and re-create.
+		assert.Contains(err.Error(), "myaccount.google.com/permissions")
+		assert.NotContains(out, "Headless Server Setup")
+	})
+
+	t.Run("warns before printing instructions that would widen", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--no-default-identity")
+
+		require.NoError(err)
+		assert.Contains(out, "currently has read-only Gmail access")
+		assert.Contains(out, "Headless Server Setup")
+	})
+
+	t.Run("brand new account prints instructions with no warning", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			"fresh@example.com", "--headless", "--readonly", "--no-default-identity")
+
+		require.NoError(err)
+		assert.Contains(out, "Headless Server Setup")
+		assert.Contains(out, "--readonly")
+		assert.NotContains(out, "Warning")
+	})
+}
+
+// TestAddAccount_ReadonlyReusesAlreadyNarrowToken covers requirement 6: no
+// refusal, no warning, and no pointless re-authorization.
+func TestAddAccount_ReadonlyReusesAlreadyNarrowToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailReadonlyCalendarTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.NoError(err)
+	assert.Contains(out, "already authorized")
+	assert.NotContains(out, "Warning")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "no-op must not rewrite the token")
+}
+
+// TestAddAccount_WarnsBeforeRewideningNarrowGrant covers requirement 7. The run
+// then fails on the cancelled context at the browser flow, which is expected —
+// what matters is that the warning was printed first.
+func TestAddAccount_WarnsBeforeRewideningNarrowGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+	defer restore()
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--no-default-identity")
+
+	require.Error(err, "browser authorization cannot complete on a cancelled context")
+	assert.Contains(out, "currently has read-only Gmail access")
+	assert.Contains(out, oauth.ScopeGmailModify)
+	assert.Contains(out, "--readonly")
+}
+
+// TestReadonlyGrantWarning covers the post-authorization check. Requesting
+// read-only does not guarantee receiving it — the authorization server decides
+// what to issue — so the recorded grant is read back rather than assumed.
+//
+// It warns rather than failing: the token is already written, and aborting
+// would skip source registration, leaving a token on disk that no command can
+// see while the obvious retry is refused for holding write access.
+func TestReadonlyGrantWarning(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenJSON string
+		wantWarn  bool
+		wantNamed string
+	}{
+		{
+			name:      "a genuinely narrow grant is silent",
+			tokenJSON: gmailReadonlyCalendarTokenJSON,
+		},
+		{
+			name:      "a returned modify scope is reported",
+			tokenJSON: gmailOnlyTokenJSON,
+			wantWarn:  true,
+			wantNamed: oauth.ScopeGmailModify,
+		},
+		{
+			name:      "a returned full-access scope is reported",
+			tokenJSON: gmailFullOnlyTokenJSON,
+			wantWarn:  true,
+			wantNamed: oauth.ScopeGmailFull,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			_, restore := seedTokenEnv(t, tt.tokenJSON)
+			defer restore()
+
+			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+			require.NoError(err)
+
+			got := readonlyGrantWarning(mgr, scopeEscalationAccount)
+
+			if !tt.wantWarn {
+				assert.Empty(got)
+				return
+			}
+			require.NotEmpty(got)
+			assert.Contains(got, tt.wantNamed)
+			assert.Contains(got, "myaccount.google.com/permissions")
+		})
+	}
+}
+
+// TestAddAccount_NoWarningForBrandNewAccount is the negative half of
+// requirement 7: the most common case must stay quiet.
+func TestAddAccount_NoWarningForBrandNewAccount(t *testing.T) {
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+	defer restore()
+
+	// A different address than the seeded token, so this account has no
+	// prior grant at all.
+	out, err := runAddAccountForTest(t, "fresh@example.com", "--no-default-identity")
+
+	require.Error(t, err, "browser authorization cannot complete on a cancelled context")
+	assert.NotContains(t, out, "read-only Gmail access")
+	assert.NotContains(t, out, "Warning")
+}
+
+// TestAddAccount_ReadonlyRefusesAliasOfStoredToken: authorization accepts
+// Gmail alias spellings as the same account, so a --readonly run under a
+// dot-variant of a stored token must refuse rather than read as a fresh
+// account while the stored spelling's credential keeps its access. When both
+// spellings hold tokens, the refusal names the revoke-and-re-add procedure
+// instead of bouncing between the two spellings.
+func TestAddAccount_ReadonlyRefusesAliasOfStoredToken(t *testing.T) {
+	seedAliasToken := func(t *testing.T, tokenJSON string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(cfg.TokensDir(), "username@gmail.com.json"),
+			[]byte(tokenJSON), 0600))
+	}
+
+	t.Run("alias of a stored token points at the stored spelling", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t, gmailOnlyTokenJSON)
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "username@gmail.com")
+		assert.NotContains(t, out, "Starting browser authorization")
+	})
+
+	t.Run("duplicate spellings name the revoke-and-re-add procedure", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t, gmailOnlyTokenJSON)
+		require.NoError(os.WriteFile(
+			filepath.Join(cfg.TokensDir(), "user.name@gmail.com.json"),
+			[]byte(gmailReadonlyTokenJSON), 0600))
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(err)
+		assert.Contains(err.Error(), "myaccount.google.com/permissions")
+		assert.Contains(err.Error(), "username@gmail.com")
+		assert.NotContains(out, "Starting browser authorization")
+	})
+
+	t.Run("default run ignores alias spellings", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t, gmailOnlyTokenJSON)
+
+		_, err := runAddAccountForTest(t, "user.name@gmail.com", "--no-default-identity")
+
+		require.Error(t, err, "browser authorization cannot complete on a cancelled context")
+		assert.NotContains(t, err.Error(), "username@gmail.com")
+	})
+
+	t.Run("known different OAuth client is an independent grant", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		differentClientToken := strings.Replace(
+			gmailOnlyTokenJSON,
+			`"client_id": "test.apps.googleusercontent.com"`,
+			`"client_id": "other.apps.googleusercontent.com"`,
+			1,
+		)
+		seedAliasToken(t, differentClientToken)
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(t, err, "browser authorization cannot complete on a cancelled context")
+		assert.Contains(t, out, "Starting browser authorization")
+		assert.NotContains(t, err.Error(), "username@gmail.com")
+	})
+
+	t.Run("unknown OAuth client remains conservative", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t, legacyTokenJSON)
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "username@gmail.com")
+		assert.NotContains(t, out, "Starting browser authorization")
+	})
+
+	t.Run("remediation preserves named OAuth app", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t, gmailOnlyTokenJSON)
+		mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+		require.NoError(t, err)
+
+		err = refuseReadonlyUnderAliasSpelling(mgr, "user.name@gmail.com", "workspace app")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(),
+			"msgvault add-account username@gmail.com --oauth-app 'workspace app' --readonly")
+	})
+}

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -1,0 +1,725 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/oauth"
+)
+
+// Token fixtures for the grants that only become reachable once read-only
+// accounts exist. No real credentials are present.
+
+const gmailReadonlyTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+const gmailReadonlyCalendarTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/calendar.readonly"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+// gmailFullOnlyTokenJSON holds the broad full-access scope and NOT
+// gmail.modify. Produced by narrowing an account to read-only and later
+// escalating it for permanent deletion. Any write check that looks only at
+// gmail.modify gets this account wrong.
+const gmailFullOnlyTokenJSON = `{
+  "access_token": "fake-access-token",
+  "token_type": "Bearer",
+  "refresh_token": "fake-refresh-token",
+  "expiry": "2099-01-01T00:00:00Z",
+  "scopes": [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://mail.google.com/"
+  ],
+  "client_id": "test.apps.googleusercontent.com"
+}`
+
+// saveAddAccountFlags snapshots the package-level add-account flag globals so
+// a test can set them without leaking into the rest of the package.
+func saveAddAccountFlags(t *testing.T) {
+	t.Helper()
+	savedHeadless, savedForce, savedReadonly := headless, forceReauth, readonlyGrant
+	savedApp, savedName, savedNoDefault := oauthAppName, accountDisplayName, noDefaultIdentityAddAccount
+	t.Cleanup(func() {
+		headless, forceReauth, readonlyGrant = savedHeadless, savedForce, savedReadonly
+		oauthAppName, accountDisplayName, noDefaultIdentityAddAccount = savedApp, savedName, savedNoDefault
+	})
+}
+
+// runAddAccountForTest drives the real add-account command against the seeded
+// environment and returns everything it printed. os.Stdout is captured rather
+// than a cobra buffer because the command reports progress with fmt.Printf, so
+// a buffer alone would miss most of what an operator actually sees.
+//
+// The context is pre-cancelled, so a run that reaches the browser flow fails
+// immediately instead of hanging. Tests that expect no authorization assert on
+// the absence of that failure.
+func runAddAccountForTest(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	testCmd := &cobra.Command{
+		Use:  addAccountUse,
+		Args: cobra.ExactArgs(1),
+		RunE: runAddAccountLocal,
+	}
+	registerAddAccountFlags(testCmd)
+
+	root := newTestRootCmd()
+	root.AddCommand(testCmd)
+	root.SetArgs(append([]string{"add-account"}, args...))
+
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err, "create stdout pipe")
+	savedStdout := os.Stdout
+	os.Stdout = writer
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, reader)
+		captured <- buf.String()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runErr := root.ExecuteContext(ctx)
+
+	os.Stdout = savedStdout
+	require.NoError(t, writer.Close(), "close stdout pipe")
+	out := <-captured
+	require.NoError(t, reader.Close(), "close stdout reader")
+
+	t.Log(out)
+	if runErr != nil {
+		return out, fmt.Errorf("run add-account: %w", runErr)
+	}
+	return out, nil
+}
+
+func TestAddAccountOAuthScopesForToken_Readonly(t *testing.T) {
+	tests := []struct {
+		name             string
+		hasScopeMetadata bool
+		existing         []string
+		readonly         bool
+		want             []string
+	}{
+		{
+			name:     "fresh account requests read and write by default",
+			readonly: false,
+			want:     oauth.Scopes,
+		},
+		{
+			name:     "fresh account with readonly requests read only",
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "narrowing drops every write scope and keeps calendar",
+			hasScopeMetadata: true,
+			existing: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailModify,
+				oauth.ScopeGmailFull,
+				oauth.ScopeCalendarReadonly,
+			},
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+		},
+		{
+			// Write scopes msgvault never requests still have to be stripped;
+			// a grant is read-only when nothing in it can write.
+			name:             "narrowing drops write scopes msgvault never requests",
+			hasScopeMetadata: true,
+			existing: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailSend,
+				oauth.ScopeGmailCompose,
+				oauth.ScopeGmailInsert,
+				oauth.ScopeGmailLabels,
+				oauth.ScopeGmailSettingsBasic,
+				oauth.ScopeGmailSettingsSharing,
+				oauth.ScopeCalendarReadonly,
+			},
+			readonly: true,
+			want:     []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+		},
+		{
+			// gmail.metadata is read-only and must survive narrowing.
+			name:             "narrowing keeps the read-only metadata scope",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailMetadata, oauth.ScopeGmailModify},
+			readonly:         true,
+			want:             []string{oauth.ScopeGmailMetadata, oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "narrowing an account that only holds full access still yields read only",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailFull},
+			readonly:         true,
+			want:             []string{oauth.ScopeGmailReadonly},
+		},
+		{
+			name:             "default request over an existing grant is unchanged",
+			hasScopeMetadata: true,
+			existing:         []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			readonly:         false,
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeCalendarReadonly,
+				oauth.ScopeGmailModify,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addAccountOAuthScopesForToken(tt.hasScopeMetadata, tt.existing, tt.readonly)
+			assert.ElementsMatch(t, tt.want, got)
+		})
+	}
+}
+
+func TestDecideAddAccountGrant(t *testing.T) {
+	const email = "user@example.com"
+
+	tests := []struct {
+		name             string
+		hasToken         bool
+		hasScopeMetadata bool
+		granted          []string
+		readonly         bool
+		freshClient      bool
+		wantErr          bool
+		wantErrContains  string
+		wantWarn         bool
+	}{
+		{
+			name:             "refusal names the revoke-and-re-add procedure",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "myaccount.google.com/permissions",
+		},
+		{
+			// gmail.send is write-capable but never requested by msgvault, so
+			// a set that stops at modify and full would wave it through.
+			name:             "readonly over a send-only grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailSend},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailSend,
+		},
+		{
+			name:             "readonly over a settings grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailSettingsBasic},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailSettingsBasic,
+		},
+		{
+			// Metadata is read-only, so this grant is genuinely narrow and
+			// must not be refused.
+			name:             "readonly over a metadata grant is a no-op",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailMetadata},
+			readonly:         true,
+		},
+		{
+			name:     "brand new account never warns",
+			readonly: false,
+		},
+		{
+			name:     "brand new account accepts readonly",
+			readonly: true,
+		},
+		{
+			// A token predating scope recording holds an unverifiable grant,
+			// and tokens that old were minted with read + modify. Treating
+			// "unknown" as "already narrow" would report success over a still
+			// write-capable account.
+			name:             "legacy token without scope metadata is refused under readonly",
+			hasToken:         true,
+			hasScopeMetadata: false,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "predates scope recording",
+		},
+		{
+			name:             "legacy token is left alone on a default run",
+			hasToken:         true,
+			hasScopeMetadata: false,
+			readonly:         false,
+		},
+		{
+			name:             "readonly over a modify grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  "cannot be narrowed",
+		},
+		{
+			// The full-access scope is the write scope a check that only
+			// knows gmail.modify would miss.
+			name:             "readonly over a full access grant is refused",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailFull},
+			readonly:         true,
+			wantErr:          true,
+			wantErrContains:  oauth.ScopeGmailFull,
+		},
+		{
+			// A genuinely different OAuth client has no prior grant, so this
+			// is a first authorization rather than narrowing in place. The
+			// caller sets this only when the token's recorded client_id
+			// differs — unknown provenance does not qualify.
+			name:             "readonly proceeds for a genuinely different oauth client",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         true,
+			freshClient:      true,
+		},
+		{
+			name:             "readonly over an already narrow grant is a silent no-op",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			readonly:         true,
+		},
+		{
+			name:             "default run over a narrow grant warns before widening",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeGmailReadonly},
+			readonly:         false,
+			wantWarn:         true,
+		},
+		{
+			name:             "default run over a write grant does not warn",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          oauth.Scopes,
+			readonly:         false,
+		},
+		{
+			// Adding Gmail to a Calendar-only token is a first Gmail grant,
+			// not a widening of a narrowed one.
+			name:             "calendar only token does not warn",
+			hasToken:         true,
+			hasScopeMetadata: true,
+			granted:          []string{oauth.ScopeCalendarReadonly},
+			readonly:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			got := decideAddAccountGrant(
+				email, tt.hasToken, tt.hasScopeMetadata, tt.granted, tt.readonly,
+				tt.freshClient, "/tmp/tokens/user@example.com.json")
+
+			if tt.wantErr {
+				require.Error(got.Err)
+				assert.Contains(got.Err.Error(), tt.wantErrContains)
+			} else {
+				require.NoError(got.Err)
+			}
+			if tt.wantWarn {
+				assert.Contains(got.Warning, "read-only Gmail access")
+			} else {
+				assert.Empty(got.Warning)
+			}
+		})
+	}
+}
+
+func TestAddAccountTokenHasGmailScopes_Readonly(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenJSON string
+		readonly  bool
+		want      bool
+	}{
+		{
+			name:      "readonly run accepts a read-only token",
+			tokenJSON: gmailReadonlyTokenJSON,
+			readonly:  true,
+			want:      true,
+		},
+		{
+			name:      "default run rejects a read-only token",
+			tokenJSON: gmailReadonlyTokenJSON,
+			readonly:  false,
+			want:      false,
+		},
+		{
+			name:      "default run accepts a full gmail token",
+			tokenJSON: gmailOnlyTokenJSON,
+			readonly:  false,
+			want:      true,
+		},
+		{
+			name:      "default run tolerates a legacy token with no recorded scopes",
+			tokenJSON: legacyTokenJSON,
+			readonly:  false,
+			want:      true,
+		},
+		{
+			// Never reuse an unverifiable grant as though it were narrow.
+			name:      "readonly run rejects a legacy token with no recorded scopes",
+			tokenJSON: legacyTokenJSON,
+			readonly:  true,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, restore := seedTokenEnv(t, tt.tokenJSON)
+			defer restore()
+
+			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want,
+				addAccountTokenHasGmailScopes(mgr, scopeEscalationAccount, tt.readonly))
+		})
+	}
+}
+
+// TestAddAccount_ReadonlyRefusesWriteCapableAccount covers requirement 4: the
+// run must fail rather than report success while leaving write access in
+// place, and it must leave the token untouched so nothing is lost.
+func TestAddAccount_ReadonlyRefusesWriteCapableAccount(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailCalendarTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "already has Gmail write access")
+	assert.Contains(err.Error(), oauth.ScopeGmailModify)
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "refusal must not touch the existing token")
+}
+
+// TestAddAccount_ReadonlyForceIsStillRefused is the regression for the change
+// that matters most here. --force used to waive the refusal and re-authorize
+// narrow, which measured out badly against a live account: msgvault's token
+// narrowed, but a refresh token issued beforehand kept returning write-scoped
+// access tokens, and revoking it invalidated the replacement too. There is no
+// flag combination that narrows access already granted, so --force must not
+// look like one.
+func TestAddAccount_ReadonlyForceIsStillRefused(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--force", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "already has Gmail write access")
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "Removing existing token")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after,
+		"the refusal must run before --force deletes anything")
+}
+
+// TestAddAccount_ReadonlyRefusesFullAccessAccount is the same refusal for an
+// account whose only write scope is the broad full-access one. A check written
+// against gmail.modify alone would silently downgrade nothing here and report
+// success.
+func TestAddAccount_ReadonlyRefusesFullAccessAccount(t *testing.T) {
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailFullOnlyTokenJSON)
+	defer restore()
+
+	_, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), oauth.ScopeGmailFull)
+}
+
+// TestAddAccount_ReadonlyRefusesLegacyTokenWithoutScopeMetadata is the
+// regression for a hole in the refusal contract: a token predating scope
+// recording has no scopes array, so the write-access check found nothing to
+// object to, the token was reused, and the command reported success over an
+// account that still held gmail.modify.
+//
+// Tokens that old were minted when read + modify was the only scope set, so
+// "no recorded scopes" must be treated as "possibly write-capable", not as
+// "already narrow".
+func TestAddAccount_ReadonlyRefusesLegacyTokenWithoutScopeMetadata(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, legacyTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.Error(err)
+	assert.Contains(err.Error(), "predates scope recording")
+	assert.Contains(err.Error(), "myaccount.google.com/permissions")
+	assert.NotContains(out, "already authorized")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "refusal must not touch the existing token")
+}
+
+// TestAddAccount_LegacyTokenStillReusableWithoutReadonly pins the other half:
+// only --readonly is affected. A default run keeps its existing tolerance for
+// tokens with no recorded scopes.
+func TestAddAccount_LegacyTokenStillReusableWithoutReadonly(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, legacyTokenJSON)
+	defer restore()
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--no-default-identity")
+
+	require.NoError(err)
+	assert.Contains(out, "already authorized")
+	assert.NotContains(out, "Warning")
+}
+
+// TestAddAccount_HeadlessAppliesGrantDecision is the regression for a bypass:
+// the --headless branch returned before the grant decision ran, so it printed
+// instructions for widening a narrowed account with no warning, and accepted
+// --readonly against a write-capable account that would be refused anywhere
+// else. --headless only prints, but what it prints is what the operator then
+// runs on a machine with a browser.
+func TestAddAccount_HeadlessAppliesGrantDecision(t *testing.T) {
+	t.Run("refuses readonly against a write-capable account", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--readonly", "--no-default-identity")
+
+		require.Error(err)
+		assert.Contains(err.Error(), "already has Gmail write access")
+		// The remedy is identical on every host: revoke and re-create.
+		assert.Contains(err.Error(), "myaccount.google.com/permissions")
+		assert.NotContains(out, "Headless Server Setup")
+	})
+
+	t.Run("warns before printing instructions that would widen", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--no-default-identity")
+
+		require.NoError(err)
+		assert.Contains(out, "currently has read-only Gmail access")
+		assert.Contains(out, "Headless Server Setup")
+	})
+
+	t.Run("brand new account prints instructions with no warning", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			"fresh@example.com", "--headless", "--readonly", "--no-default-identity")
+
+		require.NoError(err)
+		assert.Contains(out, "Headless Server Setup")
+		assert.Contains(out, "--readonly")
+		assert.NotContains(out, "Warning")
+	})
+}
+
+// TestAddAccount_ReadonlyReusesAlreadyNarrowToken covers requirement 6: no
+// refusal, no warning, and no pointless re-authorization.
+func TestAddAccount_ReadonlyReusesAlreadyNarrowToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	tokenPath, restore := seedTokenEnv(t, gmailReadonlyCalendarTokenJSON)
+	defer restore()
+
+	before, err := os.ReadFile(tokenPath)
+	require.NoError(err)
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.NoError(err)
+	assert.Contains(out, "already authorized")
+	assert.NotContains(out, "Warning")
+	assert.NotContains(out, "Starting browser authorization")
+
+	after, readErr := os.ReadFile(tokenPath)
+	require.NoError(readErr)
+	assert.Equal(before, after, "no-op must not rewrite the token")
+}
+
+// TestAddAccount_WarnsBeforeRewideningNarrowGrant covers requirement 7. The run
+// then fails on the cancelled context at the browser flow, which is expected —
+// what matters is that the warning was printed first.
+func TestAddAccount_WarnsBeforeRewideningNarrowGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+	defer restore()
+
+	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--no-default-identity")
+
+	require.Error(err, "browser authorization cannot complete on a cancelled context")
+	assert.Contains(out, "currently has read-only Gmail access")
+	assert.Contains(out, oauth.ScopeGmailModify)
+	assert.Contains(out, "--readonly")
+}
+
+// TestReadonlyGrantWarning covers the post-authorization check. Requesting
+// read-only does not guarantee receiving it — the authorization server decides
+// what to issue — so the recorded grant is read back rather than assumed.
+//
+// It warns rather than failing: the token is already written, and aborting
+// would skip source registration, leaving a token on disk that no command can
+// see while the obvious retry is refused for holding write access.
+func TestReadonlyGrantWarning(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenJSON string
+		wantWarn  bool
+		wantNamed string
+	}{
+		{
+			name:      "a genuinely narrow grant is silent",
+			tokenJSON: gmailReadonlyCalendarTokenJSON,
+		},
+		{
+			name:      "a returned modify scope is reported",
+			tokenJSON: gmailOnlyTokenJSON,
+			wantWarn:  true,
+			wantNamed: oauth.ScopeGmailModify,
+		},
+		{
+			name:      "a returned full-access scope is reported",
+			tokenJSON: gmailFullOnlyTokenJSON,
+			wantWarn:  true,
+			wantNamed: oauth.ScopeGmailFull,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			_, restore := seedTokenEnv(t, tt.tokenJSON)
+			defer restore()
+
+			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+			require.NoError(err)
+
+			got := readonlyGrantWarning(mgr, scopeEscalationAccount)
+
+			if !tt.wantWarn {
+				assert.Empty(got)
+				return
+			}
+			require.NotEmpty(got)
+			assert.Contains(got, tt.wantNamed)
+			assert.Contains(got, "myaccount.google.com/permissions")
+		})
+	}
+}
+
+// TestAddAccount_NoWarningForBrandNewAccount is the negative half of
+// requirement 7: the most common case must stay quiet.
+func TestAddAccount_NoWarningForBrandNewAccount(t *testing.T) {
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+	defer restore()
+
+	// A different address than the seeded token, so this account has no
+	// prior grant at all.
+	out, err := runAddAccountForTest(t, "fresh@example.com", "--no-default-identity")
+
+	require.Error(t, err, "browser authorization cannot complete on a cancelled context")
+	assert.NotContains(t, out, "read-only Gmail access")
+	assert.NotContains(t, out, "Warning")
+}

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -549,6 +550,45 @@ func TestAddAccount_LegacyTokenStillReusableWithoutReadonly(t *testing.T) {
 	require.NoError(err)
 	assert.Contains(out, "already authorized")
 	assert.NotContains(out, "Warning")
+}
+
+func TestAddAccount_AuthenticatedPreflightRegistersWiderGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+	defer restore()
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--grant-decided", "--no-default-identity")
+
+	require.NoError(err)
+	assert.Contains(out, "already authorized")
+	assert.NotContains(out, "Starting browser authorization")
+}
+
+func TestAddAccount_ImplicitDefaultRejectsKnownDifferentClient(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	saveAddAccountFlags(t)
+	otherClientToken := strings.Replace(
+		gmailReadonlyTokenJSON,
+		"test.apps.googleusercontent.com",
+		"other.apps.googleusercontent.com",
+		1,
+	)
+	_, restore := seedTokenEnv(t, otherClientToken)
+	defer restore()
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--no-default-identity")
+
+	require.ErrorIs(err, context.Canceled)
+	assert.Contains(out, "Starting browser authorization")
+	assert.NotContains(out, "already authorized")
 }
 
 // TestAddAccount_HeadlessAppliesGrantDecision is the regression for a bypass:

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/oauth"
 )
 
@@ -355,7 +356,7 @@ func TestDecideAddAccountGrant(t *testing.T) {
 
 			got := decideAddAccountGrant(
 				email, tt.hasToken, tt.hasScopeMetadata, tt.granted, tt.readonly,
-				tt.freshClient, "/tmp/tokens/user@example.com.json")
+				tt.freshClient, "/tmp/tokens/user@example.com.json", "")
 
 			if tt.wantErr {
 				require.Error(got.Err)
@@ -451,6 +452,26 @@ func TestAddAccount_ReadonlyRefusesWriteCapableAccount(t *testing.T) {
 	after, readErr := os.ReadFile(tokenPath)
 	require.NoError(readErr)
 	assert.Equal(before, after, "refusal must not touch the existing token")
+}
+
+func TestAddAccount_ReadonlyRemediationPreservesNamedOAuthApp(t *testing.T) {
+	saveAddAccountFlags(t)
+	_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+	defer restore()
+	cfg.OAuth.Apps = map[string]config.OAuthApp{
+		"workspace app": {ClientSecrets: cfg.OAuth.ClientSecrets},
+	}
+
+	_, err := runAddAccountForTest(t,
+		scopeEscalationAccount,
+		"--readonly",
+		"--oauth-app", "workspace app",
+		"--no-default-identity",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"msgvault add-account user@example.com --oauth-app 'workspace app' --readonly")
 }
 
 // TestAddAccount_ReadonlyForceIsStillRefused is the regression for the change
@@ -650,6 +671,55 @@ func TestAddAccount_HeadlessAppliesGrantDecision(t *testing.T) {
 	})
 }
 
+func TestAddAccount_HeadlessReadonlyRefusesStoredTokenWithoutOAuthCredentials(t *testing.T) {
+	t.Run("exact token", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailOnlyTokenJSON)
+		defer restore()
+		cfg.OAuth.ClientSecrets = ""
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--readonly", "--no-default-identity")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be verified")
+		assert.NotContains(t, out, "Headless Server Setup")
+	})
+
+	t.Run("equivalent token", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		require.NoError(os.WriteFile(
+			filepath.Join(cfg.TokensDir(), "username@gmail.com.json"),
+			[]byte(gmailOnlyTokenJSON), 0600))
+		cfg.OAuth.ClientSecrets = ""
+
+		out, err := runAddAccountForTest(t,
+			"user.name@gmail.com", "--headless", "--readonly", "--no-default-identity")
+
+		require.Error(err)
+		assert.Contains(err.Error(), "cannot be verified")
+		assert.NotContains(out, "Headless Server Setup")
+	})
+
+	t.Run("new account still prints instructions", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		cfg.OAuth.ClientSecrets = ""
+
+		out, err := runAddAccountForTest(t,
+			"fresh@example.com", "--headless", "--readonly", "--no-default-identity")
+
+		require.NoError(t, err)
+		assert.Contains(t, out, "Headless Server Setup")
+	})
+}
+
 // TestAddAccount_ReadonlyReusesAlreadyNarrowToken covers requirement 6: no
 // refusal, no warning, and no pointless re-authorization.
 func TestAddAccount_ReadonlyReusesAlreadyNarrowToken(t *testing.T) {
@@ -737,7 +807,7 @@ func TestReadonlyGrantWarning(t *testing.T) {
 			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
 			require.NoError(err)
 
-			got := readonlyGrantWarning(mgr, scopeEscalationAccount)
+			got := readonlyGrantWarning(mgr, scopeEscalationAccount, "")
 
 			if !tt.wantWarn {
 				assert.Empty(got)

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -591,6 +591,26 @@ func TestAddAccount_AuthenticatedPreflightRegistersWiderGrant(t *testing.T) {
 	assert.NotContains(out, "Starting browser authorization")
 }
 
+func TestAddAccount_AuthenticatedPreflightRejectsCalendarOnlyToken(t *testing.T) {
+	saveAddAccountFlags(t)
+	calendarOnlyToken := strings.Replace(
+		gmailReadonlyTokenJSON,
+		oauth.ScopeGmailReadonly,
+		oauth.ScopeCalendarReadonly,
+		1,
+	)
+	_, restore := seedTokenEnv(t, calendarOnlyToken)
+	defer restore()
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	out, err := runAddAccountForTest(t,
+		scopeEscalationAccount, "--readonly", "--grant-decided", "--no-default-identity")
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, out, "Starting browser authorization")
+	assert.NotContains(t, out, "already authorized")
+}
+
 func TestAddAccount_ImplicitDefaultRejectsKnownDifferentClient(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -587,6 +587,7 @@ func TestAddAccount_AuthenticatedPreflightRegistersWiderGrant(t *testing.T) {
 
 	require.NoError(err)
 	assert.Contains(out, "already authorized")
+	assert.Contains(out, "returned Gmail write access")
 	assert.NotContains(out, "Starting browser authorization")
 }
 

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -654,6 +654,25 @@ func TestAddAccount_HeadlessAppliesGrantDecision(t *testing.T) {
 		assert.Contains(out, "Headless Server Setup")
 	})
 
+	t.Run("copies existing token before readonly reauthorization", func(t *testing.T) {
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyCalendarTokenJSON)
+		defer restore()
+
+		out, err := runAddAccountForTest(t,
+			scopeEscalationAccount, "--headless", "--readonly", "--no-default-identity")
+
+		require.NoError(err)
+		copyToken := strings.Index(out, "Copy the existing token from the headless server")
+		reauthorize := strings.Index(out,
+			"msgvault add-account "+scopeEscalationAccount+" --readonly --force")
+		require.NotEqual(-1, copyToken)
+		require.NotEqual(-1, reauthorize)
+		assert.Less(t, copyToken, reauthorize)
+	})
+
 	t.Run("brand new account prints instructions with no warning", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
@@ -668,6 +687,7 @@ func TestAddAccount_HeadlessAppliesGrantDecision(t *testing.T) {
 		require.NoError(err)
 		assert.Contains(out, "Headless Server Setup")
 		assert.Contains(out, "--readonly")
+		assert.NotContains(out, "--force")
 		assert.NotContains(out, "Warning")
 	})
 }

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -722,4 +723,64 @@ func TestAddAccount_NoWarningForBrandNewAccount(t *testing.T) {
 	require.Error(t, err, "browser authorization cannot complete on a cancelled context")
 	assert.NotContains(t, out, "read-only Gmail access")
 	assert.NotContains(t, out, "Warning")
+}
+
+// TestAddAccount_ReadonlyRefusesAliasOfStoredToken: authorization accepts
+// Gmail alias spellings as the same account, so a --readonly run under a
+// dot-variant of a stored token must refuse rather than read as a fresh
+// account while the stored spelling's credential keeps its access. When both
+// spellings hold tokens, the refusal names the revoke-and-re-add procedure
+// instead of bouncing between the two spellings.
+func TestAddAccount_ReadonlyRefusesAliasOfStoredToken(t *testing.T) {
+	seedAliasToken := func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(cfg.TokensDir(), "username@gmail.com.json"),
+			[]byte(gmailOnlyTokenJSON), 0600))
+	}
+
+	t.Run("alias of a stored token points at the stored spelling", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t)
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "username@gmail.com")
+		assert.NotContains(t, out, "Starting browser authorization")
+	})
+
+	t.Run("duplicate spellings name the revoke-and-re-add procedure", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t)
+		require.NoError(os.WriteFile(
+			filepath.Join(cfg.TokensDir(), "user.name@gmail.com.json"),
+			[]byte(gmailReadonlyTokenJSON), 0600))
+
+		out, err := runAddAccountForTest(t, "user.name@gmail.com", "--readonly", "--no-default-identity")
+
+		require.Error(err)
+		assert.Contains(err.Error(), "myaccount.google.com/permissions")
+		assert.Contains(err.Error(), "username@gmail.com")
+		assert.NotContains(out, "Starting browser authorization")
+	})
+
+	t.Run("default run ignores alias spellings", func(t *testing.T) {
+		saveAddAccountFlags(t)
+		_, restore := seedTokenEnv(t, gmailReadonlyTokenJSON)
+		defer restore()
+		seedAliasToken(t)
+
+		_, err := runAddAccountForTest(t, "user.name@gmail.com", "--no-default-identity")
+
+		require.Error(t, err, "browser authorization cannot complete on a cancelled context")
+		assert.NotContains(t, err.Error(), "username@gmail.com")
+	})
 }

--- a/cmd/msgvault/cmd/addaccount_test.go
+++ b/cmd/msgvault/cmd/addaccount_test.go
@@ -259,10 +259,10 @@ func TestAddAccount_FullGmailScopeTokenCanBeReused(t *testing.T) {
 func TestAddAccountOAuthScopesForTokenPreservesExistingCalendarGrant(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.ElementsMatch(oauth.Scopes, addAccountOAuthScopesForToken(false, nil),
+	assert.ElementsMatch(oauth.Scopes, addAccountOAuthScopesForToken(false, nil, false),
 		"new and legacy-token Gmail auth should request only Gmail scopes")
 	assert.ElementsMatch(append(append([]string{}, oauth.Scopes...), oauth.ScopeCalendarReadonly),
-		addAccountOAuthScopesForToken(true, oauth.ScopesCalendar),
+		addAccountOAuthScopesForToken(true, oauth.ScopesCalendar, false),
 		"Calendar-only tokens should reauthorize with Gmail while preserving Calendar")
 }
 

--- a/cmd/msgvault/cmd/calendar.go
+++ b/cmd/msgvault/cmd/calendar.go
@@ -553,6 +553,13 @@ func calendarRegisteredIDs(sources []*store.Source) map[string]struct{} {
 func calendarEscalationScopes(existingScopes []string, preserveGmail bool) []string {
 	scopes := append([]string(nil), existingScopes...)
 	required := calendarAddOAuthScopes(preserveGmail)
+	// Preserving Gmail must not mean re-widening it. calendarAddOAuthScopes
+	// returns the full Gmail bundle, so an account narrowed to read-only via
+	// `add-account --readonly` would silently regain write access just by
+	// adding Calendar. Keep the Gmail access it actually has.
+	if oauth.IsNarrowedGmailGrant(existingScopes) {
+		required = oauth.WithoutGmailWriteScopes(required)
+	}
 	for _, scope := range required {
 		scopes = appendScopeIfMissing(scopes, scope)
 	}

--- a/cmd/msgvault/cmd/daemon_cli_http.go
+++ b/cmd/msgvault/cmd/daemon_cli_http.go
@@ -39,7 +39,19 @@ func runDaemonCLICommandHTTPFromCobraWithEnv(cmd *cobra.Command, args []string, 
 	if err != nil {
 		return err
 	}
-	return runDaemonCLICommandHTTPWithEnv(cmd, runArgs, env, false)
+	return runDaemonCLICommandHTTPWithEnv(cmd, runArgs, env, false, false)
+}
+
+func runDaemonCLICommandHTTPFromCobraWithGrantDecision(
+	cmd *cobra.Command,
+	args []string,
+	grantDecided bool,
+) error {
+	runArgs, err := daemonCLIArgsFromCobra(cmd, args)
+	if err != nil {
+		return err
+	}
+	return runDaemonCLICommandHTTPWithEnv(cmd, runArgs, nil, false, grantDecided)
 }
 
 func runDaemonCLICommandHTTPFromCobraWithLocalFiles(cmd *cobra.Command, args []string, env map[string]string) error {
@@ -47,10 +59,16 @@ func runDaemonCLICommandHTTPFromCobraWithLocalFiles(cmd *cobra.Command, args []s
 	if err != nil {
 		return err
 	}
-	return runDaemonCLICommandHTTPWithEnv(cmd, runArgs, env, true)
+	return runDaemonCLICommandHTTPWithEnv(cmd, runArgs, env, true, false)
 }
 
-func runDaemonCLICommandHTTPWithEnv(cmd *cobra.Command, args []string, env map[string]string, requiresLocalFiles bool) error {
+func runDaemonCLICommandHTTPWithEnv(
+	cmd *cobra.Command,
+	args []string,
+	env map[string]string,
+	requiresLocalFiles bool,
+	grantDecided bool,
+) error {
 	st, info, err := OpenHTTPStore(cmd.Context())
 	if err != nil {
 		return err
@@ -62,7 +80,9 @@ func runDaemonCLICommandHTTPWithEnv(cmd *cobra.Command, args []string, env map[s
 		return err
 	}
 
-	runErr := st.RunCLICommand(cmd.Context(), daemonclient.CLIRunRequest{Args: args, Env: env, Cwd: cwd}, func(stream, data string) error {
+	runErr := st.RunCLICommand(cmd.Context(), daemonclient.CLIRunRequest{
+		Args: args, Env: env, Cwd: cwd, GrantDecided: grantDecided,
+	}, func(stream, data string) error {
 		switch stream {
 		case cliStreamStdout:
 			if _, err := fmt.Fprint(cmd.OutOrStdout(), data); err != nil {
@@ -113,6 +133,9 @@ func daemonCLIArgsFromCobra(cmd *cobra.Command, args []string) ([]string, error)
 	flags := make([]*pflag.Flag, 0)
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
 		if !flag.Changed {
+			return
+		}
+		if flag.Name == addAccountGrantDecidedFlag {
 			return
 		}
 		if isRootPersistentFlag(cmd, flag) && !loggingPassthroughFlags[flag.Name] {

--- a/cmd/msgvault/cmd/deletion_readonly_scope_test.go
+++ b/cmd/msgvault/cmd/deletion_readonly_scope_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/msgvault/internal/oauth"
+	"go.kenn.io/msgvault/internal/store"
+	"google.golang.org/api/drive/v3"
+)
+
+// TestDeleteStagedScopeEscalationForSource_ReadonlyWorld covers the deletion
+// pre-flight for grants that only exist once accounts can be read-only.
+//
+// The regression it guards is the full-access case: an account holding
+// mail.google.com but not gmail.modify already has more than enough access to
+// trash mail, but a check requiring every member of oauth.Scopes concludes it
+// does not and prompts for an upgrade it does not need.
+func TestDeleteStagedScopeEscalationForSource_ReadonlyWorld(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokenJSON   string
+		permanent   bool
+		wantPrompt  bool
+		description string
+	}{
+		{
+			name:        "full access covers trashing",
+			tokenJSON:   gmailFullOnlyTokenJSON,
+			permanent:   false,
+			wantPrompt:  false,
+			description: "mail.google.com is a superset of gmail.modify",
+		},
+		{
+			name:        "full access covers permanent deletion",
+			tokenJSON:   gmailFullOnlyTokenJSON,
+			permanent:   true,
+			wantPrompt:  false,
+			description: "mail.google.com is exactly what batchDelete needs",
+		},
+		{
+			name:        "read-only grant cannot trash",
+			tokenJSON:   gmailReadonlyTokenJSON,
+			permanent:   false,
+			wantPrompt:  true,
+			description: "escalation must still be offered when access is genuinely missing",
+		},
+		{
+			name:        "read-only grant cannot permanently delete",
+			tokenJSON:   gmailReadonlyTokenJSON,
+			permanent:   true,
+			wantPrompt:  true,
+			description: "escalation must still be offered when access is genuinely missing",
+		},
+		{
+			name:        "modify grant covers trashing",
+			tokenJSON:   gmailOnlyTokenJSON,
+			permanent:   false,
+			wantPrompt:  false,
+			description: "unchanged from today",
+		},
+		{
+			name:        "modify grant cannot permanently delete",
+			tokenJSON:   gmailOnlyTokenJSON,
+			permanent:   true,
+			wantPrompt:  true,
+			description: "gmail.modify does not cover batchDelete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, restore := seedTokenEnv(t, tt.tokenJSON)
+			defer restore()
+
+			src := &store.Source{SourceType: sourceTypeGmail}
+			escalation, err := deleteStagedScopeEscalationForSource(
+				scopeEscalationAccount, src, tt.permanent, cfg.OAuth.ClientSecrets)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPrompt, escalation.Needed, tt.description)
+		})
+	}
+}
+
+func TestDeletionEscalationScopes_ReadonlyWorld(t *testing.T) {
+	tests := []struct {
+		name        string
+		batchDelete bool
+		existing    []string
+		want        []string
+	}{
+		{
+			name:        "trash escalation from read-only adds modify and keeps calendar",
+			batchDelete: false,
+			existing:    []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeCalendarReadonly,
+				oauth.ScopeGmailModify,
+			},
+		},
+		{
+			// Full access already permits trashing, so on the pre-flight path
+			// grantCoversDeletion returns true and this function is never
+			// reached with such a grant. The path that DOES reach it is the
+			// 403 insufficient-scope recovery, which runs precisely because
+			// the recorded scopes were wrong — there, requesting only what is
+			// already recorded makes re-consent a no-op and the next attempt
+			// 403s again. Adding modify grants nothing new over full access
+			// and keeps the recovery able to change something.
+			name:        "trash escalation still requests modify alongside full access",
+			batchDelete: false,
+			existing:    []string{oauth.ScopeGmailReadonly, oauth.ScopeGmailFull},
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailFull,
+				oauth.ScopeGmailModify,
+			},
+		},
+		{
+			name:        "permanent escalation from read-only adds full access",
+			batchDelete: true,
+			existing:    []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeCalendarReadonly,
+				oauth.ScopeGmailFull,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want,
+				deletionEscalationScopes(tt.batchDelete, tt.existing))
+		})
+	}
+}
+
+// TestCalendarEscalationScopes_DoesNotRewidenNarrowGrant is the add-calendar
+// half of the "read-only stays read-only" rule. Preserving Gmail while adding
+// Calendar must preserve the Gmail access the account has, not the full bundle.
+func TestCalendarEscalationScopes_DoesNotRewidenNarrowGrant(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		want     []string
+	}{
+		{
+			name:     "read-only gmail stays read-only",
+			existing: []string{oauth.ScopeGmailReadonly},
+			want:     []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+		},
+		{
+			name:     "read-only gmail with drive stays read-only and keeps drive",
+			existing: []string{oauth.ScopeGmailReadonly, drive.DriveReadonlyScope},
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				drive.DriveReadonlyScope,
+				oauth.ScopeCalendarReadonly,
+			},
+		},
+		{
+			name:     "write-capable gmail is unchanged",
+			existing: oauth.Scopes,
+			want: []string{
+				oauth.ScopeGmailReadonly,
+				oauth.ScopeGmailModify,
+				oauth.ScopeCalendarReadonly,
+			},
+		},
+		{
+			// Not a narrowed grant — it holds write access — so the rule does
+			// not apply. Existing scopes are carried forward regardless, so
+			// full access survives either way.
+			name:     "full access only gmail keeps its grant",
+			existing: []string{oauth.ScopeGmailFull},
+			want:     []string{oauth.ScopeGmailFull, oauth.ScopeCalendarReadonly},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			preserveGmail := calendarShouldPreserveGmail(true, true, tt.existing)
+			assert.ElementsMatch(t, tt.want,
+				calendarEscalationScopes(tt.existing, preserveGmail))
+		})
+	}
+}

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -802,12 +802,32 @@ func deleteStagedScopeEscalationForSource(
 		}
 		return deleteStagedScopeEscalation{}, nil
 	}
-	for _, scope := range requiredScopes {
-		if !oauthMgr.HasScope(account, scope) {
-			return newDeleteStagedScopeEscalation(account, permanent, clientSecretsPath), nil
-		}
+	if grantCoversDeletion(oauthMgr.GrantedScopes(account), permanent) {
+		return deleteStagedScopeEscalation{}, nil
 	}
-	return deleteStagedScopeEscalation{}, nil
+	return newDeleteStagedScopeEscalation(account, permanent, clientSecretsPath), nil
+}
+
+// grantCoversDeletion reports whether an account's granted scopes already
+// permit the requested deletion, so no re-consent prompt is needed.
+//
+// Trashing is a capability question, not a scope-list question: gmail.modify
+// grants it, and the broader full-access scope grants it too, being a superset.
+// Requiring every member of oauth.Scopes would prompt an account that holds
+// full access but not modify to "upgrade" to permissions it already exceeds —
+// reachable as soon as read-only accounts exist, since narrowing to read-only
+// and later escalating for permanent deletion produces exactly that grant.
+//
+// Permanent deletion still requires the full-access scope; modify does not
+// cover batchDelete.
+func grantCoversDeletion(grantedScopes []string, permanent bool) bool {
+	if slices.Contains(grantedScopes, oauth.ScopeGmailFull) {
+		return true
+	}
+	if permanent {
+		return false
+	}
+	return slices.Contains(grantedScopes, oauth.ScopeGmailModify)
 }
 
 func newDeleteStagedScopeEscalation(

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -707,12 +707,32 @@ func deleteStagedScopeEscalationForSource(
 		}
 		return deleteStagedScopeEscalation{}, nil
 	}
-	for _, scope := range requiredScopes {
-		if !oauthMgr.HasScope(account, scope) {
-			return newDeleteStagedScopeEscalation(account, permanent, clientSecretsPath), nil
-		}
+	if grantCoversDeletion(oauthMgr.GrantedScopes(account), permanent) {
+		return deleteStagedScopeEscalation{}, nil
 	}
-	return deleteStagedScopeEscalation{}, nil
+	return newDeleteStagedScopeEscalation(account, permanent, clientSecretsPath), nil
+}
+
+// grantCoversDeletion reports whether an account's granted scopes already
+// permit the requested deletion, so no re-consent prompt is needed.
+//
+// Trashing is a capability question, not a scope-list question: gmail.modify
+// grants it, and the broader full-access scope grants it too, being a superset.
+// Requiring every member of oauth.Scopes would prompt an account that holds
+// full access but not modify to "upgrade" to permissions it already exceeds —
+// reachable as soon as read-only accounts exist, since narrowing to read-only
+// and later escalating for permanent deletion produces exactly that grant.
+//
+// Permanent deletion still requires the full-access scope; modify does not
+// cover batchDelete.
+func grantCoversDeletion(grantedScopes []string, permanent bool) bool {
+	if slices.Contains(grantedScopes, oauth.ScopeGmailFull) {
+		return true
+	}
+	if permanent {
+		return false
+	}
+	return slices.Contains(grantedScopes, oauth.ScopeGmailModify)
 }
 
 func newDeleteStagedScopeEscalation(

--- a/cmd/msgvault/cmd/reauth_readonly_test.go
+++ b/cmd/msgvault/cmd/reauth_readonly_test.go
@@ -127,7 +127,7 @@ func TestReauthHintCommandIsNotItselfRefused(t *testing.T) {
 	// suggested command would hit.
 	decision := decideAddAccountGrant(
 		"x@gmail.com", true, true, narrowed, true, false,
-		"/tmp/tokens/x@gmail.com.json")
+		"/tmp/tokens/x@gmail.com.json", "")
 
 	require.NoError(decision.Err,
 		"the hint must not recommend a command add-account would refuse")

--- a/cmd/msgvault/cmd/reauth_readonly_test.go
+++ b/cmd/msgvault/cmd/reauth_readonly_test.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	extOAuth2 "golang.org/x/oauth2"
+
+	"go.kenn.io/msgvault/internal/oauth"
+)
+
+// scopedMockReauthorizer adds recorded grant scopes to mockReauthorizer, so
+// remediation guidance can be exercised against an account that was
+// deliberately narrowed to read-only.
+type scopedMockReauthorizer struct {
+	*mockReauthorizer
+
+	scopes []string
+}
+
+func (m *scopedMockReauthorizer) GrantedScopes(string) []string {
+	return append([]string(nil), m.scopes...)
+}
+
+func newScopedReauthorizer(scopes []string, authorizeErr error) *scopedMockReauthorizer {
+	return &scopedMockReauthorizer{
+		mockReauthorizer: &mockReauthorizer{
+			tokenSourceFn: func(_ context.Context, _ string) (extOAuth2.TokenSource, error) {
+				return nil, &extOAuth2.RetrieveError{ErrorCode: "invalid_grant"}
+			},
+			hasTokenVal: true,
+			authorizeFn: func(_ context.Context, _ string) error { return authorizeErr },
+		},
+		scopes: scopes,
+	}
+}
+
+// TestReauthHintPreservesReadonlyGrant is the regression for remediation
+// guidance that silently widened an account. A read-only account whose token
+// expired was told to run `add-account <addr> --force`, which requests write
+// access — undoing the narrowing at the moment the operator is least likely to
+// notice, since they are following instructions to fix an unrelated failure.
+func TestReauthHintPreservesReadonlyGrant(t *testing.T) {
+	tests := []struct {
+		name          string
+		scopes        []string
+		wantReadonly  bool
+		wantInCommand string
+	}{
+		{
+			name:          "narrowed account keeps --readonly",
+			scopes:        []string{oauth.ScopeGmailReadonly},
+			wantReadonly:  true,
+			wantInCommand: "add-account x@gmail.com --readonly --force",
+		},
+		{
+			name:          "narrowed account with calendar keeps --readonly",
+			scopes:        []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly},
+			wantReadonly:  true,
+			wantInCommand: "add-account x@gmail.com --readonly --force",
+		},
+		{
+			name:          "write-capable account is unchanged",
+			scopes:        oauth.Scopes,
+			wantReadonly:  false,
+			wantInCommand: "add-account x@gmail.com --force",
+		},
+		{
+			// No Gmail scopes at all is not a narrowed grant, so guidance
+			// stays exactly as it was before --readonly existed.
+			name:          "calendar-only account is unchanged",
+			scopes:        []string{oauth.ScopeCalendarReadonly},
+			wantReadonly:  false,
+			wantInCommand: "add-account x@gmail.com --force",
+		},
+		{
+			name:          "legacy token with no recorded scopes is unchanged",
+			scopes:        nil,
+			wantReadonly:  false,
+			wantInCommand: "add-account x@gmail.com --force",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			mock := newScopedReauthorizer(tt.scopes, nil)
+
+			// Non-interactive: the out-of-band remedy is printed rather than
+			// a browser being opened.
+			_, err := getTokenSourceWithReauth(
+				context.Background(), mock, "x@gmail.com", false, gmailReauthHint)
+
+			require.Error(err)
+			assert.Contains(err.Error(), tt.wantInCommand)
+			if !tt.wantReadonly {
+				assert.NotContains(err.Error(), "--readonly")
+			}
+		})
+	}
+}
+
+// TestReauthHintCommandIsNotItselfRefused closes the loop between the two
+// halves of this change. add-account refuses `--readonly --force`, and the
+// expired-token hint suggests exactly that string for a narrowed account —
+// which reads like a contradiction, and would be one if the refusal keyed on
+// the flags rather than on the grant.
+//
+// It keys on the grant: a narrowed account holds no write scope, so the
+// suggested command is accepted. Asserting that here means the two rules cannot
+// drift into genuinely contradicting each other without a test failing.
+func TestReauthHintCommandIsNotItselfRefused(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	narrowed := []string{oauth.ScopeGmailReadonly, oauth.ScopeCalendarReadonly}
+
+	hint := gmailReauthHint("x@gmail.com", true)
+	assert.Contains(hint, "--readonly --force",
+		"precondition: the hint suggests the combination under test")
+
+	// The same grant the hint was generated for, run through the decision the
+	// suggested command would hit.
+	decision := decideAddAccountGrant(
+		"x@gmail.com", true, true, narrowed, true, false,
+		"/tmp/tokens/x@gmail.com.json")
+
+	require.NoError(decision.Err,
+		"the hint must not recommend a command add-account would refuse")
+	assert.Empty(decision.Warning,
+		"re-authorizing a narrowed account at its own scope is not a widening")
+}
+
+// TestReauthAliasMismatchPreservesReadonlyGrant covers the other remediation
+// site: the alias-mismatch hint printed after an interactive reauth resolves to
+// a different Google account. Its remove-and-re-add recipe must not drop the
+// grant mode either.
+func TestReauthAliasMismatchPreservesReadonlyGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	mismatch := &oauth.TokenMismatchError{
+		Expected: "alias@gmail.com",
+		Actual:   "primary@gmail.com",
+	}
+	mock := newScopedReauthorizer([]string{oauth.ScopeGmailReadonly}, mismatch)
+
+	_, err := getTokenSourceWithReauth(
+		context.Background(), mock, "alias@gmail.com", true, gmailReauthHint)
+
+	require.Error(err)
+	var got *oauth.TokenMismatchError
+	require.ErrorAs(err, &got, "mismatch error must survive wrapping")
+	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com --readonly")
+}
+
+// TestReauthAliasMismatchUnchangedForWriteGrant pins that the alias recipe is
+// untouched for an ordinary write-capable account.
+func TestReauthAliasMismatchUnchangedForWriteGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	mismatch := &oauth.TokenMismatchError{
+		Expected: "alias@gmail.com",
+		Actual:   "primary@gmail.com",
+	}
+	mock := newScopedReauthorizer(oauth.Scopes, mismatch)
+
+	_, err := getTokenSourceWithReauth(
+		context.Background(), mock, "alias@gmail.com", true, gmailReauthHint)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com")
+	assert.NotContains(err.Error(), "--readonly")
+}
+
+// TestAddAccountGrantFlagSuffix covers the add-account mismatch hint's flag
+// rendering, which repeats the current run's grant mode rather than the
+// account's recorded one — no token exists yet at that point.
+func TestAddAccountGrantFlagSuffix(t *testing.T) {
+	saveAddAccountFlags(t)
+
+	readonlyGrant = false
+	assert.Empty(t, addAccountGrantFlagSuffix())
+
+	readonlyGrant = true
+	assert.Equal(t, " --readonly", addAccountGrantFlagSuffix())
+}
+
+// TestAddAccountAuthorizeErrorRepeatsReadonly is the behavioural half: a
+// --readonly run that hits an account mismatch must not print a re-add command
+// that would request write access.
+func TestAddAccountAuthorizeErrorRepeatsReadonly(t *testing.T) {
+	assert := assert.New(t)
+	saveAddAccountFlags(t)
+
+	mismatch := &oauth.TokenMismatchError{
+		Expected: "alias@gmail.com",
+		Actual:   "primary@gmail.com",
+	}
+
+	readonlyGrant = true
+	err := addAccountAuthorizeError(mismatch, false)
+	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com --readonly")
+
+	readonlyGrant = false
+	err = addAccountAuthorizeError(mismatch, false)
+	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com")
+	assert.NotContains(err.Error(), "--readonly")
+}

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -278,6 +278,22 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	// Remove credentials for the source type.
 	switch source.SourceType {
 	case sourceTypeGmail:
+		// Revoke the grant at Google before deleting the local file, so
+		// copies of the refresh token do not outlive the account — a later
+		// re-add (read-only or otherwise) has no way to know this grant
+		// ever existed. Best-effort, matching the Microsoft path: the
+		// credential may already be dead, and removal must still complete.
+		if err := oauth.RevokeStoredCredential(
+			cmd.Context(), cfg.TokensDir(), source.Identifier,
+		); err != nil &&
+			!errors.Is(err, os.ErrNotExist) &&
+			!errors.Is(err, oauth.ErrRevokeCredentialInvalid) {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not revoke Google grant for %s (revoke it at "+
+					"https://myaccount.google.com/permissions): %v\n",
+				source.Identifier, err,
+			)
+		}
 		tokenPath := oauth.TokenFilePath(
 			cfg.TokensDir(), source.Identifier,
 		)

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -278,21 +278,38 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	// Remove credentials for the source type.
 	switch source.SourceType {
 	case sourceTypeGmail:
+		remaining, listErr := s.ListSources(sourceTypeGmail)
+		remainingEmails := make([]string, 0, len(remaining))
+		for _, remainingSource := range remaining {
+			remainingEmails = append(remainingEmails, remainingSource.Identifier)
+		}
+		grantInUse := listErr != nil || oauth.EquivalentStoredGrantInUse(
+			cfg.TokensDir(), source.Identifier, remainingEmails,
+		)
+		if listErr != nil {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not check remaining Gmail accounts; Google grant was not revoked: %v\n",
+				listErr,
+			)
+		}
 		// Revoke the grant at Google before deleting the local file, so
 		// copies of the refresh token do not outlive the account — a later
 		// re-add (read-only or otherwise) has no way to know this grant
 		// ever existed. Best-effort, matching the Microsoft path: the
 		// credential may already be dead, and removal must still complete.
-		if err := oauth.RevokeStoredCredential(
-			cmd.Context(), cfg.TokensDir(), source.Identifier,
-		); err != nil &&
-			!errors.Is(err, os.ErrNotExist) &&
-			!errors.Is(err, oauth.ErrRevokeCredentialInvalid) {
-			fmt.Fprintf(os.Stderr,
-				"Warning: could not revoke Google grant for %s (revoke it at "+
-					"https://myaccount.google.com/permissions): %v\n",
-				source.Identifier, err,
-			)
+		// Keep a shared grant while an equivalent Gmail source still uses it.
+		if !grantInUse {
+			if err := oauth.RevokeStoredCredential(
+				cmd.Context(), cfg.TokensDir(), source.Identifier,
+			); err != nil &&
+				!errors.Is(err, os.ErrNotExist) &&
+				!errors.Is(err, oauth.ErrRevokeCredentialInvalid) {
+				fmt.Fprintf(os.Stderr,
+					"Warning: could not revoke Google grant for %s (revoke it at "+
+						"https://myaccount.google.com/permissions): %v\n",
+					source.Identifier, err,
+				)
+			}
 		}
 		tokenPath := oauth.TokenFilePath(
 			cfg.TokensDir(), source.Identifier,

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -273,6 +273,22 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	// Remove credentials for the source type.
 	switch source.SourceType {
 	case sourceTypeGmail:
+		// Revoke the grant at Google before deleting the local file, so
+		// copies of the refresh token do not outlive the account — a later
+		// re-add (read-only or otherwise) has no way to know this grant
+		// ever existed. Best-effort, matching the Microsoft path: the
+		// credential may already be dead, and removal must still complete.
+		if err := oauth.RevokeStoredCredential(
+			cmd.Context(), cfg.TokensDir(), source.Identifier,
+		); err != nil &&
+			!errors.Is(err, os.ErrNotExist) &&
+			!errors.Is(err, oauth.ErrRevokeCredentialInvalid) {
+			fmt.Fprintf(os.Stderr,
+				"Warning: could not revoke Google grant for %s (revoke it at "+
+					"https://myaccount.google.com/permissions): %v\n",
+				source.Identifier, err,
+			)
+		}
 		tokenPath := oauth.TokenFilePath(
 			cfg.TokensDir(), source.Identifier,
 		)

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -465,23 +465,65 @@ type scopePreservingReauthorizer interface {
 	AuthorizeManualPreservingGrantedScopes(ctx context.Context, email string) error
 }
 
+// grantInspector is implemented by managers that record which scopes a token
+// was granted. Remediation guidance uses it to stay faithful to the account's
+// current grant: an account deliberately narrowed to read-only must not be
+// handed a command that would widen it again.
+type grantInspector interface {
+	GrantedScopes(email string) []string
+}
+
+// accountIsNarrowed reports whether the account's recorded grant is Gmail
+// read-only. A manager that cannot report scopes, or a grant with no Gmail
+// scopes at all, is treated as not narrowed, so guidance is unchanged for
+// every pre-existing case.
+func accountIsNarrowed(mgr tokenReauthorizer, email string) bool {
+	inspector, ok := mgr.(grantInspector)
+	if !ok {
+		return false
+	}
+	return oauth.IsNarrowedGmailGrant(inspector.GrantedScopes(email))
+}
+
+// readonlyFlagSuffix renders the grant-affecting flag for inclusion in
+// remediation commands.
+func readonlyFlagSuffix(readonly bool) string {
+	if readonly {
+		return " --readonly"
+	}
+	return ""
+}
+
 // reauthHint returns caller-specific, out-of-band re-authorization guidance for
 // an expired/revoked token in a non-interactive session. Gmail and Calendar use
 // different commands (add-account vs add-calendar), so the shared reauth helper
 // must be told which one to point the user at.
-type reauthHint func(email string) string
+//
+// readonly reports whether the account's current grant is Gmail read-only, so
+// the suggested command preserves that rather than silently widening it.
+type reauthHint func(email string, readonly bool) string
 
 // gmailReauthHint points at add-account, the Gmail authorization command.
-func gmailReauthHint(email string) string {
+//
+// For a narrowed account this suggests `--readonly --force`, which looks like
+// the combination add-account refuses. It is not: that refusal fires only when
+// the account holds a Gmail write scope, and a narrowed account by definition
+// holds none. Here --force is doing its ordinary job — discard a dead token and
+// authorize again — at the same scope the account already has, which neither
+// narrows nor widens anything.
+func gmailReauthHint(email string, readonly bool) string {
+	flags := readonlyFlagSuffix(readonly)
 	return fmt.Sprintf(
-		"re-authorize with 'msgvault add-account %s --force' (or "+
-			"'msgvault add-account %s --headless' on a server without a browser)",
-		email, email,
+		"re-authorize with 'msgvault add-account %s%s --force' (or "+
+			"'msgvault add-account %s%s --headless' on a server without a browser)",
+		email, flags, email, flags,
 	)
 }
 
-// calendarReauthHint points at add-calendar, the Calendar authorization command.
-func calendarReauthHint(email string) string {
+// calendarReauthHint points at add-calendar, the Calendar authorization
+// command. Calendar has a single read-only scope, so there is no grant mode to
+// preserve.
+func calendarReauthHint(email string, _ bool) string {
 	return fmt.Sprintf(
 		"re-authorize with 'msgvault add-calendar %s' (or "+
 			"'msgvault add-calendar %s --headless' on a server without a browser)",
@@ -526,10 +568,14 @@ func getTokenSourceWithReauth(
 	// --force browser flow works even from here (it opens its own loopback
 	// callback). On a headless server with no browser, --headless prints
 	// device-code instructions instead (--force is browser-only).
+	// Read the recorded grant before any reauthorization replaces it, so the
+	// guidance reflects what the account holds now.
+	narrowed := accountIsNarrowed(mgr, email)
+
 	if !interactive {
 		return nil, fmt.Errorf(
 			"token for %s is expired or revoked; %s",
-			email, recovery(email),
+			email, recovery(email, narrowed),
 		)
 	}
 
@@ -547,9 +593,10 @@ func getTokenSourceWithReauth(
 					"If this account uses an alias, remove "+
 					"and re-add with the primary address:\n"+
 					"  msgvault remove-account %s --type gmail\n"+
-					"  msgvault add-account %s",
+					"  msgvault add-account %s%s",
 				email, authErr,
 				mismatch.Expected, mismatch.Actual,
+				readonlyFlagSuffix(narrowed),
 			)
 		}
 		return nil, fmt.Errorf("re-authorize %s: %w", email, authErr)

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1527,7 +1527,11 @@ func (a *storeAPIAdapter) runCLICommandWithRunner(
 		return emit(api.CLIRunEvent{Type: stream, Data: data})
 	}
 	runSubprocess := func(ctx context.Context) error {
-		return run(ctx, req.Args, req.Env, req.Cwd, emitSubprocess)
+		args := req.Args
+		if req.GrantDecided {
+			args = append(append([]string(nil), args...), "--"+addAccountGrantDecidedFlag+"=true")
+		}
+		return run(ctx, args, req.Env, req.Cwd, emitSubprocess)
 	}
 	if len(req.Args) > 0 && req.Args[0] == "repack-attachments" {
 		if !repackAttachmentsParentArgsAllowed(req.Args[1:]) {

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -1328,6 +1328,36 @@ func TestStoreAPIAdapterRunCLICommandPacksOnlyAllowlistedSuccess(t *testing.T) {
 	}
 }
 
+func TestStoreAPIAdapterAppendsServerOwnedGrantDecision(t *testing.T) {
+	adapter := &storeAPIAdapter{}
+	req := api.CLIRunRequest{
+		Args:         []string{"add-account", "user@example.com", "--readonly"},
+		GrantDecided: true,
+	}
+	var gotArgs []string
+
+	err := adapter.runCLICommandWithRunner(
+		context.Background(), req, nil,
+		func(
+			_ context.Context,
+			args []string,
+			_ map[string]string,
+			_ string,
+			_ func(string, string) error,
+		) error {
+			gotArgs = args
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"add-account", "user@example.com", "--readonly", "--grant-decided=true",
+	}, gotArgs)
+	assert.Equal(t, []string{"add-account", "user@example.com", "--readonly"}, req.Args,
+		"server injection must not mutate caller-owned args")
+}
+
 func TestStoreAPIAdapterInterceptsExplicitRepackInDaemonParent(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/store_resolver.go
+++ b/cmd/msgvault/cmd/store_resolver.go
@@ -159,9 +159,10 @@ func openHTTPStoreWithStartupCacheIntent(
 	}
 	url := urlFromDaemonRuntime(rt)
 	st, err := newDaemonCLIClient(ctx, daemonclient.Config{
-		URL:           url,
-		APIKey:        cfg.Server.APIKey,
-		AllowInsecure: true,
+		URL:              url,
+		APIKey:           cfg.Server.APIKey,
+		LocalDaemonToken: rt.Record.Metadata[runtimeShutdownToken],
+		AllowInsecure:    true,
 	})
 	if err != nil {
 		return nil, HTTPStoreInfo{}, err

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -61,10 +61,11 @@ msgvault add-account <email> --oauth-app <name>
 | `--headless` | Show instructions for headless server setup |
 | `--oauth-app` | Use a named OAuth app from `[oauth.apps.<name>]` in config |
 | `--force` | Delete existing token and re-authorize |
+| `--readonly` | Request Gmail read-only access instead of read + write. Refused if the account already holds write access — see [OAuth Setup](/guides/oauth-setup/#read-only-access) |
 | `--display-name` | Set a display name for the account |
 | `--no-default-identity` | Do not auto-confirm the email address as this account's "me" identity |
 
-If `[oauth].service_account_key` or `[oauth.apps.<name>].service_account_key` is configured, `add-account` authorizes via Google service account domain-wide delegation instead of browser OAuth. Service-account accounts do not use `--headless` or `--force`.
+If `[oauth].service_account_key` or `[oauth.apps.<name>].service_account_key` is configured, `add-account` authorizes via Google service account domain-wide delegation instead of browser OAuth. Service-account accounts do not use `--headless`, `--force`, or `--readonly`; their scope comes from the domain-wide delegation grant in the Admin Console.
 
 ---
 

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -10,53 +10,63 @@ msgvault requires OAuth credentials to access the Gmail API. This section walks 
 ### Step 1: Create a Google Cloud Project
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Create a new project or select an existing one
-3. Note your project ID
+2. If it's your first time using Google Cloud Console, select your country and agree to the Terms of Service
+3. Click **Select a Project** and click **New project** (recommended) or select an existing one
+4. Name your project `msgvault`. Parent resource can be left as the default of "No organization"
+5. Click **Create**
+6. The Notifications will spin for a few seconds and then allow you to click Select Project for the new `msgvault` project
 
 ### Step 2: Enable Google APIs
 
-1. Navigate to **APIs & Services > Library**
-2. Search for "Gmail API"
+1. On the left bar/under the hamburger menu, navigate to **APIs & Services > Library**
+2. In the search bar, search for "Gmail API" and click the **Gmail API** box
 3. Click **Enable**
-4. If you will sync Google Calendar too, also search for "Google Calendar API" and click **Enable**
+4. If you wish to sync Google Calendar too, click **Library**, search for "Google Calendar API", click the **Google Calendar API** box and click **Enable**
 
 ### Step 3: Configure OAuth Consent Screen
 
 1. Go to **APIs & Services > OAuth consent screen** (Google may call this **Google Auth Platform**)
-2. Choose **External** user type (or **Internal** for Google Workspace)
-3. Fill in required fields:
+2. Click **Get started**
+3. Fill in required fields as you click through:
    - App name: `msgvault`
    - User support email: your email
-   - Developer contact email: your email
-4. Click **Save and Continue**
-5. On the **Data Access** page, click **Add or Remove Scopes**
-6. Add the scope: `https://www.googleapis.com/auth/gmail.modify`
-7. If you will sync Google Calendar too, add `https://www.googleapis.com/auth/calendar.readonly`
-8. Save and continue through the remaining screens
-9. Under **Test users**, add all Gmail addresses you want to sync
+   - Audience: **External** for regular Gmail, **Internal** for Google Workspace
+   - Contact Information: your email
+   - Agree to the "Google API Services: User Data Policy" checkbox
+4. Click **Create**
+5. Click **Data Access** on the left bar and click **Add or Remove Scopes**
+6. At the bottom of the page under "Manually add scopes", enter the scopes you intend to use, one per line, then click **Add to table**:
+    - `https://www.googleapis.com/auth/gmail.readonly` — always
+    - `https://www.googleapis.com/auth/gmail.modify` — unless you will only ever run read-only (see below)
+    - `https://www.googleapis.com/auth/calendar.readonly` — if you will sync Google Calendar
+7. Click **Update** then **Save**
+8. Go to **Audience** on the left bar and in the **Test users** section, click the **Add users** button and add your Gmail email address
+
+!!! warning "This page does not restrict what gets granted"
+    The scopes listed here are a declaration used for Google's verification review. They do not limit what the authorization server grants at request time, that is determined solely by what msgvault requests. Removing `gmail.modify` here will **not** give you a read-only setup; use `--readonly` when adding the account instead.
 
 !!! note
-    The `gmail.modify` scope enables deletion features while sync operations remain read-only. When you first run `delete-staged`, msgvault will prompt you to upgrade to full `mail.google.com` access for batch deletion.
+    By default msgvault requests `gmail.readonly` and `gmail.modify`. Sync itself only ever reads, `gmail.modify` is what later enables trash-based deletion. When you first run `delete-staged --permanent`, msgvault prompts you to upgrade to full `mail.google.com` access for batch deletion.
+
+    If you never intend to delete mail from Gmail, add the account with `--readonly` (see [Read-Only Access](#read-only-access)) and you can leave `gmail.modify` off this page entirely.
 
 ### Step 4: Create OAuth Client Credentials
 
-1. Go to **APIs & Services > Credentials**
+1. Through the hamburger menu, go to **APIs & Services > Credentials**
 2. Click **Create Credentials > OAuth client ID**
-3. Choose **Desktop app** as the application type
+3. Choose **Desktop app** as the application type. Not "TVs and Limited Input devices" — Google's device-code flow does not support Gmail scopes
 4. Name it `msgvault` (or similar)
 5. Click **Create**
-6. Download the JSON file
+6. Click **Download JSON** to download the JSON file
 7. Save it as `client_secret.json` in a secure location
+8. Click OK
 
 !!! warning
     Never commit `client_secret.json` to version control.
 
-!!! warning "Desktop App Only"
-    You must choose **Desktop app** as the client type. Do not use "TVs and Limited Input devices" as Google's device code flow does not support Gmail scopes.
-
 ### Step 5: Configure msgvault
 
-Create `config.toml` in your msgvault data directory:
+Create a file called `config.toml` in your msgvault directory.
 
 - **macOS / Linux:** `~/.msgvault/config.toml`
 - **Windows:** `C:\Users\<you>\.msgvault\config.toml`
@@ -75,6 +85,16 @@ On Windows, use forward slashes or escaped backslashes for the path:
 client_secrets = "C:/Users/you/Downloads/client_secret.json"
 ```
 
+!!! tip
+    These commands will do what's needed on macOS/Linux/WSL assuming you're putting the client_secret.json file in ~/.msgvault/:
+    ```
+    mkdir -m 700 -p ~/.msgvault
+    printf '[oauth]\nclient_secrets = "~/.msgvault/client_secret.json"\n' > ~/.msgvault/config.toml
+    echo client_secret.json >> ~/.msgvault/.gitignore
+    ```
+
+Copy your `client_secret.json` file to `~/.msgvault/` or wherever you've referenced it in the configuration file and set permissions to limit access (`chmod 600 ~/.msgvault/client_secret.json` on macOS/Linux).
+
 ### Step 6: Add Your Account
 
 ```bash
@@ -82,6 +102,48 @@ msgvault add-account you@gmail.com
 ```
 
 This opens your browser to Google's OAuth consent page. Sign in, grant access, and tokens are stored locally in `~/.msgvault/tokens/`.
+
+#### Read-Only Access
+
+By default `add-account` requests read and modify access. To request read access only:
+
+```bash
+msgvault add-account you@gmail.com --readonly
+```
+
+Sync, search, and the TUI all work on a read-only grant. Deletion does not.
+
+Running `--readonly` against an account that is already read-only does nothing and reuses the existing token. A plain `add-account` run against one warns before requesting write access again.
+
+**Access already granted cannot be narrowed.** Re-authorizing with `--readonly` does not revoke what Google has on record, and a refresh token issued earlier keeps working with its original write scopes — so an account that once had write access still has it, whatever token msgvault happens to hold. `add-account --readonly` therefore refuses such an account rather than appearing to narrow it. `--force` does not change this and is refused too.
+
+To make an existing account read-only, remove its access and grant it again:
+
+1. Revoke msgvault at [myaccount.google.com/permissions](https://myaccount.google.com/permissions)
+2. `rm ~/.msgvault/tokens/you@gmail.com.json`
+3. `msgvault add-account you@gmail.com --readonly`
+
+Revoking clears every Google scope for that account, so re-run whichever commands granted them — `msgvault add-calendar` for Calendar, `msgvault add-synctech-sms-drive` for Drive. Your archived mail is untouched: this replaces credentials, not data.
+
+Confirm the result by reading the token's scopes:
+
+```bash
+python3 -c "import json,os;print(*json.load(open(os.path.expanduser('~/.msgvault/tokens/you@gmail.com.json')))['scopes'],sep='\n')"
+```
+
+#### Headless Authorization
+
+```
+Starting browser authorization...
+Opening browser for authorization...
+If browser doesn't open, visit:
+https://accounts.google.com/o/oauth2/auth?access_type=offline&LONG_STRING_HERE
+```
+
+msgvault will be unable to open a browser but will give a URL `https://accounts.google.com/o/oauth2/auth?access_type=offline&LONG_STRING_HERE`. Copy this to your browser
+- Click **Continue** at the "Google hasn't verified this app" prompt
+- Confirm the Gmail and Calendar access if chosen by clicking the **Select all** checkbox and then **Continue**
+- The browser will try open a connection to localhost:8089 with the authorization code. Copy this URL from your browser and on the headless host run: `curl -s 'http://localhost:8089/callback?DIFFERENT_LONG_STRING'` with the full URL from your browser. (Another option is to forward the port from the computer running the browser to the headless host with `ssh -L 8089:localhost:8089 user@headlessserver`)
 
 ### Multiple Accounts
 
@@ -149,6 +211,11 @@ Workspace admins can avoid per-user browser OAuth by using a Google service acco
    - `https://mail.google.com/` if you will run `delete-staged --permanent`
 4. Store the key with owner-only permissions, for example `chmod 600 /path/to/workspace-service-account.json`.
 
+Both `gmail.readonly` and `gmail.modify` are required. The Gmail service-account paths request that pair when minting a delegated token, so a delegation grant limited to `gmail.readonly` fails the token exchange and `add-account`, `sync`, `serve`, and `verify` all stop working for that account.
+
+!!! note
+    `--readonly` does not apply to service accounts, and is rejected with an error if passed. Scope is set by the delegation grant in the Admin Console rather than by msgvault flags. Narrowing what the Gmail service-account paths request, so that a read-only delegation grant becomes usable, is a possible future change.
+
 Configure the key as the default Google credential:
 
 ```toml
@@ -170,7 +237,7 @@ msgvault add-account you@acme.com
 msgvault add-account teammate@acme.com --oauth-app acme
 ```
 
-Service account mode validates the delegated Gmail profile and registers the source, but it does not create per-user token files. Do not combine service-account accounts with `--headless` or `--force`; delegated tokens are minted on demand.
+Service account mode validates the delegated Gmail profile and registers the source, but it does not create per-user token files. Do not combine service-account accounts with `--headless`, `--force` or `--readonly`; delegated tokens are minted on demand.
 
 For Google Calendar with a service account, enable the Google Calendar API and authorize the `calendar.readonly` scope above. Then configure a `[[gcal]]` source and run `msgvault sync-calendar user@domain.com --oauth-app acme` (or let `msgvault serve` run the schedule). No browser token is created.
 
@@ -208,6 +275,11 @@ Step 3: On the headless server, register the account:
 
 The token will be detected and the account registered. No browser needed.
 ```
+
+!!! note "Read-only on a headless server"
+    `--readonly` is echoed into the commands printed above, so `msgvault add-account you@gmail.com --headless --readonly` shows the read-only variant to run on the machine with a browser.
+
+    The revoke-and-re-add procedure above works unchanged on a headless host. Step 3 prints an authorization URL you can open from any browser, then waits for the callback exactly as described here.
 
 #### Step-by-Step
 

--- a/docs/guides/oauth-setup.md
+++ b/docs/guides/oauth-setup.md
@@ -123,7 +123,7 @@ To make an existing account read-only, remove its access and grant it again:
 2. `rm ~/.msgvault/tokens/you@gmail.com.json`
 3. `msgvault add-account you@gmail.com --readonly`
 
-Revoking clears every Google scope for that account, so re-run whichever commands granted them — `msgvault add-calendar` for Calendar, `msgvault add-synctech-sms-drive` for Drive. Your archived mail is untouched: this replaces credentials, not data.
+Revoking also clears Calendar and Drive access granted through the same OAuth app. Reauthorize those integrations separately. The current `add-synctech-sms-drive` command cannot restore a missing Drive scope when a token already exists. Your archived mail is untouched: this replaces credentials, not data.
 
 Confirm the result by reading the token's scopes:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,6 +45,53 @@ Wrong application type. Ensure you selected **Desktop app** when creating OAuth 
 
 You created a "TVs and Limited Input devices" OAuth client, which doesn't work with Gmail. Google's device code flow does not support Gmail scopes. Create a new OAuth client with **Desktop app** type instead.
 
+### Read-only Gmail access
+
+By default `add-account` requests `gmail.readonly` and `gmail.modify`. Pass `--readonly` to request read access only:
+
+```bash
+msgvault add-account you@gmail.com --readonly
+```
+
+Sync, search, and the TUI all work on a read-only grant. Deletion does not — see below.
+
+Restricting scopes on the **Data Access** page in the Google Cloud Console will not do this for you. That page declares which scopes your app may ask for during verification review; it does not limit what the authorization server grants at request time. Nor can you decline a scope on the consent screen: msgvault rejects a token that comes back with fewer scopes than it asked for. Changing what the client requests is the only thing that works, which is what `--readonly` does.
+
+#### "already has Gmail write access"
+
+```
+you@gmail.com already has Gmail write access (https://www.googleapis.com/auth/gmail.modify)
+```
+
+`--readonly` cannot take away access an account already has. Re-authorizing does not revoke the previous grant — a refresh token issued beforehand keeps working with its original write scopes — and revoking applies to the whole grant, so revoking the old credential would invalidate the replacement too. There is no way to narrow in place, and `--force` is refused for the same reason.
+
+To make the account read-only, remove its access and grant it again:
+
+1. Revoke msgvault at [myaccount.google.com/permissions](https://myaccount.google.com/permissions)
+2. `rm ~/.msgvault/tokens/you@gmail.com.json`
+3. `msgvault add-account you@gmail.com --readonly`
+
+Revoking clears every other Google scope for the account, so re-run whichever commands granted them — `add-calendar` for Calendar, `add-synctech-sms-drive` for Drive. Archived mail is unaffected. Confirm the result by reading the token's `scopes` array rather than the permissions page, which reports what msgvault is authorized to request.
+
+The same refusal applies to an account holding the broad `https://mail.google.com/` scope, which msgvault grants when you escalate for permanent deletion.
+
+#### "currently has read-only Gmail access"
+
+A plain `add-account` run against a read-only account warns before requesting write access again. Re-run with `--readonly` to keep the narrower grant. Running `add-account --readonly` against an account that is already read-only does nothing and reuses the existing token.
+
+#### Narrowing on a headless server
+
+The revoke-and-re-add procedure above works unchanged. Step 3 prints an authorization URL you open from any browser, then waits for the callback on `localhost:8089` — reach it with `curl` on the host, or forward the port with `ssh -L 8089:localhost:8089 user@server`. See [Headless Server Issues](#headless-server-issues).
+
+#### Deletion on a read-only account
+
+Staged deletions need write access that a read-only account does not have, so `delete-staged` offers to re-authorize:
+
+- **Trash** (the default) needs `gmail.modify`, or the broader `https://mail.google.com/` if the account already holds it.
+- **Permanent** (`--permanent`) needs `https://mail.google.com/`; `gmail.modify` does not cover batch deletion.
+
+Declining the prompt leaves both the token and the staged batch untouched. Accepting it widens the grant, so an account you want to keep read-only should decline.
+
 ### General OAuth Issues
 
 1. Remove old tokens: `rm ~/.msgvault/tokens/you@gmail.com.json`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -45,6 +45,57 @@ Wrong application type. Ensure you selected **Desktop app** when creating OAuth 
 
 You created a "TVs and Limited Input devices" OAuth client, which doesn't work with Gmail. Google's device code flow does not support Gmail scopes. Create a new OAuth client with **Desktop app** type instead.
 
+### Read-only Gmail access
+
+By default `add-account` requests `gmail.readonly` and `gmail.modify`. Pass `--readonly` to request read access only:
+
+```bash
+msgvault add-account you@gmail.com --readonly
+```
+
+Sync, search, and the TUI all work on a read-only grant. Deletion does not — see below.
+
+Restricting scopes on the **Data Access** page in the Google Cloud Console will not do this for you. That page declares which scopes your app may ask for during verification review; it does not limit what the authorization server grants at request time. Nor can you decline a scope on the consent screen: msgvault rejects a token that comes back with fewer scopes than it asked for. Changing what the client requests is the only thing that works, which is what `--readonly` does.
+
+#### "already has Gmail write access"
+
+```
+you@gmail.com already has Gmail write access (https://www.googleapis.com/auth/gmail.modify)
+```
+
+`--readonly` cannot take away access an account already has. Re-authorizing does not revoke the previous grant — a refresh token issued beforehand keeps working with its original write scopes — and revoking applies to the whole grant, so revoking the old credential would invalidate the replacement too. There is no way to narrow in place, and `--force` is refused for the same reason.
+
+To make the account read-only, remove its access and grant it again:
+
+1. Revoke msgvault at [myaccount.google.com/permissions](https://myaccount.google.com/permissions)
+2. `rm ~/.msgvault/tokens/you@gmail.com.json`
+3. `msgvault add-account you@gmail.com --readonly`
+
+Revoking clears every other Google scope for the account, so re-run whichever commands granted them — `add-calendar` for Calendar, `add-synctech-sms-drive` for Drive. Archived mail is unaffected. Confirm the result by reading the token's `scopes` array rather than the permissions page, which reports what msgvault is authorized to request.
+
+The same refusal applies to an account holding the broad `https://mail.google.com/` scope, which msgvault grants when you escalate for permanent deletion.
+
+The refusal also fires when the token is stored under a Gmail alias spelling of the address you typed (dots, `+suffix`, `googlemail.com`) — Google treats those as the same account, so setting up a second spelling read-only would leave the stored spelling's access in place. The message names the stored spelling to use, or the full revoke-and-re-add procedure when both spellings hold tokens.
+
+`msgvault remove-account` revokes the account's Google grant (best-effort) before deleting its token file, so removing an account and re-adding it with `--readonly` yields a genuinely fresh, read-only grant.
+
+#### "currently has read-only Gmail access"
+
+A plain `add-account` run against a read-only account warns before requesting write access again. Re-run with `--readonly` to keep the narrower grant. Running `add-account --readonly` against an account that is already read-only does nothing and reuses the existing token.
+
+#### Narrowing on a headless server
+
+The revoke-and-re-add procedure above works unchanged. Step 3 prints an authorization URL you open from any browser, then waits for the callback on `localhost:8089` — reach it with `curl` on the host, or forward the port with `ssh -L 8089:localhost:8089 user@server`. See [Headless Server Issues](#headless-server-issues).
+
+#### Deletion on a read-only account
+
+Staged deletions need write access that a read-only account does not have, so `delete-staged` offers to re-authorize:
+
+- **Trash** (the default) needs `gmail.modify`, or the broader `https://mail.google.com/` if the account already holds it.
+- **Permanent** (`--permanent`) needs `https://mail.google.com/`; `gmail.modify` does not cover batch deletion.
+
+Declining the prompt leaves both the token and the staged batch untouched. Accepting it widens the grant, so an account you want to keep read-only should decline.
+
 ### General OAuth Issues
 
 1. Remove old tokens: `rm ~/.msgvault/tokens/you@gmail.com.json`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,6 +75,10 @@ Revoking clears every other Google scope for the account, so re-run whichever co
 
 The same refusal applies to an account holding the broad `https://mail.google.com/` scope, which msgvault grants when you escalate for permanent deletion.
 
+The refusal also fires when the token is stored under a Gmail alias spelling of the address you typed (dots, `+suffix`, `googlemail.com`) — Google treats those as the same account, so setting up a second spelling read-only would leave the stored spelling's access in place. The message names the stored spelling to use, or the full revoke-and-re-add procedure when both spellings hold tokens.
+
+`msgvault remove-account` revokes the account's Google grant (best-effort) before deleting its token file, so removing an account and re-adding it with `--readonly` yields a genuinely fresh, read-only grant.
+
 #### "currently has read-only Gmail access"
 
 A plain `add-account` run against a read-only account warns before requesting write access again. Re-run with `--readonly` to keep the narrower grant. Running `add-account --readonly` against an account that is already read-only does nothing and reuses the existing token.

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"go.kenn.io/msgvault/internal/accountops"
+	"go.kenn.io/msgvault/internal/apiprotocol"
 	"go.kenn.io/msgvault/internal/cacheops"
 	"go.kenn.io/msgvault/internal/clirun"
 	"go.kenn.io/msgvault/internal/collectionops"
@@ -491,9 +493,10 @@ type CLIRepairEncodingEvent struct {
 }
 
 type CLIRunRequest struct {
-	Args []string          `json:"args"`
-	Env  map[string]string `json:"env,omitempty"`
-	Cwd  string            `json:"cwd,omitempty"`
+	Args         []string          `json:"args"`
+	Env          map[string]string `json:"env,omitempty"`
+	Cwd          string            `json:"cwd,omitempty"`
+	GrantDecided bool              `json:"-"`
 }
 
 type CLIAddCalendarPlanRequest struct {
@@ -1232,6 +1235,18 @@ func (s *Server) handleCLIRun(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "command_not_allowed", "command is not allowed through the daemon CLI runner")
 		return
 	}
+	if cliRunArgsContainFlag(req.Args, "grant-decided") {
+		writeError(w, http.StatusBadRequest, "invalid_args", "--grant-decided is not accepted through the daemon CLI runner")
+		return
+	}
+	if proof := r.Header.Get(apiprotocol.DaemonRuntimeTokenHeader); proof != "" {
+		if req.Args[0] != "add-account" || s.shutdownToken == "" ||
+			subtle.ConstantTimeCompare([]byte(proof), []byte(s.shutdownToken)) != 1 {
+			writeError(w, http.StatusBadRequest, "invalid_grant_preflight", "grant preflight proof is invalid")
+			return
+		}
+		req.GrantDecided = true
+	}
 	for name := range req.Env {
 		if !s.cliRunEnvAllowed(name) {
 			writeError(w, http.StatusBadRequest, "env_not_allowed", fmt.Sprintf("env %q is not allowed through the daemon CLI runner", name))
@@ -1250,6 +1265,16 @@ func (s *Server) handleCLIRun(w http.ResponseWriter, r *http.Request) {
 	if err := writeEvent(CLIRunEvent{Type: cliStreamEventTypeComplete}); err != nil {
 		s.logger.Error("failed to stream CLI run completion event", "error", err)
 	}
+}
+
+func cliRunArgsContainFlag(args []string, name string) bool {
+	flag := "--" + name
+	for _, arg := range args {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) handleCLIAddCalendarPlan(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1076,6 +1076,84 @@ func TestHandleCLIRunStreamsGenericCommandOutput(t *testing.T) {
 	assert.Equal(CLIRunEvent{Type: cliStreamEventTypeComplete}, events[2], "complete event")
 }
 
+func TestHandleCLIRunProtectsAddAccountGrantDecision(t *testing.T) {
+	t.Run("caller supplied flag is rejected", func(t *testing.T) {
+		runs := 0
+		st := &mockStore{runFunc: func(
+			context.Context, CLIRunRequest, func(CLIRunEvent) error,
+		) error {
+			runs++
+			return nil
+		}}
+		srv := newCLIHandlerTestServer(st)
+
+		body := strings.NewReader(`{"args":["add-account","user@example.com","--readonly","--grant-decided"]}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/run", body)
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		srv.Router().ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "invalid_args")
+		assert.Zero(t, runs, "rejected flag must not reach the runner")
+	})
+
+	t.Run("daemon runtime proof records a server owned decision", func(t *testing.T) {
+		require := require.New(t)
+		var gotReq CLIRunRequest
+		st := &mockStore{runFunc: func(
+			_ context.Context, req CLIRunRequest, emit func(CLIRunEvent) error,
+		) error {
+			gotReq = req
+			return emit(CLIRunEvent{Type: cliStreamEventTypeComplete})
+		}}
+		srv := NewServerWithOptions(ServerOptions{
+			Config:        &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+			Store:         st,
+			Logger:        testLogger(),
+			ShutdownToken: "runtime-secret",
+		})
+
+		body := strings.NewReader(`{"args":["add-account","user@example.com","--readonly"]}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/run", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(apiprotocol.DaemonRuntimeTokenHeader, "runtime-secret")
+		resp := httptest.NewRecorder()
+		srv.Router().ServeHTTP(resp, req)
+
+		require.Equal(http.StatusOK, resp.Code, "body: %s", resp.Body.String())
+		assert.Equal(t, []string{"add-account", "user@example.com", "--readonly"}, gotReq.Args)
+		assert.True(t, gotReq.GrantDecided)
+	})
+
+	t.Run("invalid runtime proof is rejected", func(t *testing.T) {
+		runs := 0
+		st := &mockStore{runFunc: func(
+			context.Context, CLIRunRequest, func(CLIRunEvent) error,
+		) error {
+			runs++
+			return nil
+		}}
+		srv := NewServerWithOptions(ServerOptions{
+			Config:        &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+			Store:         st,
+			Logger:        testLogger(),
+			ShutdownToken: "runtime-secret",
+		})
+
+		body := strings.NewReader(`{"args":["add-account","user@example.com","--readonly"]}`)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/run", body)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(apiprotocol.DaemonRuntimeTokenHeader, "forged")
+		resp := httptest.NewRecorder()
+		srv.Router().ServeHTTP(resp, req)
+
+		assert.Equal(t, http.StatusBadRequest, resp.Code)
+		assert.Contains(t, resp.Body.String(), "invalid_grant_preflight")
+		assert.Zero(t, runs, "invalid proof must not reach the runner")
+	})
+}
+
 func TestHandleCLIRunAllowsLegacyBuildEmbeddingsCommand(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -407,7 +407,7 @@ const (
 	inProgressLogInterval  = 30 * time.Second
 	// DaemonShutdownTokenHeader is an HTTP header name, not a credential.
 	// #nosec G101
-	DaemonShutdownTokenHeader     = "X-Msgvault-Daemon-Token"
+	DaemonShutdownTokenHeader     = apiprotocol.DaemonRuntimeTokenHeader
 	DaemonIdentityChallengeHeader = "X-Msgvault-Daemon-Challenge"
 	DaemonIdentityProofHeader     = "X-Msgvault-Daemon-Proof"
 )

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1339,6 +1339,7 @@ func TestTimeoutMiddlewareMarkedRequestPreservesCallerCancellation(t *testing.T)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/cli/stats", nil).WithContext(ctx)
+	req.RemoteAddr = "127.0.0.1:4242"
 	req.Header.Set(apiprotocol.ClientClassHeader, apiprotocol.ClientClassCLI)
 	requestDone := make(chan struct{})
 	go func() {

--- a/internal/apiprotocol/client.go
+++ b/internal/apiprotocol/client.go
@@ -3,4 +3,7 @@ package apiprotocol
 const (
 	ClientClassHeader = "X-Msgvault-Client"
 	ClientClassCLI    = "cli"
+	// DaemonRuntimeTokenHeader is an HTTP header name, not a credential.
+	// #nosec G101
+	DaemonRuntimeTokenHeader = "X-Msgvault-Daemon-Token"
 )

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -58,9 +58,10 @@ type CLIVerifyRequest struct {
 }
 
 type CLIRunRequest struct {
-	Args []string          `json:"args"`
-	Env  map[string]string `json:"env,omitempty"`
-	Cwd  string            `json:"cwd,omitempty"`
+	Args         []string          `json:"args"`
+	Env          map[string]string `json:"env,omitempty"`
+	Cwd          string            `json:"cwd,omitempty"`
+	GrantDecided bool              `json:"-"`
 }
 
 type CLIAddCalendarPlanRequest struct {
@@ -521,6 +522,12 @@ func (c *Client) RunCLICommand(
 	req CLIRunRequest,
 	output func(stream, data string) error,
 ) error {
+	if req.GrantDecided {
+		if c.localDaemonToken == "" {
+			return errors.New("grant preflight proof is unavailable for this daemon")
+		}
+		ctx = context.WithValue(ctx, grantDecisionContextKey{}, true)
+	}
 	body := generated.RunCLIBody{Args: req.Args, Env: req.Env, Cwd: optionalString(req.Cwd)}
 	return c.runCLIStream(ctx, "/api/v1/cli/run", "run", &generated.RunCLIRequestOptions{Body: &body}, output)
 }

--- a/internal/daemonclient/client.go
+++ b/internal/daemonclient/client.go
@@ -31,24 +31,26 @@ const (
 
 // Config holds configuration for creating a daemon HTTP client.
 type Config struct {
-	URL           string
-	APIKey        string
-	AllowInsecure bool
-	Timeout       time.Duration
-	HTTPClient    *http.Client
-	Context       context.Context
-	RequestMode   RequestMode
+	URL              string
+	APIKey           string
+	LocalDaemonToken string
+	AllowInsecure    bool
+	Timeout          time.Duration
+	HTTPClient       *http.Client
+	Context          context.Context
+	RequestMode      RequestMode
 }
 
 // Client provides HTTP access to a local or configured remote msgvault daemon.
 type Client struct {
-	baseURL     string
-	apiKey      string
-	httpClient  *http.Client
-	typedClient *apiclient.Client
-	busyNotify  func(message string)
-	rootContext context.Context
-	requestMode RequestMode
+	baseURL          string
+	apiKey           string
+	httpClient       *http.Client
+	typedClient      *apiclient.Client
+	busyNotify       func(message string)
+	rootContext      context.Context
+	requestMode      RequestMode
+	localDaemonToken string
 }
 
 // SetBusyNotifier registers a callback invoked when the daemon reports that
@@ -136,11 +138,12 @@ func New(cfg Config) (*Client, error) {
 	httpClient.Timeout = timeout
 
 	c := &Client{
-		baseURL:     strings.TrimSuffix(cfg.URL, "/"),
-		apiKey:      cfg.APIKey,
-		httpClient:  httpClient,
-		rootContext: rootContext,
-		requestMode: cfg.RequestMode,
+		baseURL:          strings.TrimSuffix(cfg.URL, "/"),
+		apiKey:           cfg.APIKey,
+		httpClient:       httpClient,
+		rootContext:      rootContext,
+		requestMode:      cfg.RequestMode,
+		localDaemonToken: cfg.LocalDaemonToken,
 	}
 	if _, err := c.GeneratedClient(); err != nil {
 		return nil, err
@@ -187,7 +190,7 @@ func (c *Client) GeneratedClient() (*apiclient.Client, error) {
 			client:      c.httpClient,
 			rootContext: c.requestContext(),
 		}),
-		runtime.WithRequestEditorFn(requestEditor(c.apiKey, c.requestMode)),
+		runtime.WithRequestEditorFn(requestEditor(c.apiKey, c.requestMode, c.localDaemonToken)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create generated API client: %w", err)
@@ -332,13 +335,18 @@ func (b *cancelOnCloseBody) Close() error {
 	return err
 }
 
-func requestEditor(apiKey string, mode RequestMode) apiclient.RequestEditorFn {
+type grantDecisionContextKey struct{}
+
+func requestEditor(apiKey string, mode RequestMode, localDaemonToken string) apiclient.RequestEditorFn {
 	return func(ctx context.Context, req *http.Request) error {
 		if apiKey != "" {
 			req.Header.Set("X-Api-Key", apiKey)
 		}
 		if mode == RequestModeCLI {
 			req.Header.Set(apiprotocol.ClientClassHeader, apiprotocol.ClientClassCLI)
+		}
+		if decided, _ := ctx.Value(grantDecisionContextKey{}).(bool); decided {
+			req.Header.Set(apiprotocol.DaemonRuntimeTokenHeader, localDaemonToken)
 		}
 		req.Header.Set("Accept", "application/json")
 		daemonW3CPropagator.Inject(ctx, propagation.HeaderCarrier(req.Header))

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -307,6 +307,45 @@ func TestRunCLICommandStreamsOutput(t *testing.T) {
 	assert.Equal("warning\n", stderr.String(), "stderr")
 }
 
+func TestRunCLICommandGrantDecisionUsesLocalDaemonProof(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal("runtime-secret", r.Header.Get(apiprotocol.DaemonRuntimeTokenHeader))
+		var body map[string]any
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		assert.NotContains(body, "grant_decided", "the decision must not be caller-controlled JSON")
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	st, err := New(Config{
+		URL: srv.URL, AllowInsecure: true, HTTPClient: srv.Client(), LocalDaemonToken: "runtime-secret",
+	})
+	require.NoError(err)
+	require.NoError(st.RunCLICommand(context.Background(), CLIRunRequest{
+		Args: []string{"add-account", "user@example.com", "--readonly"}, GrantDecided: true,
+	}, nil))
+	assert.Equal(1, requests)
+}
+
+func TestRunCLICommandGrantDecisionRequiresLocalDaemonProof(t *testing.T) {
+	st, err := New(Config{URL: "http://127.0.0.1:1", AllowInsecure: true})
+	require.NoError(t, err)
+
+	err = st.RunCLICommand(context.Background(), CLIRunRequest{
+		Args: []string{"add-account", "user@example.com", "--readonly"}, GrantDecided: true,
+	}, nil)
+
+	require.EqualError(t, err, "grant preflight proof is unavailable for this daemon")
+}
+
 func TestPlanCLIAddCalendarUsesGeneratedClientAdapter(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -26,16 +26,170 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+// Gmail scope identifiers. Declared once so the scope *sets* below and every
+// "does this account have write access" check derive from the same strings.
+const (
+	// ScopeGmailReadonly grants read access to mail and settings.
+	ScopeGmailReadonly = "https://www.googleapis.com/auth/gmail.readonly"
+	// ScopeGmailModify grants read plus trash/untrash/label changes.
+	ScopeGmailModify = "https://www.googleapis.com/auth/gmail.modify"
+	// ScopeGmailFull is Gmail's broad full-access scope. It is required for
+	// batchDelete and, being a superset of modify, also permits trashing.
+	ScopeGmailFull = "https://mail.google.com/"
+
+	// ScopeGmailSend and the scopes below it are the remaining write-capable
+	// Gmail scopes. msgvault never requests any of them, but a token it is
+	// asked to reuse may carry them, and narrowing must not leave one behind.
+	ScopeGmailSend            = "https://www.googleapis.com/auth/gmail.send"
+	ScopeGmailCompose         = "https://www.googleapis.com/auth/gmail.compose"
+	ScopeGmailInsert          = "https://www.googleapis.com/auth/gmail.insert"
+	ScopeGmailLabels          = "https://www.googleapis.com/auth/gmail.labels"
+	ScopeGmailSettingsBasic   = "https://www.googleapis.com/auth/gmail.settings.basic"
+	ScopeGmailSettingsSharing = "https://www.googleapis.com/auth/gmail.settings.sharing"
+
+	// ScopeGmailMetadata is read-only: headers and labels without message
+	// bodies. Named so it is not mistaken for a write scope.
+	ScopeGmailMetadata = "https://www.googleapis.com/auth/gmail.metadata"
+)
+
 // Scopes for normal msgvault operations (sync, search, read).
 var Scopes = []string{
-	"https://www.googleapis.com/auth/gmail.readonly",
-	"https://www.googleapis.com/auth/gmail.modify",
+	ScopeGmailReadonly,
+	ScopeGmailModify,
 }
 
 // ScopesDeletion includes full access required for batchDelete API.
 // gmail.modify supports trash/untrash but NOT batchDelete.
 var ScopesDeletion = []string{
+	ScopeGmailFull,
+}
+
+// ScopesGmailReadonly is the Gmail scope set requested by
+// `add-account --readonly`: read access and nothing else.
+var ScopesGmailReadonly = []string{
+	ScopeGmailReadonly,
+}
+
+// ScopesGmailWrite is every Gmail scope that confers write access, meaning any
+// ability to alter the mailbox or act as the user: modify mail, send or insert
+// it, manage labels, or change settings.
+//
+// Any decision of the form "does this account currently have Gmail write
+// access" or "which scopes should be dropped when narrowing to read-only" MUST
+// consider this whole set. Checking gmail.modify alone silently mishandles an
+// account holding only the full-access scope, and checking only those two
+// silently mishandles one holding gmail.send.
+//
+// msgvault requests only readonly, modify, and full, so the rest appear only on
+// a token minted elsewhere for the same OAuth client. Narrowing still has to
+// strip them: a grant is read-only when nothing in it can write, not when the
+// scopes msgvault happens to request are absent.
+//
+// This list names the write scopes for documentation and for messages that
+// enumerate them. It is NOT what classification consults — that is
+// isGmailWriteScope, which allow-lists the read-only scopes so an unrecognised
+// Gmail scope fails closed rather than passing as read-only.
+var ScopesGmailWrite = []string{
+	ScopeGmailModify,
+	ScopeGmailFull,
+	ScopeGmailSend,
+	ScopeGmailCompose,
+	ScopeGmailInsert,
+	ScopeGmailLabels,
+	ScopeGmailSettingsBasic,
+	ScopeGmailSettingsSharing,
+}
+
+// gmailScopePrefixes match every scope Google issues for Gmail. A scope
+// carrying one of these is Gmail's; anything else belongs to another API.
+var gmailScopePrefixes = []string{
 	"https://mail.google.com/",
+	"https://www.googleapis.com/auth/gmail.",
+}
+
+// gmailReadOnlyScopes is the complete allow-list of Gmail scopes that cannot
+// modify the mailbox or act as the user.
+//
+// Classification is an allow-list on purpose. A deny-list of known write scopes
+// fails open: a Gmail scope nobody thought of reads as read-only, so a grant
+// that can send mail passes as narrow. Enumerating what is safe fails closed
+// instead — an unrecognised Gmail scope is treated as write access, which at
+// worst refuses a narrowing that would have been fine.
+var gmailReadOnlyScopes = []string{
+	ScopeGmailReadonly,
+	ScopeGmailMetadata,
+	"https://www.googleapis.com/auth/gmail.addons.current.message.readonly",
+	"https://www.googleapis.com/auth/gmail.addons.current.message.metadata",
+}
+
+// isGmailScope reports whether a scope belongs to the Gmail API.
+func isGmailScope(scope string) bool {
+	for _, prefix := range gmailScopePrefixes {
+		if strings.HasPrefix(scope, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGmailWriteScope reports whether a scope is a Gmail scope that is not on the
+// read-only allow-list. Unrecognised Gmail scopes count as write.
+func isGmailWriteScope(scope string) bool {
+	return isGmailScope(scope) && !slices.Contains(gmailReadOnlyScopes, scope)
+}
+
+// HasGmailWriteScope reports whether scopes contain any Gmail scope that
+// grants write access. See gmailReadOnlyScopes for why this is decided by an
+// allow-list rather than by membership of ScopesGmailWrite.
+func HasGmailWriteScope(scopes []string) bool {
+	return len(GrantedGmailWriteScopes(scopes)) > 0
+}
+
+// GrantedGmailWriteScopes returns the Gmail write scopes present in scopes,
+// so callers can name exactly what an account holds in operator-facing
+// messages rather than guessing.
+func GrantedGmailWriteScopes(scopes []string) []string {
+	var granted []string
+	for _, scope := range scopes {
+		if isGmailWriteScope(scope) {
+			granted = append(granted, scope)
+		}
+	}
+	return granted
+}
+
+// WithoutGmailWriteScopes returns scopes with every Gmail write scope removed
+// and everything else — Calendar, Drive, gmail.readonly — left in place and in
+// order. This is how narrowing preserves unrelated grants.
+func WithoutGmailWriteScopes(scopes []string) []string {
+	kept := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if isGmailWriteScope(scope) {
+			continue
+		}
+		kept = append(kept, scope)
+	}
+	return kept
+}
+
+// HasAnyGmailScope reports whether scopes contain any Gmail scope at all.
+// It distinguishes "this account holds a narrower Gmail grant" from "this
+// account has no Gmail grant yet", which read differently: the first is a
+// deliberate narrowing worth preserving, the second is a first-time
+// authorization where warning about widening would be noise.
+func HasAnyGmailScope(scopes []string) bool {
+	return slices.ContainsFunc(scopes, isGmailScope)
+}
+
+// IsNarrowedGmailGrant reports whether scopes describe a Gmail grant that has
+// deliberately been narrowed: Gmail access is present, but no write scope is.
+// Re-authorization paths use this to avoid silently restoring write access to
+// an account the operator narrowed on purpose.
+//
+// A grant with no Gmail scopes at all is not "narrowed" — it has simply never
+// had Gmail — so this returns false and such accounts widen as before.
+func IsNarrowedGmailGrant(scopes []string) bool {
+	return HasAnyGmailScope(scopes) && !HasGmailWriteScope(scopes)
 }
 
 // ScopeCalendarReadonly is the read-only Calendar scope: it covers both
@@ -169,7 +323,10 @@ func (m *Manager) ForceRefresh(ctx context.Context, email string) error {
 // Google's device flow does not support Gmail scopes, so users must authorize
 // on a machine with a browser and copy the token file.
 // tokensDir should be the configured tokens directory (e.g., cfg.TokensDir()).
-func PrintHeadlessInstructions(email, tokensDir, oauthApp string) {
+// readonly echoes --readonly back into the printed commands so the operator
+// authorizes on the browser machine with the same narrowed grant they asked
+// for here.
+func PrintHeadlessInstructions(email, tokensDir, oauthApp string, readonly bool) {
 	// Use same sanitization as tokenPath for consistency
 	tokenFile := sanitizeEmail(email) + ".json"
 	tokenPath := filepath.Join(tokensDir, tokenFile)
@@ -177,6 +334,9 @@ func PrintHeadlessInstructions(email, tokensDir, oauthApp string) {
 	addCmd := "    msgvault add-account " + email
 	if oauthApp != "" {
 		addCmd += " --oauth-app " + oauthApp
+	}
+	if readonly {
+		addCmd += " --readonly"
 	}
 
 	fmt.Println()
@@ -275,6 +435,12 @@ func sanitizeEmail(email string) string {
 // Handles embedded single quotes by ending the quoted string, adding an
 // escaped single quote, and starting a new quoted string: ' -> '\”.
 func shellQuote(s string) string {
+	return ShellQuote(s)
+}
+
+// ShellQuote returns a shell-safe single-quoted form of s, so a path printed
+// into a copy-pasteable command survives spaces and quotes.
+func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
@@ -319,7 +485,22 @@ func (m *Manager) withScopes(scopes []string) *Manager {
 	return &scoped
 }
 
+// scopesWithPreservedGrants unions the scopes a caller requires with the ones
+// the account already holds, because Google's forced re-consent REPLACES the
+// granted set rather than adding to it.
+//
+// The union is asymmetric in one direction: if the existing grant is a
+// deliberately narrowed Gmail grant (read access, no write scope), the Gmail
+// write scopes are dropped from the required set rather than being restored.
+// Callers here reach this path on incidental re-authorization — a token
+// expired, or Calendar is being added — where quietly handing back write
+// access the operator removed would defeat `add-account --readonly`. Paths
+// that mean to escalate build their scope list explicitly and call Authorize
+// directly, so they are unaffected.
 func scopesWithPreservedGrants(required, granted []string) []string {
+	if IsNarrowedGmailGrant(granted) {
+		required = WithoutGmailWriteScopes(required)
+	}
 	scopes := append([]string(nil), required...)
 	for _, scope := range granted {
 		if !slices.Contains(scopes, scope) {
@@ -499,7 +680,7 @@ func tokenProfileEndpointForScopes(scopes []string) tokenProfileEndpoint {
 }
 
 func hasGmailProfileScope(scopes []string) bool {
-	if slices.Contains(scopes, "https://mail.google.com/") {
+	if slices.Contains(scopes, ScopeGmailFull) {
 		return true
 	}
 	for _, scope := range Scopes {
@@ -663,6 +844,22 @@ func (m *Manager) TokenMatchesClient(email string) bool {
 		return false // legacy token without client_id metadata
 	}
 	return tf.ClientID == m.config.ClientID
+}
+
+// TokenIssuedByDifferentClient reports whether the stored token is known to
+// have come from a different OAuth client than this manager's.
+//
+// It differs from !TokenMatchesClient in what it does with uncertainty. That
+// helper answers "can this token be trusted for this client", so an unreadable
+// token or one with no recorded client_id is a no. Callers asking the opposite
+// question — "is this definitely a different client" — must not read those same
+// cases as a yes, or an unknown provenance becomes a positive claim about it.
+func (m *Manager) TokenIssuedByDifferentClient(email string) bool {
+	tf, err := m.loadTokenFile(email)
+	if err != nil || tf.ClientID == "" {
+		return false // provenance unknown; do not claim it differs
+	}
+	return tf.ClientID != m.config.ClientID
 }
 
 // HasScopeMetadata returns true if the token file for this account has any

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -26,16 +26,170 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+// Gmail scope identifiers. Declared once so the scope *sets* below and every
+// "does this account have write access" check derive from the same strings.
+const (
+	// ScopeGmailReadonly grants read access to mail and settings.
+	ScopeGmailReadonly = "https://www.googleapis.com/auth/gmail.readonly"
+	// ScopeGmailModify grants read plus trash/untrash/label changes.
+	ScopeGmailModify = "https://www.googleapis.com/auth/gmail.modify"
+	// ScopeGmailFull is Gmail's broad full-access scope. It is required for
+	// batchDelete and, being a superset of modify, also permits trashing.
+	ScopeGmailFull = "https://mail.google.com/"
+
+	// ScopeGmailSend and the scopes below it are the remaining write-capable
+	// Gmail scopes. msgvault never requests any of them, but a token it is
+	// asked to reuse may carry them, and narrowing must not leave one behind.
+	ScopeGmailSend            = "https://www.googleapis.com/auth/gmail.send"
+	ScopeGmailCompose         = "https://www.googleapis.com/auth/gmail.compose"
+	ScopeGmailInsert          = "https://www.googleapis.com/auth/gmail.insert"
+	ScopeGmailLabels          = "https://www.googleapis.com/auth/gmail.labels"
+	ScopeGmailSettingsBasic   = "https://www.googleapis.com/auth/gmail.settings.basic"
+	ScopeGmailSettingsSharing = "https://www.googleapis.com/auth/gmail.settings.sharing"
+
+	// ScopeGmailMetadata is read-only: headers and labels without message
+	// bodies. Named so it is not mistaken for a write scope.
+	ScopeGmailMetadata = "https://www.googleapis.com/auth/gmail.metadata"
+)
+
 // Scopes for normal msgvault operations (sync, search, read).
 var Scopes = []string{
-	"https://www.googleapis.com/auth/gmail.readonly",
-	"https://www.googleapis.com/auth/gmail.modify",
+	ScopeGmailReadonly,
+	ScopeGmailModify,
 }
 
 // ScopesDeletion includes full access required for batchDelete API.
 // gmail.modify supports trash/untrash but NOT batchDelete.
 var ScopesDeletion = []string{
+	ScopeGmailFull,
+}
+
+// ScopesGmailReadonly is the Gmail scope set requested by
+// `add-account --readonly`: read access and nothing else.
+var ScopesGmailReadonly = []string{
+	ScopeGmailReadonly,
+}
+
+// ScopesGmailWrite is every Gmail scope that confers write access, meaning any
+// ability to alter the mailbox or act as the user: modify mail, send or insert
+// it, manage labels, or change settings.
+//
+// Any decision of the form "does this account currently have Gmail write
+// access" or "which scopes should be dropped when narrowing to read-only" MUST
+// consider this whole set. Checking gmail.modify alone silently mishandles an
+// account holding only the full-access scope, and checking only those two
+// silently mishandles one holding gmail.send.
+//
+// msgvault requests only readonly, modify, and full, so the rest appear only on
+// a token minted elsewhere for the same OAuth client. Narrowing still has to
+// strip them: a grant is read-only when nothing in it can write, not when the
+// scopes msgvault happens to request are absent.
+//
+// This list names the write scopes for documentation and for messages that
+// enumerate them. It is NOT what classification consults — that is
+// isGmailWriteScope, which allow-lists the read-only scopes so an unrecognised
+// Gmail scope fails closed rather than passing as read-only.
+var ScopesGmailWrite = []string{
+	ScopeGmailModify,
+	ScopeGmailFull,
+	ScopeGmailSend,
+	ScopeGmailCompose,
+	ScopeGmailInsert,
+	ScopeGmailLabels,
+	ScopeGmailSettingsBasic,
+	ScopeGmailSettingsSharing,
+}
+
+// gmailScopePrefixes match every scope Google issues for Gmail. A scope
+// carrying one of these is Gmail's; anything else belongs to another API.
+var gmailScopePrefixes = []string{
 	"https://mail.google.com/",
+	"https://www.googleapis.com/auth/gmail.",
+}
+
+// gmailReadOnlyScopes is the complete allow-list of Gmail scopes that cannot
+// modify the mailbox or act as the user.
+//
+// Classification is an allow-list on purpose. A deny-list of known write scopes
+// fails open: a Gmail scope nobody thought of reads as read-only, so a grant
+// that can send mail passes as narrow. Enumerating what is safe fails closed
+// instead — an unrecognised Gmail scope is treated as write access, which at
+// worst refuses a narrowing that would have been fine.
+var gmailReadOnlyScopes = []string{
+	ScopeGmailReadonly,
+	ScopeGmailMetadata,
+	"https://www.googleapis.com/auth/gmail.addons.current.message.readonly",
+	"https://www.googleapis.com/auth/gmail.addons.current.message.metadata",
+}
+
+// isGmailScope reports whether a scope belongs to the Gmail API.
+func isGmailScope(scope string) bool {
+	for _, prefix := range gmailScopePrefixes {
+		if strings.HasPrefix(scope, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isGmailWriteScope reports whether a scope is a Gmail scope that is not on the
+// read-only allow-list. Unrecognised Gmail scopes count as write.
+func isGmailWriteScope(scope string) bool {
+	return isGmailScope(scope) && !slices.Contains(gmailReadOnlyScopes, scope)
+}
+
+// HasGmailWriteScope reports whether scopes contain any Gmail scope that
+// grants write access. See gmailReadOnlyScopes for why this is decided by an
+// allow-list rather than by membership of ScopesGmailWrite.
+func HasGmailWriteScope(scopes []string) bool {
+	return len(GrantedGmailWriteScopes(scopes)) > 0
+}
+
+// GrantedGmailWriteScopes returns the Gmail write scopes present in scopes,
+// so callers can name exactly what an account holds in operator-facing
+// messages rather than guessing.
+func GrantedGmailWriteScopes(scopes []string) []string {
+	var granted []string
+	for _, scope := range scopes {
+		if isGmailWriteScope(scope) {
+			granted = append(granted, scope)
+		}
+	}
+	return granted
+}
+
+// WithoutGmailWriteScopes returns scopes with every Gmail write scope removed
+// and everything else — Calendar, Drive, gmail.readonly — left in place and in
+// order. This is how narrowing preserves unrelated grants.
+func WithoutGmailWriteScopes(scopes []string) []string {
+	kept := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		if isGmailWriteScope(scope) {
+			continue
+		}
+		kept = append(kept, scope)
+	}
+	return kept
+}
+
+// HasAnyGmailScope reports whether scopes contain any Gmail scope at all.
+// It distinguishes "this account holds a narrower Gmail grant" from "this
+// account has no Gmail grant yet", which read differently: the first is a
+// deliberate narrowing worth preserving, the second is a first-time
+// authorization where warning about widening would be noise.
+func HasAnyGmailScope(scopes []string) bool {
+	return slices.ContainsFunc(scopes, isGmailScope)
+}
+
+// IsNarrowedGmailGrant reports whether scopes describe a Gmail grant that has
+// deliberately been narrowed: Gmail access is present, but no write scope is.
+// Re-authorization paths use this to avoid silently restoring write access to
+// an account the operator narrowed on purpose.
+//
+// A grant with no Gmail scopes at all is not "narrowed" — it has simply never
+// had Gmail — so this returns false and such accounts widen as before.
+func IsNarrowedGmailGrant(scopes []string) bool {
+	return HasAnyGmailScope(scopes) && !HasGmailWriteScope(scopes)
 }
 
 // ScopeCalendarReadonly is the read-only Calendar scope: it covers both
@@ -80,6 +234,7 @@ type Manager struct {
 	tokensDir  string
 	logger     *slog.Logger
 	profileURL string // profile endpoint override for tests
+	revokeURL  string // revocation endpoint override for tests
 
 	// browserFlowFn overrides browserFlow in tests to avoid starting
 	// a real HTTP server and browser. When nil, the real browserFlow
@@ -169,7 +324,10 @@ func (m *Manager) ForceRefresh(ctx context.Context, email string) error {
 // Google's device flow does not support Gmail scopes, so users must authorize
 // on a machine with a browser and copy the token file.
 // tokensDir should be the configured tokens directory (e.g., cfg.TokensDir()).
-func PrintHeadlessInstructions(email, tokensDir, oauthApp string) {
+// readonly echoes --readonly back into the printed commands so the operator
+// authorizes on the browser machine with the same narrowed grant they asked
+// for here.
+func PrintHeadlessInstructions(email, tokensDir, oauthApp string, readonly bool) {
 	// Use same sanitization as tokenPath for consistency
 	tokenFile := sanitizeEmail(email) + ".json"
 	tokenPath := filepath.Join(tokensDir, tokenFile)
@@ -177,6 +335,9 @@ func PrintHeadlessInstructions(email, tokensDir, oauthApp string) {
 	addCmd := "    msgvault add-account " + email
 	if oauthApp != "" {
 		addCmd += " --oauth-app " + oauthApp
+	}
+	if readonly {
+		addCmd += " --readonly"
 	}
 
 	fmt.Println()
@@ -275,6 +436,12 @@ func sanitizeEmail(email string) string {
 // Handles embedded single quotes by ending the quoted string, adding an
 // escaped single quote, and starting a new quoted string: ' -> '\”.
 func shellQuote(s string) string {
+	return ShellQuote(s)
+}
+
+// ShellQuote returns a shell-safe single-quoted form of s, so a path printed
+// into a copy-pasteable command survives spaces and quotes.
+func ShellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
@@ -319,7 +486,22 @@ func (m *Manager) withScopes(scopes []string) *Manager {
 	return &scoped
 }
 
+// scopesWithPreservedGrants unions the scopes a caller requires with the ones
+// the account already holds, because Google's forced re-consent REPLACES the
+// granted set rather than adding to it.
+//
+// The union is asymmetric in one direction: if the existing grant is a
+// deliberately narrowed Gmail grant (read access, no write scope), the Gmail
+// write scopes are dropped from the required set rather than being restored.
+// Callers here reach this path on incidental re-authorization — a token
+// expired, or Calendar is being added — where quietly handing back write
+// access the operator removed would defeat `add-account --readonly`. Paths
+// that mean to escalate build their scope list explicitly and call Authorize
+// directly, so they are unaffected.
 func scopesWithPreservedGrants(required, granted []string) []string {
+	if IsNarrowedGmailGrant(granted) {
+		required = WithoutGmailWriteScopes(required)
+	}
 	scopes := append([]string(nil), required...)
 	for _, scope := range granted {
 		if !slices.Contains(scopes, scope) {
@@ -499,7 +681,7 @@ func tokenProfileEndpointForScopes(scopes []string) tokenProfileEndpoint {
 }
 
 func hasGmailProfileScope(scopes []string) bool {
-	if slices.Contains(scopes, "https://mail.google.com/") {
+	if slices.Contains(scopes, ScopeGmailFull) {
 		return true
 	}
 	for _, scope := range Scopes {
@@ -663,6 +845,22 @@ func (m *Manager) TokenMatchesClient(email string) bool {
 		return false // legacy token without client_id metadata
 	}
 	return tf.ClientID == m.config.ClientID
+}
+
+// TokenIssuedByDifferentClient reports whether the stored token is known to
+// have come from a different OAuth client than this manager's.
+//
+// It differs from !TokenMatchesClient in what it does with uncertainty. That
+// helper answers "can this token be trusted for this client", so an unreadable
+// token or one with no recorded client_id is a no. Callers asking the opposite
+// question — "is this definitely a different client" — must not read those same
+// cases as a yes, or an unknown provenance becomes a positive claim about it.
+func (m *Manager) TokenIssuedByDifferentClient(email string) bool {
+	tf, err := m.loadTokenFile(email)
+	if err != nil || tf.ClientID == "" {
+		return false // provenance unknown; do not claim it differs
+	}
+	return tf.ClientID != m.config.ClientID
 }
 
 // HasScopeMetadata returns true if the token file for this account has any
@@ -1018,6 +1216,122 @@ func fetchTokenProfileEmailFromEndpoint(
 func ValidateTokenEmail(ctx context.Context, ts oauth2.TokenSource, email string) error {
 	_, err := fetchTokenProfileEmail(ctx, ts, defaultProfileURL, email, tokenProfileErrorServiceAccount)
 	return err
+}
+
+// revokeTimeout bounds the revocation request; revocation is a single POST
+// and should not hang a CLI command on a stalled connection.
+const revokeTimeout = 15 * time.Second
+
+const defaultRevokeURL = "https://oauth2.googleapis.com/revoke"
+
+// ErrRevokeCredentialInvalid reports that the revocation endpoint rejected
+// the stored credential as already expired or revoked. Callers treating
+// revocation as cleanup (account removal) can read it as nothing-to-do.
+var ErrRevokeCredentialInvalid = errors.New("stored credential is already expired or revoked")
+
+// RevokeToken revokes the stored grant at Google's revocation endpoint.
+// Revoking the refresh token invalidates the grant server-side, so copies of
+// the token file (backups, other hosts, previously exposed credentials) lose
+// access too — deleting the local file alone would not achieve that.
+func (m *Manager) RevokeToken(ctx context.Context, email string) error {
+	tf, err := m.loadTokenFile(email)
+	if err != nil {
+		return fmt.Errorf("load token for %s: %w", email, err)
+	}
+	credential := tf.RefreshToken
+	if credential == "" {
+		credential = tf.AccessToken
+	}
+	if credential == "" {
+		return fmt.Errorf("token for %s holds no credential to revoke", email)
+	}
+
+	endpoint := m.revokeURL
+	if endpoint == "" {
+		endpoint = defaultRevokeURL
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, revokeTimeout)
+	defer cancel()
+	form := url.Values{"token": {credential}}
+	req, err := http.NewRequestWithContext(
+		reqCtx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("create revocation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("revoke token for %s: %w", email, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusBadRequest {
+		var apiErr struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error == "invalid_token" {
+			return fmt.Errorf("revoke token for %s: %w", email, ErrRevokeCredentialInvalid)
+		}
+	}
+	return fmt.Errorf(
+		"revoke token for %s: revocation endpoint returned HTTP %d: %s",
+		email, resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+// RevokeStoredCredential revokes the credential stored for email in
+// tokensDir at Google's revocation endpoint. Revocation needs no OAuth
+// client configuration — the endpoint takes only the token — so account
+// removal can retire the grant before deleting the file even when no
+// client secrets are configured. Behavior matches Manager.RevokeToken.
+func RevokeStoredCredential(ctx context.Context, tokensDir, email string) error {
+	m := &Manager{tokensDir: tokensDir, logger: slog.Default(), config: &oauth2.Config{}}
+	return m.RevokeToken(ctx, email)
+}
+
+// FindEquivalentTokenEmails returns every stored spelling other than email
+// itself that refers to the same Google account under Gmail's alias rules —
+// case, dots, plus-addresses, googlemail.com.
+//
+// Read-only decisions use this to fail closed: authorization accepts alias
+// variants (sameGoogleAccount), so without this check a --readonly run
+// through an alias spelling would read as a fresh account while an
+// equivalent stored spelling kept an unnarrowed, possibly write-capable
+// credential.
+//
+// A candidate that is the account's own file does not count. On
+// case-insensitive filesystems a case-variant filename resolves to the same
+// file as the exact spelling, so candidates are also compared by identity
+// (os.SameFile), not just by name.
+func (m *Manager) FindEquivalentTokenEmails(email string) []string {
+	entries, err := os.ReadDir(m.tokensDir)
+	if err != nil {
+		return nil
+	}
+	own := sanitizeEmail(email) + ".json"
+	ownInfo, ownErr := os.Stat(filepath.Join(m.tokensDir, own))
+	var equivalents []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".json") || name == own {
+			continue
+		}
+		if ownErr == nil {
+			if info, infoErr := entry.Info(); infoErr == nil && os.SameFile(ownInfo, info) {
+				continue
+			}
+		}
+		stored := strings.TrimSuffix(name, ".json")
+		if sameGoogleAccount(email, stored) {
+			equivalents = append(equivalents, stored)
+		}
+	}
+	return equivalents
 }
 
 // DeleteToken removes the token file for the given email.

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1309,12 +1309,26 @@ func RevokeStoredCredential(ctx context.Context, tokensDir, email string) error 
 // file as the exact spelling, so candidates are also compared by identity
 // (os.SameFile), not just by name.
 func (m *Manager) FindEquivalentTokenEmails(email string) []string {
-	entries, err := os.ReadDir(m.tokensDir)
+	return findEquivalentTokenEmails(m.tokensDir, email)
+}
+
+// StoredTokenOrEquivalentExists reports whether the exact address or a Gmail
+// alias spelling has a token file. It does not require OAuth client credentials.
+func StoredTokenOrEquivalentExists(tokensDir, email string) bool {
+	_, err := os.Lstat(TokenFilePath(tokensDir, email))
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return len(findEquivalentTokenEmails(tokensDir, email)) > 0
+}
+
+func findEquivalentTokenEmails(tokensDir, email string) []string {
+	entries, err := os.ReadDir(tokensDir)
 	if err != nil {
 		return nil
 	}
 	own := sanitizeEmail(email) + ".json"
-	ownInfo, ownErr := os.Stat(filepath.Join(m.tokensDir, own))
+	ownInfo, ownErr := os.Stat(filepath.Join(tokensDir, own))
 	var equivalents []string
 	for _, entry := range entries {
 		name := entry.Name()

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -331,6 +331,8 @@ func PrintHeadlessInstructions(email, tokensDir, oauthApp string, readonly bool)
 	// Use same sanitization as tokenPath for consistency
 	tokenFile := sanitizeEmail(email) + ".json"
 	tokenPath := filepath.Join(tokensDir, tokenFile)
+	_, tokenErr := os.Stat(tokenPath)
+	hasToken := tokenErr == nil
 
 	addCmd := "    msgvault add-account " + email
 	if oauthApp != "" {
@@ -347,16 +349,31 @@ func PrintHeadlessInstructions(email, tokensDir, oauthApp string, readonly bool)
 	fmt.Println("cannot directly authorize. Instead, authorize on a machine with a browser")
 	fmt.Println("and copy the token to your server.")
 	fmt.Println()
-	fmt.Println("Step 1: On a machine with a browser, run:")
+	step := 1
+	if hasToken {
+		fmt.Printf("Step %d: Copy the existing token from the headless server to the browser machine:\n", step)
+		fmt.Println()
+		fmt.Printf("    mkdir -p %s\n", shellQuote(tokensDir))
+		fmt.Printf("    scp user@server:%s %s\n", shellQuote(tokenPath), shellQuote(tokenPath))
+		fmt.Println()
+		step++
+	}
+	fmt.Printf("Step %d: On a machine with a browser, run:\n", step)
 	fmt.Println()
-	fmt.Println(addCmd)
+	if hasToken {
+		fmt.Println(addCmd + " --force")
+	} else {
+		fmt.Println(addCmd)
+	}
 	fmt.Println()
-	fmt.Println("Step 2: Copy the token file to your headless server:")
+	step++
+	fmt.Printf("Step %d: Copy the token file to your headless server:\n", step)
 	fmt.Println()
 	fmt.Printf("    ssh user@server mkdir -p %s\n", shellQuote(tokensDir))
 	fmt.Printf("    scp %s user@server:%s\n", shellQuote(tokenPath), shellQuote(tokenPath))
 	fmt.Println()
-	fmt.Println("Step 3: On the headless server, register the account:")
+	step++
+	fmt.Printf("Step %d: On the headless server, register the account:\n", step)
 	fmt.Println()
 	fmt.Println(addCmd)
 	fmt.Println()

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1322,6 +1322,30 @@ func StoredTokenOrEquivalentExists(tokensDir, email string) bool {
 	return len(findEquivalentTokenEmails(tokensDir, email)) > 0
 }
 
+// EquivalentStoredGrantInUse reports whether a remaining Gmail source has an
+// equivalent token issued by the same OAuth client. Unknown legacy client
+// provenance is treated conservatively as shared.
+func EquivalentStoredGrantInUse(tokensDir, email string, remainingEmails []string) bool {
+	m := &Manager{tokensDir: tokensDir}
+	removed, err := m.loadTokenFile(email)
+	if err != nil {
+		return false
+	}
+	for _, remainingEmail := range remainingEmails {
+		if !sameGoogleAccount(email, remainingEmail) {
+			continue
+		}
+		remaining, err := m.loadTokenFile(remainingEmail)
+		if err != nil {
+			continue
+		}
+		if removed.ClientID == "" || remaining.ClientID == "" || removed.ClientID == remaining.ClientID {
+			return true
+		}
+	}
+	return false
+}
+
 func findEquivalentTokenEmails(tokensDir, email string) []string {
 	entries, err := os.ReadDir(tokensDir)
 	if err != nil {

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -234,6 +234,7 @@ type Manager struct {
 	tokensDir  string
 	logger     *slog.Logger
 	profileURL string // profile endpoint override for tests
+	revokeURL  string // revocation endpoint override for tests
 
 	// browserFlowFn overrides browserFlow in tests to avoid starting
 	// a real HTTP server and browser. When nil, the real browserFlow
@@ -1215,6 +1216,122 @@ func fetchTokenProfileEmailFromEndpoint(
 func ValidateTokenEmail(ctx context.Context, ts oauth2.TokenSource, email string) error {
 	_, err := fetchTokenProfileEmail(ctx, ts, defaultProfileURL, email, tokenProfileErrorServiceAccount)
 	return err
+}
+
+// revokeTimeout bounds the revocation request; revocation is a single POST
+// and should not hang a CLI command on a stalled connection.
+const revokeTimeout = 15 * time.Second
+
+const defaultRevokeURL = "https://oauth2.googleapis.com/revoke"
+
+// ErrRevokeCredentialInvalid reports that the revocation endpoint rejected
+// the stored credential as already expired or revoked. Callers treating
+// revocation as cleanup (account removal) can read it as nothing-to-do.
+var ErrRevokeCredentialInvalid = errors.New("stored credential is already expired or revoked")
+
+// RevokeToken revokes the stored grant at Google's revocation endpoint.
+// Revoking the refresh token invalidates the grant server-side, so copies of
+// the token file (backups, other hosts, previously exposed credentials) lose
+// access too — deleting the local file alone would not achieve that.
+func (m *Manager) RevokeToken(ctx context.Context, email string) error {
+	tf, err := m.loadTokenFile(email)
+	if err != nil {
+		return fmt.Errorf("load token for %s: %w", email, err)
+	}
+	credential := tf.RefreshToken
+	if credential == "" {
+		credential = tf.AccessToken
+	}
+	if credential == "" {
+		return fmt.Errorf("token for %s holds no credential to revoke", email)
+	}
+
+	endpoint := m.revokeURL
+	if endpoint == "" {
+		endpoint = defaultRevokeURL
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, revokeTimeout)
+	defer cancel()
+	form := url.Values{"token": {credential}}
+	req, err := http.NewRequestWithContext(
+		reqCtx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("create revocation request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("revoke token for %s: %w", email, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusBadRequest {
+		var apiErr struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error == "invalid_token" {
+			return fmt.Errorf("revoke token for %s: %w", email, ErrRevokeCredentialInvalid)
+		}
+	}
+	return fmt.Errorf(
+		"revoke token for %s: revocation endpoint returned HTTP %d: %s",
+		email, resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+// RevokeStoredCredential revokes the credential stored for email in
+// tokensDir at Google's revocation endpoint. Revocation needs no OAuth
+// client configuration — the endpoint takes only the token — so account
+// removal can retire the grant before deleting the file even when no
+// client secrets are configured. Behavior matches Manager.RevokeToken.
+func RevokeStoredCredential(ctx context.Context, tokensDir, email string) error {
+	m := &Manager{tokensDir: tokensDir, logger: slog.Default(), config: &oauth2.Config{}}
+	return m.RevokeToken(ctx, email)
+}
+
+// FindEquivalentTokenEmails returns every stored spelling other than email
+// itself that refers to the same Google account under Gmail's alias rules —
+// case, dots, plus-addresses, googlemail.com.
+//
+// Read-only decisions use this to fail closed: authorization accepts alias
+// variants (sameGoogleAccount), so without this check a --readonly run
+// through an alias spelling would read as a fresh account while an
+// equivalent stored spelling kept an unnarrowed, possibly write-capable
+// credential.
+//
+// A candidate that is the account's own file does not count. On
+// case-insensitive filesystems a case-variant filename resolves to the same
+// file as the exact spelling, so candidates are also compared by identity
+// (os.SameFile), not just by name.
+func (m *Manager) FindEquivalentTokenEmails(email string) []string {
+	entries, err := os.ReadDir(m.tokensDir)
+	if err != nil {
+		return nil
+	}
+	own := sanitizeEmail(email) + ".json"
+	ownInfo, ownErr := os.Stat(filepath.Join(m.tokensDir, own))
+	var equivalents []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".json") || name == own {
+			continue
+		}
+		if ownErr == nil {
+			if info, infoErr := entry.Info(); infoErr == nil && os.SameFile(ownInfo, info) {
+				continue
+			}
+		}
+		stored := strings.TrimSuffix(name, ".json")
+		if sameGoogleAccount(email, stored) {
+			equivalents = append(equivalents, stored)
+		}
+	}
+	return equivalents
 }
 
 // DeleteToken removes the token file for the given email.

--- a/internal/oauth/readonly_scopes_test.go
+++ b/internal/oauth/readonly_scopes_test.go
@@ -1,0 +1,358 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const driveReadonlyScope = "https://www.googleapis.com/auth/drive.readonly"
+
+func TestGmailWriteScopeHelpers(t *testing.T) {
+	tests := []struct {
+		name           string
+		scopes         []string
+		wantWrite      bool
+		wantAnyGmail   bool
+		wantNarrowed   bool
+		wantWithoutSet []string
+	}{
+		{
+			name:           "empty grant",
+			scopes:         nil,
+			wantWithoutSet: []string{},
+		},
+		{
+			name:           "read-only gmail is a narrowed grant",
+			scopes:         []string{ScopeGmailReadonly},
+			wantAnyGmail:   true,
+			wantNarrowed:   true,
+			wantWithoutSet: []string{ScopeGmailReadonly},
+		},
+		{
+			name:           "modify is write access",
+			scopes:         Scopes,
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{ScopeGmailReadonly},
+		},
+		{
+			// The scope a check written against gmail.modify alone misses.
+			name:           "full access is write access",
+			scopes:         []string{ScopeGmailFull},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{},
+		},
+		{
+			name:           "non-gmail grants are not a narrowed gmail grant",
+			scopes:         []string{ScopeCalendarReadonly, driveReadonlyScope},
+			wantWithoutSet: []string{ScopeCalendarReadonly, driveReadonlyScope},
+		},
+		{
+			name:           "narrowing keeps non-gmail grants in order",
+			scopes:         []string{ScopeCalendarReadonly, ScopeGmailModify, driveReadonlyScope, ScopeGmailFull},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{ScopeCalendarReadonly, driveReadonlyScope},
+		},
+		{
+			// msgvault never requests gmail.send, but a token it is asked to
+			// reuse may carry it, and it confers the ability to act as the
+			// user. A set that stopped at modify and full would call this
+			// grant read-only.
+			name:           "send is write access",
+			scopes:         []string{ScopeGmailReadonly, ScopeGmailSend},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{ScopeGmailReadonly},
+		},
+		{
+			name: "every unrequested write scope is stripped",
+			scopes: []string{
+				ScopeGmailReadonly,
+				ScopeGmailCompose,
+				ScopeGmailInsert,
+				ScopeGmailLabels,
+				ScopeGmailSettingsBasic,
+				ScopeGmailSettingsSharing,
+				ScopeCalendarReadonly,
+			},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{ScopeGmailReadonly, ScopeCalendarReadonly},
+		},
+		{
+			// gmail.metadata reads headers and labels without bodies. It is
+			// read-only and must survive narrowing.
+			name:           "metadata is a narrowed gmail grant",
+			scopes:         []string{ScopeGmailMetadata},
+			wantAnyGmail:   true,
+			wantNarrowed:   true,
+			wantWithoutSet: []string{ScopeGmailMetadata},
+		},
+		{
+			// The reason classification allow-lists the read scopes rather
+			// than deny-listing the write ones. This scope is not in
+			// ScopesGmailWrite and nothing in the repo mentions it, yet it
+			// can send mail as the user. A deny-list would call this grant
+			// read-only; an allow-list calls it write.
+			name:           "an unlisted gmail scope counts as write",
+			scopes:         []string{ScopeGmailReadonly, "https://www.googleapis.com/auth/gmail.addons.current.action.compose"},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{ScopeGmailReadonly},
+		},
+		{
+			// Add-on read scopes are genuinely read-only and must survive.
+			name:           "add-on read scopes are not write",
+			scopes:         []string{"https://www.googleapis.com/auth/gmail.addons.current.message.readonly"},
+			wantAnyGmail:   true,
+			wantNarrowed:   true,
+			wantWithoutSet: []string{"https://www.googleapis.com/auth/gmail.addons.current.message.readonly"},
+		},
+		{
+			// A future Gmail scope nobody has heard of. Fails closed.
+			name:           "an entirely unknown gmail scope counts as write",
+			scopes:         []string{"https://www.googleapis.com/auth/gmail.somethingnew"},
+			wantWrite:      true,
+			wantAnyGmail:   true,
+			wantWithoutSet: []string{},
+		},
+		{
+			// Non-Gmail scopes must not be swept up by the prefix match.
+			name:           "non-gmail scopes are never gmail write",
+			scopes:         []string{ScopeCalendarReadonly, driveReadonlyScope, "https://www.googleapis.com/auth/gmailish.fake"},
+			wantWithoutSet: []string{ScopeCalendarReadonly, driveReadonlyScope, "https://www.googleapis.com/auth/gmailish.fake"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tt.wantWrite, HasGmailWriteScope(tt.scopes), "HasGmailWriteScope")
+			assert.Equal(tt.wantAnyGmail, HasAnyGmailScope(tt.scopes), "HasAnyGmailScope")
+			assert.Equal(tt.wantNarrowed, IsNarrowedGmailGrant(tt.scopes), "IsNarrowedGmailGrant")
+			assert.Equal(tt.wantWithoutSet, WithoutGmailWriteScopes(tt.scopes), "WithoutGmailWriteScopes")
+		})
+	}
+}
+
+// TestTokenIssuedByDifferentClient pins the asymmetry with TokenMatchesClient.
+// Callers waive the read-only refusal on the strength of "this is a different
+// client", so uncertainty must not read as a yes: a token with no recorded
+// client_id, or none at all, is unknown provenance rather than evidence.
+func TestTokenIssuedByDifferentClient(t *testing.T) {
+	const email = "user@example.com"
+
+	tests := []struct {
+		name      string
+		writeFile bool
+		clientID  string
+		want      bool
+	}{
+		{
+			name:      "same client",
+			writeFile: true,
+			clientID:  "client-a",
+			want:      false,
+		},
+		{
+			name:      "different client",
+			writeFile: true,
+			clientID:  "client-b",
+			want:      true,
+		},
+		{
+			// Legacy token: provenance unknown, so not evidence of a
+			// different client.
+			name:      "no recorded client id",
+			writeFile: true,
+			clientID:  "",
+			want:      false,
+		},
+		{
+			name:      "no token at all",
+			writeFile: false,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := setupTestManager(t, Scopes)
+			mgr.config.ClientID = "client-a"
+
+			if tt.writeFile {
+				tf := tokenFile{
+					Token:    oauth2.Token{AccessToken: "t", TokenType: "Bearer"},
+					Scopes:   Scopes,
+					ClientID: tt.clientID,
+				}
+				data, err := json.Marshal(tf)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(
+					filepath.Join(mgr.tokensDir, email+".json"), data, 0600))
+			}
+
+			assert.Equal(t, tt.want, mgr.TokenIssuedByDifferentClient(email))
+		})
+	}
+}
+
+// TestScopesWithPreservedGrants_DoesNotRewidenNarrowedGrant guards the
+// incidental re-authorization paths — an expired token, or adding Calendar.
+// They union the caller's required scopes with what the account already holds,
+// which would hand Gmail write access back to an account deliberately narrowed
+// with `add-account --readonly`.
+func TestScopesWithPreservedGrants_DoesNotRewidenNarrowedGrant(t *testing.T) {
+	tests := []struct {
+		name     string
+		required []string
+		granted  []string
+		want     []string
+	}{
+		{
+			name:     "narrowed gmail grant stays narrow",
+			required: Scopes,
+			granted:  []string{ScopeGmailReadonly},
+			want:     []string{ScopeGmailReadonly},
+		},
+		{
+			name:     "narrowed gmail grant keeps calendar and stays narrow",
+			required: ScopesGmailCalendar,
+			granted:  []string{ScopeGmailReadonly, ScopeCalendarReadonly},
+			want:     []string{ScopeGmailReadonly, ScopeCalendarReadonly},
+		},
+		{
+			name:     "write-capable grant is unchanged",
+			required: Scopes,
+			granted:  []string{ScopeGmailReadonly, ScopeGmailModify, ScopeCalendarReadonly},
+			want:     []string{ScopeGmailReadonly, ScopeGmailModify, ScopeCalendarReadonly},
+		},
+		{
+			name:     "full access grant is unchanged and keeps its own scope",
+			required: Scopes,
+			granted:  []string{ScopeGmailFull},
+			want:     []string{ScopeGmailReadonly, ScopeGmailModify, ScopeGmailFull},
+		},
+		{
+			// No Gmail scopes at all is not a narrowed grant; this account is
+			// getting Gmail for the first time and must widen as before.
+			name:     "grant with no gmail scopes still gains gmail",
+			required: Scopes,
+			granted:  []string{ScopeCalendarReadonly},
+			want:     []string{ScopeGmailReadonly, ScopeGmailModify, ScopeCalendarReadonly},
+		},
+		{
+			// Legacy tokens carry no scope metadata, so there is nothing to
+			// read as narrowed and behavior is unchanged.
+			name:     "legacy token with no recorded scopes is unchanged",
+			required: Scopes,
+			granted:  nil,
+			want:     []string{ScopeGmailReadonly, ScopeGmailModify},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, scopesWithPreservedGrants(tt.required, tt.granted))
+		})
+	}
+}
+
+// TestAuthorize_NarrowedRequestPersistsNarrowedGrant is the end-to-end check
+// that a narrowed request actually lands as a narrowed grant on disk, with
+// non-Gmail scopes intact. Everything above reasons about scope lists; this
+// runs the real Authorize path and reads back the stored token.
+func TestAuthorize_NarrowedRequestPersistsNarrowedGrant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const email = "user@example.com"
+	narrowed := []string{ScopeGmailReadonly, ScopeCalendarReadonly}
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"emailAddress": %q}`, email)
+		}))
+	defer srv.Close()
+
+	mgr := setupTestManager(t, narrowed)
+	mgr.profileURL = srv.URL
+
+	// The account starts out write-capable with Calendar attached. add-account
+	// now refuses to narrow such an account, because the old grant would stay
+	// live at Google — but that is a policy decision in the command layer. This
+	// test covers the layer below it: when a narrowed request IS made, the
+	// manager must record exactly what came back.
+	writeTokenFile(t, mgr, email, oauth2.Token{
+		AccessToken: "old-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}, []string{ScopeGmailReadonly, ScopeGmailModify, ScopeCalendarReadonly})
+
+	// Google echoes the granted scopes back on the token exchange.
+	mgr.browserFlowFn = func(_ context.Context, _ string, _ bool) (*oauth2.Token, error) {
+		token := &oauth2.Token{
+			AccessToken: "narrowed-token",
+			TokenType:   "Bearer",
+			Expiry:      time.Now().Add(time.Hour),
+		}
+		return token.WithExtra(map[string]any{
+			"scope": ScopeGmailReadonly + " " + ScopeCalendarReadonly,
+		}), nil
+	}
+
+	require.NoError(mgr.Authorize(context.Background(), email), "Authorize")
+
+	assert.ElementsMatch(narrowed, mgr.GrantedScopes(email),
+		"stored grant must be exactly what was requested")
+	assert.False(HasGmailWriteScope(mgr.GrantedScopes(email)),
+		"narrowing must remove Gmail write access")
+	assert.True(mgr.HasScope(email, ScopeCalendarReadonly),
+		"narrowing must not discard Calendar")
+}
+
+// TestAuthorize_StillRejectsUnderDeliveredScopes confirms the narrowing work
+// did not weaken the existing guard: a token that comes back with fewer scopes
+// than requested is still refused.
+func TestAuthorize_StillRejectsUnderDeliveredScopes(t *testing.T) {
+	const email = "user@example.com"
+
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"emailAddress": %q}`, email)
+		}))
+	defer srv.Close()
+
+	mgr := setupTestManager(t, Scopes)
+	mgr.profileURL = srv.URL
+	mgr.browserFlowFn = func(_ context.Context, _ string, _ bool) (*oauth2.Token, error) {
+		token := &oauth2.Token{
+			AccessToken: "partial-token",
+			TokenType:   "Bearer",
+			Expiry:      time.Now().Add(time.Hour),
+		}
+		return token.WithExtra(map[string]any{"scope": ScopeGmailReadonly}), nil
+	}
+
+	err := mgr.Authorize(context.Background(), email)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required OAuth scopes")
+	assert.Contains(t, err.Error(), ScopeGmailModify)
+}

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -1,0 +1,187 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// newRevokeServer records the credential each revocation request carries and
+// responds with the given status and body.
+func newRevokeServer(t *testing.T, status int, body string) (*httptest.Server, *[]string) {
+	t.Helper()
+	var revoked []string
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.NoError(t, r.ParseForm())
+			revoked = append(revoked, r.PostForm.Get("token"))
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(body))
+		}))
+	t.Cleanup(srv.Close)
+	return srv, &revoked
+}
+
+func TestRevokeToken(t *testing.T) {
+	const email = "user@example.com"
+
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantErr     bool
+		wantErrIs   error
+		errContains string
+	}{
+		{
+			name:   "success",
+			status: http.StatusOK,
+		},
+		{
+			// Google answers 400 invalid_token for an already expired or
+			// revoked credential; account removal reads the typed error as
+			// nothing-to-do.
+			name:      "already invalid credential is a typed error",
+			status:    http.StatusBadRequest,
+			body:      `{"error": "invalid_token"}`,
+			wantErr:   true,
+			wantErrIs: ErrRevokeCredentialInvalid,
+		},
+		{
+			name:        "other 400 is a real failure",
+			status:      http.StatusBadRequest,
+			body:        `{"error": "invalid_request"}`,
+			wantErr:     true,
+			errContains: "invalid_request",
+		},
+		{
+			name:        "server error is a real failure",
+			status:      http.StatusInternalServerError,
+			body:        "boom",
+			wantErr:     true,
+			errContains: "HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			srv, revoked := newRevokeServer(t, tt.status, tt.body)
+			mgr := setupTestManager(t, Scopes)
+			mgr.revokeURL = srv.URL
+			writeTokenFile(t, mgr, email, oauth2.Token{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				TokenType:    "Bearer",
+				Expiry:       time.Now().Add(time.Hour),
+			}, Scopes)
+
+			err := mgr.RevokeToken(context.Background(), email)
+
+			if tt.wantErr {
+				require.Error(err)
+				if tt.wantErrIs != nil {
+					require.ErrorIs(err, tt.wantErrIs)
+				}
+				if tt.errContains != "" {
+					assert.Contains(err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(err)
+			}
+			assert.Equal([]string{"refresh-token"}, *revoked,
+				"revocation must target the refresh token, which kills the grant")
+		})
+	}
+}
+
+// TestRevokeToken_FallsBackToAccessToken covers token files without a refresh
+// token (e.g. a partially written or hand-copied file): the access token is
+// the only revocable credential left.
+func TestRevokeToken_FallsBackToAccessToken(t *testing.T) {
+	srv, revoked := newRevokeServer(t, http.StatusOK, "")
+	mgr := setupTestManager(t, Scopes)
+	mgr.revokeURL = srv.URL
+	writeTokenFile(t, mgr, "user@example.com", oauth2.Token{
+		AccessToken: "access-only",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}, Scopes)
+
+	require.NoError(t, mgr.RevokeToken(context.Background(), "user@example.com"))
+	assert.Equal(t, []string{"access-only"}, *revoked)
+}
+
+// TestRevokeStoredCredential_NoTokenFile pins that the client-config-free
+// adapter used by account removal reports a missing file as os.ErrNotExist,
+// which removal treats as nothing-to-revoke. The revocation body itself is
+// covered by TestRevokeToken.
+func TestRevokeStoredCredential_NoTokenFile(t *testing.T) {
+	err := RevokeStoredCredential(context.Background(), t.TempDir(), "missing@example.com")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestFindEquivalentTokenEmails covers the Gmail alias rules the read-only
+// decision must honor: authorization accepts these variants as the same
+// account, so token lookup has to as well or a --readonly run through an
+// alias spelling reads as a fresh account while the stored spelling keeps
+// its credential.
+//
+// Case-only variants are deliberately absent: on a case-insensitive
+// filesystem they resolve to the account's own file (excluded via
+// os.SameFile, matching what HasToken sees), while on a case-sensitive one
+// they are distinct files that do match — the dot/plus/googlemail cases
+// below behave identically everywhere.
+func TestFindEquivalentTokenEmails(t *testing.T) {
+	mgr := setupTestManager(t, Scopes)
+	writeTokenFile(t, mgr, "username@gmail.com", testToken, Scopes)
+	writeTokenFile(t, mgr, "user.name@googlemail.com", testToken, Scopes)
+	writeTokenFile(t, mgr, "other@example.com", testToken, Scopes)
+
+	tests := []struct {
+		name  string
+		email string
+		want  []string
+	}{
+		{
+			name:  "dot variant matches every equivalent spelling",
+			email: "user.name@gmail.com",
+			want:  []string{"user.name@googlemail.com", "username@gmail.com"},
+		},
+		{
+			name:  "plus address matches every equivalent spelling",
+			email: "username+archive@gmail.com",
+			want:  []string{"user.name@googlemail.com", "username@gmail.com"},
+		},
+		{
+			name:  "exact spelling is not its own equivalent",
+			email: "username@gmail.com",
+			want:  []string{"user.name@googlemail.com"},
+		},
+		{
+			name:  "unrelated gmail account does not match",
+			email: "someoneelse@gmail.com",
+		},
+		{
+			name:  "unrelated non-gmail account does not match",
+			email: "different@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, mgr.FindEquivalentTokenEmails(tt.email))
+		})
+	}
+}

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -185,3 +185,23 @@ func TestFindEquivalentTokenEmails(t *testing.T) {
 		})
 	}
 }
+
+func TestEquivalentStoredGrantInUse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	mgr := setupTestManager(t, Scopes)
+	mgr.config.ClientID = "client-a"
+	require.NoError(mgr.saveToken("username@gmail.com", &testToken, Scopes))
+	require.NoError(mgr.saveToken("user.name@gmail.com", &testToken, Scopes))
+
+	mgr.config.ClientID = "client-b"
+	require.NoError(mgr.saveToken("username+different@gmail.com", &testToken, Scopes))
+	writeLegacyTokenFile(t, mgr, "username+legacy@gmail.com", testToken)
+
+	assert.True(EquivalentStoredGrantInUse(
+		mgr.tokensDir, "username@gmail.com", []string{"user.name@gmail.com"}))
+	assert.False(EquivalentStoredGrantInUse(
+		mgr.tokensDir, "username@gmail.com", []string{"username+different@gmail.com"}))
+	assert.True(EquivalentStoredGrantInUse(
+		mgr.tokensDir, "username@gmail.com", []string{"username+legacy@gmail.com"}))
+}


### PR DESCRIPTION
Adds a `--readonly` flag to `add-account` that requests Gmail read access (`gmail.readonly`) instead of the default read + modify pair.

Reconciliation of #567: quetza's latest revision (adopted verbatim as the base commit — its live-account testing established that access already granted cannot be narrowed in place), plus one hardening commit on top.

## What changed

- `add-account --readonly` authorizes an account with read-only Gmail access. Sync, search, and the TUI work as normal; deletion prompts to re-authorize with write access.
- Access already granted cannot be narrowed: re-authorizing does not revoke the prior grant, and revocation is grant-wide, so `--readonly` refuses an account that already holds write access (`--force` included) and prints the procedure that works — revoke msgvault at [myaccount.google.com/permissions](https://myaccount.google.com/permissions), delete the token file, re-add with `--readonly`.
- A token from a provably different OAuth client is a fresh grant and is not refused.
- After a `--readonly` authorization, the granted scopes are checked: if Google returned write access anyway, a warning names it and the removal procedure.
- Any Gmail scope not on a read-only allow-list counts as write access, so scopes msgvault never requests (e.g. `gmail.send` in an externally minted token) can't pass as narrow.
- The `--readonly` decision resolves Gmail alias spellings (dots, plus-addresses, case, `googlemail.com`) against stored tokens, so a second spelling can't read as a fresh account while the stored spelling keeps its access.
- `remove-account` revokes the Gmail grant (best-effort) before deleting the token file, so removing an account and re-adding it read-only yields a genuinely fresh grant.
- Calendar and Drive grants are carried forward on every re-authorization, and re-auth paths (expired tokens, `add-calendar`) no longer silently restore write access to a narrowed account.
- Recovery hints and headless instructions keep `--readonly`, so following them doesn't undo the narrowing.
- The deletion pre-flight accepts `mail.google.com` as sufficient for trashing; it previously demanded `gmail.modify` even from accounts with broader access.

## Why

Sync only reads mail, but `add-account` always requested `gmail.modify`, so there was no way to run msgvault with a read-only grant. Restricting scopes in the Google Cloud Console doesn't help — that page is a declaration for verification review, not a limit on what gets granted — so changing what the client requests is the only lever.

## Usage

```console
msgvault add-account you@gmail.com --readonly
```

Default behavior without `--readonly` is unchanged.

## Limitations

- Access already granted cannot be narrowed in place (verified against a live Google account); the revoke-and-re-add procedure is printed by the refusal and documented in the setup guide.
- `--readonly` is rejected for service accounts; their scopes come from the domain-wide delegation grant in the Admin Console.

Also expands the Google Cloud Console setup walkthrough in `docs/guides/oauth-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
