### PR TITLE
feat: add exact source selection

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -584,6 +584,9 @@ components:
           type: boolean
         remote_delete_enabled:
           type: boolean
+        source_id:
+          format: int64
+          type: integer
         "yes":
           type: boolean
       type: object
@@ -610,6 +613,9 @@ components:
             - "null"
         remote_delete_env_var:
           type: string
+        resolved_source_id:
+          format: int64
+          type: integer
         scope_escalation_account:
           type: string
         scope_escalation_body_lines:
@@ -1984,6 +1990,8 @@ components:
         message_count:
           format: int64
           type: integer
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
         summary:
@@ -2020,6 +2028,28 @@ components:
         - created_by
         - description
         - message_count
+      type: object
+    DeletionTarget:
+      additionalProperties: true
+      properties:
+        message_id:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_identifier:
+          type: string
+        source_message_id:
+          type: string
+        source_type:
+          type: string
+      required:
+        - message_id
+        - source_id
+        - source_type
+        - source_identifier
+        - source_message_id
       type: object
     DiscoverError:
       additionalProperties: true
@@ -3620,6 +3650,12 @@ components:
           type:
             - array
             - "null"
+        targets:
+          items:
+            $ref: "#/components/schemas/DeletionTarget"
+          type:
+            - array
+            - "null"
       required:
         - gmail_ids
       type: object
@@ -4124,6 +4160,8 @@ components:
         id:
           type: string
         raw_filter: {}
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
         summary:
@@ -7919,6 +7957,21 @@ components:
         - signals
         - confirmed_at
       type: object
+    SourceReference:
+      additionalProperties: false
+      properties:
+        id:
+          format: int64
+          type: integer
+        identifier:
+          type: string
+        type:
+          type: string
+      required:
+        - id
+        - type
+        - identifier
+      type: object
     SourceStatus:
       additionalProperties: true
       properties:
@@ -8065,6 +8118,8 @@ components:
           type:
             - array
             - "null"
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
       required:
@@ -8683,12 +8738,16 @@ components:
     UpdateRequest:
       additionalProperties: false
       properties:
+        account:
+          type: string
         display_name:
           type: string
         email:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - email
         - display_name
       type: object
     UpdateResult:
@@ -8829,7 +8888,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.3.0
+  version: 2.4.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -10824,6 +10883,12 @@ paths:
           name: email
           schema:
             type: string
+        - description: Exact source ID to sync
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: IMAP folder names to include (repeatable)
           in: query
           name: folder
@@ -10865,6 +10930,12 @@ paths:
           name: email
           schema:
             type: string
+        - description: Exact source ID to sync
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: Gmail search query
           in: query
           name: query

--- a/cmd/msgvault/cmd/daemon_cli_http.go
+++ b/cmd/msgvault/cmd/daemon_cli_http.go
@@ -112,6 +112,9 @@ func daemonCLIArgsFromCobra(cmd *cobra.Command, args []string) ([]string, error)
 
 	flags := make([]*pflag.Flag, 0)
 	cmd.Flags().Visit(func(flag *pflag.Flag) {
+		if !flag.Changed {
+			return
+		}
 		if isRootPersistentFlag(cmd, flag) && !loggingPassthroughFlags[flag.Name] {
 			return
 		}

--- a/cmd/msgvault/cmd/deletions.go
+++ b/cmd/msgvault/cmd/deletions.go
@@ -13,6 +13,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"text/tabwriter"
@@ -23,6 +24,7 @@ import (
 	"go.kenn.io/msgvault/internal/daemonclient"
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/oauth"
+	"go.kenn.io/msgvault/internal/sourceops"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -281,6 +283,7 @@ var (
 	deleteDryRun    bool
 	deleteList      bool
 	deleteAccount   string
+	deleteSourceID  int64
 	// deletePlannedBatchIDs is an internal daemon-runner guard. The
 	// foreground CLI receives this exact set from the planning endpoint after
 	// showing the summary and confirmation prompt, then passes it to the
@@ -310,14 +313,18 @@ func remoteDeleteEnabled() bool {
 }
 
 type deleteStagedPlanOptions struct {
-	BatchID             string
-	PlannedBatchIDs     []string
-	Permanent           bool
-	Yes                 bool
-	DryRun              bool
-	List                bool
-	Account             string
-	RemoteDeleteEnabled bool
+	BatchID                  string
+	PlannedBatchIDs          []string
+	Permanent                bool
+	Yes                      bool
+	DryRun                   bool
+	List                     bool
+	Account                  string
+	SourceID                 int64
+	SourceIDSet              bool
+	ResolvedSourceType       string
+	ResolvedSourceIdentifier string
+	RemoteDeleteEnabled      bool
 }
 
 type deleteStagedPlan struct {
@@ -325,6 +332,7 @@ type deleteStagedPlan struct {
 	Manifests                 []*deletion.Manifest
 	PlannedBatchIDs           []string
 	PlanFingerprint           string
+	ManifestDigests           map[string]string
 	Stdout                    string
 	NeedsExecution            bool
 	NeedsConfirmation         bool
@@ -340,6 +348,12 @@ type deleteStagedPlan struct {
 }
 
 func buildDeleteStagedPlan(opts deleteStagedPlanOptions) (deleteStagedPlan, error) {
+	if opts.SourceIDSet && opts.SourceID <= 0 {
+		return deleteStagedPlan{}, newDeleteStagedUsageError(errors.New("source ID must be positive"))
+	}
+	if opts.SourceIDSet && strings.TrimSpace(opts.Account) != "" {
+		return deleteStagedPlan{}, newDeleteStagedUsageError(errors.New("cannot use --account with --source-id"))
+	}
 	deletionsDir := filepath.Join(cfg.Data.DataDir, "deletions")
 	manager, err := deletion.NewManager(deletionsDir)
 	if err != nil {
@@ -386,13 +400,26 @@ func buildDeleteStagedPlan(opts deleteStagedPlanOptions) (deleteStagedPlan, erro
 			}
 		}
 	}
-
+	var filterErr error
+	manifests, filterErr = filterDeleteStagedManifests(manifests, opts)
+	if filterErr != nil {
+		return deleteStagedPlan{}, filterErr
+	}
 	var out strings.Builder
+	manifestDigests := make(map[string]string, len(manifests))
+	for _, manifest := range manifests {
+		digest, err := manifest.Digest()
+		if err != nil {
+			return deleteStagedPlan{}, fmt.Errorf("validate batch %s: %w", manifest.ID, err)
+		}
+		manifestDigests[manifest.ID] = digest
+	}
 	plan := deleteStagedPlan{
 		Manager:            manager,
 		Manifests:          manifests,
 		PlannedBatchIDs:    deleteStagedManifestIDs(manifests),
 		PlanFingerprint:    fingerprintDeleteStagedPlan(manifests),
+		ManifestDigests:    manifestDigests,
 		RemoteDeleteEnvVar: remoteDeleteEnvVar,
 	}
 	if len(manifests) == 0 {
@@ -455,6 +482,11 @@ func buildDeleteStagedPlan(opts deleteStagedPlanOptions) (deleteStagedPlan, erro
 		plan.Stdout = out.String()
 		return plan, nil
 	}
+	if err := requireSingleDeletionSourceTuple(
+		manifests, opts.SourceIDSet || strings.TrimSpace(opts.Account) != "",
+	); err != nil {
+		return deleteStagedPlan{}, err
+	}
 
 	plan.NeedsExecution = true
 	if !opts.RemoteDeleteEnabled {
@@ -478,6 +510,71 @@ func buildDeleteStagedPlan(opts deleteStagedPlanOptions) (deleteStagedPlan, erro
 	}
 	plan.Stdout = out.String()
 	return plan, nil
+}
+
+func requireSingleDeletionSourceTuple(manifests []*deletion.Manifest, selectorSet bool) error {
+	var sourceType, identifier string
+	hasUnboundLegacy := false
+	for _, manifest := range manifests {
+		if manifest.Version != 2 || manifest.Source == nil {
+			if manifest.Version == 1 && strings.TrimSpace(manifest.Filters.Account) == "" {
+				hasUnboundLegacy = true
+			}
+			continue
+		}
+		if sourceType == "" {
+			sourceType, identifier = manifest.Source.Type, manifest.Source.Identifier
+			continue
+		}
+		if sourceType != manifest.Source.Type || identifier != manifest.Source.Identifier {
+			return newDeleteStagedUsageError(errors.New(
+				"pending batches target multiple sources; select one batch or use --source-id"))
+		}
+	}
+	if hasUnboundLegacy && !selectorSet {
+		return newDeleteStagedUsageError(errors.New(
+			"legacy deletion manifest does not identify a source; use --account or --source-id"))
+	}
+	return nil
+}
+
+func filterDeleteStagedManifests(manifests []*deletion.Manifest, opts deleteStagedPlanOptions) ([]*deletion.Manifest, error) {
+	if len(opts.PlannedBatchIDs) > 0 {
+		// The daemon planner already selected these exact IDs against the
+		// current source catalog. The subprocess still verifies the plan
+		// fingerprint and resolves the selector again before any remote call.
+		return manifests, nil
+	}
+	if !opts.SourceIDSet && strings.TrimSpace(opts.Account) == "" {
+		return manifests, nil
+	}
+	explicit := opts.BatchID != "" || len(opts.PlannedBatchIDs) > 0
+	filtered := make([]*deletion.Manifest, 0, len(manifests))
+	for _, manifest := range manifests {
+		var matches bool
+		switch {
+		case opts.SourceIDSet:
+			matches = manifest.Version == 2 && manifest.Source != nil &&
+				manifest.Source.Type == opts.ResolvedSourceType &&
+				manifest.Source.Identifier == opts.ResolvedSourceIdentifier
+			if manifest.Version == 1 {
+				legacyAccount := strings.TrimSpace(manifest.Filters.Account)
+				matches = legacyAccount == "" || legacyAccount == opts.ResolvedSourceIdentifier
+			}
+		case manifest.Version == 2 && manifest.Source != nil:
+			matches = manifest.Source.Identifier == opts.Account
+		default:
+			matches = manifest.Filters.Account == "" || manifest.Filters.Account == opts.Account
+		}
+		if matches {
+			filtered = append(filtered, manifest)
+			continue
+		}
+		if explicit {
+			return nil, newDeleteStagedUsageError(fmt.Errorf("batch %s does not match the requested source", manifest.ID))
+		}
+	}
+	return filtered, nil
 }
 
 // assertDeleteStagedMethodMatchesFlag rejects a run whose --permanent flag
@@ -531,30 +628,7 @@ func fingerprintDeleteStagedPlan(manifests []*deletion.Manifest) string {
 	if len(manifests) == 0 {
 		return ""
 	}
-	type manifestFingerprint struct {
-		ID          string           `json:"id"`
-		Status      deletion.Status  `json:"status"`
-		Description string           `json:"description"`
-		Account     string           `json:"account,omitempty"`
-		GmailIDs    []string         `json:"gmail_ids"`
-		Execution   *deletion.Method `json:"execution_method,omitempty"`
-	}
-	parts := make([]manifestFingerprint, 0, len(manifests))
-	for _, manifest := range manifests {
-		part := manifestFingerprint{
-			ID:          manifest.ID,
-			Status:      manifest.Status,
-			Description: manifest.Description,
-			Account:     manifest.Filters.Account,
-			GmailIDs:    append([]string(nil), manifest.GmailIDs...),
-		}
-		if manifest.Execution != nil {
-			method := manifest.Execution.Method
-			part.Execution = &method
-		}
-		parts = append(parts, part)
-	}
-	data, err := json.Marshal(parts)
+	data, err := json.Marshal(manifests)
 	if err != nil {
 		panic(fmt.Sprintf("marshal deletion plan fingerprint: %v", err))
 	}
@@ -593,85 +667,106 @@ func resolveDeleteStagedTarget(
 	manifests []*deletion.Manifest,
 	requestedAccount string,
 ) (deleteStagedTarget, error) {
-	if requestedAccount != "" {
-		return resolveExplicitDeleteStagedTarget(st, manifests, requestedAccount)
-	}
-
-	accountSet := make(map[string]bool)
-	for _, manifest := range manifests {
-		if manifest.Filters.Account != "" {
-			accountSet[manifest.Filters.Account] = true
-		}
-	}
-
-	accounts := make([]string, 0, len(accountSet))
-	for account := range accountSet {
-		accounts = append(accounts, account)
-	}
-	slices.Sort(accounts)
-	switch len(accounts) {
-	case 0:
-		return deleteStagedTarget{}, newDeleteStagedUsageError(errors.New("no account in deletion manifest - use --account flag"))
-	case 1:
-		src, err := lookupDeleteStagedSyncableSource(st, accounts[0])
-		if err != nil {
-			return deleteStagedTarget{}, err
-		}
-		return deleteStagedTarget{Account: accounts[0], Source: src}, nil
-	default:
-		return deleteStagedTarget{}, newDeleteStagedUsageError(
-			fmt.Errorf("multiple accounts in pending batches (%v) - use --account flag to specify which account", accounts),
-		)
-	}
+	return resolveDeleteStagedTargetWithSourceID(st, manifests, requestedAccount, 0, false)
 }
 
-func resolveExplicitDeleteStagedTarget(
+func resolveDeleteStagedTargetWithSourceID(
 	st *store.Store,
 	manifests []*deletion.Manifest,
 	requestedAccount string,
+	requestedSourceID int64,
+	requestedSourceIDSet bool,
 ) (deleteStagedTarget, error) {
-	resolved, err := st.GetSourcesByIdentifierOrDisplayName(requestedAccount)
-	if err != nil {
-		return deleteStagedTarget{}, fmt.Errorf("look up source for %s: %w", requestedAccount, err)
-	}
-	var syncable []*store.Source
-	for _, candidate := range resolved {
-		if candidate.SourceType == sourceTypeGmail || candidate.SourceType == sourceTypeIMAP {
-			syncable = append(syncable, candidate)
-		}
-	}
-	if len(syncable) == 0 {
-		return deleteStagedTarget{}, fmt.Errorf("no gmail or imap source found for %s", requestedAccount)
-	}
-	if len(syncable) > 1 {
-		var types []string
-		for _, candidate := range syncable {
-			types = append(types, fmt.Sprintf("%s (%s)", candidate.Identifier, candidate.SourceType))
-		}
-		return deleteStagedTarget{}, fmt.Errorf("multiple accounts match %q: %s\nUse the full identifier with --account to disambiguate", requestedAccount, strings.Join(types, ", "))
-	}
-
-	found := syncable[0]
-	account := found.Identifier
+	var durable *deletion.SourceReference
 	for _, manifest := range manifests {
-		if manifest.Filters.Account != "" && manifest.Filters.Account != account {
-			return deleteStagedTarget{}, fmt.Errorf("batch %s is for account %s, not %s - filter batches by account or execute separately", manifest.ID, manifest.Filters.Account, account)
+		if err := manifest.ValidateVersion(); err != nil {
+			return deleteStagedTarget{}, fmt.Errorf("batch %s: %w", manifest.ID, err)
+		}
+		if manifest.Version != 2 {
+			continue
+		}
+		if durable == nil {
+			copyRef := *manifest.Source
+			durable = &copyRef
+			continue
+		}
+		if durable.Type != manifest.Source.Type || durable.Identifier != manifest.Source.Identifier {
+			return deleteStagedTarget{}, newDeleteStagedUsageError(errors.New(
+				"pending batches target multiple sources; select one batch or use --source-id"))
 		}
 	}
-	return deleteStagedTarget{Account: account, Source: found}, nil
-}
 
-func lookupDeleteStagedSyncableSource(st *store.Store, account string) (*store.Source, error) {
-	sources, err := st.GetSourcesByIdentifier(account)
-	if err != nil {
-		return nil, fmt.Errorf("look up source for %s: %w", account, err)
+	if durable != nil {
+		source, err := st.GetSourceByTypeAndIdentifier(durable.Type, durable.Identifier)
+		if err != nil {
+			return deleteStagedTarget{}, err
+		}
+		if source.SourceType != sourceTypeGmail && source.SourceType != sourceTypeIMAP {
+			return deleteStagedTarget{}, fmt.Errorf("source %d is not a gmail or imap source", source.ID)
+		}
+		if requestedSourceIDSet {
+			selected, selectErr := sourceops.ResolveExactOne(st, sourceops.Selector{
+				SourceID: requestedSourceID, SourceIDSet: true,
+			})
+			if selectErr != nil {
+				return deleteStagedTarget{}, selectErr
+			}
+			if selected.SourceType != durable.Type || selected.Identifier != durable.Identifier {
+				return deleteStagedTarget{}, newDeleteStagedUsageError(fmt.Errorf(
+					"requested source ID resolves to %s/%s, which does not match manifest source %s/%s",
+					selected.SourceType, selected.Identifier, durable.Type, durable.Identifier))
+			}
+		}
+		if strings.TrimSpace(requestedAccount) != "" {
+			selected, selectErr := sourceops.ResolveExactOne(st, sourceops.Selector{Account: requestedAccount})
+			if selectErr != nil {
+				return deleteStagedTarget{}, selectErr
+			}
+			if selected.SourceType != durable.Type || selected.Identifier != durable.Identifier {
+				return deleteStagedTarget{}, newDeleteStagedUsageError(fmt.Errorf(
+					"requested account resolves to %s/%s, which does not match manifest source %s/%s",
+					selected.SourceType, selected.Identifier, durable.Type, durable.Identifier))
+			}
+		}
+		for _, manifest := range manifests {
+			if manifest.Version == 1 && manifest.Filters.Account != "" && manifest.Filters.Account != source.Identifier {
+				return deleteStagedTarget{}, newDeleteStagedUsageError(fmt.Errorf(
+					"batch %s is for account %s, not %s", manifest.ID, manifest.Filters.Account, source.Identifier))
+			}
+		}
+		return deleteStagedTarget{Account: source.Identifier, Source: source}, nil
 	}
-	for _, candidate := range sources {
-		if candidate.SourceType == sourceTypeGmail || candidate.SourceType == sourceTypeIMAP {
-			return candidate, nil
+
+	selector := sourceops.Selector{Account: requestedAccount, SourceID: requestedSourceID, SourceIDSet: requestedSourceIDSet}
+	if !requestedSourceIDSet && strings.TrimSpace(requestedAccount) == "" {
+		accountSet := make(map[string]struct{})
+		for _, manifest := range manifests {
+			if manifest.Filters.Account != "" {
+				accountSet[manifest.Filters.Account] = struct{}{}
+			}
+		}
+		if len(accountSet) != 1 {
+			return deleteStagedTarget{}, newDeleteStagedUsageError(errors.New(
+				"legacy deletion manifests do not identify one unambiguous account; use --account or --source-id"))
+		}
+		for account := range accountSet {
+			selector.Account = account
 		}
 	}
-	return nil, fmt.Errorf("no gmail or imap source found for %s", account)
+	source, err := sourceops.ResolveExactOne(st, selector)
+	if err != nil {
+		return deleteStagedTarget{}, err
+	}
+	if source.SourceType != sourceTypeGmail && source.SourceType != sourceTypeIMAP {
+		return deleteStagedTarget{}, fmt.Errorf("source %d is not a gmail or imap source", source.ID)
+	}
+	for _, manifest := range manifests {
+		if manifest.Filters.Account != "" && manifest.Filters.Account != source.Identifier {
+			return deleteStagedTarget{}, newDeleteStagedUsageError(fmt.Errorf(
+				"batch %s is for account %s, not %s", manifest.ID, manifest.Filters.Account, source.Identifier))
+		}
+	}
+	return deleteStagedTarget{Account: source.Identifier, Source: source}, nil
 }
 
 type deleteStagedScopeEscalation struct {
@@ -786,6 +881,8 @@ Examples:
 			DryRun:              deleteDryRun,
 			List:                deleteList,
 			Account:             deleteAccount,
+			SourceID:            deleteSourceID,
+			SourceIDSet:         cmd.Flags().Changed("source-id"),
 			RemoteDeleteEnabled: remoteDeleteEnabled(),
 		})
 		if err != nil {
@@ -832,8 +929,13 @@ Examples:
 		if err := runStartupMigrations(s); err != nil {
 			return fmt.Errorf("startup migrations: %w", err)
 		}
-
-		target, err := resolveDeleteStagedTarget(s, manifests, deleteAccount)
+		// Resolve the target before any durable claim. The digest-checked claim
+		// below rejects a manifest replacement between this preflight and the
+		// remote call, while the direct write lock keeps the source catalog
+		// stable for the duration of the command.
+		target, err := resolveDeleteStagedTargetWithSourceID(
+			s, manifests, deleteAccount, deleteSourceID, cmd.Flags().Changed("source-id"),
+		)
 		if err != nil {
 			if isDeleteStagedUsageError(err) {
 				return usageErr(cmd, err)
@@ -925,79 +1027,105 @@ Examples:
 
 		// Create executor
 		executor := deletion.NewExecutor(manager, s, client).
+			WithSourceID(src.ID).
 			WithLogger(logger).
 			WithProgress(&CLIDeletionProgress{})
-
-		// Execute each manifest
-		for i, m := range manifests {
-			if i > 0 {
-				fmt.Println()
-			}
-			fmt.Printf("  [%d/%d] %s (%d messages)\n", i+1, len(manifests), m.Description, len(m.GmailIDs))
-
-			var execErr error
-			// The confirmed method wins: the summary, the confirmation, and
-			// the OAuth scopes above all describe this flag. Planning already
-			// refused a batch whose stored method disagrees, and the executor
-			// refuses again before touching a message, so a batch resumed
-			// through the wrong path fails loudly instead of silently
-			// switching between trash and permanent deletion.
-			useTrash := !deletePermanent
-
-			if useTrash {
-				// Use individual trash calls (slower but recoverable)
-				opts := deletion.DefaultExecuteOptions()
-				opts.Method = deletion.MethodTrash
-				execErr = executor.Execute(ctx, m.ID, opts)
-			} else {
-				// Use batch delete for permanent deletion (fast - 1 API call per 1000 messages)
-				execErr = executor.ExecuteBatch(ctx, m.ID)
-			}
-
-			if execErr != nil {
-				if ctx.Err() != nil {
-					fmt.Println("\nInterrupted. Run again to resume.")
-					return nil
-				}
-
-				// A concurrent cancel (e.g. from the web UI/daemon) moved this
-				// batch out of in_progress. Report it plainly and move on to the
-				// next batch rather than surfacing it as a failure.
-				if errors.Is(execErr, deletion.ErrManifestCancelled) {
-					fmt.Printf("  Cancelled: %s\n", m.ID)
-					continue
-				}
-
-				// Check if this is a scope error - offer to re-authorize (Gmail only)
-				if src.SourceType == sourceTypeGmail && isInsufficientScopeError(execErr) {
-					if cfg.OAuth.ServiceAccountKeyFor(sourceOAuthApp(src)) != "" {
-						return fmt.Errorf(
-							"service account lacks required Gmail deletion scope for %s: "+
-								"authorize https://mail.google.com/ for the service account client "+
-								"in Google Admin Console, then run delete-staged again",
-							account,
-						)
-					}
-					if err := promptDeletionScopeEscalation(ctx, account, !useTrash, clientSecretsPath); err != nil {
-						if errors.Is(err, errUserCanceled) {
-							return nil
-						}
-						return err
-					}
-					fmt.Println("Run delete-staged again to continue.")
-					return nil
-				}
-
-				logger.Warn("deletion failed", "batch", m.ID, "error", execErr)
-				continue
-			}
+		method := deletion.MethodTrash
+		if deletePermanent {
+			method = deletion.MethodDelete
 		}
 
-		fmt.Println("\nDeletion complete!")
+		return runDeleteStagedExecution(func(markCacheDirty func()) error {
+			// Claim each manifest immediately before its executor call. All
+			// credential, scope, and client setup has completed by this point,
+			// and a later batch is never left claimed if an earlier/later claim
+			// fails.
+			for i, plannedManifest := range manifests {
+				m, claimErr := manager.ClaimManifestWithDigest(
+					plannedManifest.ID, method, plan.ManifestDigests[plannedManifest.ID],
+				)
+				if claimErr != nil {
+					return fmt.Errorf("claim batch %s: %w", plannedManifest.ID, claimErr)
+				}
+				if i > 0 {
+					fmt.Println()
+				}
+				fmt.Printf("  [%d/%d] %s (%d messages)\n", i+1, len(manifests), m.Description, len(m.GmailIDs))
 
-		// Refresh analytics cache to reflect deleted messages.
-		return rebuildCacheAfterWrite(dbPath)
+				var execErr error
+				// The confirmed method wins: the summary, the confirmation, and
+				// the OAuth scopes above all describe this flag. Planning already
+				// refused a batch whose stored method disagrees, and the executor
+				// refuses again before touching a message, so a batch resumed
+				// through the wrong path fails loudly instead of silently
+				// switching between trash and permanent deletion.
+				useTrash := !deletePermanent
+				markCacheDirty()
+
+				if useTrash {
+					// Use individual trash calls (slower but recoverable)
+					opts := deletion.DefaultExecuteOptions()
+					opts.Method = deletion.MethodTrash
+					execErr = executor.Execute(ctx, m.ID, opts)
+				} else {
+					// Use batch delete for permanent deletion (fast - 1 API call per 1000 messages)
+					execErr = executor.ExecuteBatch(ctx, m.ID)
+				}
+
+				if execErr != nil {
+					if ctx.Err() != nil {
+						fmt.Println("\nInterrupted. Run again to resume.")
+						return nil
+					}
+
+					// A concurrent cancel (e.g. from the web UI/daemon) moved this
+					// batch out of in_progress. Report it plainly and move on to the
+					// next batch rather than surfacing it as a failure.
+					if errors.Is(execErr, deletion.ErrManifestCancelled) {
+						fmt.Printf("  Cancelled: %s\n", m.ID)
+						continue
+					}
+
+					// Check if this is a scope error - offer to re-authorize (Gmail only)
+					if src.SourceType == sourceTypeGmail && isInsufficientScopeError(execErr) {
+						if cfg.OAuth.ServiceAccountKeyFor(sourceOAuthApp(src)) != "" {
+							return fmt.Errorf(
+								"service account lacks required Gmail deletion scope for %s: "+
+									"authorize https://mail.google.com/ for the service account client "+
+									"in Google Admin Console, then run delete-staged again",
+								account,
+							)
+						}
+						if err := promptDeletionScopeEscalation(ctx, account, !useTrash, clientSecretsPath); err != nil {
+							if errors.Is(err, errUserCanceled) {
+								return nil
+							}
+							return err
+						}
+						fmt.Println("Run delete-staged again to continue.")
+						return nil
+					}
+
+					logger.Warn("deletion failed", "batch", m.ID, "error", execErr)
+					continue
+				}
+			}
+
+			fmt.Println("\nDeletion complete!")
+			return nil
+		}, func() error {
+			return rebuildCacheAfterWrite(dbPath)
+		})
 	},
+}
+
+func runDeleteStagedExecution(work func(markCacheDirty func()) error, refreshCache func() error) error {
+	cacheDirty := false
+	workErr := work(func() { cacheDirty = true })
+	if !cacheDirty {
+		return workErr
+	}
+	return errors.Join(workErr, refreshCache())
 }
 
 func runDeleteStagedHTTP(cmd *cobra.Command, args []string) error {
@@ -1019,6 +1147,7 @@ func runDeleteStagedHTTP(cmd *cobra.Command, args []string) error {
 		DryRun:              deleteDryRun,
 		List:                deleteList,
 		Account:             deleteAccount,
+		SourceID:            deleteStagedSourceIDPtr(cmd),
 		RemoteDeleteEnabled: remoteDeleteAllowed,
 	})
 	if err != nil {
@@ -1072,6 +1201,15 @@ func runDeleteStagedHTTP(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("set --%s after planning: %w", deleteStagedPlanFingerprintFlag, err)
 		}
 	}
+	if plan.ResolvedSourceID != nil {
+		deleteAccount = ""
+		if accountFlag := cmd.Flags().Lookup("account"); accountFlag != nil {
+			accountFlag.Changed = false
+		}
+		if err := cmd.Flags().Set("source-id", strconv.FormatInt(*plan.ResolvedSourceID, 10)); err != nil {
+			return fmt.Errorf("set resolved deletion source ID: %w", err)
+		}
+	}
 	for _, batchID := range plan.PlannedBatchIDs {
 		if err := cmd.Flags().Set(deleteStagedPlannedBatchFlag, batchID); err != nil {
 			return fmt.Errorf("set --%s after planning: %w", deleteStagedPlannedBatchFlag, err)
@@ -1082,6 +1220,14 @@ func runDeleteStagedHTTP(cmd *cobra.Command, args []string) error {
 		env = map[string]string{remoteDeleteEnvVar: "1"}
 	}
 	return runDaemonCLICommandHTTPFromCobraWithEnv(cmd, nil, env)
+}
+
+func deleteStagedSourceIDPtr(cmd *cobra.Command) *int64 {
+	if !cmd.Flags().Changed("source-id") {
+		return nil
+	}
+	value := deleteSourceID
+	return &value
 }
 
 // preflightDeleteStagedScopeEscalation performs the confirmed Gmail scope
@@ -1161,20 +1307,49 @@ func planCLIDeleteStaged(
 	st *store.Store,
 	req api.CLIDeleteStagedPlanRequest,
 ) (api.CLIDeleteStagedPlanResponse, error) {
+	var resolvedSource *store.Source
+	if req.SourceID != nil {
+		resolved, err := sourceops.ResolveExactOne(st, sourceops.Selector{
+			Account: req.Account, SourceID: *req.SourceID, SourceIDSet: true,
+		})
+		if err != nil {
+			return api.CLIDeleteStagedPlanResponse{}, err
+		}
+		resolvedSource = resolved
+	} else if strings.TrimSpace(req.Account) != "" {
+		resolved, err := sourceops.ResolveExactOne(st, sourceops.Selector{Account: req.Account})
+		if err != nil {
+			return api.CLIDeleteStagedPlanResponse{}, err
+		}
+		resolvedSource = resolved
+	}
+	resolvedSourceID := int64(0)
+	resolvedSourceType := ""
+	resolvedSourceIdentifier := ""
+	if resolvedSource != nil {
+		resolvedSourceID = resolvedSource.ID
+		resolvedSourceType = resolvedSource.SourceType
+		resolvedSourceIdentifier = resolvedSource.Identifier
+	}
 	plan, err := buildDeleteStagedPlan(deleteStagedPlanOptions{
-		BatchID:             req.BatchID,
-		Permanent:           req.Permanent,
-		Yes:                 req.Yes,
-		DryRun:              req.DryRun,
-		List:                req.List,
-		Account:             req.Account,
-		RemoteDeleteEnabled: req.RemoteDeleteEnabled,
+		BatchID:                  req.BatchID,
+		Permanent:                req.Permanent,
+		Yes:                      req.Yes,
+		DryRun:                   req.DryRun,
+		List:                     req.List,
+		SourceID:                 resolvedSourceID,
+		SourceIDSet:              resolvedSource != nil,
+		ResolvedSourceType:       resolvedSourceType,
+		ResolvedSourceIdentifier: resolvedSourceIdentifier,
+		RemoteDeleteEnabled:      req.RemoteDeleteEnabled,
 	})
 	if err != nil {
 		return api.CLIDeleteStagedPlanResponse{}, err
 	}
 	if plan.NeedsExecution && req.RemoteDeleteEnabled {
-		target, err := resolveDeleteStagedTarget(st, plan.Manifests, req.Account)
+		target, err := resolveDeleteStagedTargetWithSourceID(
+			st, plan.Manifests, "", resolvedSourceID, resolvedSource != nil,
+		)
 		if err != nil {
 			return api.CLIDeleteStagedPlanResponse{}, err
 		}
@@ -1203,6 +1378,10 @@ func planCLIDeleteStaged(
 			}
 		}
 	}
+	var resolvedSourceIDPtr *int64
+	if resolvedSource != nil {
+		resolvedSourceIDPtr = &resolvedSourceID
+	}
 	return api.CLIDeleteStagedPlanResponse{
 		Stdout:                    plan.Stdout,
 		NeedsExecution:            plan.NeedsExecution,
@@ -1210,6 +1389,7 @@ func planCLIDeleteStaged(
 		ConfirmationMode:          plan.ConfirmationMode,
 		PlannedBatchIDs:           plan.PlannedBatchIDs,
 		PlanFingerprint:           plan.PlanFingerprint,
+		ResolvedSourceID:          resolvedSourceIDPtr,
 		NeedsScopeEscalation:      plan.NeedsScopeEscalation,
 		ScopeEscalationHeadline:   plan.ScopeEscalationHeadline,
 		ScopeEscalationBodyLines:  plan.ScopeEscalationBodyLines,
@@ -1527,6 +1707,7 @@ func init() {
 	deleteStagedCmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Show what would be deleted")
 	deleteStagedCmd.Flags().BoolVarP(&deleteList, "list", "l", false, "List staged batches without executing")
 	deleteStagedCmd.Flags().StringVar(&deleteAccount, "account", "", "Account to use (Gmail or IMAP)")
+	deleteStagedCmd.Flags().Int64Var(&deleteSourceID, "source-id", 0, "Exact source ID to use")
 	deleteStagedCmd.Flags().Bool(deleteStagedConfirmedFlag, false, "Internal confirmation marker")
 	deleteStagedCmd.Flags().Bool(deleteStagedSkipPreludeFlag, false, "Internal planning marker")
 	deleteStagedCmd.Flags().StringArrayVar(&deletePlannedBatchIDs, deleteStagedPlannedBatchFlag, nil, "Internal planned batch marker")
@@ -1539,6 +1720,7 @@ func init() {
 	_ = deleteStagedCmd.Flags().MarkHidden(deleteStagedScopeEscalationConfirmedFlag)
 
 	deleteStagedCmd.MarkFlagsMutuallyExclusive("permanent", "yes")
+	deleteStagedCmd.MarkFlagsMutuallyExclusive("account", "source-id")
 	listDeletionsCmd.Flags().BoolVar(&listDeletionsJSON, flagJSON, false, "Output as JSON with full batch IDs")
 	rootCmd.AddCommand(listDeletionsCmd)
 	rootCmd.AddCommand(showDeletionCmd)

--- a/cmd/msgvault/cmd/deletions_routing_test.go
+++ b/cmd/msgvault/cmd/deletions_routing_test.go
@@ -128,6 +128,45 @@ func TestDeleteStagedTrashPromptsBeforeDaemonRunner(t *testing.T) {
 	assert.Contains(stdout.String(), "Deletion complete!", "daemon output")
 }
 
+func TestDeleteStagedDisplayNamePlanPinsSourceIDForDaemonRunner(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	resetDeleteStagedRoutingGlobals(t)
+	t.Setenv(remoteDeleteEnvVar, "1")
+
+	server, runRequests, planRequests := newDaemonCLIDeleteStagedTestServer(t, func(req daemonCLIDeleteStagedPlanTestRequest) {
+		assert.Equal("Work", req.Account, "account selector")
+		assert.True(req.Yes, "yes")
+		assert.True(req.RemoteDeleteEnabled, "remote delete enabled")
+	}, map[string]any{
+		"stdout":                "Deletion Summary:\n  Batches:  1\n  Messages: 1\n  Method:   trash (30-day recovery)\n\n",
+		"needs_execution":       true,
+		"needs_confirmation":    false,
+		"planned_batch_ids":     []string{"batch-123"},
+		"plan_fingerprint":      "fp-display-name",
+		"resolved_source_id":    42,
+		"remote_delete_env_var": remoteDeleteEnvVar,
+	}, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{
+			"delete-staged",
+			"--confirmed",
+			"--plan-fingerprint=fp-display-name",
+			"--planned-batch=batch-123",
+			"--skip-prelude",
+			"--source-id=42",
+			"--yes",
+		}, req.Args, "args")
+	}, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+
+	cmd := newDeleteStagedRoutingTestCommand()
+	cmd.SetArgs([]string{"--account", "Work", "--yes"})
+
+	require.NoError(cmd.Execute(), "delete-staged")
+	assert.Equal(1, int(planRequests.Load()), "plan endpoint calls")
+	assert.Equal(1, int(runRequests.Load()), "runner endpoint calls")
+}
+
 func TestDeleteStagedPermanentPromptsBeforeDaemonRunner(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -338,12 +377,14 @@ func resetDeleteStagedRoutingGlobals(t *testing.T) {
 	savedDryRun := deleteDryRun
 	savedList := deleteList
 	savedAccount := deleteAccount
+	savedSourceID := deleteSourceID
 	savedPlannedBatchIDs := deletePlannedBatchIDs
 	deletePermanent = false
 	deleteYes = false
 	deleteDryRun = false
 	deleteList = false
 	deleteAccount = ""
+	deleteSourceID = 0
 	deletePlannedBatchIDs = nil
 	t.Cleanup(func() {
 		deletePermanent = savedPermanent
@@ -351,6 +392,7 @@ func resetDeleteStagedRoutingGlobals(t *testing.T) {
 		deleteDryRun = savedDryRun
 		deleteList = savedList
 		deleteAccount = savedAccount
+		deleteSourceID = savedSourceID
 		deletePlannedBatchIDs = savedPlannedBatchIDs
 	})
 }
@@ -366,6 +408,7 @@ func newDeleteStagedRoutingTestCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&deleteDryRun, "dry-run", false, "Dry run")
 	cmd.Flags().BoolVarP(&deleteList, "list", "l", false, "List")
 	cmd.Flags().StringVar(&deleteAccount, "account", "", "Account")
+	cmd.Flags().Int64Var(&deleteSourceID, "source-id", 0, "Exact source ID")
 	cmd.Flags().Bool("confirmed", false, "Internal confirmation marker")
 	cmd.Flags().Bool("skip-prelude", false, "Internal prelude marker")
 	cmd.Flags().StringArrayVar(&deletePlannedBatchIDs, "planned-batch", nil, "Internal planned batch marker")
@@ -377,6 +420,7 @@ func newDeleteStagedRoutingTestCommand() *cobra.Command {
 	_ = cmd.Flags().MarkHidden("plan-fingerprint")
 	_ = cmd.Flags().MarkHidden("scope-escalation-confirmed")
 	cmd.MarkFlagsMutuallyExclusive("permanent", "yes")
+	cmd.MarkFlagsMutuallyExclusive("account", "source-id")
 	return cmd
 }
 

--- a/cmd/msgvault/cmd/deletions_test.go
+++ b/cmd/msgvault/cmd/deletions_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -12,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/api"
 	"go.kenn.io/msgvault/internal/deletion"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
@@ -176,6 +180,347 @@ func TestBuildDeleteStagedPlanPinsPlannedBatches(t *testing.T) {
 	assert.NotEqual(plan.PlanFingerprint, changed.PlanFingerprint, "fingerprint should change when confirmed manifest content changes")
 }
 
+func TestBuildDeleteStagedPlanFiltersVersionTwoBySourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	first := deletion.NewManifestForSource("first", []string{"gm-1"}, deletion.SourceReference{
+		ID: 11, Type: "gmail", Identifier: "first@example.invalid",
+	})
+	second := deletion.NewManifestForSource("second", []string{"gm-2"}, deletion.SourceReference{
+		ID: 22, Type: "gmail", Identifier: "second@example.invalid",
+	})
+	require.NoError(mgr.SaveManifest(first))
+	require.NoError(mgr.SaveManifest(second))
+
+	plan, err := buildDeleteStagedPlan(deleteStagedPlanOptions{
+		SourceID: 22, SourceIDSet: true, List: true,
+		ResolvedSourceType: "gmail", ResolvedSourceIdentifier: "second@example.invalid",
+	})
+	require.NoError(err)
+	assert.Equal([]string{second.ID}, plan.PlannedBatchIDs)
+	assert.NotContains(plan.Stdout, first.Description)
+	assert.Contains(plan.Stdout, second.Description)
+}
+
+func TestBuildDeleteStagedPlanDoesNotSelectVersionTwoByLegacyFilterAccount(t *testing.T) {
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(t, err)
+	manifest := deletion.NewManifestForSource("durable source", []string{"gm-1"}, deletion.SourceReference{
+		ID: 11, Type: "gmail", Identifier: "source@example.invalid",
+	})
+	manifest.Filters.Account = "other@example.invalid"
+	require.NoError(t, mgr.SaveManifest(manifest))
+
+	_, err = buildDeleteStagedPlan(deleteStagedPlanOptions{
+		BatchID: manifest.ID, Account: "other@example.invalid", List: true,
+	})
+	require.ErrorContains(t, err, "does not match the requested source")
+}
+
+func TestBuildDeleteStagedPlanAllowsExplicitSelectorForUnboundLegacyManifest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	manifest, err := mgr.CreateManifest("legacy", []string{"gm-1"}, deletion.Filters{})
+	require.NoError(err)
+
+	plan, err := buildDeleteStagedPlan(deleteStagedPlanOptions{
+		Account: "source@example.invalid", List: true,
+	})
+	require.NoError(err)
+	assert.Equal([]string{manifest.ID}, plan.PlannedBatchIDs)
+}
+
+func TestBuildDeleteStagedPlanAllowsSourceIDForLegacyManifestWithMatchingAccount(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	manifest, err := mgr.CreateManifest("legacy", []string{"gm-1"}, deletion.Filters{
+		Account: "source@example.invalid",
+	})
+	require.NoError(err)
+	other, err := mgr.CreateManifest("other legacy", []string{"gm-2"}, deletion.Filters{
+		Account: "other@example.invalid",
+	})
+	require.NoError(err)
+
+	plan, err := buildDeleteStagedPlan(deleteStagedPlanOptions{
+		SourceID: 11, SourceIDSet: true, List: true,
+		ResolvedSourceType: "gmail", ResolvedSourceIdentifier: "source@example.invalid",
+	})
+	require.NoError(err)
+	assert.Equal([]string{manifest.ID}, plan.PlannedBatchIDs)
+	assert.NotContains(plan.Stdout, other.Description)
+}
+
+func TestBuildDeleteStagedPlanInspectsUnboundLegacyManifestMixedWithVersionTwo(t *testing.T) {
+	tests := []struct {
+		name string
+		opts deleteStagedPlanOptions
+		want string
+	}{
+		{name: "list", opts: deleteStagedPlanOptions{List: true}, want: "Staged deletions: 2 batch(es)"},
+		{name: "dry run", opts: deleteStagedPlanOptions{DryRun: true}, want: "Dry run - no messages will be deleted."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			dataDir := t.TempDir()
+			withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+			mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+			require.NoError(err)
+			legacy, err := mgr.CreateManifest("legacy", []string{"gm-1"}, deletion.Filters{})
+			require.NoError(err)
+			bound := deletion.NewManifestForSource("bound", []string{"gm-2"}, deletion.SourceReference{
+				ID: 11, Type: "gmail", Identifier: "source@example.invalid",
+			})
+			require.NoError(mgr.SaveManifest(bound))
+
+			plan, err := buildDeleteStagedPlan(tt.opts)
+			require.NoError(err)
+			assert.ElementsMatch([]string{legacy.ID, bound.ID}, plan.PlannedBatchIDs)
+			assert.Contains(plan.Stdout, tt.want)
+			assert.False(plan.NeedsExecution)
+		})
+	}
+}
+
+func TestBuildDeleteStagedPlanRejectsUnboundLegacyManifestMixedWithVersionTwoDuringExecution(t *testing.T) {
+	require := require.New(t)
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	_, err = mgr.CreateManifest("legacy", []string{"gm-1"}, deletion.Filters{})
+	require.NoError(err)
+	require.NoError(mgr.SaveManifest(deletion.NewManifestForSource("bound", []string{"gm-2"}, deletion.SourceReference{
+		ID: 11, Type: "gmail", Identifier: "source@example.invalid",
+	})))
+
+	_, err = buildDeleteStagedPlan(deleteStagedPlanOptions{RemoteDeleteEnabled: true, Yes: true})
+	require.ErrorContains(err, "legacy deletion manifest")
+}
+
+func TestResolveDeleteStagedTargetUsesStableTupleAfterSourceIDChanges(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "source@example.invalid")
+	require.NoError(t, err)
+	manifest := deletion.NewManifestForSource("stale snapshot", []string{"gm-1"}, deletion.SourceReference{
+		ID: source.ID + 1000, Type: source.SourceType, Identifier: source.Identifier,
+	})
+
+	target, err := resolveDeleteStagedTargetWithSourceID(
+		st, []*deletion.Manifest{manifest}, "", source.ID, true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, source.ID, target.Source.ID)
+}
+
+func TestResolveDeleteStagedTargetRejectsSnapshotIDThatNowNamesAnotherSource(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	intended, err := st.GetOrCreateSource("gmail", "intended@example.invalid")
+	require.NoError(t, err)
+	other, err := st.GetOrCreateSource("imap", "other@example.invalid")
+	require.NoError(t, err)
+	manifest := deletion.NewManifestForSource("mismatched snapshot", []string{"gm-1"}, deletion.SourceReference{
+		ID: other.ID, Type: intended.SourceType, Identifier: intended.Identifier,
+	})
+
+	_, err = resolveDeleteStagedTargetWithSourceID(
+		st, []*deletion.Manifest{manifest}, "", other.ID, true,
+	)
+	require.ErrorContains(t, err, "does not match manifest source")
+}
+
+func TestResolveDeleteStagedTargetRejectsRequestedAccountOutsideDurableTuple(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("gmail", "source@example.invalid")
+	require.NoError(t, err)
+	_, err = st.GetOrCreateSource("gmail", "other@example.invalid")
+	require.NoError(t, err)
+	manifest := deletion.NewManifestForSource("bound", []string{"gm-1"}, deletion.SourceReference{
+		ID: source.ID, Type: source.SourceType, Identifier: source.Identifier,
+	})
+
+	_, err = resolveDeleteStagedTarget(st, []*deletion.Manifest{manifest}, "other@example.invalid")
+	require.ErrorContains(t, err, "does not match manifest source")
+}
+
+func TestDeleteStagedRejectsUnsupportedSourceBeforeClaim(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	t.Setenv(remoteDeleteEnvVar, "1")
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+	resetDeleteStagedRoutingGlobals(t)
+
+	st, err := store.Open(cfg.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("slack", "workspace.example.invalid")
+	require.NoError(err)
+	require.NoError(st.Close())
+
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	manifest := deletion.NewManifestForSource("unsupported source", []string{"remote-1"}, deletion.SourceReference{
+		ID: source.ID, Type: source.SourceType, Identifier: source.Identifier,
+	})
+	require.NoError(mgr.SaveManifest(manifest))
+
+	cmd := newDeleteStagedRoutingTestCommand()
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--yes", manifest.ID})
+	err = cmd.Execute()
+	require.ErrorContains(err, "not a gmail or imap source")
+	assert.FileExists(filepath.Join(mgr.PendingDir(), manifest.ID+".json"))
+	assert.NoFileExists(filepath.Join(mgr.InProgressDir(), manifest.ID+".json"))
+}
+
+func TestDeleteStagedOAuthSetupFailureLeavesManifestPending(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	t.Setenv(remoteDeleteEnvVar, "1")
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+	resetDeleteStagedRoutingGlobals(t)
+
+	st, err := store.Open(cfg.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("gmail", "account@example.invalid")
+	require.NoError(err)
+	require.NoError(st.Close())
+
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	manifest := deletion.NewManifestForSource("missing OAuth setup", []string{"remote-1"}, deletion.SourceReference{
+		ID: source.ID, Type: source.SourceType, Identifier: source.Identifier,
+	})
+	require.NoError(mgr.SaveManifest(manifest))
+
+	cmd := newDeleteStagedRoutingTestCommand()
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--yes", manifest.ID})
+	err = cmd.Execute()
+	require.ErrorContains(err, "OAuth client secrets not configured")
+	assert.FileExists(filepath.Join(mgr.PendingDir(), manifest.ID+".json"))
+	assert.NoFileExists(filepath.Join(mgr.InProgressDir(), manifest.ID+".json"))
+}
+
+func TestRunDeleteStagedExecutionRefreshesAfterPartialRunFailure(t *testing.T) {
+	claimErr := errors.New("claim second batch")
+	refreshCalls := 0
+
+	err := runDeleteStagedExecution(func(markCacheDirty func()) error {
+		markCacheDirty()
+		return claimErr
+	}, func() error {
+		refreshCalls++
+		return nil
+	})
+
+	require.ErrorIs(t, err, claimErr)
+	assert.Equal(t, 1, refreshCalls)
+}
+
+func TestRunDeleteStagedExecutionSkipsRefreshBeforeExecution(t *testing.T) {
+	claimErr := errors.New("claim first batch")
+	refreshCalls := 0
+
+	err := runDeleteStagedExecution(func(func()) error {
+		return claimErr
+	}, func() error {
+		refreshCalls++
+		return nil
+	})
+
+	require.ErrorIs(t, err, claimErr)
+	assert.Zero(t, refreshCalls)
+}
+
+func TestBuildDeleteStagedPlanInspectsMultipleVersionTwoSources(t *testing.T) {
+	tests := []struct {
+		name string
+		opts deleteStagedPlanOptions
+		want string
+	}{
+		{name: "list", opts: deleteStagedPlanOptions{List: true}, want: "Staged deletions: 2 batch(es)"},
+		{name: "dry run", opts: deleteStagedPlanOptions{DryRun: true}, want: "Dry run - no messages will be deleted."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			dataDir := t.TempDir()
+			withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+			mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+			require.NoError(err)
+			first := deletion.NewManifestForSource("first", []string{"gm-1"}, deletion.SourceReference{
+				ID: 11, Type: "gmail", Identifier: "first@example.invalid",
+			})
+			second := deletion.NewManifestForSource("second", []string{"gm-2"}, deletion.SourceReference{
+				ID: 22, Type: "gmail", Identifier: "second@example.invalid",
+			})
+			require.NoError(mgr.SaveManifest(first))
+			require.NoError(mgr.SaveManifest(second))
+
+			plan, err := buildDeleteStagedPlan(tt.opts)
+			require.NoError(err)
+			assert.ElementsMatch([]string{first.ID, second.ID}, plan.PlannedBatchIDs)
+			assert.Contains(plan.Stdout, tt.want)
+			assert.False(plan.NeedsExecution)
+		})
+	}
+}
+
+func TestBuildDeleteStagedPlanRejectsMultipleVersionTwoSourcesDuringExecution(t *testing.T) {
+	require := require.New(t)
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	require.NoError(mgr.SaveManifest(deletion.NewManifestForSource("first", []string{"gm-1"}, deletion.SourceReference{
+		ID: 11, Type: "gmail", Identifier: "first@example.invalid",
+	})))
+	require.NoError(mgr.SaveManifest(deletion.NewManifestForSource("second", []string{"gm-2"}, deletion.SourceReference{
+		ID: 22, Type: "gmail", Identifier: "second@example.invalid",
+	})))
+
+	_, err = buildDeleteStagedPlan(deleteStagedPlanOptions{RemoteDeleteEnabled: true, Yes: true})
+	require.ErrorContains(err, "multiple sources")
+}
+
+func TestDeleteStagedFingerprintIncludesSourceReference(t *testing.T) {
+	manifest := deletion.NewManifestForSource("confirmed", []string{"gm-1"}, deletion.SourceReference{
+		ID: 11, Type: "gmail", Identifier: "first@example.invalid",
+	})
+	before := fingerprintDeleteStagedPlan([]*deletion.Manifest{manifest})
+	manifest.Source.Identifier = "changed@example.invalid"
+	after := fingerprintDeleteStagedPlan([]*deletion.Manifest{manifest})
+	assert.NotEqual(t, before, after)
+}
+
 // TestBuildDeleteStagedPlanRejectsMethodFlagMismatch verifies that resuming an
 // in-progress batch with a --permanent flag that disagrees with the method it
 // was started with is refused during planning. The summary, confirmation
@@ -244,6 +589,39 @@ func TestPlanCLIDeleteStagedReportsDeletionScopeEscalation(t *testing.T) {
 	assert.Equal(scopeEscalationAccount, got.ScopeEscalationAccount,
 		"plan names the account so the frontend can authorize client-side")
 	assert.Empty(got.ScopeEscalationOAuthApp, "default app binding")
+}
+
+func TestPlanCLIDeleteStagedResolvesDisplayNameBeforeFiltering(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+	st := testutil.NewTestStore(t)
+	gmailSource, err := st.GetOrCreateSource(sourceTypeGmail, "source@example.invalid")
+	require.NoError(err)
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, "source@example.invalid")
+	require.NoError(err)
+	require.NoError(st.UpdateSourceDisplayName(source.ID, "Work"))
+
+	mgr, err := deletion.NewManager(filepath.Join(dataDir, "deletions"))
+	require.NoError(err)
+	manifest := deletion.NewManifestForSource("display name target", []string{"remote-1"}, deletion.SourceReference{
+		ID: source.ID, Type: source.SourceType, Identifier: source.Identifier,
+	})
+	require.NoError(mgr.SaveManifest(manifest))
+	gmailManifest := deletion.NewManifestForSource("other source type", []string{"remote-2"}, deletion.SourceReference{
+		ID: gmailSource.ID, Type: gmailSource.SourceType, Identifier: gmailSource.Identifier,
+	})
+	require.NoError(mgr.SaveManifest(gmailManifest))
+
+	got, err := planCLIDeleteStaged(context.Background(), st, api.CLIDeleteStagedPlanRequest{
+		Account: "Work", Yes: true, RemoteDeleteEnabled: true,
+	})
+	require.NoError(err)
+	assert.Equal([]string{manifest.ID}, got.PlannedBatchIDs)
+	require.NotNil(got.ResolvedSourceID)
+	assert.Equal(source.ID, *got.ResolvedSourceID)
 }
 
 func TestPlanCLIDeleteStagedEscalatesLegacyGmailTokenForPermanentDelete(t *testing.T) {

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/sourceops"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -32,7 +33,7 @@ var removeAccountAfterCascadeHook func()
 
 func newRemoveAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   removeAccountCommandName + " <email>",
+		Use:   removeAccountCommandName + " [account]",
 		Short: "Remove an account and all its data",
 		Long: `Remove an account and all associated messages, labels, and sync data
 from the local database. This is irreversible.
@@ -52,7 +53,7 @@ Examples:
   msgvault remove-account you@gmail.com
   msgvault remove-account you@gmail.com --yes
   msgvault remove-account you@gmail.com --type mbox`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: runRemoveAccount,
 	}
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
@@ -64,6 +65,7 @@ Examples:
 		"type", "",
 		"Source type to remove (gmail, mbox, etc.)",
 	)
+	cmd.Flags().Int64("source-id", 0, "Exact source ID to remove")
 	return cmd
 }
 
@@ -75,6 +77,9 @@ func runRemoveAccount(cmd *cobra.Command, args []string) error {
 }
 
 func runRemoveAccountHTTP(cmd *cobra.Command, args []string) error {
+	if _, err := removeAccountSelector(cmd, args); err != nil {
+		return usageErr(cmd, err)
+	}
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return fmt.Errorf("read --yes flag: %w", err)
@@ -116,15 +121,14 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read --yes flag: %w", err)
 	}
-	sourceType, err := cmd.Flags().GetString("type")
-	if err != nil {
-		return fmt.Errorf("read --type flag: %w", err)
-	}
 	confirmed, err := cmd.Flags().GetBool(removeAccountConfirmedFlag)
 	if err != nil {
 		return fmt.Errorf("read --%s flag: %w", removeAccountConfirmedFlag, err)
 	}
-	email := args[0]
+	selector, err := removeAccountSelector(cmd, args)
+	if err != nil {
+		return usageErr(cmd, err)
+	}
 
 	s, cleanup, err := openWritableStoreAndInit()
 	if err != nil {
@@ -132,10 +136,11 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	}
 	defer cleanup()
 
-	source, err := resolveSource(s, email, sourceType)
+	source, err := sourceops.ResolveExactOne(s, selector)
 	if err != nil {
 		return err
 	}
+	email := source.Identifier
 
 	activeSync, err := s.GetActiveSync(source.ID)
 	if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
@@ -563,40 +568,38 @@ func deleteOneAttachmentFile(
 func resolveSource(
 	s *store.Store, identifier, sourceType string,
 ) (*store.Source, error) {
-	sources, err := s.GetSourcesByIdentifierOrDisplayName(identifier)
+	return sourceops.ResolveExactOne(s, sourceops.Selector{
+		Account: identifier, SourceType: sourceType,
+	})
+}
+
+func removeAccountSelector(cmd *cobra.Command, args []string) (sourceops.Selector, error) {
+	sourceID, err := cmd.Flags().GetInt64("source-id")
 	if err != nil {
-		return nil, fmt.Errorf("look up account: %w", err)
+		return sourceops.Selector{}, fmt.Errorf("read --source-id flag: %w", err)
 	}
-	if len(sources) == 0 {
-		return nil, fmt.Errorf("account %q not found", identifier)
+	sourceType, err := cmd.Flags().GetString("type")
+	if err != nil {
+		return sourceops.Selector{}, fmt.Errorf("read --type flag: %w", err)
 	}
-
-	if sourceType != "" {
-		for _, src := range sources {
-			if src.SourceType == sourceType {
-				return src, nil
-			}
-		}
-		return nil, fmt.Errorf(
-			"account %q with type %q not found",
-			identifier, sourceType,
-		)
+	account := ""
+	if len(args) == 1 {
+		account = args[0]
 	}
-
-	if len(sources) == 1 {
-		return sources[0], nil
+	sourceIDSet := cmd.Flags().Changed("source-id")
+	switch {
+	case sourceIDSet && sourceID <= 0:
+		return sourceops.Selector{}, errors.New("source ID must be positive")
+	case sourceIDSet && account != "":
+		return sourceops.Selector{}, errors.New("account and source ID are mutually exclusive")
+	case sourceIDSet && sourceType != "":
+		return sourceops.Selector{}, errors.New("source type and source ID are mutually exclusive")
+	case !sourceIDSet && account == "":
+		return sourceops.Selector{}, errors.New("account or source ID is required")
 	}
-
-	// Multiple matches — require --type to disambiguate
-	var types []string
-	for _, src := range sources {
-		types = append(types, src.SourceType)
-	}
-	return nil, fmt.Errorf(
-		"multiple accounts found for %q (types: %s)\n"+
-			"Use --type to specify which one to remove",
-		identifier, strings.Join(types, ", "),
-	)
+	return sourceops.Selector{
+		Account: account, SourceID: sourceID, SourceIDSet: sourceIDSet, SourceType: sourceType,
+	}, nil
 }
 
 func init() {

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -56,31 +57,33 @@ func seedMessageWithAttachment(
 	email, threadKey, msgKey, storagePath, contentHash string,
 ) {
 	t.Helper()
+	require := require.New(t)
 	src, err := s.GetOrCreateSource("gmail", email)
-	require.NoError(t, err, "GetOrCreateSource(%s)", email)
+	require.NoError(err, "GetOrCreateSource(%s)", email)
 	convID, err := s.EnsureConversation(src.ID, threadKey, "Thread")
-	require.NoError(t, err, "EnsureConversation")
+	require.NoError(err, "EnsureConversation")
 	msgID, err := s.UpsertMessage(&store.Message{
 		ConversationID:  convID,
 		SourceID:        src.ID,
 		SourceMessageID: msgKey,
 		MessageType:     "email",
 	})
-	require.NoError(t, err, "UpsertMessage")
-	require.NoError(t, s.UpsertAttachment(msgID, "a.pdf", "application/pdf",
+	require.NoError(err, "UpsertMessage")
+	require.NoError(s.UpsertAttachment(msgID, "a.pdf", "application/pdf",
 		storagePath, contentHash, 0), "UpsertAttachment")
 }
 
 func seedQueryableMessageWithAttachment(t *testing.T, s *store.Store) {
 	t.Helper()
+	require := require.New(t)
 	const email = "test@example.com"
 	const storagePath = "aa/bb/a.pdf"
 	src, err := s.GetOrCreateSource(sourceTypeGmail, email)
-	require.NoError(t, err)
+	require.NoError(err)
 	convID, err := s.EnsureConversation(src.ID, "thread-1", "Thread")
-	require.NoError(t, err)
+	require.NoError(err)
 	senderID, err := s.EnsureParticipant(email, "Sender", "example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 	msgID, err := s.UpsertMessage(&store.Message{
 		ConversationID:  convID,
 		SourceID:        src.ID,
@@ -89,9 +92,9 @@ func seedQueryableMessageWithAttachment(t *testing.T, s *store.Store) {
 		SentAt:          sql.NullTime{Time: time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC), Valid: true},
 		SenderID:        sql.NullInt64{Int64: senderID, Valid: true},
 	})
-	require.NoError(t, err)
-	require.NoError(t, s.ReplaceMessageRecipients(msgID, "from", []int64{senderID}, []string{""}))
-	require.NoError(t, s.UpsertAttachment(msgID, "a.pdf", "application/pdf", storagePath, "hash-a", 10))
+	require.NoError(err)
+	require.NoError(s.ReplaceMessageRecipients(msgID, "from", []int64{senderID}, []string{""}))
+	require.NoError(s.UpsertAttachment(msgID, "a.pdf", "application/pdf", storagePath, "hash-a", 10))
 }
 
 func executeRemoveAccount(t *testing.T) error {
@@ -163,6 +166,146 @@ func TestRemoveAccountUsesDaemonCLIRunnerAndPreservesStreams(t *testing.T) {
 	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
 	assert.Equal("Account removed\n", stdout.String(), "stdout")
 	assert.Equal("remove warning\n", stderr.String(), "stderr")
+}
+
+func TestRemoveAccountSourceIDUsesDaemonCLIRunner(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	requests := &atomic.Int32{}
+	mux := http.NewServeMux()
+	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
+		Service: daemonService,
+		Version: Version,
+	}))
+	mux.HandleFunc("/api/v1/cli/run", func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		var req struct {
+			Args []string `json:"args"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&req)) {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		assert.Equal([]string{"remove-account", "--source-id=42", "--yes"}, req.Args)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	savedCfg := cfg
+	savedUseLocal := useLocal
+	t.Cleanup(func() {
+		cfg = savedCfg
+		useLocal = savedUseLocal
+	})
+	cfg = &config.Config{
+		HomeDir: t.TempDir(),
+		Remote: config.RemoteConfig{
+			URL:           server.URL,
+			AllowInsecure: true,
+		},
+	}
+	useLocal = false
+
+	cmd := newRemoveAccountCmd()
+	cmd.SetArgs([]string{"--source-id", "42", "--yes"})
+	require.NoError(cmd.Execute())
+	assert.Equal(int32(1), requests.Load())
+}
+
+func TestRemoveAccountSelectorValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "explicit zero", args: []string{"--source-id", "0", "--yes"}, want: "positive"},
+		{name: "token plus ID", args: []string{"alice@example.test", "--source-id", "42", "--yes"}, want: "mutually exclusive"},
+		{name: "ID plus type", args: []string{"--source-id", "42", "--type", "gmail", "--yes"}, want: "mutually exclusive"},
+		{name: "missing selector", args: []string{"--yes"}, want: "required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRemoveAccountCmd()
+			cmd.RunE = runRemoveAccountHTTP
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestRemoveAccountTypeRejectsSameTypeDisplayCollision(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	s, err := store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	require.NoError(err)
+	require.NoError(s.InitSchema())
+	first, err := s.GetOrCreateSource("gmail", "first@example.test")
+	require.NoError(err)
+	second, err := s.GetOrCreateSource("gmail", "second@example.test")
+	require.NoError(err)
+	require.NoError(s.UpdateSourceDisplayName(first.ID, "Work"))
+	require.NoError(s.UpdateSourceDisplayName(second.ID, "Work"))
+	require.NoError(s.Close())
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountLocalTestCmd())
+	root.SetArgs([]string{"remove-account", "Work", "--yes", "--type", "gmail"})
+	err = root.Execute()
+	require.ErrorContains(err, "ambiguous")
+
+	s, err = store.Open(filepath.Join(tmpDir, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = s.Close() })
+	sources, err := s.ListSources("gmail")
+	require.NoError(err)
+	assert.Len(sources, 2)
+}
+
+func TestRemoveAccountSourceIDDeletesOnlyExactSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "msgvault.db")
+	s, err := store.Open(dbPath)
+	require.NoError(err)
+	require.NoError(s.InitSchema())
+	gmail, err := s.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	imap, err := s.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+	require.NoError(s.Close())
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountLocalTestCmd())
+	root.SetArgs([]string{
+		"remove-account", "--source-id", strconv.FormatInt(imap.ID, 10), "--yes",
+	})
+	require.NoError(root.Execute())
+
+	s, err = store.Open(dbPath)
+	require.NoError(err)
+	t.Cleanup(func() { _ = s.Close() })
+	remaining, err := s.GetSourceByID(gmail.ID)
+	require.NoError(err)
+	assert.Equal(gmail.ID, remaining.ID)
+	_, err = s.GetSourceByID(imap.ID)
+	assert.ErrorIs(err, store.ErrSourceNotFound)
 }
 
 func TestRemoveAccountPromptsBeforeDaemonCLIRunner(t *testing.T) {
@@ -550,7 +693,7 @@ func TestRemoveAccountCmd_NotFound(t *testing.T) {
 
 	err = root.Execute()
 	require.Error(err, "expected error for unknown email")
-	assert.ErrorContains(t, err, "not found")
+	assert.ErrorContains(t, err, "no account found")
 }
 
 func TestRemoveAccountCmd_WithYesFlag(t *testing.T) {
@@ -909,7 +1052,7 @@ func TestRemoveAccountCmd_DuplicateIdentifierRequiresType(
 
 	err = root.Execute()
 	require.Error(err, "expected error for ambiguous identifier")
-	require.ErrorContains(err, "multiple accounts")
+	require.ErrorContains(err, "ambiguous")
 
 	// With --type should succeed
 	root2 := newTestRootCmd()

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1421,6 +1421,9 @@ func emitFolderArgs(args []string, flag string, values []string) []string {
 func cliSyncSubprocessArgs(req api.CLISyncRequest) []string {
 	if req.Full {
 		args := []string{"sync-full"}
+		if req.SourceIDSet {
+			args = append(args, "--source-id", strconv.FormatInt(req.SourceID, 10))
+		}
 		if req.Query != "" {
 			args = append(args, "--query", req.Query)
 		}
@@ -1444,6 +1447,9 @@ func cliSyncSubprocessArgs(req api.CLISyncRequest) []string {
 		return args
 	}
 	args := []string{syncIncrementalCmd.Name()}
+	if req.SourceIDSet {
+		args = append(args, "--source-id", strconv.FormatInt(req.SourceID, 10))
+	}
 	args = emitFolderArgs(args, "--folder", req.Folders)
 	args = emitFolderArgs(args, "--skip-folder", req.SkipFolders)
 	if req.Email != "" {

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -1042,21 +1042,24 @@ func TestOpenDaemonAnalyticsEngineExplicitDuckDBOpenFailureMarksIntentFailed(t *
 }
 
 func TestOpenDaemonAnalyticsEngineSQLLeavesExplicitIntentUnconsumed(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	c, s := openTestDaemonAnalyticsStore(t)
 	c.Analytics.Engine = config.AnalyticsEngineSQL
 	stubStartupCacheBuild(t, func(context.Context, startupCacheBuildIntent) error {
-		require.FailNow(t, "SQL engine must leave cache intent for the HTTP path")
+		require.FailNow("SQL engine must leave cache intent for the HTTP path")
 		return nil
 	})
 
 	engine, mode, outcome, err := openDaemonAnalyticsEngine(
 		context.Background(), c, s, startupCacheBuildIntentDefault,
 	)
-	require.NoError(t, err)
+	require.NoError(err)
 	defer func() { _ = engine.Close() }()
 
-	assert.Equal(t, api.AnalyticsModeSQL, mode)
-	assert.Equal(t, startupCacheBuildOutcomeUnconsumed, outcome)
+	assert.Equal(api.AnalyticsModeSQL, mode)
+	assert.Equal(startupCacheBuildOutcomeUnconsumed, outcome)
 }
 
 func TestOpenDaemonAnalyticsEngineExplicitDuckDBFailureIsFatal(t *testing.T) {
@@ -1239,6 +1242,17 @@ func TestCLISyncSubprocessArgsIncrementalIncludesFolderFilters(t *testing.T) {
 			Folders:     []string{"Path\\To\\File"},
 			SkipFolders: []string{"Fold,er"},
 		}),
+	)
+}
+
+func TestCLISyncSubprocessArgsIncludesExactSourceID(t *testing.T) {
+	assert.Equal(t,
+		[]string{"sync", "--source-id", "42"},
+		cliSyncSubprocessArgs(api.CLISyncRequest{SourceID: 42, SourceIDSet: true}),
+	)
+	assert.Equal(t,
+		[]string{"sync-full", "--source-id", "42"},
+		cliSyncSubprocessArgs(api.CLISyncRequest{Full: true, SourceID: 42, SourceIDSet: true}),
 	)
 }
 

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -50,6 +50,10 @@ Examples:
 }
 
 func runSyncIncrementalLocal(cmd *cobra.Command, args []string) error {
+	selector, selectorSet, err := syncSourceSelector(cmd, args)
+	if err != nil {
+		return usageErr(cmd, err)
+	}
 	s, cleanup, err := openWritableStoreAndInit()
 	if err != nil {
 		return err
@@ -86,12 +90,12 @@ func runSyncIncrementalLocal(cmd *cobra.Command, args []string) error {
 	var imapTargets []*store.Source
 	var syncErrors []string
 
-	if len(args) == 1 {
+	if selectorSet {
 		// Resolve all sources for the identifier and route
 		// each by type, same as sync-full.
-		allMatches, lookupErr := s.GetSourcesByIdentifierOrDisplayName(args[0])
+		allMatches, legacy, lookupErr := resolveSyncSources(s, selector)
 		if lookupErr != nil {
-			return fmt.Errorf("look up source: %w", lookupErr)
+			return lookupErr
 		}
 		for _, src := range allMatches {
 			switch src.SourceType {
@@ -103,10 +107,12 @@ func runSyncIncrementalLocal(cmd *cobra.Command, args []string) error {
 		}
 		if len(gmailTargets) == 0 && len(imapTargets) == 0 {
 			if len(allMatches) > 0 {
-				return fmt.Errorf("account %q exists but its source type cannot be synced (only gmail and imap are supported)", args[0])
+				return fmt.Errorf("%s exists but its source type cannot be synced (only gmail and imap are supported)", syncSelectorLabel(selector))
 			}
-			// Not in DB — assume Gmail (legacy behaviour)
-			gmailTargets = []syncTarget{{email: args[0]}}
+			if legacy {
+				// Token not in DB — assume Gmail (legacy behaviour).
+				gmailTargets = []syncTarget{{email: selector.Account}}
+			}
 		}
 	} else {
 		// Discover all sources.
@@ -305,6 +311,7 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 }
 
 func init() {
+	syncIncrementalCmd.Flags().Int64("source-id", 0, "Exact source ID to sync")
 	syncIncrementalCmd.Flags().StringArrayVar(&syncFolders, "folder", []string{}, "IMAP folder to scan (repeatable)")
 	syncIncrementalCmd.Flags().StringArrayVar(&syncSkipFolders, "skip-folder", []string{}, "IMAP folder to skip (repeatable)")
 	rootCmd.AddCommand(syncIncrementalCmd)

--- a/cmd/msgvault/cmd/sync_http.go
+++ b/cmd/msgvault/cmd/sync_http.go
@@ -14,17 +14,27 @@ import (
 )
 
 func runSyncIncrementalHTTP(cmd *cobra.Command, args []string) error {
+	selector, _, err := syncSourceSelector(cmd, args)
+	if err != nil {
+		return usageErr(cmd, err)
+	}
 	req := daemonclient.CLISyncRequest{
 		Folders:     parseFolderFilter(syncFolders),
 		SkipFolders: parseFolderFilter(syncSkipFolders),
+		SourceID:    selector.SourceID,
+		SourceIDSet: selector.SourceIDSet,
 	}
 	if len(args) == 1 {
-		req.Email = args[0]
+		req.Email = selector.Account
 	}
 	return runSyncHTTP(cmd, req)
 }
 
 func runSyncFullHTTP(cmd *cobra.Command, args []string) error {
+	selector, _, err := syncSourceSelector(cmd, args)
+	if err != nil {
+		return usageErr(cmd, err)
+	}
 	req := daemonclient.CLISyncRequest{
 		Full:        true,
 		Query:       syncQuery,
@@ -34,9 +44,11 @@ func runSyncFullHTTP(cmd *cobra.Command, args []string) error {
 		Limit:       syncLimit,
 		Folders:     parseFolderFilter(syncFolders),
 		SkipFolders: parseFolderFilter(syncSkipFolders),
+		SourceID:    selector.SourceID,
+		SourceIDSet: selector.SourceIDSet,
 	}
 	if len(args) == 1 {
-		req.Email = args[0]
+		req.Email = selector.Account
 	}
 	return runSyncHTTP(cmd, req)
 }
@@ -48,7 +60,7 @@ func runSyncHTTP(cmd *cobra.Command, req daemonclient.CLISyncRequest) error {
 	}
 	defer func() { _ = st.Close() }()
 
-	if err := preflightReauth(cmd.Context(), buildSyncPreflight(st, info), req.Email); err != nil {
+	if err := preflightReauth(cmd.Context(), buildSyncPreflight(st, info), req.Email, req.SourceID); err != nil {
 		return err
 	}
 
@@ -77,6 +89,7 @@ type preflightReauthManager interface {
 
 // preflightAccount is a single Gmail account the preflight may re-authorize.
 type preflightAccount struct {
+	ID          int64
 	Email       string
 	DisplayName string
 	OAuthApp    string
@@ -124,6 +137,7 @@ func buildSyncPreflight(st *daemonclient.Client, info HTTPStoreInfo) preflightCo
 					continue
 				}
 				gmail = append(gmail, preflightAccount{
+					ID:          a.ID,
 					Email:       a.Email,
 					DisplayName: a.DisplayName,
 					OAuthApp:    a.OAuthApp,
@@ -147,7 +161,7 @@ func buildSyncPreflight(st *daemonclient.Client, info HTTPStoreInfo) preflightCo
 // which cannot open a browser itself. It is strictly best-effort: it only
 // re-authorizes tokens that already exist and have expired/been revoked, and
 // it never enrolls a new account (that is add-account's job).
-func preflightReauth(ctx context.Context, p preflightConfig, reqIdentifier string) error {
+func preflightReauth(ctx context.Context, p preflightConfig, reqIdentifier string, reqSourceID int64) error {
 	if !p.Local || !p.Interactive || !p.OAuthConfigured {
 		return nil
 	}
@@ -156,7 +170,9 @@ func preflightReauth(ctx context.Context, p preflightConfig, reqIdentifier strin
 	if err != nil {
 		return fmt.Errorf("list accounts for reauth preflight: %w", err)
 	}
-	if reqIdentifier != "" {
+	if reqSourceID > 0 {
+		targets = filterPreflightAccountsByID(targets, reqSourceID)
+	} else if reqIdentifier != "" {
 		targets = filterPreflightAccounts(targets, reqIdentifier)
 	}
 
@@ -166,6 +182,16 @@ func preflightReauth(ctx context.Context, p preflightConfig, reqIdentifier strin
 		}
 	}
 	return nil
+}
+
+func filterPreflightAccountsByID(accounts []preflightAccount, sourceID int64) []preflightAccount {
+	var matched []preflightAccount
+	for _, account := range accounts {
+		if account.ID == sourceID {
+			matched = append(matched, account)
+		}
+	}
+	return matched
 }
 
 // filterPreflightAccounts keeps the Gmail accounts whose email OR display name

--- a/cmd/msgvault/cmd/sync_http_test.go
+++ b/cmd/msgvault/cmd/sync_http_test.go
@@ -61,6 +61,49 @@ func TestSyncUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	assert.Equal("sync warning\n", stderr.String())
 }
 
+func TestSyncSourceIDUsesConfiguredRemoteHTTP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.4.0"}`))
+			return
+		}
+		assert.Equal(t, "42", r.URL.Query().Get("source_id"))
+		assert.Empty(t, r.URL.Query().Get("email"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(server.Close)
+	configureRemoteSyncTest(t, server.URL)
+	resetSyncFullFlagsForTest(t)
+
+	cmd := &cobra.Command{Use: syncIncrementalCmd.Use, Args: syncIncrementalCmd.Args, RunE: syncIncrementalCmd.RunE}
+	cmd.Flags().Int64("source-id", 0, "Exact source ID")
+	cmd.SetArgs([]string{"--source-id", "42"})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestSyncSourceIDSelectorValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "explicit zero", args: []string{"--source-id", "0"}, want: "positive"},
+		{name: "token plus ID", args: []string{"alice@example.test", "--source-id", "42"}, want: "mutually exclusive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: syncIncrementalCmd.Use, Args: syncIncrementalCmd.Args, RunE: syncIncrementalCmd.RunE}
+			cmd.Flags().Int64("source-id", 0, "Exact source ID")
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
 func TestSyncFullUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 	assert := assert.New(t)
 
@@ -254,7 +297,7 @@ func TestPreflightReauth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			managers := map[string]*mockReauthorizer{"": tt.manager}
-			err := preflightReauth(context.Background(), tt.config(managers), "")
+			err := preflightReauth(context.Background(), tt.config(managers), "", 0)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -276,9 +319,23 @@ func TestPreflightReauth_SpecificEmail(t *testing.T) {
 		preflightAccount{Email: "bob@example.com", OAuthApp: "bob-app"},
 	)
 
-	require.NoError(t, preflightReauth(context.Background(), c, "bob@example.com"))
+	require.NoError(t, preflightReauth(context.Background(), c, "bob@example.com", 0))
 	assert.Equal(t, 0, alice.authorizeCount, "alice must not be re-authorized")
 	assert.Equal(t, 1, bob.authorizeCount, "bob must be re-authorized")
+}
+
+func TestPreflightReauth_SourceIDTargetsOneDuplicateAccount(t *testing.T) {
+	first := newExpiredPreflightManager()
+	second := newExpiredPreflightManager()
+	managers := map[string]*mockReauthorizer{"first-app": first, "second-app": second}
+	c := basePreflight(managers,
+		preflightAccount{ID: 41, Email: "shared@example.com", OAuthApp: "first-app"},
+		preflightAccount{ID: 42, Email: "shared@example.com", OAuthApp: "second-app"},
+	)
+
+	require.NoError(t, preflightReauth(context.Background(), c, "", 42))
+	assert.Equal(t, 0, first.authorizeCount)
+	assert.Equal(t, 1, second.authorizeCount)
 }
 
 // TestPreflightReauth_IMAPRequestSkips verifies a request for a non-Gmail
@@ -288,7 +345,7 @@ func TestPreflightReauth_IMAPRequestSkips(t *testing.T) {
 	managers := map[string]*mockReauthorizer{"": gmailMgr}
 	c := basePreflight(managers, preflightAccount{Email: "alice@example.com"})
 
-	require.NoError(t, preflightReauth(context.Background(), c, "imap-user@example.com"))
+	require.NoError(t, preflightReauth(context.Background(), c, "imap-user@example.com", 0))
 	assert.Equal(t, 0, gmailMgr.authorizeCount, "no reauth for non-Gmail request")
 }
 
@@ -304,7 +361,7 @@ func TestPreflightReauth_DisplayName(t *testing.T) {
 		preflightAccount{Email: "bob@example.com", DisplayName: "Personal", OAuthApp: "personal-app"},
 	)
 
-	require.NoError(t, preflightReauth(context.Background(), c, "Work Gmail"))
+	require.NoError(t, preflightReauth(context.Background(), c, "Work Gmail", 0))
 	assert.Equal(t, 1, work.authorizeCount, "display-name match must be re-authorized")
 	assert.Equal(t, 0, personal.authorizeCount, "non-matching account untouched")
 }
@@ -318,7 +375,7 @@ func TestPreflightReauth_NoMatch(t *testing.T) {
 		preflightAccount{Email: "alice@example.com", DisplayName: "Work Gmail"},
 	)
 
-	require.NoError(t, preflightReauth(context.Background(), c, "Nonexistent"))
+	require.NoError(t, preflightReauth(context.Background(), c, "Nonexistent", 0))
 	assert.Equal(t, 0, mgr.authorizeCount, "no reauth when nothing matches")
 }
 

--- a/cmd/msgvault/cmd/sync_selection.go
+++ b/cmd/msgvault/cmd/sync_selection.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/sourceops"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func syncSourceSelector(cmd *cobra.Command, args []string) (sourceops.Selector, bool, error) {
+	account := ""
+	if len(args) == 1 {
+		account = strings.TrimSpace(args[0])
+	}
+	flag := cmd.Flags().Lookup("source-id")
+	if flag == nil || !flag.Changed {
+		return sourceops.Selector{Account: account}, account != "", nil
+	}
+	sourceID, err := cmd.Flags().GetInt64("source-id")
+	if err != nil {
+		return sourceops.Selector{}, false, fmt.Errorf("read --source-id flag: %w", err)
+	}
+	switch {
+	case sourceID <= 0:
+		return sourceops.Selector{}, false, errors.New("source ID must be positive")
+	case account != "":
+		return sourceops.Selector{}, false, errors.New("account and source ID are mutually exclusive")
+	default:
+		return sourceops.Selector{SourceID: sourceID, SourceIDSet: true}, true, nil
+	}
+}
+
+func resolveSyncSources(
+	st sourceops.Store,
+	selector sourceops.Selector,
+) ([]*store.Source, bool, error) {
+	selection, err := sourceops.ResolveAllMatches(st, selector)
+	if err == nil {
+		return selection.Sources, false, nil
+	}
+	if selector.Account != "" && opserr.KindOf(err) == opserr.KindNotFound {
+		return nil, true, nil
+	}
+	return nil, false, err
+}
+
+func syncSelectorLabel(selector sourceops.Selector) string {
+	if selector.SourceIDSet {
+		return fmt.Sprintf("source ID %d", selector.SourceID)
+	}
+	return fmt.Sprintf("account %q", selector.Account)
+}

--- a/cmd/msgvault/cmd/sync_test.go
+++ b/cmd/msgvault/cmd/sync_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/sourceops"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
 // fakeClientSecrets is a minimal Google OAuth client_secret.json that
@@ -122,6 +124,40 @@ func TestSyncCmd_DuplicateIdentifierRoutesCorrectly(t *testing.T) {
 	// error produced by getTokenSourceWithReauth.
 	assert.Contains(output, "add-account",
 		"Gmail error should originate from runIncrementalSync; output:\n%s", output)
+}
+
+func TestResolveSyncSourcesSourceIDIsExact(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	gmail, err := f.Store.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	_, err = f.Store.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+
+	sources, legacy, err := resolveSyncSources(f.Store, sourceops.Selector{
+		SourceID: gmail.ID, SourceIDSet: true,
+	})
+	require.NoError(err)
+	assert.False(legacy)
+	require.Len(sources, 1)
+	assert.Equal(gmail.ID, sources[0].ID)
+}
+
+func TestResolveSyncSourcesNumericTokenDoesNotBecomeSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	numeric, err := f.Store.GetOrCreateSource("imap", "15551234567")
+	require.NoError(err)
+
+	sources, legacy, err := resolveSyncSources(f.Store, sourceops.Selector{Account: "15551234567"})
+	require.NoError(err)
+	assert.False(legacy)
+	require.Len(sources, 1)
+	assert.Equal(numeric.ID, sources[0].ID)
 }
 
 // TestSyncCmd_SingleSourceNoAmbiguity verifies that a single
@@ -674,8 +710,12 @@ func TestTrimFolderFilter(t *testing.T) {
 }
 
 func TestSyncCommandRegistersFolderFlags(t *testing.T) {
-	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("folder"))
-	require.NotNil(t, syncIncrementalCmd.Flags().Lookup("skip-folder"))
+	require := require.New(t)
+
+	require.NotNil(syncIncrementalCmd.Flags().Lookup("folder"))
+	require.NotNil(syncIncrementalCmd.Flags().Lookup("skip-folder"))
+	require.NotNil(syncIncrementalCmd.Flags().Lookup("source-id"))
+	require.NotNil(syncFullCmd.Flags().Lookup("source-id"))
 }
 
 // Full e2e integration with an in-memory IMAP server is tested in

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -82,6 +82,10 @@ func validateSyncFullFlags(cmd *cobra.Command) error {
 }
 
 func runSyncFullLocal(cmd *cobra.Command, args []string) error {
+	selector, selectorSet, err := syncSourceSelector(cmd, args)
+	if err != nil {
+		return usageErr(cmd, err)
+	}
 	s, cleanup, err := openWritableStoreAndInit()
 	if err != nil {
 		return err
@@ -94,14 +98,14 @@ func runSyncFullLocal(cmd *cobra.Command, args []string) error {
 	// Determine which sources to sync
 	var sources []*store.Source
 	var syncErrors []string
-	if len(args) == 1 {
+	if selectorSet {
 		// Look up all sources matching the identifier and
 		// keep only syncable types (gmail, imap). Non-syncable
 		// sources like mbox/apple-mail imports share the same
 		// identifier namespace but cannot be synced.
-		allMatches, err := s.GetSourcesByIdentifierOrDisplayName(args[0])
+		allMatches, legacy, err := resolveSyncSources(s, selector)
 		if err != nil {
-			return fmt.Errorf("look up source: %w", err)
+			return err
 		}
 		for _, src := range allMatches {
 			if src.SourceType == sourceTypeGmail || src.SourceType == sourceTypeIMAP {
@@ -111,10 +115,12 @@ func runSyncFullLocal(cmd *cobra.Command, args []string) error {
 		if len(sources) == 0 {
 			if len(allMatches) > 0 {
 				// Identifier exists but has no syncable source types.
-				return fmt.Errorf("account %q exists but its source type cannot be synced (only gmail and imap are supported)", args[0])
+				return fmt.Errorf("%s exists but its source type cannot be synced (only gmail and imap are supported)", syncSelectorLabel(selector))
 			}
-			// Not in DB yet - assume Gmail (legacy behaviour)
-			sources = []*store.Source{{SourceType: sourceTypeGmail, Identifier: args[0]}}
+			if legacy {
+				// Token not in DB yet - assume Gmail (legacy behaviour).
+				sources = []*store.Source{{SourceType: sourceTypeGmail, Identifier: selector.Account}}
+			}
 		}
 	} else {
 		// Sync all configured sources
@@ -914,6 +920,7 @@ func imapSkipReason(src *store.Source) (string, error) {
 }
 
 func init() {
+	syncFullCmd.Flags().Int64("source-id", 0, "Exact source ID to sync")
 	syncFullCmd.Flags().StringVar(&syncQuery, "query", "", "Gmail search query")
 	syncFullCmd.Flags().BoolVar(&syncNoResume, "noresume", false, "Force fresh sync (don't resume; re-enumerates all IMAP folders)")
 	syncFullCmd.Flags().StringVar(&syncBefore, "before", "", "Only messages before this date (YYYY-MM-DD)")

--- a/cmd/msgvault/cmd/update_account.go
+++ b/cmd/msgvault/cmd/update_account.go
@@ -8,27 +8,48 @@ import (
 	"go.kenn.io/msgvault/internal/daemonclient"
 )
 
-var updateDisplayName string
+var (
+	updateDisplayName     string
+	updateAccountSourceID int64
+)
 
-var updateAccountCmd = &cobra.Command{
-	Use:   "update-account <email>",
-	Short: "Update account settings",
-	Long: `Update settings for an existing account.
+var updateAccountCmd = newUpdateAccountCmd()
+
+func newUpdateAccountCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update-account [account]",
+		Short: "Update account settings",
+		Long: `Update settings for an existing account.
 
 Currently supports updating the display name for an account.
 
 Examples:
   msgvault update-account you@gmail.com --display-name "Work"
-  msgvault update-account you@gmail.com --display-name "Personal Email"`,
-	Args: cobra.ExactArgs(1),
-	RunE: runUpdateAccount,
+  msgvault update-account --source-id 42 --display-name "Personal Email"`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runUpdateAccount,
+	}
+	cmd.Flags().StringVar(&updateDisplayName, "display-name", "", "Set the display name for the account")
+	cmd.Flags().Int64Var(&updateAccountSourceID, "source-id", 0, "Exact source ID to update")
+	return cmd
 }
 
 func runUpdateAccount(cmd *cobra.Command, args []string) error {
-	email := args[0]
-
 	if updateDisplayName == "" {
 		return usageErr(cmd, errors.New("nothing to update: use --display-name to set a display name"))
+	}
+	account := ""
+	if len(args) == 1 {
+		account = args[0]
+	}
+	sourceIDSet := cmd.Flags().Changed("source-id")
+	switch {
+	case sourceIDSet && updateAccountSourceID <= 0:
+		return usageErr(cmd, errors.New("source ID must be positive"))
+	case sourceIDSet && account != "":
+		return usageErr(cmd, errors.New("account and source ID are mutually exclusive"))
+	case !sourceIDSet && account == "":
+		return usageErr(cmd, errors.New("account or source ID is required"))
 	}
 
 	st, _, err := OpenHTTPStore(cmd.Context())
@@ -38,7 +59,9 @@ func runUpdateAccount(cmd *cobra.Command, args []string) error {
 	defer func() { _ = st.Close() }()
 
 	result, err := st.UpdateCLIAccount(cmd.Context(), daemonclient.CLIAccountUpdateRequest{
-		Email:       email,
+		Email:       account,
+		SourceID:    updateAccountSourceID,
+		SourceIDSet: sourceIDSet,
 		DisplayName: updateDisplayName,
 	})
 	if err != nil {
@@ -52,5 +75,4 @@ func runUpdateAccount(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(updateAccountCmd)
-	updateAccountCmd.Flags().StringVar(&updateDisplayName, "display-name", "", "Set the display name for the account")
 }

--- a/cmd/msgvault/cmd/update_account_test.go
+++ b/cmd/msgvault/cmd/update_account_test.go
@@ -84,3 +84,87 @@ func TestUpdateAccountUsesLocalDaemonHTTPAndPreservesOutput(t *testing.T) {
 	assert.Empty(stderr.String(), "stderr")
 	assert.Equal("Updated account alice@example.com: display name set to \"Work\"\n", stdout.String())
 }
+
+func TestUpdateAccountSourceIDUsesTypedDaemonRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	savedDisplayName := updateDisplayName
+	savedSourceID := updateAccountSourceID
+	t.Cleanup(func() {
+		updateDisplayName = savedDisplayName
+		updateAccountSourceID = savedSourceID
+	})
+	requests := &atomic.Int32{}
+	dataDir := t.TempDir()
+	mux := http.NewServeMux()
+	mux.Handle("/api/ping", daemon.NewPingHandler(daemon.PingHandlerOptions{
+		Service: daemonService,
+		Version: Version,
+	}))
+	registerStatsProbeHandler(mux)
+	mux.HandleFunc("/api/v1/cli/account", func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		var req struct {
+			SourceID    int64  `json:"source_id"`
+			DisplayName string `json:"display_name"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&req)) {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(int64(42), req.SourceID)
+		assert.Equal("Work", req.DisplayName)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"email":"alice@example.com","display_name":"Work"}`))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	writeStatsHTTPDaemonRuntime(t, dataDir, server)
+
+	savedCfg := cfg
+	savedUseLocal := useLocal
+	t.Cleanup(func() {
+		cfg = savedCfg
+		useLocal = savedUseLocal
+	})
+	cfg = &config.Config{
+		HomeDir: dataDir,
+		Data:    config.DataConfig{DataDir: dataDir},
+		Remote:  config.RemoteConfig{URL: server.URL},
+	}
+	useLocal = true
+
+	cmd := newUpdateAccountCmd()
+	cmd.SetArgs([]string{"--source-id", "42", "--display-name", "Work"})
+	require.NoError(cmd.Execute())
+	assert.Equal(int32(1), requests.Load())
+}
+
+func TestUpdateAccountSelectorValidation(t *testing.T) {
+	savedDisplayName := updateDisplayName
+	savedSourceID := updateAccountSourceID
+	t.Cleanup(func() {
+		updateDisplayName = savedDisplayName
+		updateAccountSourceID = savedSourceID
+	})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "explicit zero", args: []string{"--source-id", "0", "--display-name", "Work"}, want: "positive"},
+		{name: "token plus ID", args: []string{"alice@example.test", "--source-id", "42", "--display-name", "Work"}, want: "mutually exclusive"},
+		{name: "missing selector", args: []string{"--display-name", "Work"}, want: "required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newUpdateAccountCmd()
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -13,7 +13,7 @@ background sync scheduler to keep accounts up to date on a cron-based schedule.
 The complete UI is embedded in the release binary; see [Web UI](/web-ui/) for
 browser login, secure remote deployment, search states, and keyboard controls.
 
-The API is registered through Huma and exposes a generated OpenAPI document at `/openapi.json`. You can also run `msgvault openapi` to print the same checked-in contract without starting a daemon or opening the archive database. The OpenAPI `info.version` is the API schema version used for client/server compatibility; the running daemon binary version is exposed separately in the generated document metadata. The API queries the same archive database and attachment store as the CLI, Web UI, and TUI. SQLite is the default archive database; PostgreSQL is supported when `[data].database_url` is a PostgreSQL DSN. Keyword search and ordinary archive reads stay local to that database. If vector search is enabled, semantic and hybrid search also call the embedding endpoint configured in `[vector.embeddings]`. The server is designed for interactive archive use, local integrations, dashboards, and automation scripts.
+The API is registered through Huma and exposes a generated OpenAPI document at `/openapi.json`. You can also run `msgvault openapi` to print the same checked-in contract without starting a daemon or opening the archive database. The OpenAPI `info.version` is the API schema version used for client/server compatibility; the current schema is 2.4.0. The running daemon binary version is exposed separately in the generated document metadata. The API queries the same archive database and attachment store as the CLI, Web UI, and TUI. SQLite is the default archive database; PostgreSQL is supported when `[data].database_url` is a PostgreSQL DSN. Keyword search and ordinary archive reads stay local to that database. If vector search is enabled, semantic and hybrid search also call the embedding endpoint configured in `[vector.embeddings]`. The server is designed for interactive archive use, local integrations, dashboards, and automation scripts.
 
 Go integrations can use the generated client in `pkg/client`. The wrapper
 handles msgvault-specific response details such as deletion staging dry-runs
@@ -1415,8 +1415,10 @@ command. The endpoint accepts three request shapes:
 
 In every shape, resolution is restricted to live Gmail-source messages, and a
 staged manifest executes against a single mailbox: the selection must resolve
-to exactly one Gmail account. The resolved account is stamped on the manifest
-(`delete-staged` uses it to pick the mailbox) and reported in the response;
+to exactly one Gmail source. The durable source tuple (`type` and `identifier`,
+plus the local numeric `id`) is stamped on the manifest and reported as
+`source` in dry-run and created responses; `delete-staged` resolves that tuple
+again before it claims the manifest. The account identifier is also reported;
 selections spanning multiple accounts are rejected with
 `400 multi_account_selection` — scope the request (for example with
 `filter.source_id` or a `source` filter dimension) or stage per account.
@@ -1449,6 +1451,7 @@ the request and returns `200` without writing anything:
   "dry_run": true,
   "message_count": 1234,
   "account": "you@gmail.com",
+  "source": {"id": 1, "type": "gmail", "identifier": "you@gmail.com"},
   "sample_gmail_ids": ["18c2f5a1b2c3d4e5", "..."]
 }
 ```
@@ -1472,6 +1475,7 @@ A pending manifest is written and `201` returned:
   "dry_run": false,
   "message_count": 2,
   "account": "you@gmail.com",
+  "source": {"id": 1, "type": "gmail", "identifier": "you@gmail.com"},
   "id": "20260706-153000-old-newsletters-a1b2",
   "status": "pending"
 }
@@ -1622,7 +1626,7 @@ monitor schedule state and `/api/v1/sync/{account}` to trigger supported
 account syncs outside the schedule. Discord's dedicated manual command is
 `msgvault sync-discord`.
 
-The same HTTP server backs configured remote CLI access and the local background daemon used by archive-access CLI commands.
+The same HTTP server backs configured remote CLI access and the local background daemon used by archive-access CLI commands. In API schema 2.4.0, the CLI sync transport accepts `source_id`, allowing `sync` and `sync-full` to select one source exactly even when several source types share an identifier.
 
 !!! note
     Gmail accounts must have completed an initial `msgvault sync-full` before

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,8 @@ All notable changes to msgvault, grouped by release.
 **Breaking changes**
 
 - The HTTP API separates observed participant analytics from durable curated
-  people, and the API schema version moves from 1.44.0 to 2.1.0. The
+  people, crossing the API schema 2.0 compatibility boundary at 2.1.0. The
+  current unreleased API schema is 2.4.0. The
   analytical routes formerly under `/api/v1/people/*` (search, detail,
   summary, timeline, files) now live under `/api/v1/participants/*`, and the
   durable person routes formerly under `/api/v1/persons/*` now live under
@@ -22,7 +23,20 @@ All notable changes to msgvault, grouped by release.
   `/api/v1/health`, and a CLI in remote mode verifies it on connect,
   rejecting daemons that predate schema 2.0.
 
+- Deletion staging now requires every selected message to belong to one exact
+  source. TUI and MCP selections that span accounts are rejected instead of
+  creating a manifest that could mark or delete the wrong account's messages.
+  In the TUI, press `a` to filter by account before staging again; MCP callers
+  should pass `account` or stage each source separately.
+
 **Features**
+
+- Exact source selection is available through `--source-id` on `sync`,
+  `sync-full`, `update-account`, `remove-account`, and `delete-staged`.
+  Account arguments continue to accept identifiers and display names, while
+  destructive commands reject ambiguous tokens. Version-2 deletion manifests
+  and staging responses preserve the source type and identifier so execution
+  remains scoped when two source types share the same identifier.
 
 - Person profile catalog and tracking foundation: eleven reconciled system
   profile attributes (location, birthplace, membership, religion, politics,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -193,10 +193,12 @@ rules.
 
 ## sync-full
 
-Download all messages from a Gmail or IMAP account. When called without an email argument, syncs all configured syncable accounts.
+Download all messages from a Gmail or IMAP account. The optional account can
+be an identifier or display name. When it is omitted, the command syncs all
+configured syncable accounts.
 
 ```bash
-msgvault sync-full [email] [flags]
+msgvault sync-full [account] [flags]
 ```
 
 | Flag | Description |
@@ -208,7 +210,11 @@ msgvault sync-full [email] [flags]
 | `--noresume` | Ignore checkpoints, start fresh |
 | `--folder NAME` | Scan this IMAP folder (repeatable) |
 | `--skip-folder NAME` | Skip this IMAP folder (repeatable) |
+| `--source-id ID` | Sync exactly one source by numeric ID; mutually exclusive with the account argument |
 | `--verbose` | Detailed progress output |
+
+An account token can select more than one matching source. Use `--source-id`
+when Gmail and IMAP, or two other sources, share the same identifier.
 
 The CLI sends the sync request to the configured remote server or local daemon
 and streams the daemon's stdout/stderr back to the terminal. This keeps local
@@ -219,16 +225,17 @@ SQLite writer beside `msgvault serve`.
 
 ## sync
 
-Sync new and changed messages. Gmail accounts use the Gmail History API; IMAP accounts perform a mailbox scan and skip messages already in the database. When called without an email argument, syncs all accounts that have completed an initial full sync.
+Sync new and changed messages. Gmail accounts use the Gmail History API; IMAP accounts perform a mailbox scan and skip messages already in the database. The optional account can be an identifier or display name. When it is omitted, the command syncs all accounts that have completed an initial full sync.
 
 ```bash
-msgvault sync [email] [flags]
+msgvault sync [account] [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `--folder NAME` | Scan this IMAP folder (repeatable) |
 | `--skip-folder NAME` | Skip this IMAP folder (repeatable) |
+| `--source-id ID` | Sync exactly one source by numeric ID; mutually exclusive with the account argument |
 
 The CLI sends the incremental sync request to the configured remote server or
 local daemon and streams the daemon's stdout/stderr back to the terminal. The
@@ -1753,12 +1760,16 @@ Update account settings through the configured remote server or local daemon.
 Use `--local` to force the local daemon when a remote is configured.
 
 ```bash
-msgvault update-account <email> [flags]
+msgvault update-account [account] [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `--display-name` | Set a display name for the account |
+| `--source-id ID` | Update exactly one source by numeric ID; mutually exclusive with the account argument |
+
+The account argument accepts an identifier or a unique display name. Supply
+either an account or `--source-id`.
 
 ---
 
@@ -1767,14 +1778,18 @@ msgvault update-account <email> [flags]
 Remove an account or source and all its archived data from the selected msgvault archive. Deletes messages, labels, sync state, credentials no longer shared by another source, and attachment files unique to this source. This is irreversible but does not touch the remote provider.
 
 ```bash
-msgvault remove-account <email> [flags]
+msgvault remove-account [account] [flags]
 msgvault remove-account 123456789012345678 --type discord
+msgvault remove-account --source-id 42
 ```
 
 | Flag | Description |
 |---|---|
 | `-y`, `--yes` | Skip the confirmation prompt (and allow removal when an active sync is in progress) |
 | `--type` | Source type to remove when the same identifier exists across source types (`gmail`, `imap`, `mbox`, `discord`, etc.) |
+| `--source-id ID` | Remove exactly one source by numeric ID; mutually exclusive with the account argument and `--type` |
+
+The account argument accepts an identifier or a unique display name.
 
 Attachment files are only deleted when no other account references the same
 content hash. A Discord bot token is preserved while another registered guild
@@ -1832,7 +1847,8 @@ msgvault delete-staged [batch-id] [flags]
 | `--permanent` | Permanently delete through the Gmail batch API instead of moving to trash |
 | `--dry-run` | Show what would be deleted without deleting |
 | `-l`, `--list` | List staged deletion batches |
-| `--account` | Filter to a specific account |
+| `--account` | Filter to one source by identifier or unique display name |
+| `--source-id ID` | Filter to exactly one source by numeric ID; mutually exclusive with `--account` |
 
 Execution requires `MSGVAULT_ENABLE_REMOTE_DELETE=1`. `--list` and `--dry-run` work without the gate. `--permanent` and `--yes` are mutually exclusive because permanent deletion always requires the destructive confirmation prompt.
 

--- a/internal/accountops/accountops.go
+++ b/internal/accountops/accountops.go
@@ -1,23 +1,43 @@
 package accountops
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
-	"go.kenn.io/msgvault/internal/collectionops"
 	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/sourceops"
 )
 
 // Store is the source surface needed by account mutation operations.
 type Store interface {
-	collectionops.AccountResolverStore
+	sourceops.Store
 	UpdateSourceDisplayName(sourceID int64, displayName string) error
 }
 
 // UpdateRequest updates CLI-facing account settings.
 type UpdateRequest struct {
-	Email       string `json:"email"`
+	Account     string `json:"account,omitempty"`
+	Email       string `json:"email,omitempty"`
+	SourceID    int64  `json:"source_id,omitempty"`
+	SourceIDSet bool   `json:"-"`
 	DisplayName string `json:"display_name"`
+}
+
+func (r *UpdateRequest) UnmarshalJSON(data []byte) error {
+	type updateRequest UpdateRequest
+	var decoded updateRequest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	_, decoded.SourceIDSet = fields["source_id"]
+	*r = UpdateRequest(decoded)
+	return nil
 }
 
 // UpdateResult is returned after updating CLI-facing account settings.
@@ -28,26 +48,32 @@ type UpdateResult struct {
 
 // UpdateDisplayName updates one account's display name.
 func UpdateDisplayName(st Store, req UpdateRequest) (UpdateResult, error) {
-	if req.Email == "" {
-		return UpdateResult{}, opserr.Invalid(errors.New("account email is required"))
+	account := strings.TrimSpace(req.Account)
+	email := strings.TrimSpace(req.Email)
+	if account != "" && email != "" && account != email {
+		return UpdateResult{}, opserr.Invalid(errors.New("account and email selectors are mutually exclusive"))
 	}
-	if req.DisplayName == "" {
+	if account == "" {
+		account = email
+	}
+	if strings.TrimSpace(req.DisplayName) == "" {
 		return UpdateResult{}, opserr.Invalid(errors.New("display name is required"))
 	}
 
-	scope, err := collectionops.ResolveAccount(st, req.Email)
+	source, err := sourceops.ResolveExactOne(st, sourceops.Selector{
+		Account:     account,
+		SourceID:    req.SourceID,
+		SourceIDSet: req.SourceIDSet,
+	})
 	if err != nil {
 		return UpdateResult{}, err
 	}
-	if scope.Source == nil {
-		return UpdateResult{}, opserr.Invalid(fmt.Errorf("no primary account source found for %q", req.Email))
-	}
 
-	if err := st.UpdateSourceDisplayName(scope.Source.ID, req.DisplayName); err != nil {
+	if err := st.UpdateSourceDisplayName(source.ID, req.DisplayName); err != nil {
 		return UpdateResult{}, opserr.Internal(fmt.Errorf("update display name: %w", err))
 	}
 	return UpdateResult{
-		Email:       scope.Source.Identifier,
+		Email:       source.Identifier,
 		DisplayName: req.DisplayName,
 	}, nil
 }

--- a/internal/accountops/accountops_test.go
+++ b/internal/accountops/accountops_test.go
@@ -1,0 +1,70 @@
+package accountops_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/accountops"
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestUpdateDisplayNameRejectsAmbiguousDisplayName(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	first, err := f.Store.GetOrCreateSource("gmail", "first@example.test")
+	require.NoError(err)
+	second, err := f.Store.GetOrCreateSource("imap", "second@example.test")
+	require.NoError(err)
+	require.NoError(f.Store.UpdateSourceDisplayName(first.ID, "Work"))
+	require.NoError(f.Store.UpdateSourceDisplayName(second.ID, "Work"))
+
+	_, err = accountops.UpdateDisplayName(f.Store, accountops.UpdateRequest{
+		Email: "Work", DisplayName: "Renamed",
+	})
+	require.Error(err)
+	assert.Equal(opserr.KindInvalid, opserr.KindOf(err))
+	assert.ErrorContains(err, "ambiguous")
+}
+
+func TestUpdateDisplayNameTargetsExactSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	first, err := f.Store.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	second, err := f.Store.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+
+	result, err := accountops.UpdateDisplayName(f.Store, accountops.UpdateRequest{
+		SourceID: first.ID, SourceIDSet: true, DisplayName: "Primary",
+	})
+	require.NoError(err)
+	assert.Equal(first.Identifier, result.Email)
+
+	updated, err := f.Store.GetSourceByID(first.ID)
+	require.NoError(err)
+	assert.Equal("Primary", updated.DisplayName.String)
+	untouched, err := f.Store.GetSourceByID(second.ID)
+	require.NoError(err)
+	assert.False(untouched.DisplayName.Valid)
+}
+
+func TestUpdateRequestJSONPreservesExplicitZeroSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var req accountops.UpdateRequest
+	require.NoError(json.Unmarshal([]byte(`{"source_id":0,"display_name":"Work"}`), &req))
+	assert.True(req.SourceIDSet)
+
+	_, err := accountops.UpdateDisplayName(storetest.New(t).Store, req)
+	require.Error(err)
+	assert.Equal(opserr.KindInvalid, opserr.KindOf(err))
+	assert.ErrorContains(err, "source ID must be positive")
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -454,6 +454,8 @@ type CLICacheBuildEvent struct {
 type CLISyncRequest struct {
 	Full        bool
 	Email       string
+	SourceID    int64
+	SourceIDSet bool
 	Query       string
 	NoResume    bool
 	Before      string
@@ -535,6 +537,7 @@ type CLIDeleteStagedPlanRequest struct {
 	DryRun              bool   `json:"dry_run,omitempty"`
 	List                bool   `json:"list,omitempty"`
 	Account             string `json:"account,omitempty"`
+	SourceID            *int64 `json:"source_id,omitempty"`
 	RemoteDeleteEnabled bool   `json:"remote_delete_enabled,omitempty"`
 }
 
@@ -545,6 +548,7 @@ type CLIDeleteStagedPlanResponse struct {
 	ConfirmationMode          string   `json:"confirmation_mode,omitempty"`
 	PlannedBatchIDs           []string `json:"planned_batch_ids,omitempty"`
 	PlanFingerprint           string   `json:"plan_fingerprint,omitempty"`
+	ResolvedSourceID          *int64   `json:"resolved_source_id,omitempty"`
 	NeedsScopeEscalation      bool     `json:"needs_scope_escalation,omitempty"`
 	ScopeEscalationHeadline   string   `json:"scope_escalation_headline,omitempty"`
 	ScopeEscalationBodyLines  []string `json:"scope_escalation_body_lines,omitempty"`
@@ -1050,6 +1054,32 @@ func parseCLISyncRequest(r *http.Request, full bool) (CLISyncRequest, *apiHTTPEr
 		Before: values.Get("before"),
 		After:  values.Get("after"),
 	}
+	if rawSourceID, sourceIDSet := values["source_id"]; sourceIDSet {
+		if len(rawSourceID) != 1 {
+			return CLISyncRequest{}, newAPIHTTPError(
+				http.StatusBadRequest,
+				"invalid_source_id",
+				"source_id must be specified exactly once",
+			)
+		}
+		sourceID, err := strconv.ParseInt(rawSourceID[0], 10, 64)
+		if err != nil || sourceID <= 0 {
+			return CLISyncRequest{}, newAPIHTTPError(
+				http.StatusBadRequest,
+				"invalid_source_id",
+				"source_id must be a positive integer",
+			)
+		}
+		if req.Email != "" {
+			return CLISyncRequest{}, newAPIHTTPError(
+				http.StatusBadRequest,
+				"invalid_source_selector",
+				"email and source_id are mutually exclusive",
+			)
+		}
+		req.SourceID = sourceID
+		req.SourceIDSet = true
+	}
 	for _, v := range values["folder"] {
 		if v != "" {
 			req.Folders = append(req.Folders, v)
@@ -1342,6 +1372,9 @@ func validateCLIDeletionManifest(manifest *deletion.Manifest) *apiHTTPError {
 	}
 	if manifest.Version == 0 {
 		manifest.Version = 1
+	}
+	if err := manifest.ValidateVersion(); err != nil {
+		return newAPIHTTPError(http.StatusBadRequest, "invalid_manifest_version", err.Error())
 	}
 	if manifest.CreatedBy == "" {
 		manifest.CreatedBy = "cli"

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -21,16 +21,7 @@ const stageDeletionSampleSize = 10
 // resolving internal message IDs to Gmail IDs. SQLite/DuckDB engines
 // implement it; the daemonclient HTTP engine does not need to.
 type deletionMessageIDResolver interface {
-	GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error)
-}
-
-// deletionAccountResolver is the optional engine capability for mapping
-// staged Gmail IDs back to their owning account. Staging requires it:
-// delete-staged executes a manifest against a single mailbox chosen via
-// Manifest.Filters.Account, so every staged manifest must carry exactly
-// one account.
-type deletionAccountResolver interface {
-	GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error)
+	GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]query.DeletionTarget, error)
 }
 
 // DeletionManifestLister lists staged deletion manifests. Implemented by
@@ -107,12 +98,13 @@ type StageDeletionRequest struct {
 
 // StageDeletionResponse covers both dry-run (200) and create (201).
 type StageDeletionResponse struct {
-	DryRun         bool     `json:"dry_run"`
-	MessageCount   int      `json:"message_count"`
-	Account        string   `json:"account,omitempty"`
-	SampleGmailIDs []string `json:"sample_gmail_ids,omitempty"`
-	ID             string   `json:"id,omitempty"`
-	Status         string   `json:"status,omitempty"`
+	DryRun         bool                      `json:"dry_run"`
+	MessageCount   int                       `json:"message_count"`
+	Account        string                    `json:"account,omitempty"`
+	SampleGmailIDs []string                  `json:"sample_gmail_ids,omitempty"`
+	ID             string                    `json:"id,omitempty"`
+	Status         string                    `json:"status,omitempty"`
+	Source         *deletion.SourceReference `json:"source,omitempty"`
 }
 
 // DeletionManifestSummary is one row of GET /api/v1/deletions.
@@ -131,15 +123,16 @@ type ListDeletionsResponse struct {
 }
 
 type DeletionManifestDetail struct {
-	ID           string              `json:"id"`
-	Status       string              `json:"status"`
-	CreatedAt    time.Time           `json:"created_at"`
-	CreatedBy    string              `json:"created_by"`
-	Description  string              `json:"description"`
-	Account      string              `json:"account,omitempty"`
-	MessageCount int                 `json:"message_count"`
-	Summary      *deletion.Summary   `json:"summary,omitempty"`
-	Execution    *deletion.Execution `json:"execution,omitempty"`
+	ID           string                    `json:"id"`
+	Status       string                    `json:"status"`
+	CreatedAt    time.Time                 `json:"created_at"`
+	CreatedBy    string                    `json:"created_by"`
+	Description  string                    `json:"description"`
+	Account      string                    `json:"account,omitempty"`
+	MessageCount int                       `json:"message_count"`
+	Summary      *deletion.Summary         `json:"summary,omitempty"`
+	Execution    *deletion.Execution       `json:"execution,omitempty"`
+	Source       *deletion.SourceReference `json:"source,omitempty"`
 }
 
 // CancelDeletionResponse is the DELETE /api/v1/deletions/{id} body.
@@ -190,32 +183,34 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var gmailIDs []string
+	var targets []query.DeletionTarget
 	var claim *deletionOperationClaim
 	if req.Selection != nil {
 		var ok bool
-		gmailIDs, claim, ok = s.resolveAuthorizedDeletionSelection(w, r, *req.Selection, req.OperationToken)
+		targets, claim, ok = s.resolveAuthorizedDeletionSelection(w, r, *req.Selection, req.OperationToken)
 		if !ok {
 			return
 		}
 	} else {
 		var httpErr *apiHTTPError
-		gmailIDs, httpErr = s.resolveStageDeletionIDs(r.Context(), &req)
+		targets, httpErr = s.resolveStageDeletionTargets(r.Context(), &req)
 		if httpErr != nil {
 			writeAPIHTTPError(w, httpErr)
 			return
 		}
 	}
-	if len(gmailIDs) == 0 {
+	if len(targets) == 0 {
 		writeError(w, http.StatusBadRequest, "no_messages_matched", "No messages matched the given criteria")
 		return
 	}
 
-	account, httpErr := s.resolveStageDeletionAccount(r.Context(), gmailIDs)
+	source, httpErr := sourceReferenceForTargets(targets)
 	if httpErr != nil {
 		writeAPIHTTPError(w, httpErr)
 		return
 	}
+	account := source.Identifier
+	gmailIDs := deletion.SourceMessageIDs(targets)
 
 	if req.DryRun {
 		sample := gmailIDs
@@ -226,6 +221,7 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 			DryRun:         true,
 			MessageCount:   len(gmailIDs),
 			Account:        account,
+			Source:         source,
 			SampleGmailIDs: sample,
 		})
 		return
@@ -235,7 +231,7 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 	if description == "" {
 		description = "staged via API"
 	}
-	manifest := deletion.NewManifest(description, gmailIDs)
+	manifest := deletion.NewManifestForSource(description, gmailIDs, *source)
 	manifest.CreatedBy = "api"
 	manifest.Filters = manifestFiltersFromRequest(req.Filter)
 	// delete-staged selects the mailbox to execute against from
@@ -277,7 +273,25 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 		Account:      account,
 		ID:           manifest.ID,
 		Status:       string(manifest.Status),
+		Source:       source,
 	})
+}
+
+func sourceReferenceForTargets(targets []query.DeletionTarget) (*deletion.SourceReference, *apiHTTPError) {
+	source, err := deletion.SourceReferenceForTargets(targets)
+	switch {
+	case err == nil:
+		return &source, nil
+	case errors.Is(err, deletion.ErrNoDeletionTargets):
+		return nil, newAPIHTTPError(http.StatusConflict, "source_resolution_conflict", "selection has no deletion targets")
+	case errors.Is(err, deletion.ErrIncompleteDeletionSource):
+		return nil, newAPIHTTPError(http.StatusConflict, "source_resolution_conflict", "selected message has incomplete source provenance")
+	case errors.Is(err, deletion.ErrMultipleDeletionSources):
+		return nil, newAPIHTTPError(http.StatusBadRequest, "multi_account_selection",
+			"selection spans multiple sources; scope the request with filter.source_id or stage each source separately")
+	default:
+		return nil, newAPIHTTPError(http.StatusConflict, "source_resolution_conflict", err.Error())
+	}
 }
 
 // deletionOperationClaim defers one-shot consumption of a preflight
@@ -309,7 +323,7 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	r *http.Request,
 	selection ExploreSelection,
 	token string,
-) ([]string, *deletionOperationClaim, bool) {
+) ([]query.DeletionTarget, *deletionOperationClaim, bool) {
 	if token == "" {
 		writeError(w, http.StatusPreconditionRequired, "preflight_required",
 			"operation_token from deletion preflight is required")
@@ -396,64 +410,34 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 			"selection deletion staging is not supported by this query engine")
 		return nil, nil, false
 	}
-	gmailIDs, err := resolver.GetGmailIDsByMessageIDs(r.Context(), stats.DeletableMessageIDs)
+	targets, err := resolver.GetDeletionTargetsByMessageIDs(r.Context(), stats.DeletableMessageIDs)
 	if err != nil {
 		s.logger.Error("stage deletion selection resolution failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
 		return nil, nil, false
 	}
-	if int64(len(gmailIDs)) != stats.Count {
+	if int64(len(targets)) != stats.Count {
 		writeError(w, http.StatusConflict, "selection_changed",
 			"The reviewed selection changed before staging; run preflight again")
 		return nil, nil, false
 	}
 	claim := &deletionOperationClaim{state: state, token: token, selectionHash: selectionHash}
-	return gmailIDs, claim, true
+	return targets, claim, true
 }
 
-// resolveStageDeletionAccount maps the staged Gmail IDs to their owning
-// account and requires exactly one: deletion manifests execute against a
-// single mailbox, so selections spanning multiple Gmail accounts must be
-// split into per-account requests (e.g. scoped with filter.source_id).
-func (s *Server) resolveStageDeletionAccount(ctx context.Context, gmailIDs []string) (string, *apiHTTPError) {
-	resolver, ok := s.queryEngineForContext(ctx).(deletionAccountResolver)
-	if !ok {
-		return "", newAPIHTTPError(http.StatusServiceUnavailable, "engine_unavailable",
-			"deletion staging is not supported by this query engine")
-	}
-	accounts, err := resolver.GetAccountsByGmailIDs(ctx, gmailIDs)
-	if err != nil {
-		s.logger.Error("stage deletion account resolution failed", "error", err)
-		return "", newAPIHTTPError(http.StatusInternalServerError, "internal_error", "Account resolution failed")
-	}
-	switch len(accounts) {
-	case 1:
-		return accounts[0], nil
-	case 0:
-		// The IDs were just resolved from live Gmail messages, so an
-		// empty account set means the archive changed underneath us.
-		return "", newAPIHTTPError(http.StatusConflict, "account_resolution_conflict",
-			"Staged messages no longer resolve to a Gmail account; retry the request")
-	default:
-		return "", newAPIHTTPError(http.StatusBadRequest, "multi_account_selection",
-			fmt.Sprintf("selection spans multiple Gmail accounts (%s); deletion manifests execute against a single mailbox — scope the request with filter.source_id or stage per account",
-				strings.Join(accounts, ", ")))
-	}
-}
-
-// resolveStageDeletionIDs unions filter-resolved and explicitly listed
-// message IDs into a deduplicated, order-preserving Gmail-ID list.
-func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletionRequest) ([]string, *apiHTTPError) {
+// resolveStageDeletionTargets unions filter-resolved and explicitly selected
+// rows without flattening away source provenance.
+func (s *Server) resolveStageDeletionTargets(ctx context.Context, req *StageDeletionRequest) ([]query.DeletionTarget, *apiHTTPError) {
 	engine := s.queryEngineForContext(ctx)
-	var out []string
-	seen := make(map[string]struct{})
-	appendIDs := func(ids []string) {
-		for _, id := range ids {
-			if _, dup := seen[id]; dup {
+	var out []query.DeletionTarget
+	seen := make(map[int64]struct{})
+	appendTargets := func(targets []query.DeletionTarget) {
+		for _, target := range targets {
+			if _, dup := seen[target.MessageID]; dup {
 				continue
 			}
-			seen[id] = struct{}{}
-			out = append(out, id)
+			seen[target.MessageID] = struct{}{}
+			out = append(out, target)
 		}
 	}
 
@@ -462,12 +446,12 @@ func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletion
 		if httpErr != nil {
 			return nil, httpErr
 		}
-		ids, err := engine.GetGmailIDsByFilter(ctx, mf)
+		targets, err := engine.GetDeletionTargetsByFilter(ctx, mf)
 		if err != nil {
 			s.logger.Error("stage deletion filter query failed", "error", err)
 			return nil, newAPIHTTPError(http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
 		}
-		appendIDs(ids)
+		appendTargets(targets)
 	}
 	if len(req.MessageIDs) > 0 {
 		resolver, ok := engine.(deletionMessageIDResolver)
@@ -475,12 +459,12 @@ func (s *Server) resolveStageDeletionIDs(ctx context.Context, req *StageDeletion
 			return nil, newAPIHTTPError(http.StatusServiceUnavailable, "engine_unavailable",
 				"message_ids staging is not supported by this query engine")
 		}
-		ids, err := resolver.GetGmailIDsByMessageIDs(ctx, req.MessageIDs)
+		targets, err := resolver.GetDeletionTargetsByMessageIDs(ctx, req.MessageIDs)
 		if err != nil {
 			s.logger.Error("stage deletion message-id query failed", "error", err)
 			return nil, newAPIHTTPError(http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
 		}
-		appendIDs(ids)
+		appendTargets(targets)
 	}
 	return out, nil
 }
@@ -548,7 +532,7 @@ func (s *Server) handleGetDeletion(w http.ResponseWriter, r *http.Request) {
 		ID: manifest.ID, Status: string(status), CreatedAt: manifest.CreatedAt,
 		CreatedBy: manifest.CreatedBy, Description: manifest.Description,
 		Account: manifest.Filters.Account, MessageCount: len(manifest.GmailIDs),
-		Summary: manifest.Summary, Execution: manifest.Execution,
+		Summary: manifest.Summary, Execution: manifest.Execution, Source: manifest.Source,
 	})
 }
 

--- a/internal/api/deletions_test.go
+++ b/internal/api/deletions_test.go
@@ -116,11 +116,13 @@ func TestStageDeletionLegacyFilterIsDryRunOnly(t *testing.T) {
 	st := &deletionMockStore{}
 	var gotFilter query.MessageFilter
 	engine := &querytest.MockEngine{
-		GetGmailIDsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]string, error) {
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]query.DeletionTarget, error) {
 			gotFilter = f
-			return []string{"gm-1", "gm-2"}, nil
+			return []query.DeletionTarget{
+				{MessageID: 1, SourceID: 7, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-1"},
+				{MessageID: 2, SourceID: 7, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-2"},
+			}, nil
 		},
-		GmailAccounts: []string{"user@example.com"},
 	}
 	srv := newDeletionTestServer(t, st, engine)
 
@@ -155,11 +157,13 @@ func TestStageDeletionLegacyExplicitMessageIDsRemainCompatible(t *testing.T) {
 
 	st := &deletionMockStore{}
 	engine := &querytest.MockEngine{
-		GetGmailIDsByMessageIDsFunc: func(_ context.Context, ids []int64) ([]string, error) {
+		GetDeletionTargetsByMessageIDsFunc: func(_ context.Context, ids []int64) ([]query.DeletionTarget, error) {
 			assert.Equal([]int64{7, 8}, ids)
-			return []string{"gm-2", "gm-3"}, nil
+			return []query.DeletionTarget{
+				{MessageID: 7, SourceID: 9, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-2"},
+				{MessageID: 8, SourceID: 9, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-3"},
+			}, nil
 		},
-		GmailAccounts: []string{"user@example.com"},
 	}
 	srv := newDeletionTestServer(t, st, engine)
 
@@ -189,12 +193,10 @@ func TestStageDeletionRejectsMultiAccountSelection(t *testing.T) {
 	assert := assert.New(t)
 
 	st := &deletionMockStore{}
-	var gotGmailIDs []string
 	engine := &querytest.MockEngine{
-		GmailIDs: []string{"gm-1", "gm-2"},
-		GetAccountsByGmailIDsFunc: func(_ context.Context, gmailIDs []string) ([]string, error) {
-			gotGmailIDs = gmailIDs
-			return []string{"a@example.com", "b@example.com"}, nil
+		DeletionTargets: []query.DeletionTarget{
+			{MessageID: 1, SourceID: 10, SourceType: "gmail", SourceIdentifier: "a@example.invalid", SourceMessageID: "gm-1"},
+			{MessageID: 2, SourceID: 20, SourceType: "gmail", SourceIdentifier: "b@example.invalid", SourceMessageID: "gm-2"},
 		},
 	}
 	srv := newDeletionTestServer(t, st, engine)
@@ -205,9 +207,8 @@ func TestStageDeletionRejectsMultiAccountSelection(t *testing.T) {
 		w := postDeletions(t, srv, body)
 		assert.Equal(http.StatusBadRequest, w.Code, "body %s -> status", body)
 		assert.Contains(w.Body.String(), "multi_account_selection", "body %s -> error code", body)
-		assert.Contains(w.Body.String(), "a@example.com, b@example.com", "body %s -> accounts listed", body)
+		assert.Contains(w.Body.String(), "multiple sources", "body %s -> guidance", body)
 	}
-	assert.Equal([]string{"gm-1", "gm-2"}, gotGmailIDs, "resolution queried with staged IDs")
 	assert.Empty(st.saved, "nothing staged across accounts")
 }
 
@@ -220,7 +221,10 @@ func TestStageDeletionDryRun(t *testing.T) {
 	for i := range ids {
 		ids[i] = "gm-" + string(rune('a'+i))
 	}
-	engine := &querytest.MockEngine{GmailIDs: ids, GmailAccounts: []string{"user@example.com"}}
+	engine := &querytest.MockEngine{
+		GmailIDs: ids,
+		Accounts: []query.AccountInfo{{ID: 1, SourceType: "gmail", Identifier: "user@example.com"}},
+	}
 	srv := newDeletionTestServer(t, st, engine)
 
 	w := postDeletions(t, srv, `{"filter": {"domain": "example.com"}, "dry_run": true}`)
@@ -231,6 +235,8 @@ func TestStageDeletionDryRun(t *testing.T) {
 	assert.True(resp.DryRun)
 	assert.Equal(25, resp.MessageCount)
 	assert.Equal("user@example.com", resp.Account, "dry run reports the account")
+	require.NotNil(resp.Source)
+	assert.Equal(deletion.SourceReference{ID: 1, Type: "gmail", Identifier: "user@example.com"}, *resp.Source)
 	assert.Len(resp.SampleGmailIDs, 10, "sample capped at 10")
 	assert.Empty(resp.ID, "dry run stages nothing")
 	assert.Empty(st.saved, "dry run writes nothing")
@@ -417,7 +423,7 @@ func TestStageDeletionRejectsEmptyFilter(t *testing.T) {
 func TestStageDeletionNoMatches(t *testing.T) {
 	st := &deletionMockStore{}
 	engine := &querytest.MockEngine{
-		GetGmailIDsByFilterFunc: func(_ context.Context, _ query.MessageFilter) ([]string, error) {
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, _ query.MessageFilter) ([]query.DeletionTarget, error) {
 			return nil, nil
 		},
 	}
@@ -509,9 +515,10 @@ func TestGetDeletionReturnsManifestLifecycleDetail(t *testing.T) {
 	assertions := assert.New(t)
 	completedAt := time.Date(2026, 7, 1, 13, 0, 0, 0, time.UTC)
 	manifest := &deletion.Manifest{
-		ID: "batch-1", Status: deletion.StatusFailed, CreatedAt: completedAt.Add(-time.Hour),
+		Version: 2, ID: "batch-1", Status: deletion.StatusFailed, CreatedAt: completedAt.Add(-time.Hour),
 		CreatedBy: "api", Description: "reviewed batch", GmailIDs: []string{"gm-1", "gm-2"},
 		Filters: deletion.Filters{Account: "user@example.com"},
+		Source:  &deletion.SourceReference{ID: 42, Type: "gmail", Identifier: "user@example.com"},
 		Execution: &deletion.Execution{StartedAt: completedAt.Add(-time.Minute), CompletedAt: &completedAt,
 			Method: deletion.MethodTrash, Succeeded: 1, Failed: 1, FailedIDs: []string{"gm-2"}},
 	}
@@ -529,6 +536,8 @@ func TestGetDeletionReturnsManifestLifecycleDetail(t *testing.T) {
 	assertions.Equal("failed", detail.Status)
 	assertions.Equal("user@example.com", detail.Account)
 	assertions.Equal(2, detail.MessageCount)
+	requirements.NotNil(detail.Source)
+	assertions.Equal(*manifest.Source, *detail.Source)
 	requirements.NotNil(detail.Execution)
 	assertions.Equal(1, detail.Execution.Failed)
 	assertions.Equal([]string{"gm-2"}, detail.Execution.FailedIDs)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -19,6 +19,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/deletion"
 	msgexport "go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/query"
@@ -217,7 +218,8 @@ type FilteredMessagesResponse struct {
 }
 
 type GmailIDsResponse struct {
-	GmailIDs []string `json:"gmail_ids"`
+	GmailIDs []string               `json:"gmail_ids"`
+	Targets  []query.DeletionTarget `json:"targets,omitempty"`
 }
 
 type DeepSearchResponse struct {
@@ -3024,17 +3026,18 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 		s.rejectBadParam(w, err)
 		return
 	}
-	ids, err := engine.GetGmailIDsByFilter(r.Context(), filter)
+	targets, err := engine.GetDeletionTargetsByFilter(r.Context(), filter)
 	if err != nil {
 		s.logger.Error("gmail id filter query failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
 		return
 	}
-	if ids == nil {
-		ids = []string{}
+	if targets == nil {
+		targets = []query.DeletionTarget{}
 	}
-
-	writeJSON(w, http.StatusOK, GmailIDsResponse{GmailIDs: ids})
+	writeJSON(w, http.StatusOK, GmailIDsResponse{
+		GmailIDs: deletion.SourceMessageIDs(targets), Targets: targets,
+	})
 }
 
 func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -265,6 +265,8 @@ func TestMarkedCLIScopedStatsCancellationInterruptsStore(t *testing.T) {
 
 func testMarkedCLIStatsCancellationInterruptsStore(t *testing.T, target string, scoped bool) {
 	t.Helper()
+	require := require.New(t)
+	assert := assert.New(t)
 
 	callStarted := make(chan struct{})
 	callReturned := make(chan struct{})
@@ -326,32 +328,32 @@ func testMarkedCLIStatsCancellationInterruptsStore(t *testing.T, target string, 
 		select {
 		case <-handlerDone:
 		case <-time.After(time.Second):
-			assert.Fail(t, "CLI stats handler did not finish during cleanup")
+			assert.Fail("CLI stats handler did not finish during cleanup")
 		}
 	})
 
 	select {
 	case <-callStarted:
 	case <-time.After(time.Second):
-		require.FailNow(t, "CLI stats store call did not start")
+		require.FailNow("CLI stats store call did not start")
 	}
 	cancel()
 
 	select {
 	case <-callReturned:
 	case <-time.After(time.Second):
-		require.FailNow(t, "CLI stats store call continued after marked request cancellation")
+		require.FailNow("CLI stats store call continued after marked request cancellation")
 	}
 	select {
 	case <-handlerDone:
 	case <-time.After(time.Second):
-		require.FailNow(t, "CLI stats handler did not return after store cancellation")
+		require.FailNow("CLI stats handler did not return after store cancellation")
 	}
 
-	require.Equal(t, http.StatusServiceUnavailable, resp.Code, "status (body: %s)", resp.Body.String())
+	require.Equal(http.StatusServiceUnavailable, resp.Code, "status (body: %s)", resp.Body.String())
 	var errResp ErrorResponse
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp), "decode error response")
-	assert.Equal(t, "query_canceled", errResp.Error, "error code")
+	require.NoError(json.NewDecoder(resp.Body).Decode(&errResp), "decode error response")
+	assert.Equal("query_canceled", errResp.Error, "error code")
 }
 
 func TestHandleCLICreateDeletionManifest(t *testing.T) {
@@ -946,6 +948,41 @@ func TestHandleCLISyncAcceptsFolderFilters(t *testing.T) {
 	}, gotReq)
 }
 
+func TestHandleCLISyncParsesExactSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var gotReq CLISyncRequest
+	st := &mockStore{
+		syncFunc: func(_ context.Context, req CLISyncRequest, _ func(CLISyncEvent) error) error {
+			gotReq = req
+			return nil
+		},
+	}
+	srv := newCLIHandlerTestServer(st)
+
+	resp := servePOSTTestRequest(srv, "/api/v1/cli/sync?source_id=42")
+	requireNDJSONResponse(t, resp)
+	assert.Equal(int64(42), gotReq.SourceID)
+	assert.True(gotReq.SourceIDSet)
+	events := decodeNDJSONEvents[map[string]any](t, resp.Body)
+	require.Len(events, 1)
+	assert.Equal(cliStreamEventTypeComplete, events[0]["type"])
+	assert.NotContains(events[0], "applied_source_id")
+}
+
+func TestHandleCLISyncRejectsInvalidSourceID(t *testing.T) {
+	srv := newCLIHandlerTestServer(&mockStore{})
+	for _, path := range []string{
+		"/api/v1/cli/sync?source_id=0",
+		"/api/v1/cli/sync?source_id=wat",
+		"/api/v1/cli/sync?source_id=42&email=alice@example.test",
+	} {
+		resp := servePOSTTestRequest(srv, path)
+		assert.Equal(t, http.StatusBadRequest, resp.Code, "path: %s", path)
+	}
+}
+
 func TestHandleCLIVerifyStreamsOutput(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1376,7 +1413,7 @@ func TestHandleCLIDeleteStagedPlanReturnsPrompt(t *testing.T) {
 	}
 	srv := newCLIHandlerTestServer(st)
 
-	body := strings.NewReader(`{"batch_id":"batch-123","permanent":false,"yes":false,"dry_run":false,"list":false,"account":"alice@example.com","remote_delete_enabled":true}`)
+	body := strings.NewReader(`{"batch_id":"batch-123","permanent":false,"yes":false,"dry_run":false,"list":false,"account":"alice@example.com","source_id":42,"remote_delete_enabled":true}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/delete-staged/plan", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp := httptest.NewRecorder()
@@ -1386,6 +1423,7 @@ func TestHandleCLIDeleteStagedPlanReturnsPrompt(t *testing.T) {
 	assert.Equal(CLIDeleteStagedPlanRequest{
 		BatchID:             "batch-123",
 		Account:             "alice@example.com",
+		SourceID:            func() *int64 { value := int64(42); return &value }(),
 		RemoteDeleteEnabled: true,
 	}, gotReq, "plan request")
 
@@ -2703,6 +2741,40 @@ func TestHandleCLIUpdateAccountDisplayName(t *testing.T) {
 	assert.Equal("Work", updated.DisplayName.String, "stored display name")
 }
 
+func TestHandleCLIUpdateAccountTargetsExactSourceID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	st := testutil.NewTestStore(t)
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st,
+		Logger: testLogger(),
+	})
+
+	first, err := st.GetOrCreateSource("gmail", "shared@example.test")
+	require.NoError(err)
+	second, err := st.GetOrCreateSource("imap", "shared@example.test")
+	require.NoError(err)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/cli/account",
+		strings.NewReader(fmt.Sprintf(`{"source_id":%d,"display_name":"Primary"}`, first.ID)),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+	assert.Equal(http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	updated, err := st.GetSourceByID(first.ID)
+	require.NoError(err)
+	assert.Equal("Primary", updated.DisplayName.String)
+	untouched, err := st.GetSourceByID(second.ID)
+	require.NoError(err)
+	assert.False(untouched.DisplayName.Valid)
+}
+
 func TestHandleCLIUpdateAccountResolvesCurrentDisplayName(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -2934,17 +3006,18 @@ func TestHandleCLIAttachmentReturnsContentAddressedBytes(t *testing.T) {
 // require.New(t)/assert.New(t) bound to the subtest's own *testing.T.
 func buildTestPack(t *testing.T, attachmentsDir string, content []byte) store.PackIndexEntry {
 	t.Helper()
+	require := require.New(t)
 	staging := t.TempDir()
 	w, err := pack.NewWriter(staging, pack.WriterOptions{})
-	require.NoError(t, err, "NewWriter")
+	require.NoError(err, "NewWriter")
 	_, err = w.Append(content)
-	require.NoError(t, err, "Append")
+	require.NoError(err, "Append")
 	packID := w.ID()
 	final := filepath.Join(attachmentsDir, "packs", packID[:2], packID+packstore.PackExt)
-	require.NoError(t, os.MkdirAll(filepath.Dir(final), 0o700), "create pack dir")
+	require.NoError(os.MkdirAll(filepath.Dir(final), 0o700), "create pack dir")
 	sealed, err := w.Seal(final)
-	require.NoError(t, err, "Seal")
-	require.Len(t, sealed, 1, "sealed entries")
+	require.NoError(err, "Seal")
+	require.Len(sealed, 1, "sealed entries")
 
 	return store.PackIndexEntry{
 		BlobHash:  sealed[0].ID.String(),
@@ -4742,9 +4815,12 @@ func TestHandleGmailIDsByFilterUsesQueryEngine(t *testing.T) {
 	assert := assert.New(t)
 	var gotFilter query.MessageFilter
 	engine := &querytest.MockEngine{
-		GetGmailIDsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]string, error) {
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
 			gotFilter = filter
-			return []string{"gm-1", "gm-2"}, nil
+			return []query.DeletionTarget{
+				{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-1"},
+				{MessageID: 2, SourceID: 1, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "gm-2"},
+			}, nil
 		},
 	}
 	srv := newTestServerWithEngine(t, engine)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -211,7 +211,9 @@ import (
 // Additive (minor bump): the archive-wide file routes are unchanged.
 // 2.3.0 bounds organization profile replacements to 200 structured values and
 // 32 MiB of logical inline media, and documents the resulting 413 response.
-const APISchemaVersion = "2.3.0"
+// 2.4.0 adds exact source selection to CLI sync and deletion transports. CLI
+// clients check this version before asking a daemon to perform a scoped sync.
+const APISchemaVersion = "2.4.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,7 +38,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.3.0", APISchemaVersion)
+	assert.Equal("2.4.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -59,16 +59,16 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.3.0", APISchemaVersion)
+	assert.Equal(t, "2.4.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.3.0", APISchemaVersion)
+	assert.Equal(t, "2.4.0", APISchemaVersion)
 }
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.3.0", APISchemaVersion,
+	assert.Equal(t, "2.4.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -102,17 +102,18 @@ func operationBodySchema(
 	t *testing.T, document *huma.OpenAPI, operation *huma.Operation,
 ) *huma.Schema {
 	t.Helper()
-	require.NotNil(t, operation)
-	require.NotNil(t, operation.RequestBody)
+	require := require.New(t)
+	require.NotNil(operation)
+	require.NotNil(operation.RequestBody)
 	schema := operation.RequestBody.Content["application/json"].Schema
-	require.NotNil(t, schema)
+	require.NotNil(schema)
 	if schema.Ref == "" {
 		return schema
 	}
 	const prefix = "#/components/schemas/"
-	require.True(t, strings.HasPrefix(schema.Ref, prefix), schema.Ref)
+	require.True(strings.HasPrefix(schema.Ref, prefix), schema.Ref)
 	resolved := document.Components.Schemas.Map()[strings.TrimPrefix(schema.Ref, prefix)]
-	require.NotNil(t, resolved)
+	require.NotNil(resolved)
 	return resolved
 }
 
@@ -347,7 +348,7 @@ func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.3.0", APISchemaVersion,
+	assert.Equal("2.4.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -420,7 +421,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.3.0", APISchemaVersion,
+	assertions.Equal("2.4.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -440,7 +441,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.3.0", APISchemaVersion,
+	assert.Equal("2.4.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -468,7 +469,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.3.0", APISchemaVersion,
+	assertions.Equal("2.4.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -512,8 +513,8 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// routes added in 1.42.0, cache-readiness responses added in 1.43.0,
 	// document search added in 1.44.0, participant/people separation added in
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
-	// 2.3.0 did not touch it.
-	assert.Equal("2.3.0", APISchemaVersion, "meeting import is an additive schema release")
+	// 2.4.0 did not touch it.
+	assert.Equal("2.4.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -605,12 +605,14 @@ func rawRouteParameters(operationID string) []*huma.Param {
 	case "syncCLI":
 		return []*huma.Param{
 			queryStringParam("email", "Account email or display name to sync", false),
+			queryIntegerParam("source_id", "Exact source ID to sync"),
 			queryRefArrayParam("folder", "IMAP folder names to include (repeatable)"),
 			queryRefArrayParam("skip-folder", "IMAP folder names to exclude (repeatable)"),
 		}
 	case "syncFullCLI":
 		return []*huma.Param{
 			queryStringParam("email", "Account email or display name to sync", false),
+			queryIntegerParam("source_id", "Exact source ID to sync"),
 			queryStringParam("query", "Gmail search query", false),
 			queryStringParam("after", "Only messages on or after this YYYY-MM-DD date", false),
 			queryStringParam("before", "Only messages before this YYYY-MM-DD date", false),

--- a/internal/api/scheduler_jobs.go
+++ b/internal/api/scheduler_jobs.go
@@ -28,6 +28,7 @@ type sourceScheduleClassification struct {
 // because it isn't exported, so the literal is duplicated here.
 const (
 	sourceTypeBeeper = "beeper"
+	sourceTypeGmail  = "gmail"
 	sourceTypeSlack  = "slack"
 )
 
@@ -45,7 +46,7 @@ const SlackJobName = sourceTypeSlack
 // types cannot borrow a scheduled account merely by sharing its identifier.
 func classifySourceScheduling(sourceType, identifier string) sourceScheduleClassification {
 	switch sourceType {
-	case "", "gmail", "imap", "teams", "discord":
+	case "", sourceTypeGmail, "imap", "teams", "discord":
 		return sourceScheduleClassification{kind: sourceScheduleAccount}
 	case meetingimport.SourceType:
 		return sourceScheduleClassification{kind: sourceScheduleNonSchedulable}

--- a/internal/collectionops/collectionops.go
+++ b/internal/collectionops/collectionops.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/sourceops"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -23,8 +23,7 @@ var (
 // AccountResolverStore is the source/collection lookup surface needed to
 // resolve user-supplied account tokens.
 type AccountResolverStore interface {
-	GetSourcesByIdentifierOrDisplayName(query string) ([]*store.Source, error)
-	GetSourcesByTypeAndAccount(sourceType, accountEmail string) ([]*store.Source, error)
+	sourceops.Store
 	GetCollectionByName(name string) (*store.CollectionWithSources, error)
 }
 
@@ -196,50 +195,18 @@ func ResolveAccount(st AccountResolverStore, input string) (Scope, error) {
 		return scope, nil
 	}
 
-	sources, err := st.GetSourcesByIdentifierOrDisplayName(input)
-	if err != nil {
-		return scope, opserr.Internal(fmt.Errorf("look up source for %q: %w", input, err))
-	}
-	calendarSources, err := st.GetSourcesByTypeAndAccount(gcal.SourceType, input)
-	if err != nil {
-		return scope, opserr.Internal(fmt.Errorf("look up calendar sources for %q: %w", input, err))
-	}
-	if len(sources) > 1 {
-		names := make([]string, 0, len(sources))
-		for _, src := range sources {
-			names = append(names, fmt.Sprintf(
-				"%s (%s, id=%d)",
-				src.Identifier, src.SourceType, src.ID,
-			))
-		}
-		return scope, opserr.Invalid(fmt.Errorf(
-			"ambiguous account %q matches multiple sources: %v",
-			input, names,
-		))
-	}
-	if len(sources) == 1 {
-		scope.Source = sources[0]
-		if sources[0].SourceType != gcal.SourceType &&
-			!store.EqualIdentifier(sources[0].Identifier, input) {
-			resolvedCalendarSources, err := st.GetSourcesByTypeAndAccount(
-				gcal.SourceType,
-				sources[0].Identifier,
-			)
-			if err != nil {
-				return scope, opserr.Internal(fmt.Errorf(
-					"look up calendar sources for %q: %w",
-					sources[0].Identifier,
-					err,
-				))
+	selection, err := sourceops.ResolveAccountFamily(st, sourceops.Selector{Account: input})
+	if err == nil {
+		scope.Source = selection.Primary
+		for _, source := range selection.Sources {
+			if scope.Source == nil || source.ID != scope.Source.ID {
+				scope.AdditionalSourceIDs = append(scope.AdditionalSourceIDs, source.ID)
 			}
-			calendarSources = appendUniqueSources(calendarSources, resolvedCalendarSources)
 		}
-		scope.AdditionalSourceIDs = sourceIDsExcept(calendarSources, sources[0].ID)
 		return scope, nil
 	}
-	if len(calendarSources) > 0 {
-		scope.AdditionalSourceIDs = sourceIDsExcept(calendarSources, 0)
-		return scope, nil
+	if opserr.KindOf(err) != opserr.KindNotFound {
+		return scope, err
 	}
 
 	_, collErr := st.GetCollectionByName(input)
@@ -306,46 +273,6 @@ func ResolveCollection(st AccountResolverStore, input string) (CollectionScope, 
 	return scope, opserr.NotFound(fmt.Errorf(
 		"no collection named %q (try 'msgvault collection list')", input),
 	)
-}
-
-func appendUniqueSources(dst []*store.Source, srcs []*store.Source) []*store.Source {
-	seen := make(map[int64]struct{}, len(dst)+len(srcs))
-	for _, src := range dst {
-		if src == nil {
-			continue
-		}
-		seen[src.ID] = struct{}{}
-	}
-	for _, src := range srcs {
-		if src == nil {
-			continue
-		}
-		if _, ok := seen[src.ID]; ok {
-			continue
-		}
-		seen[src.ID] = struct{}{}
-		dst = append(dst, src)
-	}
-	return dst
-}
-
-func sourceIDsExcept(sources []*store.Source, exclude int64) []int64 {
-	ids := make([]int64, 0, len(sources))
-	seen := map[int64]struct{}{}
-	if exclude != 0 {
-		seen[exclude] = struct{}{}
-	}
-	for _, src := range sources {
-		if src == nil {
-			continue
-		}
-		if _, ok := seen[src.ID]; ok {
-			continue
-		}
-		seen[src.ID] = struct{}{}
-		ids = append(ids, src.ID)
-	}
-	return ids
 }
 
 func storeMutationError(err error) error {

--- a/internal/collectionops/collectionops_test.go
+++ b/internal/collectionops/collectionops_test.go
@@ -1,6 +1,7 @@
 package collectionops
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,38 @@ import (
 	"go.kenn.io/msgvault/internal/opserr"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
+
+func TestResolveAccountNumericIdentifierRemainsToken(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	numeric, err := f.Store.GetOrCreateSource("synctech-sms", "15551234567")
+	require.NoError(err)
+
+	scope, err := ResolveAccount(f.Store, "15551234567")
+	require.NoError(err)
+	require.NotNil(scope.Source)
+	assert.Equal(numeric.ID, scope.Source.ID)
+}
+
+func TestResolveAccountPreservesPrimaryThenCalendarOrdering(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	primary, err := f.Store.GetOrCreateSource("gmail", "family@example.test")
+	require.NoError(err)
+	calendar, err := f.Store.GetOrCreateSource("gcal", "family@example.test/primary")
+	require.NoError(err)
+	config, err := json.Marshal(map[string]string{"account_email": primary.Identifier})
+	require.NoError(err)
+	require.NoError(f.Store.UpdateSourceSyncConfig(calendar.ID, string(config)))
+
+	scope, err := ResolveAccount(f.Store, primary.Identifier)
+	require.NoError(err)
+	assert.Equal([]int64{primary.ID, calendar.ID}, scope.SourceIDs())
+}
 
 func TestResolveCollection(t *testing.T) {
 	t.Run("valid collection", func(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -309,7 +309,7 @@ func (s FastmailSource) Selector() (identityops.SourceSelector, error) {
 	case s.SourceID > 0 && account != "":
 		return identityops.SourceSelector{}, errors.New("account and source_id are mutually exclusive")
 	case s.SourceID > 0:
-		return identityops.SourceSelector{SourceID: s.SourceID}, nil
+		return identityops.SourceSelector{SourceID: s.SourceID, SourceIDSet: true}, nil
 	case account == "":
 		return identityops.SourceSelector{}, errors.New("account or source_id is required")
 	default:

--- a/internal/config/config_fastmail_test.go
+++ b/internal/config/config_fastmail_test.go
@@ -156,7 +156,7 @@ func TestFastmailSourceSelector(t *testing.T) {
 		{
 			name:   "source ID",
 			source: FastmailSource{SourceID: 14},
-			want:   identityops.SourceSelector{SourceID: 14},
+			want:   identityops.SourceSelector{SourceID: 14, SourceIDSet: true},
 		},
 		{
 			name:    "missing selector",

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -10,6 +10,8 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/doordash-oss/oapi-codegen-dd/v3/pkg/runtime"
@@ -37,6 +39,8 @@ type CLICacheStats = cacheops.CacheStats
 type CLISyncRequest struct {
 	Full        bool
 	Email       string
+	SourceID    int64
+	SourceIDSet bool
 	Query       string
 	NoResume    bool
 	Before      string
@@ -94,6 +98,7 @@ type CLIDeleteStagedPlanRequest struct {
 	DryRun              bool   `json:"dry_run,omitempty"`
 	List                bool   `json:"list,omitempty"`
 	Account             string `json:"account,omitempty"`
+	SourceID            *int64 `json:"source_id,omitempty"`
 	RemoteDeleteEnabled bool   `json:"remote_delete_enabled,omitempty"`
 }
 
@@ -104,6 +109,7 @@ type CLIDeleteStagedPlan struct {
 	ConfirmationMode          string   `json:"confirmation_mode,omitempty"`
 	PlannedBatchIDs           []string `json:"planned_batch_ids,omitempty"`
 	PlanFingerprint           string   `json:"plan_fingerprint,omitempty"`
+	ResolvedSourceID          *int64   `json:"resolved_source_id,omitempty"`
 	NeedsScopeEscalation      bool     `json:"needs_scope_escalation,omitempty"`
 	ScopeEscalationHeadline   string   `json:"scope_escalation_headline,omitempty"`
 	ScopeEscalationBodyLines  []string `json:"scope_escalation_body_lines,omitempty"`
@@ -396,12 +402,18 @@ func (c *Client) RunCLISync(
 	req CLISyncRequest,
 	output func(stream, data string) error,
 ) error {
+	if req.SourceIDSet {
+		if err := c.requireSourceIDSyncCapability(ctx); err != nil {
+			return err
+		}
+	}
 	path := "/api/v1/cli/sync"
 	if req.Full {
 		path = "/api/v1/cli/sync-full"
 		return c.runCLIStream(ctx, path, "sync", &generated.SyncFullCLIRequestOptions{
 			Query: &generated.SyncFullCLIQuery{
 				Email:      optionalString(req.Email),
+				SourceID:   optionalCLIIdentitySourceID(req.SourceID, req.SourceIDSet),
 				Query:      optionalString(req.Query),
 				Noresume:   optionalBool(req.NoResume),
 				Before:     optionalString(req.Before),
@@ -415,10 +427,70 @@ func (c *Client) RunCLISync(
 	return c.runCLIStream(ctx, path, "sync", &generated.SyncCLIRequestOptions{
 		Query: &generated.SyncCLIQuery{
 			Email:      optionalString(req.Email),
+			SourceID:   optionalCLIIdentitySourceID(req.SourceID, req.SourceIDSet),
 			Folder:     req.Folders,
 			SkipFolder: req.SkipFolders,
 		},
 	}, output)
+}
+
+const sourceIDSyncMinAPISchemaVersion = "2.4.0"
+
+func (c *Client) requireSourceIDSyncCapability(ctx context.Context) error {
+	version, err := c.daemonAPISchemaVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("check daemon source-ID sync capability: %w", err)
+	}
+	if !apiSchemaVersionAtLeast(version, sourceIDSyncMinAPISchemaVersion) {
+		return fmt.Errorf(
+			"source-ID sync requires daemon API schema %s or newer (daemon reports %q)",
+			sourceIDSyncMinAPISchemaVersion, version,
+		)
+	}
+	return nil
+}
+
+func (c *Client) daemonAPISchemaVersion(ctx context.Context) (string, error) {
+	resp, err := APIResponse(c, func(client *apiclient.Client) (*generated.GetHealthResp, error) {
+		return client.GetHealthWithResponse(ctx)
+	})
+	if err != nil {
+		return "", err
+	}
+	version := ""
+	if resp.JSON200 != nil && resp.JSON200.APISchemaVersion != nil {
+		version = *resp.JSON200.APISchemaVersion
+	}
+	return version, nil
+}
+
+func apiSchemaVersionAtLeast(version, minimum string) bool {
+	parse := func(raw string) ([3]int, bool) {
+		var parsed [3]int
+		parts := strings.Split(raw, ".")
+		if len(parts) != len(parsed) {
+			return parsed, false
+		}
+		for i, part := range parts {
+			value, err := strconv.Atoi(part)
+			if err != nil || value < 0 {
+				return parsed, false
+			}
+			parsed[i] = value
+		}
+		return parsed, true
+	}
+	got, gotOK := parse(version)
+	want, wantOK := parse(minimum)
+	if !gotOK || !wantOK {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return got[i] > want[i]
+		}
+	}
+	return true
 }
 
 func (c *Client) RunCLIVerify(
@@ -559,6 +631,7 @@ func (c *Client) PlanCLIDeleteStaged(
 ) (*CLIDeleteStagedPlan, error) {
 	body := generated.PlanCLIDeleteStagedBody{
 		Account:             optionalString(req.Account),
+		SourceID:            req.SourceID,
 		BatchID:             optionalString(req.BatchID),
 		DryRun:              optionalBool(req.DryRun),
 		List:                optionalBool(req.List),
@@ -581,6 +654,18 @@ func (c *Client) CreateCLIDeletionManifest(
 ) (*CLIDeletionManifestResult, error) {
 	if manifest == nil {
 		return nil, errors.New("missing deletion manifest")
+	}
+	if manifest.Version == 2 {
+		version, err := c.daemonAPISchemaVersion(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("check daemon deletion manifest capability: %w", err)
+		}
+		if !apiSchemaVersionAtLeast(version, sourceIDSyncMinAPISchemaVersion) {
+			return nil, fmt.Errorf(
+				"version-2 deletion manifests require daemon API schema %s or newer (daemon reports %q)",
+				sourceIDSyncMinAPISchemaVersion, version,
+			)
+		}
 	}
 	body := cliDeletionManifestToGenerated(manifest)
 	resp, err := CLIResponse(c, func(client *apiclient.Client) (*generated.CreateCLIDeletionManifestResp, error) {
@@ -809,10 +894,23 @@ func (c *Client) UpdateCLIAccount(
 	ctx context.Context,
 	req CLIAccountUpdateRequest,
 ) (*CLIAccountUpdateResult, error) {
+	var account, email *string
+	if req.Account != "" {
+		account = &req.Account
+	}
+	if req.Email != "" {
+		email = &req.Email
+	}
+	var sourceID *int64
+	if req.SourceIDSet || req.SourceID != 0 {
+		sourceID = &req.SourceID
+	}
 	resp, err := CLIResponse(c, func(client *apiclient.Client) (*generated.UpdateCLIAccountResp, error) {
 		return client.UpdateCLIAccountWithResponse(ctx, &generated.UpdateCLIAccountRequestOptions{
 			Body: &generated.UpdateCLIAccountBody{
-				Email:       req.Email,
+				Account:     account,
+				Email:       email,
+				SourceID:    sourceID,
 				DisplayName: req.DisplayName,
 			},
 		})

--- a/internal/daemonclient/convert.go
+++ b/internal/daemonclient/convert.go
@@ -102,6 +102,7 @@ func cliDeleteStagedPlanFromGenerated(resp *generated.PlanCLIDeleteStagedRespons
 		ConfirmationMode:          stringValue(resp.ConfirmationMode),
 		PlannedBatchIDs:           append([]string(nil), resp.PlannedBatchIds...),
 		PlanFingerprint:           stringValue(resp.PlanFingerprint),
+		ResolvedSourceID:          resp.ResolvedSourceID,
 		NeedsScopeEscalation:      boolValue(resp.NeedsScopeEscalation),
 		ScopeEscalationHeadline:   stringValue(resp.ScopeEscalationHeadline),
 		ScopeEscalationBodyLines:  append([]string(nil), resp.ScopeEscalationBodyLines...),
@@ -139,6 +140,11 @@ func cliDeletionManifestToGenerated(manifest *deletion.Manifest) generated.Creat
 	}
 	if manifest.Execution != nil {
 		out.Execution = cliDeletionExecutionToGenerated(manifest.Execution)
+	}
+	if manifest.Source != nil {
+		out.Source = &generated.SourceReference{
+			ID: manifest.Source.ID, Type: manifest.Source.Type, Identifier: manifest.Source.Identifier,
+		}
 	}
 	if manifest.Summary != nil {
 		out.Summary = cliDeletionSummaryToGenerated(manifest.Summary)

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -913,7 +913,7 @@ func (e *Engine) SearchFastWithStats(ctx context.Context, q *search.Query, query
 	}, nil
 }
 
-func (e *Engine) GetGmailIDsByFilter(ctx context.Context, filter query.MessageFilter) ([]string, error) {
+func (e *Engine) GetDeletionTargetsByFilter(ctx context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
 	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.GetGmailIDsByFilterResp, error) {
 		return client.GetGmailIDsByFilterWithResponse(ctx, &generated.GetGmailIDsByFilterRequestOptions{
 			Query: gmailIDsFilterQuery(filter),
@@ -922,10 +922,18 @@ func (e *Engine) GetGmailIDsByFilter(ctx context.Context, filter query.MessageFi
 	if err != nil {
 		return nil, err
 	}
-	if resp.JSON200.GmailIds == nil {
-		return []string{}, nil
+	if len(resp.JSON200.Targets) == 0 && len(resp.JSON200.GmailIds) > 0 {
+		return nil, errors.New("daemon did not return deletion source provenance; upgrade the daemon and retry")
 	}
-	return resp.JSON200.GmailIds, nil
+	targets := make([]query.DeletionTarget, len(resp.JSON200.Targets))
+	for i, target := range resp.JSON200.Targets {
+		targets[i] = query.DeletionTarget{
+			MessageID: target.MessageID, SourceID: target.SourceID,
+			SourceType: target.SourceType, SourceIdentifier: target.SourceIdentifier,
+			SourceMessageID: target.SourceMessageID,
+		}
+	}
+	return targets, nil
 }
 
 func (e *Engine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]query.MessageSummary, error) {

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -622,65 +622,22 @@ func TestEngineGetAttachmentUsesGeneratedClientAdapter(t *testing.T) {
 	assert.Equal("hash-42", att.ContentHash, "ContentHash")
 }
 
-func TestEngineGetGmailIDsByFilterUsesAuthoritativeEndpoint(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal("/api/v1/messages/gmail-ids", r.URL.Path, "path")
-		assert.Equal("alice@example.com", r.URL.Query().Get("sender"), "sender")
-		assert.Empty(r.URL.Query().Get("offset"), "offset must not be client-paginated")
-		assert.Equal("10", r.URL.Query().Get("limit"), "limit remains a staging safety cap")
-		assert.Empty(r.URL.Query().Get("sort"), "sort must not affect ID enumeration")
-		assert.Empty(r.URL.Query().Get("direction"), "direction must not affect ID enumeration")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"gmail_ids": []string{"gm-1", "gm-2", "gm-3"},
-		})
-	}))
-	defer srv.Close()
-
-	store := newTestStore(srv, "")
-	engine := NewEngineAdapter(store)
-
-	ids, err := engine.GetGmailIDsByFilter(
-		context.Background(),
-		query.MessageFilter{
-			Sender:     "alice@example.com",
-			Pagination: query.Pagination{Offset: 50, Limit: 10},
-			Sorting:    query.MessageSorting{Field: query.MessageSortBySubject, Direction: query.SortAsc},
-		},
-	)
-	require.NoError(err, "GetGmailIDsByFilter")
-
-	assert.Equal([]string{"gm-1", "gm-2", "gm-3"}, ids)
-}
-
-func TestEngineGetGmailIDsByFilterUsesGeneratedClientAdapter(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
+func TestEngineGetDeletionTargetsByFilterPreservesSource(t *testing.T) {
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal("/api/v1/messages/gmail-ids", r.URL.Path, "path")
-		assert.Equal("alice@example.com", r.URL.Query().Get("sender"), "sender")
-		assert.Equal("sms", r.URL.Query().Get("message_type"), "message_type")
-		assert.Equal("true", r.URL.Query().Get("hide_deleted"), "hide_deleted")
 		writeJSONResponse(t, w, map[string]any{
-			"gmail_ids": []string{"gm-1", "gm-2"},
+			"gmail_ids": []string{"shared-id"},
+			"targets": []map[string]any{{
+				"message_id": 7, "source_id": 42, "source_type": "gmail",
+				"source_identifier": "account@example.invalid", "source_message_id": "shared-id",
+			}},
 		})
 	})
-
-	engine := NewEngineAdapter(store)
-
-	ids, err := engine.GetGmailIDsByFilter(
-		context.Background(),
-		query.MessageFilter{
-			Sender:                "alice@example.com",
-			MessageType:           "sms",
-			HideDeletedFromSource: true,
-		},
-	)
-	require.NoError(err, "GetGmailIDsByFilter")
-	assert.Equal([]string{"gm-1", "gm-2"}, ids)
+	targets, err := NewEngineAdapter(store).GetDeletionTargetsByFilter(context.Background(), query.MessageFilter{})
+	require.NoError(t, err)
+	assert.Equal(t, []query.DeletionTarget{{
+		MessageID: 7, SourceID: 42, SourceType: "gmail",
+		SourceIdentifier: "account@example.invalid", SourceMessageID: "shared-id",
+	}}, targets)
 }
 
 func TestEngineSearchByDomainsUsesGeneratedClientAdapter(t *testing.T) {
@@ -965,24 +922,30 @@ func TestEngineGetTotalStatsUsesGeneratedClientAdapter(t *testing.T) {
 }
 
 func TestEngineGetTotalStatsOmitsSearchScopeByDefault(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/stats/total", r.URL.Path, "path")
+		assert.Equal("/api/v1/stats/total", r.URL.Path, "path")
 		_, hasSearchScope := r.URL.Query()["search_scope"]
-		assert.False(t, hasSearchScope, "default stats must not opt into search scope")
+		assert.False(hasSearchScope, "default stats must not opt into search scope")
 		writeJSONResponse(t, w, map[string]any{"message_count": 5})
 	})
 
 	engine := NewEngineAdapter(store)
 	stats, err := engine.GetTotalStats(context.Background(), query.StatsOptions{SearchQuery: "urgent"})
-	require.NoError(t, err, "GetTotalStats")
-	require.NotNil(t, stats, "stats")
-	assert.Equal(t, int64(5), stats.MessageCount)
+	require.NoError(err, "GetTotalStats")
+	require.NotNil(stats, "stats")
+	assert.Equal(int64(5), stats.MessageCount)
 }
 
 func TestEngineGetTotalStatsForwardsSourceIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/stats/total", r.URL.Path, "path")
-		assert.ElementsMatch(t, []string{"8", "7", "8"}, r.URL.Query()["source_ids"], "source_ids")
+		assert.Equal("/api/v1/stats/total", r.URL.Path, "path")
+		assert.ElementsMatch([]string{"8", "7", "8"}, r.URL.Query()["source_ids"], "source_ids")
 		writeJSONResponse(t, w, map[string]any{
 			"message_count":        2,
 			"applied_search_scope": true,
@@ -996,9 +959,9 @@ func TestEngineGetTotalStatsForwardsSourceIDs(t *testing.T) {
 		SearchQuery: "urgent",
 		SearchScope: true,
 	})
-	require.NoError(t, err, "GetTotalStats")
-	require.NotNil(t, stats, "stats")
-	assert.Equal(t, int64(2), stats.MessageCount)
+	require.NoError(err, "GetTotalStats")
+	require.NotNil(stats, "stats")
+	assert.Equal(int64(2), stats.MessageCount)
 }
 
 func TestEngineGetTotalStatsRequiresCapabilityEchoes(t *testing.T) {
@@ -1458,26 +1421,29 @@ func TestEngineSearchMethodsRejectParsedQueryErrorsBeforeHTTP(t *testing.T) {
 }
 
 func TestEngineSearchPreservesExactTimeBounds(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	after := time.Date(2024, 2, 1, 10, 30, 15, 123456789,
 		time.FixedZone("UTC-5", -5*60*60))
 	before := time.Date(2024, 3, 1, 0, 0, 0, 0,
 		time.FixedZone("UTC+2", 2*60*60))
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
 		got := search.Parse(r.URL.Query().Get("q"))
-		if !assert.NoError(t, got.Err()) ||
-			!assert.NotNil(t, got.AfterDate) ||
-			!assert.NotNil(t, got.BeforeDate) {
+		if !assert.NoError(got.Err()) ||
+			!assert.NotNil(got.AfterDate) ||
+			!assert.NotNil(got.BeforeDate) {
 			http.Error(w, "invalid exact-time query", http.StatusBadRequest)
 			return
 		}
-		assert.True(t, after.Equal(*got.AfterDate), "after instant")
-		assert.True(t, before.Equal(*got.BeforeDate), "before instant")
+		assert.True(after.Equal(*got.AfterDate), "after instant")
+		assert.True(before.Equal(*got.BeforeDate), "before instant")
 		_, wantAfterOffset := after.Zone()
 		_, gotAfterOffset := got.AfterDate.Zone()
 		_, wantBeforeOffset := before.Zone()
 		_, gotBeforeOffset := got.BeforeDate.Zone()
-		assert.Equal(t, wantAfterOffset, gotAfterOffset, "after timezone offset")
-		assert.Equal(t, wantBeforeOffset, gotBeforeOffset, "before timezone offset")
+		assert.Equal(wantAfterOffset, gotAfterOffset, "after timezone offset")
+		assert.Equal(wantBeforeOffset, gotBeforeOffset, "before timezone offset")
 		writeJSONResponse(t, w, map[string]any{
 			"query": r.URL.Query().Get("q"), "messages": []map[string]any{},
 			"count": 0, "has_more": false, "offset": 0, "limit": 10,
@@ -1488,7 +1454,7 @@ func TestEngineSearchPreservesExactTimeBounds(t *testing.T) {
 	_, err := engine.Search(context.Background(), &search.Query{
 		TextTerms: []string{"needle"}, AfterDate: &after, BeforeDate: &before,
 	}, 10, 0)
-	require.NoError(t, err)
+	require.NoError(err)
 }
 
 func TestEngineSearchMessageBodiesForwardsAndRequiresScopeEcho(t *testing.T) {

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -208,6 +208,49 @@ func TestRunCLISyncSendsIncrementalFolderFilters(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestRunCLISyncSendsExactSourceID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.4.0"}`))
+			return
+		}
+		assert.Equal(t, "42", r.URL.Query().Get("source_id"))
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	st, err := New(Config{URL: srv.URL, AllowInsecure: true, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	require.NoError(t, st.RunCLISync(context.Background(), CLISyncRequest{
+		SourceID: 42, SourceIDSet: true,
+	}, func(string, string) error { return nil }))
+}
+
+func TestRunCLISyncRejectsOldDaemonBeforeStartingSourceScopedSync(t *testing.T) {
+	syncCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.3.0"}`))
+			return
+		}
+		syncCalls++
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	st, err := New(Config{URL: srv.URL, AllowInsecure: true, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	err = st.RunCLISync(context.Background(), CLISyncRequest{
+		SourceID: 42, SourceIDSet: true,
+	}, func(string, string) error { return nil })
+	require.ErrorContains(t, err, "requires daemon API schema 2.4.0")
+	assert.Zero(t, syncCalls, "source-scoped sync must not start on an older daemon")
+}
+
 func TestRunCLICommandStreamsOutput(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -377,6 +420,7 @@ func TestPlanCLIDeleteStagedUsesGeneratedClientAdapter(t *testing.T) {
 			Permanent           bool   `json:"permanent"`
 			Yes                 bool   `json:"yes"`
 			Account             string `json:"account"`
+			SourceID            *int64 `json:"source_id"`
 			RemoteDeleteEnabled bool   `json:"remote_delete_enabled"`
 		}
 		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body), "decode request") {
@@ -387,6 +431,11 @@ func TestPlanCLIDeleteStagedUsesGeneratedClientAdapter(t *testing.T) {
 		assert.True(body.Permanent, "permanent")
 		assert.False(body.Yes, "yes")
 		assert.Equal("alice@example.com", body.Account, "account")
+		if !assert.NotNil(body.SourceID) {
+			http.Error(w, "missing source ID", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(int64(42), *body.SourceID)
 		assert.True(body.RemoteDeleteEnabled, "remote delete enabled")
 
 		w.Header().Set("Content-Type", "application/json")
@@ -417,6 +466,7 @@ func TestPlanCLIDeleteStagedUsesGeneratedClientAdapter(t *testing.T) {
 		BatchID:             "batch-123",
 		Permanent:           true,
 		Account:             "alice@example.com",
+		SourceID:            func() *int64 { value := int64(42); return &value }(),
 		RemoteDeleteEnabled: true,
 	})
 
@@ -440,10 +490,16 @@ func TestPlanCLIDeleteStagedUsesGeneratedClientAdapter(t *testing.T) {
 func TestCreateCLIDeletionManifestUsesGeneratedClientAdapter(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	manifest := deletion.NewManifest("tui selection", []string{"gid1", "gid2"})
+	manifest := deletion.NewManifestForSource("tui selection", []string{"gid1", "gid2"}, deletion.SourceReference{
+		ID: 42, Type: "gmail", Identifier: "account@example.invalid",
+	})
 	manifest.CreatedBy = "tui"
 
 	s := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.4.0"})
+			return
+		}
 		assert.Equal(http.MethodPost, r.Method, "method")
 		assert.Equal("/api/v1/cli/deletion-manifests", r.URL.Path, "path")
 		var body deletion.Manifest
@@ -454,6 +510,11 @@ func TestCreateCLIDeletionManifestUsesGeneratedClientAdapter(t *testing.T) {
 		assert.Equal(manifest.ID, body.ID, "manifest id")
 		assert.Equal("tui", body.CreatedBy, "created by")
 		assert.Equal([]string{"gid1", "gid2"}, body.GmailIDs, "gmail ids")
+		if !assert.NotNil(body.Source) {
+			http.Error(w, "missing source", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(*manifest.Source, *body.Source)
 
 		w.Header().Set("Content-Type", "application/json")
 		if !assert.NoError(json.NewEncoder(w).Encode(map[string]any{
@@ -469,6 +530,25 @@ func TestCreateCLIDeletionManifestUsesGeneratedClientAdapter(t *testing.T) {
 	require.NotNil(got, "result")
 	assert.Equal(manifest.ID, got.ID, "id")
 	assert.Equal(2, got.MessageCount, "message count")
+}
+
+func TestCreateCLIDeletionManifestRejectsOldDaemonBeforeSubmittingVersionTwo(t *testing.T) {
+	manifestPosts := 0
+	s := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.3.0"})
+			return
+		}
+		manifestPosts++
+		writeJSONResponse(t, w, map[string]any{"id": "unexpected", "message_count": 1})
+	})
+	manifest := deletion.NewManifestForSource("tui selection", []string{"gid1"}, deletion.SourceReference{
+		ID: 42, Type: "gmail", Identifier: "account@example.invalid",
+	})
+
+	_, err := s.CreateCLIDeletionManifest(context.Background(), manifest)
+	require.ErrorContains(t, err, "version-2 deletion manifests require daemon API schema 2.4.0")
+	assert.Zero(t, manifestPosts, "version-2 manifest must not be submitted to an older daemon")
 }
 
 func TestPlanCLIDeduplicateUsesGeneratedClientAdapter(t *testing.T) {
@@ -675,9 +755,12 @@ func TestGetStatsRejectsEmptyGeneratedOKBody(t *testing.T) {
 }
 
 func TestCreateCLICollectionRejectsEmptyGeneratedOKBody(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method, "method")
-		assert.Equal(t, "/api/v1/cli/collections", r.URL.Path, "path")
+		assert.Equal(http.MethodPost, r.Method, "method")
+		assert.Equal("/api/v1/cli/collections", r.URL.Path, "path")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -686,8 +769,8 @@ func TestCreateCLICollectionRejectsEmptyGeneratedOKBody(t *testing.T) {
 	s := newTestStore(srv, "key")
 	_, err := s.CreateCLICollection(context.Background(), CLICollectionCreateRequest{Name: "archive"})
 
-	require.Error(t, err, "empty 200 mutation body must fail")
-	assert.NotContains(t, err.Error(), "API error (200)", "empty success decode failures are not API errors")
+	require.Error(err, "empty 200 mutation body must fail")
+	assert.NotContains(err.Error(), "API error (200)", "empty success decode failures are not API errors")
 }
 
 func TestHandleErrorResponse_JSONBody(t *testing.T) {
@@ -1294,9 +1377,12 @@ func TestCLICollectionMutations(t *testing.T) {
 }
 
 func TestGetCLICollection_NotFound(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/cli/collection", r.URL.Path, "path")
-		assert.Equal(t, "missing", r.URL.Query().Get("name"), "name query")
+		assert.Equal("/api/v1/cli/collection", r.URL.Path, "path")
+		assert.Equal("missing", r.URL.Query().Get("name"), "name query")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"error":"not_found","message":"Collection not found"}`))
@@ -1306,8 +1392,8 @@ func TestGetCLICollection_NotFound(t *testing.T) {
 	s := newTestStore(srv, "key")
 	collection, err := s.GetCLICollection(context.Background(), "missing")
 
-	require.ErrorIs(t, err, store.ErrCollectionNotFound, "GetCLICollection(missing)")
-	assert.Nil(t, collection, "collection")
+	require.ErrorIs(err, store.ErrCollectionNotFound, "GetCLICollection(missing)")
+	assert.Nil(collection, "collection")
 }
 
 func TestRebuildCLIFTSStreamsProgress(t *testing.T) {
@@ -1787,9 +1873,12 @@ func TestGetMessageUsesGeneratedClientAdapter(t *testing.T) {
 }
 
 func TestListMessages_ZeroLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ps := r.URL.Query().Get("page_size")
-		assert.NotEqual(t, "0", ps, "page_size should not be 0")
+		assert.NotEqual("0", ps, "page_size should not be 0")
 		resp := generated.MessageListResponse{
 			Total:    0,
 			Page:     1,
@@ -1804,9 +1893,9 @@ func TestListMessages_ZeroLimit(t *testing.T) {
 
 	// This previously panicked with divide-by-zero
 	msgs, total, err := s.ListMessages(0, 0)
-	require.NoError(t, err, "ListMessages(0, 0) error")
-	assert.Equal(t, int64(0), total, "total")
-	assert.Empty(t, msgs, "len(msgs)")
+	require.NoError(err, "ListMessages(0, 0) error")
+	assert.Equal(int64(0), total, "total")
+	assert.Empty(msgs, "len(msgs)")
 }
 
 func TestListMessages_NegativeLimit(t *testing.T) {
@@ -1867,9 +1956,12 @@ func TestListMessagesUsesGeneratedClientAdapter(t *testing.T) {
 }
 
 func TestSearchMessages_ZeroLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ps := r.URL.Query().Get("page_size")
-		assert.NotEqual(t, "0", ps, "page_size should not be 0")
+		assert.NotEqual("0", ps, "page_size should not be 0")
 		resp := generated.SearchResult{
 			Query:    "test",
 			Total:    0,
@@ -1885,9 +1977,9 @@ func TestSearchMessages_ZeroLimit(t *testing.T) {
 
 	// This previously panicked with divide-by-zero
 	msgs, total, err := s.SearchMessages("test", 0, 0)
-	require.NoError(t, err, "SearchMessages(test, 0, 0) error")
-	assert.Equal(t, int64(0), total, "total")
-	assert.Empty(t, msgs, "len(msgs)")
+	require.NoError(err, "SearchMessages(test, 0, 0) error")
+	assert.Equal(int64(0), total, "total")
+	assert.Empty(msgs, "len(msgs)")
 }
 
 func TestSearchMessages_QueryEncoding(t *testing.T) {
@@ -1984,8 +2076,11 @@ func TestListMessages_PageCalculation(t *testing.T) {
 }
 
 func TestListAccounts_Success(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v1/accounts", r.URL.Path, "path")
+		assert.Equal("/api/v1/accounts", r.URL.Path, "path")
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(generated.AccountListResponse{
 			Accounts: []generated.AccountInfo{
@@ -1997,9 +2092,9 @@ func TestListAccounts_Success(t *testing.T) {
 
 	s := newTestStore(srv, "key")
 	accounts, err := s.ListAccounts()
-	require.NoError(t, err, "ListAccounts error")
-	require.Len(t, accounts, 1, "len(accounts)")
-	assert.Equal(t, "user@gmail.com", accounts[0].Email, "Email")
+	require.NoError(err, "ListAccounts error")
+	require.Len(accounts, 1, "len(accounts)")
+	assert.Equal("user@gmail.com", accounts[0].Email, "Email")
 }
 
 func TestListAccountsUsesGeneratedClientAdapter(t *testing.T) {

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -239,6 +239,7 @@ type StagedManifest struct {
 type remoteKey struct {
 	Account    string
 	SourceType string
+	SourceID   int64
 }
 
 // Scan finds all duplicate groups that dedup would prune.
@@ -825,6 +826,36 @@ func sourcePriority(sourceType string, priorityMap map[string]int) int {
 	return len(priorityMap)
 }
 
+func remoteDeletionTargets(ctx context.Context, report *Report) (map[remoteKey][]string, error) {
+	bySource := make(map[remoteKey][]string)
+	for _, group := range report.Groups {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		survivor := group.Messages[group.Survivor]
+		for i, message := range group.Messages {
+			if i == group.Survivor || !remoteSourceTypes[message.SourceType] || message.SourceID != survivor.SourceID {
+				continue
+			}
+			switch {
+			case message.SourceID <= 0:
+				return nil, fmt.Errorf("message %d selected for remote deletion has no source ID", message.ID)
+			case strings.TrimSpace(message.SourceType) == "":
+				return nil, fmt.Errorf("message %d selected for remote deletion has no source type", message.ID)
+			case strings.TrimSpace(message.SourceIdentifier) == "":
+				return nil, fmt.Errorf("message %d selected for remote deletion has no source identifier", message.ID)
+			case strings.TrimSpace(message.SourceMessageID) == "":
+				return nil, fmt.Errorf("message %d selected for remote deletion has no source message ID", message.ID)
+			}
+			key := remoteKey{
+				Account: message.SourceIdentifier, SourceType: message.SourceType, SourceID: message.SourceID,
+			}
+			bySource[key] = append(bySource[key], message.SourceMessageID)
+		}
+	}
+	return bySource, nil
+}
+
 // Execute merges every duplicate group: unions labels onto the
 // survivor, soft-deletes the pruned duplicates, and — when
 // DeleteDupsFromSourceServer is enabled AND a pruned copy shares a
@@ -844,6 +875,13 @@ func (e *Engine) Execute(
 	)
 
 	remoteByKey := make(map[remoteKey][]string)
+	if e.config.DeleteDupsFromSourceServer {
+		var err error
+		remoteByKey, err = remoteDeletionTargets(ctx, report)
+		if err != nil {
+			return summary, err
+		}
+	}
 
 	for i, group := range report.Groups {
 		if ctx.Err() != nil {
@@ -858,24 +896,6 @@ func (e *Engine) Execute(
 				continue
 			}
 			dupIDs = append(dupIDs, m.ID)
-
-			if !e.config.DeleteDupsFromSourceServer {
-				continue
-			}
-			if !remoteSourceTypes[m.SourceType] {
-				continue
-			}
-			if m.SourceID != survivor.SourceID {
-				continue
-			}
-			acct := m.SourceIdentifier
-			if acct == "" {
-				acct = e.config.Account
-			}
-			key := remoteKey{Account: acct, SourceType: m.SourceType}
-			remoteByKey[key] = append(
-				remoteByKey[key], m.SourceMessageID,
-			)
 		}
 
 		mergeResult, err := e.store.MergeDuplicates(
@@ -936,7 +956,10 @@ func (e *Engine) stageDeletionManifests(
 		if keys[i].Account != keys[j].Account {
 			return keys[i].Account < keys[j].Account
 		}
-		return keys[i].SourceType < keys[j].SourceType
+		if keys[i].SourceType != keys[j].SourceType {
+			return keys[i].SourceType < keys[j].SourceType
+		}
+		return keys[i].SourceID < keys[j].SourceID
 	})
 
 	// Single-type accounts keep the original manifest ID (no source-type
@@ -956,9 +979,11 @@ func (e *Engine) stageDeletionManifests(
 		}
 
 		description := fmt.Sprintf("Dedup pruned duplicates (%s)", batchID)
-		manifest := deletion.NewManifest(description, ids)
+		manifest := deletion.NewManifestForSource(description, ids, deletion.SourceReference{
+			ID: k.SourceID, Type: k.SourceType, Identifier: k.Account,
+		})
 		if typesPerAccount[k.Account] > 1 {
-			manifest.ID = manifestIDFor(batchID, k.Account+"-"+k.SourceType)
+			manifest.ID = manifestIDFor(batchID, fmt.Sprintf("%s-%s-%d", k.Account, k.SourceType, k.SourceID))
 		} else {
 			manifest.ID = manifestIDFor(batchID, k.Account)
 		}

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -248,6 +248,9 @@ func TestEngine_OptIn_StagesOnlyWithinSameSourceID(t *testing.T) {
 	require.NoError(err, "ListPending")
 	require.Len(pending, 1, "pending")
 	assert.Equal([]string{"g-2"}, pending[0].GmailIDs, "manifest GmailIDs")
+	assert.Equal(2, pending[0].Version)
+	require.NotNil(pending[0].Source)
+	assert.Equal(deletion.SourceReference{ID: gmail.ID, Type: "gmail", Identifier: "test@example.com"}, *pending[0].Source)
 
 	restored, stillExec, err := eng.Undo("batch-opt")
 	require.NoError(err, "Undo")
@@ -256,6 +259,44 @@ func TestEngine_OptIn_StagesOnlyWithinSameSourceID(t *testing.T) {
 	pending, err = mgr.ListPending()
 	require.NoError(err, "ListPending after undo")
 	assert.Empty(pending, "pending after undo")
+}
+
+func TestEngine_OptIn_RejectsMissingSourceIdentifierBeforeMerge(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	source := f.Source
+
+	winnerID := addMessage(t, st, source, "g-1", "rfc-missing-source", false)
+	loserID := addMessage(t, st, source, "g-2", "rfc-missing-source", false)
+	deletionsDir := filepath.Join(t.TempDir(), "deletions")
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs:           []int64{source.ID},
+		Account:                    "Work",
+		DeleteDupsFromSourceServer: true,
+		DeletionsDir:               deletionsDir,
+	}, nil)
+
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1)
+	group := &report.Groups[0]
+	for i := range group.Messages {
+		if i != group.Survivor {
+			group.Messages[i].SourceIdentifier = ""
+		}
+	}
+
+	_, err = eng.Execute(context.Background(), report, "batch-missing-source")
+	require.ErrorContains(err, "has no source identifier")
+	assertSoftDeleted(t, st, winnerID, false)
+	assertSoftDeleted(t, st, loserID, false)
+
+	mgr, err := deletion.NewManager(deletionsDir)
+	require.NoError(err, "NewManager")
+	pending, err := mgr.ListPending()
+	require.NoError(err, "ListPending")
+	assert.Empty(t, pending)
 }
 
 func TestEngine_ScopedToSingleSource_IgnoresCrossAccount(t *testing.T) {
@@ -574,10 +615,11 @@ func addMessageWithFrom(
 	srcMsgID, rfc822ID, fromEmail string,
 ) int64 {
 	t.Helper()
+	require := require.New(t)
 	convID, err := st.EnsureConversation(
 		source.ID, "thread-"+srcMsgID, "Subject",
 	)
-	require.NoError(t, err, "EnsureConversation")
+	require.NoError(err, "EnsureConversation")
 	id, err := st.UpsertMessage(&store.Message{
 		ConversationID:  convID,
 		SourceID:        source.ID,
@@ -589,12 +631,11 @@ func addMessageWithFrom(
 		IsFromMe:     false, // no is_from_me so MatchedIdentity is the deciding signal
 		SizeEstimate: 1000,
 	})
-	require.NoError(t, err, "UpsertMessage")
+	require.NoError(err, "UpsertMessage")
 	if fromEmail != "" {
 		pid, pErr := st.EnsureParticipant(fromEmail, "", "")
-		require.NoError(t, pErr, "EnsureParticipant")
-		require.NoError(t,
-			st.ReplaceMessageRecipients(id, "from", []int64{pid}, []string{""}),
+		require.NoError(pErr, "EnsureParticipant")
+		require.NoError(st.ReplaceMessageRecipients(id, "from", []int64{pid}, []string{""}),
 			"ReplaceMessageRecipients",
 		)
 	}

--- a/internal/deletion/executor.go
+++ b/internal/deletion/executor.go
@@ -60,6 +60,14 @@ type Executor struct {
 	client   gmail.API
 	logger   *slog.Logger
 	progress Progress
+	sourceID int64
+}
+
+// WithSourceID scopes legacy version-1 manifests to the source selected by
+// the caller's ambiguity-checked planning step.
+func (e *Executor) WithSourceID(sourceID int64) *Executor {
+	e.sourceID = sourceID
+	return e
 }
 
 // NewExecutor creates a deletion executor.
@@ -113,7 +121,7 @@ const (
 // deleteOne attempts to delete a single message and updates the local database on success.
 // Returns resultSuccess (including 404/already-deleted), resultFailed for transient errors,
 // or resultFatal for scope errors that should halt execution.
-func (e *Executor) deleteOne(ctx context.Context, gmailID string, method Method) (deleteResult, error) {
+func (e *Executor) deleteOne(ctx context.Context, sourceID int64, gmailID string, method Method) (deleteResult, error) {
 	var err error
 	if method == MethodTrash {
 		err = e.client.TrashMessage(ctx, gmailID)
@@ -125,7 +133,7 @@ func (e *Executor) deleteOne(ctx context.Context, gmailID string, method Method)
 		if err != nil {
 			e.logger.Debug("message already deleted", "gmail_id", gmailID)
 		}
-		if markErr := e.store.MarkMessageDeletedByGmailID(method == MethodDelete, gmailID); markErr != nil {
+		if markErr := e.store.MarkMessageDeletedBySourceMessageID(sourceID, method == MethodDelete, gmailID); markErr != nil {
 			e.logger.Warn("failed to mark deleted in DB", "gmail_id", gmailID, "error", markErr)
 		}
 		return resultSuccess, nil
@@ -137,6 +145,20 @@ func (e *Executor) deleteOne(ctx context.Context, gmailID string, method Method)
 
 	e.logger.Warn("failed to delete message", "gmail_id", gmailID, "error", err)
 	return resultFailed, err
+}
+
+func (e *Executor) manifestSourceID(manifest *Manifest) (int64, error) {
+	if err := manifest.ValidateVersion(); err != nil {
+		return 0, err
+	}
+	if manifest.Version == 1 {
+		return e.sourceID, nil
+	}
+	source, err := e.store.GetSourceByTypeAndIdentifier(manifest.Source.Type, manifest.Source.Identifier)
+	if err != nil {
+		return 0, fmt.Errorf("resolve manifest source: %w", err)
+	}
+	return source.ID, nil
 }
 
 // manifestCancelled reports whether the manifest was cancelled by a concurrent
@@ -290,6 +312,10 @@ func (e *Executor) Execute(ctx context.Context, manifestID string, opts *Execute
 	if err != nil {
 		return err
 	}
+	sourceID, err := e.manifestSourceID(manifest)
+	if err != nil {
+		return fmt.Errorf("validate manifest source: %w", err)
+	}
 
 	// Determine starting point
 	startIndex := 0
@@ -341,7 +367,7 @@ func (e *Executor) Execute(ctx context.Context, manifestID string, opts *Execute
 			return ErrManifestCancelled
 		}
 
-		result, delErr := e.deleteOne(ctx, gmailID, opts.Method)
+		result, delErr := e.deleteOne(ctx, sourceID, gmailID, opts.Method)
 		switch result {
 		case resultSuccess:
 			succeeded++
@@ -371,7 +397,7 @@ func (e *Executor) Execute(ctx context.Context, manifestID string, opts *Execute
 			return ErrManifestCancelled
 		}
 
-		result, delErr := e.deleteOne(ctx, manifest.GmailIDs[i], opts.Method)
+		result, delErr := e.deleteOne(ctx, sourceID, manifest.GmailIDs[i], opts.Method)
 		switch result {
 		case resultSuccess:
 			succeeded++
@@ -398,6 +424,10 @@ func (e *Executor) ExecuteBatch(ctx context.Context, manifestID string) error {
 	manifest, err := e.prepareExecution(manifestID, MethodDelete)
 	if err != nil {
 		return err
+	}
+	sourceID, err := e.manifestSourceID(manifest)
+	if err != nil {
+		return fmt.Errorf("validate manifest source: %w", err)
 	}
 
 	if e.manifestCancelled(manifestID) {
@@ -477,7 +507,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, manifestID string) error {
 				return ErrManifestCancelled
 			}
 
-			result, delErr := e.deleteOne(ctx, gmailID, MethodDelete)
+			result, delErr := e.deleteOne(ctx, sourceID, gmailID, MethodDelete)
 			switch result {
 			case resultSuccess:
 				succeeded++
@@ -535,7 +565,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, manifestID string) error {
 					return ErrManifestCancelled
 				}
 
-				result, delErr := e.deleteOne(ctx, gmailID, MethodDelete)
+				result, delErr := e.deleteOne(ctx, sourceID, gmailID, MethodDelete)
 				switch result {
 				case resultSuccess:
 					succeeded++
@@ -551,7 +581,7 @@ func (e *Executor) ExecuteBatch(ctx context.Context, manifestID string) error {
 		} else {
 			succeeded += len(batch)
 			// Mark all as deleted in DB using batch update
-			if markErr := e.store.MarkMessagesDeletedByGmailIDBatch(batch); markErr != nil {
+			if markErr := e.store.MarkMessagesDeletedBySourceMessageIDBatch(sourceID, batch); markErr != nil {
 				e.logger.Warn("failed to mark batch as deleted in DB", "count", len(batch), "error", markErr)
 			}
 		}

--- a/internal/deletion/executor_e2e_test.go
+++ b/internal/deletion/executor_e2e_test.go
@@ -37,16 +37,17 @@ type e2eFixture struct {
 
 func newE2EFixture(t *testing.T) *e2eFixture {
 	t.Helper()
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 
 	srcA, err := st.GetOrCreateSource("gmail", "alice@example.com")
-	require.NoError(t, err, "GetOrCreateSource A")
+	require.NoError(err, "GetOrCreateSource A")
 	srcB, err := st.GetOrCreateSource("gmail", "bob@example.com")
-	require.NoError(t, err, "GetOrCreateSource B")
+	require.NoError(err, "GetOrCreateSource B")
 	convA, err := st.EnsureConversation(srcA.ID, "thread-A", "Thread A")
-	require.NoError(t, err, "EnsureConversation A")
+	require.NoError(err, "EnsureConversation A")
 	convB, err := st.EnsureConversation(srcB.ID, "thread-B", "Thread B")
-	require.NoError(t, err, "EnsureConversation B")
+	require.NoError(err, "EnsureConversation B")
 
 	f := &e2eFixture{
 		t:       t,
@@ -79,6 +80,11 @@ func newE2EFixture(t *testing.T) *e2eFixture {
 
 func (f *e2eFixture) addMessage(gmailID string, sourceID, convID int64) {
 	f.t.Helper()
+	f.msgIDs[gmailID] = f.addMessageReturningID(gmailID, sourceID, convID)
+}
+
+func (f *e2eFixture) addMessageReturningID(gmailID string, sourceID, convID int64) int64 {
+	f.t.Helper()
 	id, err := f.store.UpsertMessage(&store.Message{
 		ConversationID:  convID,
 		SourceID:        sourceID,
@@ -87,7 +93,7 @@ func (f *e2eFixture) addMessage(gmailID string, sourceID, convID int64) {
 		SizeEstimate:    1024,
 	})
 	require.NoErrorf(f.t, err, "UpsertMessage(%s)", gmailID)
-	f.msgIDs[gmailID] = id
+	return id
 }
 
 func (f *e2eFixture) upsertAttachment(gmailID, filename, storagePath, contentHash string) {
@@ -165,6 +171,78 @@ func TestExecutor_E2E_TrashOnlyMarksTargetSource(t *testing.T) {
 	// Mock Gmail was called for each ID exactly once via TrashMessage.
 	assert.Len(tc.MockAPI.TrashCalls, 3, "TrashCalls")
 	assert.Empty(tc.MockAPI.DeleteCalls, "DeleteCalls (trash method)")
+}
+
+func TestExecutor_E2E_VersionTwoScopesDuplicateRemoteID(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*e2eContext, string) error
+	}{
+		{name: "trash", execute: func(tc *e2eContext, id string) error {
+			return tc.Exec.Execute(context.Background(), id, DefaultExecuteOptions())
+		}},
+		{name: "permanent", execute: func(tc *e2eContext, id string) error {
+			opts := DefaultExecuteOptions()
+			opts.Method = MethodDelete
+			return tc.Exec.Execute(context.Background(), id, opts)
+		}},
+		{name: "batch", execute: func(tc *e2eContext, id string) error {
+			return tc.Exec.ExecuteBatch(context.Background(), id)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			f := newE2EFixture(t)
+			tc := newE2EContext(t, f)
+			const sharedID = "shared-remote-id"
+			targetRowID := f.addMessageReturningID(sharedID, f.sourceA.ID, f.convA)
+			otherRowID := f.addMessageReturningID(sharedID, f.sourceB.ID, f.convB)
+
+			manifest := NewManifestForSource("source-bound collision", []string{sharedID}, SourceReference{
+				// The snapshot deliberately points at source B. The stable tuple
+				// remains authoritative and resolves source A.
+				ID: f.sourceB.ID, Type: f.sourceA.SourceType, Identifier: f.sourceA.Identifier,
+			})
+			require.NoError(tc.Mgr.SaveManifest(manifest))
+			require.NoError(tt.execute(tc, manifest.ID))
+
+			var otherDeletedAt any
+			require.NoError(f.store.DB().QueryRow(
+				f.store.Rebind(`SELECT deleted_from_source_at FROM messages WHERE id = ?`), otherRowID,
+			).Scan(&otherDeletedAt))
+			assert.Nil(otherDeletedAt)
+			var targetCount int
+			require.NoError(f.store.DB().QueryRow(
+				f.store.Rebind(`SELECT COUNT(*) FROM messages WHERE id = ?`), targetRowID,
+			).Scan(&targetCount))
+			if tt.name == "permanent" {
+				assert.Zero(targetCount)
+			} else {
+				assert.Equal(1, targetCount)
+			}
+		})
+	}
+}
+
+func TestExecutor_E2E_MissingVersionTwoSourceMakesNoRemoteCall(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newE2EFixture(t)
+	tc := newE2EContext(t, f)
+	manifest := NewManifestForSource("missing source", []string{"msg-a1"}, SourceReference{
+		ID: 999, Type: "gmail", Identifier: "missing@example.invalid",
+	})
+	require.NoError(tc.Mgr.SaveManifest(manifest))
+
+	err := tc.Exec.Execute(context.Background(), manifest.ID, DefaultExecuteOptions())
+	require.ErrorContains(err, "resolve manifest source")
+	assert.Empty(tc.MockAPI.TrashCalls)
+	assert.Empty(tc.MockAPI.DeleteCalls)
+	assert.Empty(tc.MockAPI.BatchDeleteCalls)
 }
 
 // TestExecutor_E2E_PermanentDeleteCascadesAttachments verifies that

--- a/internal/deletion/manifest.go
+++ b/internal/deletion/manifest.go
@@ -3,6 +3,7 @@ package deletion
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -18,6 +19,20 @@ import (
 	"github.com/gofrs/flock"
 	"go.kenn.io/msgvault/internal/fileutil"
 )
+
+// Digest returns the canonical SHA-256 fingerprint of the complete serialized
+// manifest state used for execution confirmation.
+func (m *Manifest) Digest() (string, error) {
+	if err := m.ValidateVersion(); err != nil {
+		return "", err
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest digest: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
 
 // Status represents the state of a deletion batch.
 type Status string
@@ -79,23 +94,59 @@ type Execution struct {
 	LastProcessedIndex int        `json:"last_processed_index"` // For resumability
 }
 
+// SourceReference is the durable identity of the one source a deletion batch
+// targets. Type and Identifier are portable across archives; ID is a local
+// snapshot used for diagnostics and fast-path validation.
+type SourceReference struct {
+	ID         int64  `json:"id"`
+	Type       string `json:"type"`
+	Identifier string `json:"identifier"`
+}
+
 // Manifest represents a deletion batch.
 type Manifest struct {
-	Version     int        `json:"version"`
-	ID          string     `json:"id"`
-	CreatedAt   time.Time  `json:"created_at"`
-	CreatedBy   string     `json:"created_by"` // "tui", "cli", "api"
-	Description string     `json:"description"`
-	Filters     Filters    `json:"filters"`
-	Summary     *Summary   `json:"summary,omitempty"`
-	GmailIDs    []string   `json:"gmail_ids"`
-	Status      Status     `json:"status"`
-	Execution   *Execution `json:"execution,omitempty"`
+	Version     int              `json:"version"`
+	ID          string           `json:"id"`
+	CreatedAt   time.Time        `json:"created_at"`
+	CreatedBy   string           `json:"created_by"` // "tui", "cli", "api"
+	Description string           `json:"description"`
+	Filters     Filters          `json:"filters"`
+	Summary     *Summary         `json:"summary,omitempty"`
+	GmailIDs    []string         `json:"gmail_ids"`
+	Status      Status           `json:"status"`
+	Execution   *Execution       `json:"execution,omitempty"`
+	Source      *SourceReference `json:"source,omitempty"`
 	// RawFilter records the serialized HTTP API staging request fields for
 	// provenance — Filters cannot represent every request field
 	// (sender_name, recipient_name, source_id). Absent on manifests created
 	// by the TUI/CLI.
 	RawFilter json.RawMessage `json:"raw_filter,omitempty"`
+}
+
+// NewManifestForSource creates a source-bound version-2 manifest.
+func NewManifestForSource(description string, gmailIDs []string, source SourceReference) *Manifest {
+	manifest := NewManifest(description, gmailIDs)
+	manifest.Version = 2
+	manifest.Source = &source
+	return manifest
+}
+
+// ValidateVersion enforces the manifest-version/source contract.
+func (m *Manifest) ValidateVersion() error {
+	switch m.Version {
+	case 1:
+		if m.Source != nil {
+			return errors.New("version 1 manifest must not contain a source reference")
+		}
+		return nil
+	case 2:
+		if m.Source == nil || m.Source.ID <= 0 || strings.TrimSpace(m.Source.Type) == "" || strings.TrimSpace(m.Source.Identifier) == "" {
+			return errors.New("version 2 manifest requires a complete source reference")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported manifest version %d", m.Version)
+	}
 }
 
 // NewManifest creates a new deletion manifest.
@@ -191,12 +242,18 @@ func LoadManifest(path string) (*Manifest, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, err
 	}
+	if err := m.ValidateVersion(); err != nil {
+		return nil, err
+	}
 
 	return &m, nil
 }
 
 // Save writes the manifest to a JSON file.
 func (m *Manifest) Save(path string) error {
+	if err := m.ValidateVersion(); err != nil {
+		return err
+	}
 	// Ensure parent directory exists
 	//
 	// codeql[go/path-injection] -- manifest paths are explicit local CLI
@@ -481,6 +538,12 @@ func (m *Manager) FinalizeInProgress(id string, target Status) error {
 // ErrManifestCancelled). Only one manifest's lock is ever held at a time, so
 // there is no lock-ordering cycle to deadlock on.
 func (m *Manager) ClaimManifest(id string, method Method) (*Manifest, error) {
+	return m.ClaimManifestWithDigest(id, method, "")
+}
+
+// ClaimManifestWithDigest claims a manifest only if its complete persisted
+// state still matches the state confirmed by the caller.
+func (m *Manager) ClaimManifestWithDigest(id string, method Method, expectedDigest string) (*Manifest, error) {
 	if err := ValidateManifestID(id); err != nil {
 		return nil, err
 	}
@@ -499,6 +562,9 @@ func (m *Manager) ClaimManifest(id string, method Method) (*Manifest, error) {
 	manifest, err := LoadManifest(inProgressPath)
 	switch {
 	case err == nil:
+		if err := requireManifestDigest(manifest, expectedDigest); err != nil {
+			return nil, err
+		}
 		return m.resumeClaimedManifest(manifest, inProgressPath, method)
 	case !errors.Is(err, os.ErrNotExist):
 		return nil, fmt.Errorf("load in-progress manifest %s: %w", id, err)
@@ -519,12 +585,29 @@ func (m *Manager) ClaimManifest(id string, method Method) (*Manifest, error) {
 	manifest, err = LoadManifest(pendingPath)
 	switch {
 	case err == nil:
+		if err := requireManifestDigest(manifest, expectedDigest); err != nil {
+			return nil, err
+		}
 		return m.claimPendingManifest(manifest, pendingPath, inProgressPath, method)
 	case !errors.Is(err, os.ErrNotExist):
 		return nil, fmt.Errorf("load pending manifest %s: %w", id, err)
 	}
 
 	return nil, fmt.Errorf("manifest %s not found", id)
+}
+
+func requireManifestDigest(manifest *Manifest, expected string) error {
+	if expected == "" {
+		return nil
+	}
+	actual, err := manifest.Digest()
+	if err != nil {
+		return err
+	}
+	if actual != expected {
+		return errors.New("staged deletion manifest changed since confirmation")
+	}
+	return nil
 }
 
 // resumeClaimedManifest handles the ClaimManifest resume branch: the manifest

--- a/internal/deletion/manifest_test.go
+++ b/internal/deletion/manifest_test.go
@@ -250,6 +250,86 @@ func TestNewManifest(t *testing.T) {
 	assert.False(m.CreatedAt.IsZero(), "CreatedAt is zero")
 }
 
+func TestNewManifestForSourceRoundTrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	path := filepath.Join(t.TempDir(), "source-bound.json")
+	wantSource := SourceReference{ID: 42, Type: "gmail", Identifier: "account@example.invalid"}
+	manifest := NewManifestForSource("source-bound", []string{"gm-1"}, wantSource)
+
+	require.NoError(manifest.Save(path))
+	loaded, err := LoadManifest(path)
+	require.NoError(err)
+	assert.Equal(2, loaded.Version)
+	require.NotNil(loaded.Source)
+	assert.Equal(wantSource, *loaded.Source)
+}
+
+func TestManifestVersionSourceContract(t *testing.T) {
+	validSource := &SourceReference{ID: 42, Type: "gmail", Identifier: "account@example.invalid"}
+	tests := []struct {
+		name     string
+		version  int
+		source   *SourceReference
+		wantPart string
+	}{
+		{name: "v1 with source", version: 1, source: validSource, wantPart: "version 1"},
+		{name: "v2 missing source", version: 2, wantPart: "complete source"},
+		{name: "v2 zero id", version: 2, source: &SourceReference{Type: "gmail", Identifier: "account@example.invalid"}, wantPart: "complete source"},
+		{name: "unsupported", version: 3, wantPart: "unsupported"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := NewManifest("invalid", []string{"gm-1"})
+			manifest.Version = tt.version
+			manifest.Source = tt.source
+			err := manifest.Save(filepath.Join(t.TempDir(), "manifest.json"))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantPart)
+		})
+	}
+}
+
+func TestLoadLiteralVersionOneManifest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	path := filepath.Join(t.TempDir(), "legacy.json")
+	require.NoError(os.WriteFile(path, []byte(`{
+		"version":1,"id":"legacy-batch","created_at":"2026-08-19T00:00:00Z",
+		"created_by":"cli","description":"legacy","filters":{"account":"legacy@example.invalid"},
+		"gmail_ids":["gm-1"],"status":"pending"
+	}`), 0o600))
+
+	manifest, err := LoadManifest(path)
+	require.NoError(err)
+	assert.Equal(1, manifest.Version)
+	assert.Nil(manifest.Source)
+}
+
+func TestClaimManifestWithDigestRejectsReplacement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	mgr := testManager(t)
+	manifest := NewManifestForSource("confirmed", []string{"gm-1"}, SourceReference{
+		ID: 42, Type: "gmail", Identifier: "account@example.invalid",
+	})
+	require.NoError(mgr.SaveManifest(manifest))
+	digest, err := manifest.Digest()
+	require.NoError(err)
+
+	replacement := *manifest
+	replacement.Filters.Account = "changed@example.invalid"
+	require.NoError(replacement.Save(filepath.Join(mgr.PendingDir(), manifest.ID+".json")))
+
+	_, err = mgr.ClaimManifestWithDigest(manifest.ID, MethodTrash, digest)
+	require.ErrorContains(err, "changed since confirmation")
+	assert.FileExists(filepath.Join(mgr.PendingDir(), manifest.ID+".json"))
+	assert.NoFileExists(filepath.Join(mgr.InProgressDir(), manifest.ID+".json"))
+}
+
 func TestManifest_SaveAndLoad(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "test-manifest.json")
@@ -983,6 +1063,7 @@ func setupInProgress(t *testing.T, mgr *Manager, desc string) *Manifest {
 // This is the invariant a torn checkpoint write would violate.
 func assertSingleValidManifest(t *testing.T, mgr *Manager, id string) {
 	t.Helper()
+	require := require.New(t)
 	found := 0
 	for _, status := range persistedStatuses {
 		path := filepath.Join(mgr.dirForStatus(status), id+".json")
@@ -991,12 +1072,12 @@ func assertSingleValidManifest(t *testing.T, mgr *Manager, id string) {
 			continue
 		}
 		found++
-		require.Positive(t, info.Size(), "manifest %s in %s must not be empty", id, status)
+		require.Positive(info.Size(), "manifest %s in %s must not be empty", id, status)
 		loaded, err := LoadManifest(path)
-		require.NoError(t, err, "manifest %s in %s must be fully parseable", id, status)
-		require.Equal(t, id, loaded.ID, "parsed manifest %s in %s has wrong ID", id, status)
+		require.NoError(err, "manifest %s in %s must be fully parseable", id, status)
+		require.Equal(id, loaded.ID, "parsed manifest %s in %s has wrong ID", id, status)
 	}
-	require.Equal(t, 1, found, "manifest %s must exist in exactly one status directory", id)
+	require.Equal(1, found, "manifest %s must exist in exactly one status directory", id)
 }
 
 // TestManager_CheckpointCancelSerialize deterministically drives the

--- a/internal/deletion/targets.go
+++ b/internal/deletion/targets.go
@@ -1,0 +1,45 @@
+package deletion
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/query"
+)
+
+var (
+	ErrNoDeletionTargets        = errors.New("selection has no deletion targets")
+	ErrIncompleteDeletionSource = errors.New("deletion target has incomplete source metadata")
+	ErrMultipleDeletionSources  = errors.New("deletion targets span multiple sources")
+)
+
+// SourceReferenceForTargets returns the one source shared by every target.
+func SourceReferenceForTargets(targets []query.DeletionTarget) (SourceReference, error) {
+	if len(targets) == 0 {
+		return SourceReference{}, ErrNoDeletionTargets
+	}
+	var source SourceReference
+	for i, target := range targets {
+		if target.SourceID <= 0 || strings.TrimSpace(target.SourceType) == "" || strings.TrimSpace(target.SourceIdentifier) == "" {
+			return SourceReference{}, fmt.Errorf("%w: message %d", ErrIncompleteDeletionSource, target.MessageID)
+		}
+		if i == 0 {
+			source = SourceReference{ID: target.SourceID, Type: target.SourceType, Identifier: target.SourceIdentifier}
+			continue
+		}
+		if target.SourceID != source.ID || target.SourceType != source.Type || target.SourceIdentifier != source.Identifier {
+			return SourceReference{}, ErrMultipleDeletionSources
+		}
+	}
+	return source, nil
+}
+
+// SourceMessageIDs returns target provider IDs in their existing order.
+func SourceMessageIDs(targets []query.DeletionTarget) []string {
+	ids := make([]string, len(targets))
+	for i := range targets {
+		ids[i] = targets[i].SourceMessageID
+	}
+	return ids
+}

--- a/internal/deletion/targets_test.go
+++ b/internal/deletion/targets_test.go
@@ -1,0 +1,64 @@
+package deletion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/query"
+)
+
+func TestSourceReferenceForTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		targets []query.DeletionTarget
+		want    SourceReference
+		wantErr error
+	}{
+		{name: "empty", wantErr: ErrNoDeletionTargets},
+		{
+			name: "incomplete",
+			targets: []query.DeletionTarget{
+				{MessageID: 1, SourceID: 1, SourceIdentifier: "user@example.invalid", SourceMessageID: "remote-1"},
+			},
+			wantErr: ErrIncompleteDeletionSource,
+		},
+		{
+			name: "multiple sources",
+			targets: []query.DeletionTarget{
+				{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "user@example.invalid", SourceMessageID: "remote-1"},
+				{MessageID: 2, SourceID: 2, SourceType: "imap", SourceIdentifier: "user@example.invalid", SourceMessageID: "remote-2"},
+			},
+			wantErr: ErrMultipleDeletionSources,
+		},
+		{
+			name: "one source",
+			targets: []query.DeletionTarget{
+				{MessageID: 1, SourceID: 7, SourceType: "gmail", SourceIdentifier: "user@example.invalid", SourceMessageID: "remote-1"},
+				{MessageID: 2, SourceID: 7, SourceType: "gmail", SourceIdentifier: "user@example.invalid", SourceMessageID: "remote-2"},
+			},
+			want: SourceReference{ID: 7, Type: "gmail", Identifier: "user@example.invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SourceReferenceForTargets(tt.targets)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSourceMessageIDs(t *testing.T) {
+	targets := []query.DeletionTarget{
+		{SourceMessageID: "remote-2"},
+		{SourceMessageID: "remote-1"},
+	}
+
+	assert.Equal(t, []string{"remote-2", "remote-1"}, SourceMessageIDs(targets))
+}

--- a/internal/identityops/identityops.go
+++ b/internal/identityops/identityops.go
@@ -10,6 +10,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/collectionops"
 	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/sourceops"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -21,17 +22,12 @@ const (
 
 type Store interface {
 	collectionops.AccountResolverStore
-	GetSourceByID(id int64) (*store.Source, error)
 	ListAccountIdentities(sourceID int64) ([]store.AccountIdentity, error)
 	AddAccountIdentity(sourceID int64, address, signal string) error
 	RemoveAccountIdentity(sourceID int64, address string) (int64, error)
 }
 
-type SourceSelector struct {
-	Account     string `json:"account,omitempty"`
-	SourceID    int64  `json:"source_id,omitempty"`
-	sourceIDSet bool
-}
+type SourceSelector = sourceops.Selector
 
 type AddRequest struct {
 	SourceSelector
@@ -50,7 +46,7 @@ func (r *AddRequest) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	decoded.sourceIDSet = set
+	decoded.SourceIDSet = set
 	*r = AddRequest(decoded)
 	return nil
 }
@@ -84,7 +80,7 @@ func (r *RemoveRequest) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	decoded.sourceIDSet = set
+	decoded.SourceIDSet = set
 	*r = RemoveRequest(decoded)
 	return nil
 }
@@ -206,37 +202,22 @@ func Remove(st Store, req RemoveRequest) (RemoveResult, error) {
 }
 
 func ResolveSource(st Store, selector SourceSelector) (*store.Source, error) {
-	account := strings.TrimSpace(selector.Account)
-	switch {
-	case selector.SourceID < 0 || (selector.sourceIDSet && selector.SourceID == 0):
-		return nil, opserr.Invalid(errors.New("source ID must be positive"))
-	case selector.SourceID > 0 && account != "":
-		return nil, opserr.Invalid(errors.New("account and source ID are mutually exclusive"))
-	case selector.SourceID > 0:
-		src, err := st.GetSourceByID(selector.SourceID)
-		if errors.Is(err, store.ErrSourceNotFound) {
-			return nil, opserr.NotFound(err)
-		}
-		if err != nil {
-			return nil, opserr.Internal(err)
-		}
-		return src, nil
-	case account == "":
-		return nil, opserr.Invalid(errors.New("account or source ID is required"))
-	default:
-		return resolveAccountSource(st, account)
+	source, err := sourceops.ResolveExactOne(st, selector)
+	if err == nil || opserr.KindOf(err) != opserr.KindNotFound ||
+		selector.SourceIDSet || selector.SourceID != 0 || strings.TrimSpace(selector.Account) == "" {
+		return source, err
 	}
-}
 
-func resolveAccountSource(st Store, input string) (*store.Source, error) {
-	scope, err := collectionops.ResolveAccount(st, input)
-	if err != nil {
+	account := strings.TrimSpace(selector.Account)
+	_, collectionErr := st.GetCollectionByName(account)
+	switch {
+	case collectionErr == nil:
+		return nil, opserr.Invalid(fmt.Errorf("%q is a collection, not an account", account))
+	case errors.Is(collectionErr, store.ErrCollectionNotFound):
 		return nil, err
+	default:
+		return nil, opserr.Internal(fmt.Errorf("look up collection %q: %w", account, collectionErr))
 	}
-	if scope.Source == nil {
-		return nil, opserr.Invalid(fmt.Errorf("no primary account source found for %q", input))
-	}
-	return scope.Source, nil
 }
 
 // SplitSignalSet parses a stored source_signal field into a sorted slice.

--- a/internal/identityops/import.go
+++ b/internal/identityops/import.go
@@ -40,7 +40,7 @@ func (r *ImportRequest) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	decoded.sourceIDSet = set
+	decoded.SourceIDSet = set
 	*r = ImportRequest(decoded)
 	return nil
 }

--- a/internal/identityops/selector_test.go
+++ b/internal/identityops/selector_test.go
@@ -1,13 +1,29 @@
 package identityops_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/identityops"
+	"go.kenn.io/msgvault/internal/opserr"
 	"go.kenn.io/msgvault/internal/testutil"
 )
+
+func TestSourceSelectorJSONPreservesExplicitSourceIDPresence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var req identityops.AddRequest
+	require.NoError(json.Unmarshal([]byte(`{"source_id":0,"identifier":"me@example.test"}`), &req))
+
+	assert.True(req.SourceIDSet)
+	_, err := identityops.ResolveSource(testutil.NewTestStore(t), req.SourceSelector)
+	require.Error(err)
+	assert.Equal(opserr.KindInvalid, opserr.KindOf(err))
+	assert.ErrorContains(err, "source ID must be positive")
+}
 
 func TestResolveSourceRequiresExactlyOneSelector(t *testing.T) {
 	requirements := require.New(t)

--- a/internal/mcp/contract_integration_test.go
+++ b/internal/mcp/contract_integration_test.go
@@ -137,8 +137,7 @@ func newTask5Fixture(t *testing.T, shape string) task5Fixture {
 		AggregateRows: []query.AggregateRow{{
 			Key: "example.com", Count: 2, TotalSize: 3072, AttachmentSize: int64(len(attachmentBytes)), AttachmentCount: 1, TotalUnique: 1,
 		}},
-		GmailIDs:      []string{"source-message-42"},
-		GmailAccounts: []string{"alice@example.com"},
+		GmailIDs: []string{"source-message-42"},
 		SearchFastCountFunc: func(context.Context, *search.Query, query.MessageFilter) (int64, error) {
 			return 1, nil
 		},

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -326,10 +326,18 @@ func (h *handlers) getAccountID(ctx context.Context, account string) (*int64, er
 	if err != nil {
 		return nil, newInternalError("list accounts", err)
 	}
+	var matched *int64
 	for _, acc := range accounts {
 		if acc.Identifier == account {
-			return &acc.ID, nil
+			if matched != nil {
+				return nil, &expectedHandlerError{message: "account matches multiple sources: " + account}
+			}
+			id := acc.ID
+			matched = &id
 		}
+	}
+	if matched != nil {
+		return matched, nil
 	}
 	return nil, &expectedHandlerError{message: "account not found: " + account}
 }
@@ -1885,7 +1893,16 @@ func (h *handlers) stageDeletion(ctx context.Context, req toolRequest) (*toolRes
 		return toolErrorResult("must provide either 'query' or at least one filter (from, domain, label, after, before, has_attachment)"), nil
 	}
 
-	var gmailIDs []string
+	accounts, err := h.engine.ListAccounts(ctx)
+	if err != nil {
+		return dependencyError("list deletion sources", err)
+	}
+	accountsByID := make(map[int64]query.AccountInfo, len(accounts))
+	for _, info := range accounts {
+		accountsByID[info.ID] = info
+	}
+
+	var targets []query.DeletionTarget
 	var description string
 
 	if hasQuery {
@@ -1914,7 +1931,20 @@ func (h *handlers) stageDeletion(ctx context.Context, req toolRequest) (*toolRes
 		}
 
 		for _, msg := range results {
-			gmailIDs = append(gmailIDs, msg.SourceMessageID)
+			if msg.SourceID <= 0 {
+				return toolErrorResult(fmt.Sprintf("selected message %d has no source metadata", msg.ID)), nil
+			}
+			info, ok := accountsByID[msg.SourceID]
+			if !ok {
+				return toolErrorResult(fmt.Sprintf("selected message %d has no source metadata", msg.ID)), nil
+			}
+			if strings.TrimSpace(info.SourceType) == "" || strings.TrimSpace(info.Identifier) == "" {
+				return toolErrorResult(fmt.Sprintf("selected message %d has incomplete source metadata", msg.ID)), nil
+			}
+			targets = append(targets, query.DeletionTarget{
+				MessageID: msg.ID, SourceID: msg.SourceID, SourceType: info.SourceType,
+				SourceIdentifier: info.Identifier, SourceMessageID: msg.SourceMessageID,
+			})
 		}
 		description = "query: " + queryStr
 		if len(description) > 50 {
@@ -1936,7 +1966,7 @@ func (h *handlers) stageDeletion(ctx context.Context, req toolRequest) (*toolRes
 		}
 
 		var err error
-		gmailIDs, err = h.engine.GetGmailIDsByFilter(ctx, filter)
+		targets, err = h.engine.GetDeletionTargetsByFilter(ctx, filter)
 		if err != nil {
 			return nil, newInternalError("filter messages for deletion", err)
 		}
@@ -1967,15 +1997,26 @@ func (h *handlers) stageDeletion(ctx context.Context, req toolRequest) (*toolRes
 		}
 	}
 
-	if len(gmailIDs) == 0 {
+	if len(targets) == 0 {
 		return toolErrorResult("no messages match the specified criteria"), nil
 	}
+	source, sourceErr := deletion.SourceReferenceForTargets(targets)
+	if errors.Is(sourceErr, deletion.ErrMultipleDeletionSources) {
+		return toolErrorResult("selected messages span multiple sources; set account or stage each source separately"), nil
+	}
+	if errors.Is(sourceErr, deletion.ErrIncompleteDeletionSource) {
+		return toolErrorResult("selected message has incomplete source metadata"), nil
+	}
+	if sourceErr != nil {
+		return toolErrorResult(sourceErr.Error()), nil
+	}
+	gmailIDs := deletion.SourceMessageIDs(targets)
 
-	manifest := deletion.NewManifest(description, gmailIDs)
+	manifest := deletion.NewManifestForSource(description, gmailIDs, source)
 	manifest.CreatedBy = "mcp"
 
 	// Set filter metadata for execution
-	manifest.Filters.Account = account
+	manifest.Filters.Account = source.Identifier
 	if fromStr != "" {
 		manifest.Filters.Senders = []string{fromStr}
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2991,19 +2991,11 @@ func (s *captureDeletionManifestSaver) SaveManifest(_ context.Context, manifest 
 func TestStageDeletion(t *testing.T) {
 	eng := &querytest.MockEngine{
 		Accounts: []query.AccountInfo{
-			{ID: 1, Identifier: "alice@gmail.com"},
+			{ID: 1, SourceType: "gmail", Identifier: "alice@gmail.com"},
 		},
 		SearchFastResults: []query.MessageSummary{
-			testutil.NewMessageSummary(1).
-				WithSubject("Newsletter").
-				WithFromEmail("news@example.com").
-				WithSourceMessageID("gmail-001").
-				Build(),
-			testutil.NewMessageSummary(2).
-				WithSubject("Promo").
-				WithFromEmail("promo@example.com").
-				WithSourceMessageID("gmail-002").
-				Build(),
+			{ID: 1, SourceID: 1, Subject: "Newsletter", FromEmail: "news@example.com", SourceMessageID: "gmail-001"},
+			{ID: 2, SourceID: 1, Subject: "Promo", FromEmail: "promo@example.com", SourceMessageID: "gmail-002"},
 		},
 		GmailIDs: []string{"gmail-010", "gmail-011"},
 	}
@@ -3047,7 +3039,40 @@ func TestStageDeletion(t *testing.T) {
 		require.NotNil(t, saver.manifest, "manifest saver should receive manifest")
 		assert.Equal(resp.BatchID, saver.manifest.ID, "manifest ID")
 		assert.Equal([]string{"gmail-001", "gmail-002"}, saver.manifest.GmailIDs, "gmail IDs")
+		assert.Equal(2, saver.manifest.Version)
+		require.NotNil(t, saver.manifest.Source)
+		assert.Equal(deletion.SourceReference{ID: 1, Type: "gmail", Identifier: "alice@gmail.com"}, *saver.manifest.Source)
 		assert.NoDirExists(filepath.Join(dataDir, "deletions"), "local fallback should not be used")
+	})
+
+	t.Run("query result without source ID is rejected", func(t *testing.T) {
+		saver := &captureDeletionManifestSaver{}
+		h := &handlers{
+			engine: &querytest.MockEngine{
+				Accounts:          []query.AccountInfo{{ID: 1, SourceType: "gmail", Identifier: "alice@gmail.com"}},
+				SearchFastResults: []query.MessageSummary{{ID: 7, SourceMessageID: "gmail-007"}},
+			},
+			dataDir: t.TempDir(), manifestSaver: saver,
+		}
+
+		result := runToolExpectError(t, "stage_deletion", h.stageDeletion, map[string]any{"query": "from:news"})
+		assert.Contains(t, resultText(t, result), "has no source metadata")
+		assert.Nil(t, saver.manifest)
+	})
+
+	t.Run("query result with incomplete account source is rejected", func(t *testing.T) {
+		saver := &captureDeletionManifestSaver{}
+		h := &handlers{
+			engine: &querytest.MockEngine{
+				Accounts:          []query.AccountInfo{{ID: 1, Identifier: "alice@gmail.com"}},
+				SearchFastResults: []query.MessageSummary{{ID: 8, SourceID: 1, SourceMessageID: "gmail-008"}},
+			},
+			dataDir: t.TempDir(), manifestSaver: saver,
+		}
+
+		result := runToolExpectError(t, "stage_deletion", h.stageDeletion, map[string]any{"query": "from:news"})
+		assert.Contains(t, resultText(t, result), "has incomplete source metadata")
+		assert.Nil(t, saver.manifest)
 	})
 
 	t.Run("whitespace-only query rejected", func(t *testing.T) {
@@ -3125,9 +3150,12 @@ func TestStageDeletion(t *testing.T) {
 			Accounts: []query.AccountInfo{
 				{ID: 1, Identifier: "alice@gmail.com"},
 			},
-			GetGmailIDsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]string, error) {
+			GetDeletionTargetsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]query.DeletionTarget, error) {
 				capturedFilter = f
-				return []string{"gmail-100"}, nil
+				return []query.DeletionTarget{{
+					MessageID: 100, SourceID: 1, SourceType: "gmail",
+					SourceIdentifier: "alice@gmail.com", SourceMessageID: "gmail-100",
+				}}, nil
 			},
 		}
 		h := &handlers{engine: eng, dataDir: dataDir}
@@ -3158,13 +3186,36 @@ func TestStageDeletion(t *testing.T) {
 		assert.Contains(t, txt, "account not found", "expected account error, got: %s")
 	})
 
+	t.Run("ambiguous account rejected", func(t *testing.T) {
+		dataDir := t.TempDir()
+		ambiguous := &querytest.MockEngine{
+			Accounts: []query.AccountInfo{
+				{ID: 1, SourceType: "gmail", Identifier: "shared@example.invalid"},
+				{ID: 2, SourceType: "imap", Identifier: "shared@example.invalid"},
+			},
+		}
+		h := &handlers{engine: ambiguous, dataDir: dataDir}
+
+		r := runToolExpectError(
+			t, "stage_deletion", h.stageDeletion,
+			map[string]any{
+				"account": "shared@example.invalid",
+				"from":    "news@example.invalid",
+			},
+		)
+		assert.Contains(t, resultText(t, r), "matches multiple sources")
+	})
+
 	t.Run("structured filter limit enforced", func(t *testing.T) {
 		dataDir := t.TempDir()
 		var capturedFilter query.MessageFilter
 		eng := &querytest.MockEngine{
-			GetGmailIDsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]string, error) {
+			GetDeletionTargetsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]query.DeletionTarget, error) {
 				capturedFilter = f
-				return []string{"gmail-200"}, nil
+				return []query.DeletionTarget{{
+					MessageID: 200, SourceID: 1, SourceType: "gmail",
+					SourceIdentifier: "test@gmail.com", SourceMessageID: "gmail-200",
+				}}, nil
 			},
 		}
 		h := &handlers{engine: eng, dataDir: dataDir}

--- a/internal/query/deletion_targets_test.go
+++ b/internal/query/deletion_targets_test.go
@@ -1,0 +1,12 @@
+package query
+
+func deletionTargetSourceMessageIDs(targets []DeletionTarget, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(targets))
+	for i := range targets {
+		ids[i] = targets[i].SourceMessageID
+	}
+	return ids, nil
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -2234,16 +2234,16 @@ func (e *DuckDBEngine) SearchByDomains(ctx context.Context, domains []string, af
 	return nil, errors.New("SearchByDomains requires SQLite engine (participant data not in Parquet cache)")
 }
 
-func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error) {
+func (e *DuckDBEngine) GetDeletionTargetsByFilter(ctx context.Context, filter MessageFilter) ([]DeletionTarget, error) {
 	// Delegate to SQLite for authoritative deletion status.
 	// Parquet cache may be stale if deletions occurred after the last build.
 	if e.sqliteEngine != nil {
-		return e.sqliteEngine.GetGmailIDsByFilter(ctx, filter)
+		return e.sqliteEngine.GetDeletionTargetsByFilter(ctx, filter)
 	}
 
 	// Fall back to Parquet if no SQLite engine available (shouldn't happen in practice)
 	if e.analyticsDir == "" {
-		return nil, errors.New("GetGmailIDsByFilter requires SQLite or Parquet data")
+		return nil, errors.New("GetDeletionTargetsByFilter requires SQLite or Parquet data")
 	}
 	release, err := e.acquireCacheRead(ctx)
 	if err != nil {
@@ -2370,7 +2370,7 @@ func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 
 	if filter.TimeRange.Period != "" {
 		granularity := inferTimeGranularity(filter.TimeRange.Granularity, filter.TimeRange.Period)
-		// GetGmailIDsByFilter uses strftime for time filtering (no year/month columns)
+		// GetDeletionTargetsByFilter uses strftime for time filtering (no year/month columns)
 		var te string
 		switch granularity {
 		case TimeYear:
@@ -2396,7 +2396,7 @@ func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 	// Build query — JOIN src to scope to Gmail sources authoritatively.
 	query := fmt.Sprintf(`
 		WITH %s
-		SELECT msg.source_message_id
+		SELECT msg.id, msg.source_id, COALESCE(src.source_type, 'gmail'), src.account_email, msg.source_message_id
 		FROM msg
 		JOIN src ON src.id = msg.source_id AND COALESCE(src.source_type, 'gmail') = 'gmail'
 		WHERE %s
@@ -2411,25 +2411,19 @@ func (e *DuckDBEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 
 	rows, err := e.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("get gmail ids: %w", err)
+		return nil, fmt.Errorf("get deletion targets: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	return collectGmailIDs(rows)
+	return collectDeletionTargets(rows)
 }
 
-// GetGmailIDsByMessageIDs returns Gmail message IDs for internal message
-// IDs, enforcing the same live-message and Gmail-source constraints as
-// GetGmailIDsByFilter. Non-qualifying IDs are silently dropped. The
-// lookup is chunked so large explicit selections stay under
-// bind-parameter limits.
-func (e *DuckDBEngine) GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error) {
-	// Delegate to SQLite for authoritative deletion status.
+func (e *DuckDBEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error) {
 	if e.sqliteEngine != nil {
-		return e.sqliteEngine.GetGmailIDsByMessageIDs(ctx, ids)
+		return e.sqliteEngine.GetDeletionTargetsByMessageIDs(ctx, ids)
 	}
 	if e.analyticsDir == "" {
-		return nil, errors.New("GetGmailIDsByMessageIDs requires SQLite or Parquet data")
+		return nil, errors.New("GetDeletionTargetsByMessageIDs requires SQLite or Parquet data")
 	}
 	if len(ids) == 0 {
 		return nil, nil
@@ -2439,83 +2433,29 @@ func (e *DuckDBEngine) GetGmailIDsByMessageIDs(ctx context.Context, ids []int64)
 		return nil, err
 	}
 	defer release()
-	return gmailIDsByMessageIDsChunked(ctx, ids, e.gmailIDsForMessageIDChunk)
+	return deletionTargetsByMessageIDsChunked(ctx, ids, e.deletionTargetsForMessageIDChunk)
 }
 
-func (e *DuckDBEngine) gmailIDsForMessageIDChunk(ctx context.Context, ids []int64) ([]gmailIDRow, error) {
+func (e *DuckDBEngine) deletionTargetsForMessageIDChunk(ctx context.Context, ids []int64) ([]deletionTargetRow, error) {
 	placeholders := make([]string, len(ids))
 	args := make([]any, len(ids))
 	for i, id := range ids {
 		placeholders[i] = "?"
 		args[i] = id
 	}
-	query := fmt.Sprintf(`
+	q := fmt.Sprintf(`
 		WITH %s
-		SELECT msg.source_message_id, msg.sent_at, msg.id
+		SELECT msg.id, msg.source_id, COALESCE(src.source_type, 'gmail'), src.account_email,
+		       msg.source_message_id, msg.sent_at
 		FROM msg
 		JOIN src ON src.id = msg.source_id AND COALESCE(src.source_type, 'gmail') = 'gmail'
 		WHERE %s AND msg.id IN (%s)
 	`, e.parquetCTEs(), store.LiveMessagesWhere("msg", true), strings.Join(placeholders, ","))
-
-	rows, err := e.db.QueryContext(ctx, query, args...)
+	rows, err := e.db.QueryContext(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("get gmail ids by message ids: %w", err)
+		return nil, fmt.Errorf("get deletion targets by message ids: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	return collectGmailIDRows(rows)
-}
-
-// GetAccountsByGmailIDs returns the distinct Gmail account identifiers
-// owning live messages with the given Gmail IDs, sorted ascending. See
-// the SQLite implementation for the deletion-staging rationale and the
-// chunking that keeps large selections under bind-parameter limits.
-func (e *DuckDBEngine) GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error) {
-	// Delegate to SQLite for authoritative deletion status.
-	if e.sqliteEngine != nil {
-		return e.sqliteEngine.GetAccountsByGmailIDs(ctx, gmailIDs)
-	}
-	if e.analyticsDir == "" {
-		return nil, errors.New("GetAccountsByGmailIDs requires SQLite or Parquet data")
-	}
-	if len(gmailIDs) == 0 {
-		return nil, nil
-	}
-	release, err := e.acquireCacheRead(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer release()
-	return accountsByGmailIDsChunked(ctx, gmailIDs, e.accountsForGmailIDChunk)
-}
-
-func (e *DuckDBEngine) accountsForGmailIDChunk(ctx context.Context, gmailIDs []string) ([]string, error) {
-	placeholders := make([]string, len(gmailIDs))
-	args := make([]any, len(gmailIDs))
-	for i, id := range gmailIDs {
-		placeholders[i] = "?"
-		args[i] = id
-	}
-	// The Parquet sources dataset exposes the account identifier as
-	// account_email (see build-cache ETL).
-	query := fmt.Sprintf(`
-		WITH %s
-		SELECT src.account_email
-		FROM src
-		WHERE COALESCE(src.source_type, 'gmail') = 'gmail' AND EXISTS (
-			SELECT 1 FROM msg
-			WHERE msg.source_id = src.id AND %s AND msg.source_message_id IN (%s)
-		)
-		ORDER BY src.account_email
-	`, e.parquetCTEs(), store.LiveMessagesWhere("msg", true), strings.Join(placeholders, ","))
-
-	rows, err := e.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("get accounts by gmail ids: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	return collectGmailIDs(rows)
+	return collectDeletionTargetRows(rows)
 }
 
 // RequiredParquetDirs lists the analytics subdirectories that must each

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -651,7 +651,7 @@ func TestDuckDBEngine_ListMessages_SenderNameFilter(t *testing.T) {
 // has two authors: the queried email lives on Author A's from-row and the
 // queried name on Author B's — a cross-row match must NOT match, while the
 // same-row case still does. Covers both buildFilterConditions (ListMessages)
-// and GetGmailIDsByFilter.
+// and GetDeletionTargetsByFilter.
 func TestDuckDBEngine_SenderEmailAndName_SameFromRow(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -688,22 +688,24 @@ func TestDuckDBEngine_SenderEmailAndName_SameFromRow(t *testing.T) {
 	assert.True(slices.ContainsFunc(sameRow, func(m MessageSummary) bool { return m.Subject == "Two Authors" }),
 		"same-row sender email+name must still match")
 
-	// GetGmailIDsByFilter path.
-	crossIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{
+	// GetDeletionTargetsByFilter path.
+	crossIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{
 		Sender:     "author-a@example.com",
 		SenderName: "Author B",
-	})
-	require.NoError(err, "GetGmailIDsByFilter cross-row")
-	assert.NotContains(crossIDs, gmailID,
-		"cross-row sender email+name must not match in GetGmailIDsByFilter")
+	}))
 
-	sameIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{
+	require.NoError(err, "GetDeletionTargetsByFilter cross-row")
+	assert.NotContains(crossIDs, gmailID,
+		"cross-row sender email+name must not match in GetDeletionTargetsByFilter")
+
+	sameIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{
 		Sender:     "author-a@example.com",
 		SenderName: "Author A",
-	})
-	require.NoError(err, "GetGmailIDsByFilter same-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter same-row")
 	assert.Contains(sameIDs, gmailID,
-		"same-row sender email+name must still match in GetGmailIDsByFilter")
+		"same-row sender email+name must still match in GetDeletionTargetsByFilter")
 }
 
 // TestDuckDBEngine_RecipientEmailAndName_SameToRow asserts the analytics
@@ -712,7 +714,7 @@ func TestDuckDBEngine_SenderEmailAndName_SameFromRow(t *testing.T) {
 // engine. The message has two recipients: the queried email lives on Recip A's
 // to-row and the queried name on Recip B's — a cross-row match must NOT match,
 // while the same-row case still does. Covers both buildFilterConditions
-// (ListMessages) and GetGmailIDsByFilter.
+// (ListMessages) and GetDeletionTargetsByFilter.
 func TestDuckDBEngine_RecipientEmailAndName_SameToRow(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -749,31 +751,33 @@ func TestDuckDBEngine_RecipientEmailAndName_SameToRow(t *testing.T) {
 	assert.True(slices.ContainsFunc(sameRow, func(m MessageSummary) bool { return m.Subject == "Two Recipients" }),
 		"same-row recipient email+name must still match")
 
-	// GetGmailIDsByFilter path.
-	crossIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{
+	// GetDeletionTargetsByFilter path.
+	crossIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{
 		Recipient:     "recip-a@example.com",
 		RecipientName: "Recip B",
-	})
-	require.NoError(err, "GetGmailIDsByFilter cross-row")
-	assert.NotContains(crossIDs, gmailID,
-		"cross-row recipient email+name must not match in GetGmailIDsByFilter")
+	}))
 
-	sameIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{
+	require.NoError(err, "GetDeletionTargetsByFilter cross-row")
+	assert.NotContains(crossIDs, gmailID,
+		"cross-row recipient email+name must not match in GetDeletionTargetsByFilter")
+
+	sameIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{
 		Recipient:     "recip-a@example.com",
 		RecipientName: "Recip A",
-	})
-	require.NoError(err, "GetGmailIDsByFilter same-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter same-row")
 	assert.Contains(sameIDs, gmailID,
-		"same-row recipient email+name must still match in GetGmailIDsByFilter")
+		"same-row recipient email+name must still match in GetDeletionTargetsByFilter")
 }
 
-func TestDuckDBEngine_GetGmailIDsByFilter_SenderName(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByFilter_SenderName(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
 	filter := MessageFilter{SenderName: "Alice"}
-	ids, err := engine.GetGmailIDsByFilter(ctx, filter)
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, filter))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 
 	assert.Len(t, ids, 3, "expected 3 gmail IDs for Alice")
 }
@@ -1979,7 +1983,7 @@ func TestDuckDBEngine_ListMessages_Filters(t *testing.T) {
 	}
 }
 
-func TestDuckDBEngine_GetGmailIDsByFilter(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByFilter(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
@@ -2052,14 +2056,14 @@ func TestDuckDBEngine_GetGmailIDsByFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ids, err := engine.GetGmailIDsByFilter(ctx, tt.filter)
-			require.NoError(t, err, "GetGmailIDsByFilter")
+			ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, tt.filter))
+			require.NoError(t, err, "GetDeletionTargetsByFilter")
 			assertSetEqual(t, ids, tt.wantIDs)
 		})
 	}
 }
 
-func TestDuckDBEngine_GetGmailIDsByFilter_MessageTypeEmailIncludesLegacy(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByFilter_MessageTypeEmailIncludesLegacy(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	b := NewTestDataBuilder(t)
@@ -2070,7 +2074,7 @@ func TestDuckDBEngine_GetGmailIDsByFilter_MessageTypeEmailIncludesLegacy(t *test
 	b.AddMessage(MessageOpt{Subject: "text", MessageType: "sms"})
 	engine := b.BuildEngine()
 
-	ids, err := engine.GetGmailIDsByFilter(context.Background(), MessageFilter{MessageType: "email"})
+	ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(context.Background(), MessageFilter{MessageType: "email"}))
 	require.NoError(err)
 	assert.ElementsMatch(
 		[]string{fmt.Sprintf("msg%d", typedEmailID), fmt.Sprintf("msg%d", legacyEmailID)},
@@ -2376,20 +2380,20 @@ func TestDuckDBEngine_SubAggregate_MultipleEmptyTargets(t *testing.T) {
 	}
 }
 
-// TestDuckDBEngine_GetGmailIDsByFilter_NoDataSource verifies error when no SQLite or Parquet available.
-func TestDuckDBEngine_GetGmailIDsByFilter_NoDataSource(t *testing.T) {
+// TestDuckDBEngine_GetDeletionTargetsByFilter_NoDataSource verifies error when no SQLite or Parquet available.
+func TestDuckDBEngine_GetDeletionTargetsByFilter_NoDataSource(t *testing.T) {
 	// Create engine without SQLite or Parquet
 	engine, err := NewDuckDBEngine("", "", nil)
 	require.NoError(t, err, "NewDuckDBEngine")
 	defer func() { _ = engine.Close() }()
 
 	ctx := context.Background()
-	_, err = engine.GetGmailIDsByFilter(ctx, MessageFilter{Sender: "test@example.com"})
+	_, err = deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{Sender: "test@example.com"}))
 	require.ErrorContains(t, err, "requires SQLite or Parquet")
 }
 
-// TestDuckDBEngine_GetGmailIDsByFilter_NonExistent verifies empty results for non-existent values.
-func TestDuckDBEngine_GetGmailIDsByFilter_NonExistent(t *testing.T) {
+// TestDuckDBEngine_GetDeletionTargetsByFilter_NonExistent verifies empty results for non-existent values.
+func TestDuckDBEngine_GetDeletionTargetsByFilter_NonExistent(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
@@ -2405,28 +2409,28 @@ func TestDuckDBEngine_GetGmailIDsByFilter_NonExistent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ids, err := engine.GetGmailIDsByFilter(ctx, tt.filter)
-			require.NoError(t, err, "GetGmailIDsByFilter")
+			ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, tt.filter))
+			require.NoError(t, err, "GetDeletionTargetsByFilter")
 			assert.Empty(t, ids, "results for non-existent filter")
 		})
 	}
 }
 
-// TestDuckDBEngine_GetGmailIDsByFilter_EmptyFilter verifies that empty filter returns all messages.
-func TestDuckDBEngine_GetGmailIDsByFilter_EmptyFilter(t *testing.T) {
+// TestDuckDBEngine_GetDeletionTargetsByFilter_EmptyFilter verifies that empty filter returns all messages.
+func TestDuckDBEngine_GetDeletionTargetsByFilter_EmptyFilter(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
 	// Empty filter - should return all 5 messages
-	ids, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{})
-	require.NoError(t, err, "GetGmailIDsByFilter with empty filter")
+	ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{}))
+	require.NoError(t, err, "GetDeletionTargetsByFilter with empty filter")
 
 	assertSetEqual(t, ids, []string{"msg1", "msg2", "msg3", "msg4", "msg5"})
 }
 
-// TestDuckDBEngine_GetGmailIDsByFilter_CombinedNoMatch verifies empty results for
+// TestDuckDBEngine_GetDeletionTargetsByFilter_CombinedNoMatch verifies empty results for
 // combined filters that match nothing.
-func TestDuckDBEngine_GetGmailIDsByFilter_CombinedNoMatch(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByFilter_CombinedNoMatch(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
@@ -2439,29 +2443,29 @@ func TestDuckDBEngine_GetGmailIDsByFilter_CombinedNoMatch(t *testing.T) {
 		Label:  "IMPORTANT",
 	}
 
-	ids, err := engine.GetGmailIDsByFilter(ctx, filter)
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, filter))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 
 	assert.Empty(t, ids, "results for bob+IMPORTANT")
 }
 
-// TestDuckDBEngine_GetGmailIDsByFilter_AfterBefore verifies that After/Before date
-// filters work correctly on the Parquet fallback of GetGmailIDsByFilter.
-func TestDuckDBEngine_GetGmailIDsByFilter_AfterBefore(t *testing.T) {
+// TestDuckDBEngine_GetDeletionTargetsByFilter_AfterBefore verifies that After/Before date
+// filters work correctly on the Parquet fallback of GetDeletionTargetsByFilter.
+func TestDuckDBEngine_GetDeletionTargetsByFilter_AfterBefore(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 	feb1 := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
 	mar1 := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
 
-	afterIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{After: &feb1})
+	afterIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{After: &feb1}))
 	require.NoError(t, err, "after-only")
 	assertSetEqual(t, afterIDs, []string{"msg3", "msg4", "msg5"})
 
-	beforeIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{Before: &feb1})
+	beforeIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{Before: &feb1}))
 	require.NoError(t, err, "before-only")
 	assertSetEqual(t, beforeIDs, []string{"msg1", "msg2"})
 
-	rangeIDs, err := engine.GetGmailIDsByFilter(ctx, MessageFilter{After: &feb1, Before: &mar1})
+	rangeIDs, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, MessageFilter{After: &feb1, Before: &mar1}))
 	require.NoError(t, err, "range")
 	assertSetEqual(t, rangeIDs, []string{"msg3", "msg4"})
 }
@@ -2848,13 +2852,13 @@ func TestDuckDBEngine_ListMessages_RecipientNameFilter(t *testing.T) {
 	assert.Len(t, results, 3, "messages to Bob")
 }
 
-func TestDuckDBEngine_GetGmailIDsByFilter_RecipientName(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByFilter_RecipientName(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
 
 	filter := MessageFilter{RecipientName: "Alice"}
-	ids, err := engine.GetGmailIDsByFilter(ctx, filter)
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(ctx, filter))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 
 	// Alice received msgs 4, 5
 	assert.Len(t, ids, 2, "gmail IDs for Alice")
@@ -4020,23 +4024,23 @@ func TestDuckDBEngine_StaleParquetSchema(t *testing.T) {
 	})
 }
 
-func TestDuckDBEngine_GetGmailIDsByMessageIDs(t *testing.T) {
-	ctx := context.Background()
+func TestDuckDBEngine_GetDeletionTargetsByMessageIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 
-	// Parquet fallback path (no SQLite engine attached).
-	parquet := newParquetEngine(t)
-	ids, err := parquet.GetGmailIDsByMessageIDs(ctx, []int64{1, 2, 999999})
-	require.NoError(t, err, "parquet path")
-	assertSetEqual(t, ids, []string{"msg1", "msg2"})
-
-	// SQLite delegation path.
-	sqlited := newSQLiteEngine(t)
-	ids, err = sqlited.GetGmailIDsByMessageIDs(ctx, []int64{1, 2, 999999})
-	require.NoError(t, err, "sqlite delegation path")
-	assertSetEqual(t, ids, []string{"msg1", "msg2"})
+	for _, engine := range []*DuckDBEngine{newParquetEngine(t), newSQLiteEngine(t)} {
+		targets, err := engine.GetDeletionTargetsByMessageIDs(context.Background(), []int64{1})
+		require.NoError(err)
+		require.Len(targets, 1)
+		assert.Equal(int64(1), targets[0].MessageID)
+		assert.Equal(int64(1), targets[0].SourceID)
+		assert.Equal("gmail", targets[0].SourceType)
+		assert.Equal("test@gmail.com", targets[0].SourceIdentifier)
+		assert.Equal("msg1", targets[0].SourceMessageID)
+	}
 }
 
-func TestDuckDBEngine_GetGmailIDsByMessageIDs_ChunkedLargeSelection(t *testing.T) {
+func TestDuckDBEngine_GetDeletionTargetsByMessageIDs_ChunkedLargeSelection(t *testing.T) {
 	ctx := context.Background()
 	parquet := newParquetEngine(t)
 
@@ -4050,49 +4054,9 @@ func TestDuckDBEngine_GetGmailIDsByMessageIDs_ChunkedLargeSelection(t *testing.T
 	}
 	ids = append(ids, 5)
 
-	gmailIDs, err := parquet.GetGmailIDsByMessageIDs(ctx, ids)
+	targets, err := parquet.GetDeletionTargetsByMessageIDs(ctx, ids)
 	require.NoError(t, err, "chunked parquet lookup")
+	gmailIDs, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(t, err)
 	assert.Equal(t, []string{"msg5", "msg1"}, gmailIDs, "newest-first across chunks")
-}
-
-func TestDuckDBEngine_GetAccountsByGmailIDs(t *testing.T) {
-	require := require.New(t)
-
-	ctx := context.Background()
-
-	// Parquet fallback path (no SQLite engine attached).
-	parquet := newParquetEngine(t)
-	accounts, err := parquet.GetAccountsByGmailIDs(ctx, []string{"msg1", "msg2", "does-not-exist"})
-	require.NoError(err, "parquet path")
-	assertSetEqual(t, accounts, []string{"test@gmail.com"})
-
-	// SQLite delegation path.
-	sqlited := newSQLiteEngine(t)
-	accounts, err = sqlited.GetAccountsByGmailIDs(ctx, []string{"msg1", "msg2", "does-not-exist"})
-	require.NoError(err, "sqlite delegation path")
-	assertSetEqual(t, accounts, []string{"test@gmail.com"})
-
-	// Empty input short-circuits.
-	accounts, err = parquet.GetAccountsByGmailIDs(ctx, nil)
-	require.NoError(err, "empty input")
-	assert.Empty(t, accounts)
-}
-
-func TestDuckDBEngine_GetAccountsByGmailIDs_ChunkedLargeSelection(t *testing.T) {
-	ctx := context.Background()
-	parquet := newParquetEngine(t)
-
-	// More IDs than one account-lookup chunk, with the real IDs in the
-	// first and last chunk so the Parquet path exercises the cross-chunk
-	// union.
-	ids := make([]string, 0, 1200)
-	ids = append(ids, "msg1")
-	for len(ids) < 1199 {
-		ids = append(ids, fmt.Sprintf("missing-%d", len(ids)))
-	}
-	ids = append(ids, "msg5")
-
-	accounts, err := parquet.GetAccountsByGmailIDs(ctx, ids)
-	require.NoError(t, err, "chunked parquet lookup")
-	assertSetEqual(t, accounts, []string{"test@gmail.com"})
 }

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -84,9 +84,9 @@ type Engine interface {
 	SearchFastWithStats(ctx context.Context, query *search.Query, queryStr string,
 		filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error)
 
-	// GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
-	// This is useful for batch operations like staging messages for deletion.
-	GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error)
+	// GetDeletionTargetsByFilter returns deletion candidates without losing
+	// their source provenance.
+	GetDeletionTargetsByFilter(ctx context.Context, filter MessageFilter) ([]DeletionTarget, error)
 
 	// SearchByDomains returns messages where any participant (from, to, cc, or bcc)
 	// belongs to one of the given domains.

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -49,6 +49,16 @@ type MessageSummary struct {
 	BodyContextSnippetsTruncated bool       `json:"-"`
 }
 
+// DeletionTarget preserves the source provenance of a message selected for
+// remote deletion. SourceMessageID is unique only within SourceID.
+type DeletionTarget struct {
+	MessageID        int64  `json:"message_id"`
+	SourceID         int64  `json:"source_id"`
+	SourceType       string `json:"source_type"`
+	SourceIdentifier string `json:"source_identifier"`
+	SourceMessageID  string `json:"source_message_id"`
+}
+
 // MessageDetail represents a full message with body and attachments.
 type MessageDetail struct {
 	ID                   int64      `json:"id"`

--- a/internal/query/pg_compat_test.go
+++ b/internal/query/pg_compat_test.go
@@ -18,20 +18,12 @@ import (
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
-type gmailIDsByMessageIDsResolver interface {
-	GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error)
-}
-
-type accountsByGmailIDsResolver interface {
-	GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error)
-}
-
 // TestQueryEngine_PostgresPortability exercises the three SQL shapes
 // the external review flagged as failing on PostgreSQL:
 //
 //   - Aggregate uses `FROM ( … ) AS agg` (PG rejects unaliased derived
 //     tables in FROM).
-//   - GetGmailIDsByFilter avoids SELECT DISTINCT entirely (PG rejects
+//   - GetDeletionTargetsByFilter avoids SELECT DISTINCT entirely (PG rejects
 //     DISTINCT when ORDER BY references columns missing from SELECT).
 //   - ListMessages sorts via expressions that textually match the
 //     SELECT list (PG enforces this for SELECT DISTINCT).
@@ -95,11 +87,11 @@ func TestQueryEngine_PostgresPortability(t *testing.T) {
 		require.NotEmpty(rows, "Aggregate returned no rows; expected at least the Alice sender bucket")
 	})
 
-	// (2) GetGmailIDsByFilter — must not error from a SELECT DISTINCT +
+	// (2) GetDeletionTargetsByFilter — must not error from a SELECT DISTINCT +
 	// ORDER BY collision on PG. Use a label filter to exercise the
 	// previously-multiplying join (now an EXISTS subquery).
 	t.Run("gmail_ids_by_filter_label", func(t *testing.T) {
-		ids, err := eng.GetGmailIDsByFilter(ctx, query.MessageFilter{
+		targets, err := eng.GetDeletionTargetsByFilter(ctx, query.MessageFilter{
 			SourceID: &src.ID,
 			Label:    "Important",
 			Sorting: query.MessageSorting{
@@ -107,7 +99,12 @@ func TestQueryEngine_PostgresPortability(t *testing.T) {
 				Direction: query.SortDesc,
 			},
 		})
-		require.NoError(err, "GetGmailIDsByFilter")
+
+		require.NoError(err, "GetDeletionTargetsByFilter")
+		ids := make([]string, len(targets))
+		for i := range targets {
+			ids[i] = targets[i].SourceMessageID
+		}
 		assert.Len(t, ids, 4, "label join must not multiply")
 		// Confirm no duplicates after dropping DISTINCT — every message
 		// row should appear exactly once because the label filter is an
@@ -145,34 +142,6 @@ func TestQueryEngine_PostgresPortability(t *testing.T) {
 			assert.Len(t, msgs, 4, "ListMessages %s", sort.name)
 		})
 	}
-}
-
-func TestNewEnginePostgresSatisfiesGmailIDsByMessageIDsResolver(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	st := testutil.NewTestStore(t)
-	eng := query.NewEngine(st.DB(), true)
-
-	resolver, ok := eng.(gmailIDsByMessageIDsResolver)
-	require.True(ok, "PostgreSQL engine should expose the deletion message-id resolver")
-	ids, err := resolver.GetGmailIDsByMessageIDs(context.Background(), nil)
-	require.NoError(err, "empty input should not need a backend query")
-	assert.Empty(ids)
-}
-
-func TestNewEnginePostgresSatisfiesAccountsByGmailIDsResolver(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	st := testutil.NewTestStore(t)
-	eng := query.NewEngine(st.DB(), true)
-
-	resolver, ok := eng.(accountsByGmailIDsResolver)
-	require.True(ok, "PostgreSQL engine should expose the deletion account resolver")
-	accounts, err := resolver.GetAccountsByGmailIDs(context.Background(), nil)
-	require.NoError(err, "empty input should not need a backend query")
-	assert.Empty(accounts)
 }
 
 func TestNewEnginePostgresSatisfiesMessageBodySearcher(t *testing.T) {

--- a/internal/query/postgres.go
+++ b/internal/query/postgres.go
@@ -35,35 +35,16 @@ type pgEngine struct {
 
 var _ MessageBodySearcher = (*pgEngine)(nil)
 
-type gmailIDsByMessageIDsResolver interface {
-	GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error)
+type deletionTargetsByMessageIDsResolver interface {
+	GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error)
 }
 
-type accountsByGmailIDsResolver interface {
-	GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error)
-}
-
-// GetGmailIDsByMessageIDs forwards the optional deletion-staging resolver
-// capability through the PostgreSQL wrapper. pgEngine intentionally embeds only
-// Engine to hide SQLite-only TextEngine methods, so optional methods that are
-// valid on PostgreSQL need explicit forwarding.
-func (e *pgEngine) GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error) {
-	resolver, ok := e.Engine.(gmailIDsByMessageIDsResolver)
+func (e *pgEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error) {
+	resolver, ok := e.Engine.(deletionTargetsByMessageIDsResolver)
 	if !ok {
 		return nil, ErrNotImplemented
 	}
-	return resolver.GetGmailIDsByMessageIDs(ctx, ids)
-}
-
-// GetAccountsByGmailIDs forwards the optional deletion-staging account
-// resolver capability through the PostgreSQL wrapper, for the same reason
-// as GetGmailIDsByMessageIDs above.
-func (e *pgEngine) GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error) {
-	resolver, ok := e.Engine.(accountsByGmailIDsResolver)
-	if !ok {
-		return nil, ErrNotImplemented
-	}
-	return resolver.GetAccountsByGmailIDs(ctx, gmailIDs)
+	return resolver.GetDeletionTargetsByMessageIDs(ctx, ids)
 }
 
 // SearchMessageBodies forwards exact body-only search through the PostgreSQL

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -23,28 +23,27 @@ type MockEngine struct {
 	Accounts          []query.AccountInfo
 	AggregateRows     []query.AggregateRow
 	GmailIDs          []string
-	GmailAccounts     []string
+	DeletionTargets   []query.DeletionTarget
 
 	// MessagesBySourceID maps source IDs to message details for GetMessageBySourceID.
 	// When nil, GetMessageBySourceID falls back to scanning Messages for a matching SourceMessageID.
 	MessagesBySourceID map[string]*query.MessageDetail
 
 	// Optional overrides — set these to customise behavior per-test.
-	SearchFastFunc               func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
-	SearchFunc                   func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
-	SearchMessageBodiesFunc      func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
-	GetMessageFunc               func(context.Context, int64) (*query.MessageDetail, error)
-	GetMessageBySourceIDFunc     func(context.Context, string) (*query.MessageDetail, error)
-	GetTotalStatsFunc            func(context.Context, query.StatsOptions) (*query.TotalStats, error)
-	ListMessagesFunc             func(context.Context, query.MessageFilter) ([]query.MessageSummary, error)
-	SearchFastCountFunc          func(context.Context, *search.Query, query.MessageFilter) (int64, error)
-	GetGmailIDsByFilterFunc      func(context.Context, query.MessageFilter) ([]string, error)
-	GetGmailIDsByMessageIDsFunc  func(context.Context, []int64) ([]string, error)
-	GetAccountsByGmailIDsFunc    func(context.Context, []string) ([]string, error)
-	SearchByDomainsFunc          func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
-	SearchFastWithStatsFunc      func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
-	GetMessageRawFunc            func(context.Context, int64) ([]byte, error)
-	GetMessageSummariesByIDsFunc func(context.Context, []int64) ([]query.MessageSummary, error)
+	SearchFastFunc                     func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
+	SearchFunc                         func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+	SearchMessageBodiesFunc            func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+	GetMessageFunc                     func(context.Context, int64) (*query.MessageDetail, error)
+	GetMessageBySourceIDFunc           func(context.Context, string) (*query.MessageDetail, error)
+	GetTotalStatsFunc                  func(context.Context, query.StatsOptions) (*query.TotalStats, error)
+	ListMessagesFunc                   func(context.Context, query.MessageFilter) ([]query.MessageSummary, error)
+	SearchFastCountFunc                func(context.Context, *search.Query, query.MessageFilter) (int64, error)
+	GetDeletionTargetsByFilterFunc     func(context.Context, query.MessageFilter) ([]query.DeletionTarget, error)
+	GetDeletionTargetsByMessageIDsFunc func(context.Context, []int64) ([]query.DeletionTarget, error)
+	SearchByDomainsFunc                func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
+	SearchFastWithStatsFunc            func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
+	GetMessageRawFunc                  func(context.Context, int64) ([]byte, error)
+	GetMessageSummariesByIDsFunc       func(context.Context, []int64) ([]query.MessageSummary, error)
 
 	RawMessages map[int64][]byte
 }
@@ -194,25 +193,44 @@ func (m *MockEngine) SearchFastWithStats(ctx context.Context, q *search.Query, q
 	}, nil
 }
 
-func (m *MockEngine) GetGmailIDsByFilter(ctx context.Context, filter query.MessageFilter) ([]string, error) {
-	if m.GetGmailIDsByFilterFunc != nil {
-		return m.GetGmailIDsByFilterFunc(ctx, filter)
+func (m *MockEngine) GetDeletionTargetsByFilter(ctx context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+	if m.GetDeletionTargetsByFilterFunc != nil {
+		return m.GetDeletionTargetsByFilterFunc(ctx, filter)
 	}
-	return m.GmailIDs, nil
+	return m.defaultDeletionTargets(), nil
 }
 
-func (m *MockEngine) GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error) {
-	if m.GetGmailIDsByMessageIDsFunc != nil {
-		return m.GetGmailIDsByMessageIDsFunc(ctx, ids)
+func (m *MockEngine) defaultDeletionTargets() []query.DeletionTarget {
+	if m.DeletionTargets != nil {
+		return m.DeletionTargets
 	}
-	return m.GmailIDs, nil
+	return m.targetsForIDs(m.GmailIDs)
 }
 
-func (m *MockEngine) GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error) {
-	if m.GetAccountsByGmailIDsFunc != nil {
-		return m.GetAccountsByGmailIDsFunc(ctx, gmailIDs)
+func (m *MockEngine) targetsForIDs(ids []string) []query.DeletionTarget {
+	account := query.AccountInfo{ID: 1, SourceType: "gmail", Identifier: "test@gmail.com"}
+	if len(m.Accounts) == 1 {
+		account = m.Accounts[0]
+		if account.ID == 0 {
+			account.ID = 1
+		}
+		if account.SourceType == "" {
+			account.SourceType = "gmail"
+		}
 	}
-	return m.GmailAccounts, nil
+	targets := make([]query.DeletionTarget, len(ids))
+	for i, id := range ids {
+		targets[i] = query.DeletionTarget{MessageID: int64(i + 1), SourceID: account.ID,
+			SourceType: account.SourceType, SourceIdentifier: account.Identifier, SourceMessageID: id}
+	}
+	return targets
+}
+
+func (m *MockEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]query.DeletionTarget, error) {
+	if m.GetDeletionTargetsByMessageIDsFunc != nil {
+		return m.GetDeletionTargetsByMessageIDsFunc(ctx, ids)
+	}
+	return m.defaultDeletionTargets(), nil
 }
 
 func (m *MockEngine) SearchByDomains(ctx context.Context, domains []string, after, before *time.Time, limit, offset int) ([]query.MessageSummary, error) {

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -554,71 +554,61 @@ func getMessageByQueryShared(ctx context.Context, db *sql.DB, rebind rebindFunc,
 	return &msg, nil
 }
 
-// collectGmailIDs scans rows for source_message_id strings.
-func collectGmailIDs(rows *sql.Rows) ([]string, error) {
-	defer func() { _ = rows.Close() }()
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan gmail id: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate gmail ids: %w", err)
-	}
-	return ids, nil
+type deletionTargetRow struct {
+	target DeletionTarget
+	sentAt sql.NullTime
 }
 
-// gmailIDRow carries the ORDER BY keys (sent_at, message id) alongside a
-// source_message_id so chunked message-ID resolution can be merged back
-// into the single-query newest-first order.
-type gmailIDRow struct {
-	gmailID string
-	sentAt  sql.NullTime
-	id      int64
-}
-
-// collectGmailIDRows scans (source_message_id, sent_at, id) rows.
-func collectGmailIDRows(rows *sql.Rows) ([]gmailIDRow, error) {
+func collectDeletionTargets(rows *sql.Rows) ([]DeletionTarget, error) {
 	defer func() { _ = rows.Close() }()
-	var out []gmailIDRow
+	var targets []DeletionTarget
 	for rows.Next() {
-		var r gmailIDRow
-		if err := rows.Scan(&r.gmailID, &r.sentAt, &r.id); err != nil {
-			return nil, fmt.Errorf("scan gmail id row: %w", err)
+		var target DeletionTarget
+		if err := rows.Scan(&target.MessageID, &target.SourceID, &target.SourceType,
+			&target.SourceIdentifier, &target.SourceMessageID); err != nil {
+			return nil, fmt.Errorf("scan deletion target: %w", err)
 		}
-		out = append(out, r)
+		targets = append(targets, target)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate gmail id rows: %w", err)
+		return nil, fmt.Errorf("iterate deletion targets: %w", err)
+	}
+	return targets, nil
+}
+
+func collectDeletionTargetRows(rows *sql.Rows) ([]deletionTargetRow, error) {
+	defer func() { _ = rows.Close() }()
+	var out []deletionTargetRow
+	for rows.Next() {
+		var row deletionTargetRow
+		if err := rows.Scan(&row.target.MessageID, &row.target.SourceID,
+			&row.target.SourceType, &row.target.SourceIdentifier,
+			&row.target.SourceMessageID, &row.sentAt); err != nil {
+			return nil, fmt.Errorf("scan deletion target row: %w", err)
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate deletion target rows: %w", err)
 	}
 	return out, nil
 }
 
-// gmailIDsByMessageIDsChunked resolves message IDs to Gmail IDs in
-// inListChunkSize batches so arbitrarily large explicit selections stay
-// under the backend's bind-parameter limit. Input IDs are deduplicated
-// (each message row surfaces from exactly one chunk) and the merged
-// result is re-sorted to the single-query contract: sent_at DESC,
-// id DESC, with NULL sent_at last.
-func gmailIDsByMessageIDsChunked(
+func deletionTargetsByMessageIDsChunked(
 	ctx context.Context,
 	ids []int64,
-	queryChunk func(ctx context.Context, chunk []int64) ([]gmailIDRow, error),
-) ([]string, error) {
+	queryChunk func(context.Context, []int64) ([]deletionTargetRow, error),
+) ([]DeletionTarget, error) {
 	seen := make(map[int64]struct{}, len(ids))
 	unique := make([]int64, 0, len(ids))
 	for _, id := range ids {
-		if _, dup := seen[id]; dup {
+		if _, duplicate := seen[id]; duplicate {
 			continue
 		}
 		seen[id] = struct{}{}
 		unique = append(unique, id)
 	}
-
-	var merged []gmailIDRow
+	var merged []deletionTargetRow
 	for start := 0; start < len(unique); start += inListChunkSize {
 		end := min(start+inListChunkSize, len(unique))
 		rows, err := queryChunk(ctx, unique[start:end])
@@ -627,18 +617,17 @@ func gmailIDsByMessageIDsChunked(
 		}
 		merged = append(merged, rows...)
 	}
-
-	slices.SortFunc(merged, compareGmailIDRowsNewestFirst)
-	out := make([]string, len(merged))
-	for i, r := range merged {
-		out[i] = r.gmailID
+	slices.SortFunc(merged, compareDeletionTargetRowsNewestFirst)
+	targets := make([]DeletionTarget, len(merged))
+	for i := range merged {
+		targets[i] = merged[i].target
 	}
-	return out, nil
+	return targets, nil
 }
 
-// compareGmailIDRowsNewestFirst orders by sent_at DESC then id DESC,
+// compareDeletionTargetRowsNewestFirst orders by sent_at DESC then message ID DESC,
 // with NULL sent_at sorting last (matching SQLite DESC semantics).
-func compareGmailIDRowsNewestFirst(a, b gmailIDRow) int {
+func compareDeletionTargetRowsNewestFirst(a, b deletionTargetRow) int {
 	switch {
 	case a.sentAt.Valid && !b.sentAt.Valid:
 		return -1
@@ -650,6 +639,6 @@ func compareGmailIDRowsNewestFirst(a, b gmailIDRow) int {
 		}
 		return 1
 	default:
-		return cmp.Compare(b.id, a.id)
+		return cmp.Compare(b.target.MessageID, a.target.MessageID)
 	}
 }

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -795,7 +794,7 @@ func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) (
 	}
 	// Stable tiebreaker on the PK so pagination is deterministic when the
 	// primary sort field ties (e.g. identical sent_at). m.id is non-null
-	// and unique, mirroring GetGmailIDsByFilter's ORDER BY ... , m.id DESC.
+	// and unique, mirroring GetDeletionTargetsByFilter's ORDER BY ... , m.id DESC.
 	orderBy += ", m.id DESC"
 
 	limit := filter.Pagination.Limit
@@ -1265,7 +1264,7 @@ func statsUseMatchingPopulation(opts StatsOptions) bool {
 		opts.SearchQuery != ""
 }
 
-// GetGmailIDsByFilter returns Gmail message IDs (source_message_id) matching a filter.
+// GetDeletionTargetsByFilter returns source-bound message targets matching a filter.
 // This is more efficient than ListMessages when you only need the IDs.
 //
 // All filter predicates that would otherwise need 1:N joins
@@ -1276,7 +1275,7 @@ func statsUseMatchingPopulation(opts StatsOptions) bool {
 // the "most recent first" ordering callers (MCP, TUI) depend on under
 // Pagination.Limit. The EXISTS form also matches the SQL guidance in
 // CLAUDE.md ("Never use SELECT DISTINCT with JOINs — use EXISTS").
-func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFilter) ([]string, error) {
+func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter MessageFilter) ([]DeletionTarget, error) {
 	var conditions []string
 	var args []any
 
@@ -1447,7 +1446,7 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 	// subquery; messages.id is PK so each row contributes exactly one
 	// source_message_id.
 	query := fmt.Sprintf(`
-		SELECT m.source_message_id
+		SELECT m.id, m.source_id, s_gmail.source_type, s_gmail.identifier, m.source_message_id
 		FROM messages m
 		%s
 		WHERE %s
@@ -1462,124 +1461,46 @@ func (e *SQLiteEngine) GetGmailIDsByFilter(ctx context.Context, filter MessageFi
 
 	rows, err := e.queryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("get gmail ids: %w", err)
+		return nil, fmt.Errorf("get deletion targets: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	return collectGmailIDs(rows)
+	return collectDeletionTargets(rows)
 }
 
-// GetGmailIDsByMessageIDs returns Gmail message IDs (source_message_id)
-// for the given internal message IDs. It enforces the same constraints
-// as GetGmailIDsByFilter: only live messages (LiveMessagesWhere — not
-// remote-deleted, not dedup-soft-deleted) from Gmail sources.
-// Non-qualifying IDs are silently dropped, mirroring
-// GetMessageSummariesByIDs semantics. The lookup is chunked so large
-// explicit selections stay under the backend's bind-parameter limit.
-func (e *SQLiteEngine) GetGmailIDsByMessageIDs(ctx context.Context, ids []int64) ([]string, error) {
+func (e *SQLiteEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	return gmailIDsByMessageIDsChunked(ctx, ids, e.gmailIDsForMessageIDChunk)
+	return deletionTargetsByMessageIDsChunked(ctx, ids, e.deletionTargetsForMessageIDChunk)
 }
 
-func (e *SQLiteEngine) gmailIDsForMessageIDChunk(ctx context.Context, ids []int64) ([]gmailIDRow, error) {
+func (e *SQLiteEngine) deletionTargetsForMessageIDChunk(ctx context.Context, ids []int64) ([]deletionTargetRow, error) {
 	placeholders := make([]string, len(ids))
 	args := make([]any, len(ids))
 	for i, id := range ids {
 		placeholders[i] = "?"
 		args[i] = id
 	}
-	query := fmt.Sprintf(`
-		SELECT m.source_message_id, m.sent_at, m.id
+	q := fmt.Sprintf(`
+		SELECT m.id, m.source_id, s_gmail.source_type, s_gmail.identifier,
+		       m.source_message_id, m.sent_at
 		FROM messages m
 		JOIN sources s_gmail ON s_gmail.id = m.source_id AND s_gmail.source_type = 'gmail'
 		WHERE %s AND m.id IN (%s)
 	`, store.LiveMessagesWhere("m", true), strings.Join(placeholders, ","))
-
-	rows, err := e.queryContext(ctx, query, args...)
+	rows, err := e.queryContext(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("get gmail ids by message ids: %w", err)
+		return nil, fmt.Errorf("get deletion targets by message ids: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
-
-	return collectGmailIDRows(rows)
+	return collectDeletionTargetRows(rows)
 }
 
 // inListChunkSize bounds the IN-list size per deletion-staging lookup.
-// Staging feeds full resolved Gmail-ID sets into GetAccountsByGmailIDs
-// and full explicit selections into GetGmailIDsByMessageIDs, either of
-// which can exceed the SQLite bind-parameter limit
+// Explicit selections can exceed the SQLite bind-parameter limit
 // (SQLITE_MAX_VARIABLE_NUMBER, 32766 by default). 500 stays well under
 // every backend's limit.
 const inListChunkSize = 500
-
-// accountsByGmailIDsChunked runs queryChunk over gmailIDs in
-// inListChunkSize batches and returns the union of accounts,
-// deduplicated and sorted ascending.
-func accountsByGmailIDsChunked(
-	ctx context.Context,
-	gmailIDs []string,
-	queryChunk func(ctx context.Context, chunk []string) ([]string, error),
-) ([]string, error) {
-	seen := make(map[string]struct{})
-	for start := 0; start < len(gmailIDs); start += inListChunkSize {
-		end := min(start+inListChunkSize, len(gmailIDs))
-		accounts, err := queryChunk(ctx, gmailIDs[start:end])
-		if err != nil {
-			return nil, err
-		}
-		for _, a := range accounts {
-			seen[a] = struct{}{}
-		}
-	}
-	accounts := make([]string, 0, len(seen))
-	for a := range seen {
-		accounts = append(accounts, a)
-	}
-	slices.Sort(accounts)
-	return accounts, nil
-}
-
-// GetAccountsByGmailIDs returns the distinct Gmail account identifiers
-// owning live messages with the given Gmail IDs (source_message_id),
-// sorted ascending. Deletion staging uses this to stamp the manifest
-// with its account and to reject selections spanning multiple accounts,
-// since delete-staged executes a manifest against a single mailbox.
-// The lookup is chunked so arbitrarily large selections stay under the
-// backend's bind-parameter limit.
-func (e *SQLiteEngine) GetAccountsByGmailIDs(ctx context.Context, gmailIDs []string) ([]string, error) {
-	if len(gmailIDs) == 0 {
-		return nil, nil
-	}
-	return accountsByGmailIDsChunked(ctx, gmailIDs, e.accountsForGmailIDChunk)
-}
-
-func (e *SQLiteEngine) accountsForGmailIDChunk(ctx context.Context, gmailIDs []string) ([]string, error) {
-	placeholders := make([]string, len(gmailIDs))
-	args := make([]any, len(gmailIDs))
-	for i, id := range gmailIDs {
-		placeholders[i] = "?"
-		args[i] = id
-	}
-	query := fmt.Sprintf(`
-		SELECT s.identifier
-		FROM sources s
-		WHERE s.source_type = 'gmail' AND EXISTS (
-			SELECT 1 FROM messages m
-			WHERE m.source_id = s.id AND %s AND m.source_message_id IN (%s)
-		)
-		ORDER BY s.identifier
-	`, store.LiveMessagesWhere("m", true), strings.Join(placeholders, ","))
-
-	rows, err := e.queryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("get accounts by gmail ids: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	return collectGmailIDs(rows)
-}
 
 // SearchByDomains returns messages where any participant (from, to, cc, or bcc)
 // belongs to one of the given domains. Uses the shared executeSearchQuery

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -694,7 +694,7 @@ func TestMatchEmptySenderName_CombinedWithDomain(t *testing.T) {
 	assert.Empty(t, messages, "expected 0 messages for MatchEmptySenderName+Domain")
 }
 
-func TestGetGmailIDsByFilter_Label(t *testing.T) {
+func TestGetDeletionTargetsByFilter_Label(t *testing.T) {
 	env := newTestEnv(t)
 
 	tests := []struct {
@@ -709,24 +709,24 @@ func TestGetGmailIDsByFilter_Label(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ids, err := env.Engine.GetGmailIDsByFilter(
-				env.Ctx, MessageFilter{Label: tt.label},
-			)
-			require.NoError(t, err, "GetGmailIDsByFilter")
+			ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(
+				env.Ctx, MessageFilter{Label: tt.label}))
+
+			require.NoError(t, err, "GetDeletionTargetsByFilter")
 			assert.Len(t, ids, tt.wantLen)
 		})
 	}
 }
 
-func TestGetGmailIDsByFilter_SenderName(t *testing.T) {
+func TestGetDeletionTargetsByFilter_SenderName(t *testing.T) {
 	env := newTestEnv(t)
 
-	ids, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{SenderName: "Alice"})
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{SenderName: "Alice"}))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 	assert.Len(t, ids, 3, "expected 3 gmail IDs for Alice")
 }
 
-func TestGetGmailIDsByFilter_AfterBefore(t *testing.T) {
+func TestGetDeletionTargetsByFilter_AfterBefore(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -734,19 +734,19 @@ func TestGetGmailIDsByFilter_AfterBefore(t *testing.T) {
 	feb1 := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
 	mar1 := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
 
-	afterIDs, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{After: &feb1})
+	afterIDs, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{After: &feb1}))
 	require.NoError(err, "after-only")
 	assert.ElementsMatch([]string{"msg3", "msg4", "msg5"}, afterIDs, "after >= Feb 1 (boundary inclusive)")
 
-	beforeIDs, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{Before: &feb1})
+	beforeIDs, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{Before: &feb1}))
 	require.NoError(err, "before-only")
 	assert.ElementsMatch([]string{"msg1", "msg2"}, beforeIDs, "before < Feb 1 (boundary exclusive)")
 
-	rangeIDs, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{After: &feb1, Before: &mar1})
+	rangeIDs, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{After: &feb1, Before: &mar1}))
 	require.NoError(err, "range")
 	assert.ElementsMatch([]string{"msg3", "msg4"}, rangeIDs, "Feb window")
 
-	combined, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{Sender: "alice@example.com", After: &feb1})
+	combined, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{Sender: "alice@example.com", After: &feb1}))
 	require.NoError(err, "combined with sender")
 	assert.ElementsMatch([]string{"msg3"}, combined, "sender+after")
 }
@@ -809,10 +809,10 @@ func TestListMessages_SenderEmailAndName_SameFromRow(t *testing.T) {
 		"same-row sender email+name must still match")
 }
 
-// TestGetGmailIDsByFilter_SenderEmailAndName_SameFromRow mirrors
-// TestListMessages_SenderEmailAndName_SameFromRow for the GetGmailIDsByFilter
+// TestGetDeletionTargetsByFilter_SenderEmailAndName_SameFromRow mirrors
+// TestListMessages_SenderEmailAndName_SameFromRow for the GetDeletionTargetsByFilter
 // builder site (deletion/staging path).
-func TestGetGmailIDsByFilter_SenderEmailAndName_SameFromRow(t *testing.T) {
+func TestGetDeletionTargetsByFilter_SenderEmailAndName_SameFromRow(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	env := newTestEnv(t)
@@ -821,19 +821,21 @@ func TestGetGmailIDsByFilter_SenderEmailAndName_SameFromRow(t *testing.T) {
 	crossRowMsgID := env.LastMessageID()
 	crossRowGmailID := fmt.Sprintf("msg%d", crossRowMsgID)
 
-	crossRow, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{
+	crossRow, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{
 		Sender:     "author-a@example.com",
 		SenderName: "Author B",
-	})
-	require.NoError(err, "GetGmailIDsByFilter cross-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter cross-row")
 	assert.NotContains(crossRow, crossRowGmailID,
 		"cross-row sender email+name must not match a multi-author message")
 
-	sameRow, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{
+	sameRow, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{
 		Sender:     "author-a@example.com",
 		SenderName: "Author A",
-	})
-	require.NoError(err, "GetGmailIDsByFilter same-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter same-row")
 	assert.Contains(sameRow, crossRowGmailID,
 		"same-row sender email+name must still match")
 }
@@ -890,10 +892,10 @@ func TestListMessages_RecipientEmailAndName_SameToRow(t *testing.T) {
 		"same-row recipient email+name must still match")
 }
 
-// TestGetGmailIDsByFilter_RecipientEmailAndName_SameToRow mirrors
-// TestListMessages_RecipientEmailAndName_SameToRow for the GetGmailIDsByFilter
+// TestGetDeletionTargetsByFilter_RecipientEmailAndName_SameToRow mirrors
+// TestListMessages_RecipientEmailAndName_SameToRow for the GetDeletionTargetsByFilter
 // builder site (deletion/staging path).
-func TestGetGmailIDsByFilter_RecipientEmailAndName_SameToRow(t *testing.T) {
+func TestGetDeletionTargetsByFilter_RecipientEmailAndName_SameToRow(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	env := newTestEnv(t)
@@ -902,40 +904,42 @@ func TestGetGmailIDsByFilter_RecipientEmailAndName_SameToRow(t *testing.T) {
 	crossRowMsgID := env.LastMessageID()
 	crossRowGmailID := fmt.Sprintf("msg%d", crossRowMsgID)
 
-	crossRow, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{
+	crossRow, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{
 		Recipient:     "recip-a@example.com",
 		RecipientName: "Recip B",
-	})
-	require.NoError(err, "GetGmailIDsByFilter cross-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter cross-row")
 	assert.NotContains(crossRow, crossRowGmailID,
 		"cross-row recipient email+name must not match a multi-recipient message")
 
-	sameRow, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{
+	sameRow, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{
 		Recipient:     "recip-a@example.com",
 		RecipientName: "Recip A",
-	})
-	require.NoError(err, "GetGmailIDsByFilter same-row")
+	}))
+
+	require.NoError(err, "GetDeletionTargetsByFilter same-row")
 	assert.Contains(sameRow, crossRowGmailID,
 		"same-row recipient email+name must still match")
 }
 
-func TestGetGmailIDsByFilter_RecipientName(t *testing.T) {
+func TestGetDeletionTargetsByFilter_RecipientName(t *testing.T) {
 	env := newTestEnv(t)
 
-	ids, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{RecipientName: "Bob"})
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{RecipientName: "Bob"}))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 	assert.Len(t, ids, 3, "expected 3 gmail IDs for Bob")
 }
 
-func TestGetGmailIDsByFilter_RecipientName_WithMatchEmptyRecipient(t *testing.T) {
+func TestGetDeletionTargetsByFilter_RecipientName_WithMatchEmptyRecipient(t *testing.T) {
 	env := newTestEnv(t)
 
 	filter := MessageFilter{
 		RecipientName:     "Bob",
 		EmptyValueTargets: emptyTargets(ViewRecipients),
 	}
-	ids, err := env.Engine.GetGmailIDsByFilter(env.Ctx, filter)
-	require.NoError(t, err, "GetGmailIDsByFilter")
+	ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, filter))
+	require.NoError(t, err, "GetDeletionTargetsByFilter")
 	assert.Len(t, ids, 3, "expected 3 gmail IDs")
 }
 
@@ -1149,9 +1153,9 @@ func TestRecipientNameFilter_IncludesBCC(t *testing.T) {
 		assert.Equal(t, "alice-bcc@example.com", rows[0].Key)
 	})
 
-	t.Run("GetGmailIDsByFilter", func(t *testing.T) {
-		ids, err := env.Engine.GetGmailIDsByFilter(env.Ctx, MessageFilter{RecipientName: "Secret Bob"})
-		require.NoError(t, err, "GetGmailIDsByFilter")
+	t.Run("GetDeletionTargetsByFilter", func(t *testing.T) {
+		ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{RecipientName: "Secret Bob"}))
+		require.NoError(t, err, "GetDeletionTargetsByFilter")
 		assert.Len(t, ids, 1)
 	})
 
@@ -1757,29 +1761,76 @@ func TestGetMessage_PopulatesDeletedAt(t *testing.T) {
 	assert.NotNil(t, msg.DeletedAt, "DeletedAt should be non-nil for deleted message")
 }
 
-func TestGetGmailIDsByMessageIDs(t *testing.T) {
+func TestGetDeletionTargetsByMessageIDs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
 	env := newTestEnv(t)
 
 	// Happy path: two known fixture messages (msg1=id 1, msg2=id 2).
-	ids, err := env.Engine.GetGmailIDsByMessageIDs(env.Ctx, []int64{1, 2})
+	targets, err := env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, []int64{1, 2})
 	require.NoError(err, "resolve fixture ids")
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
 	assert.ElementsMatch([]string{"msg1", "msg2"}, ids)
 
 	// Unknown IDs are silently dropped.
-	ids, err = env.Engine.GetGmailIDsByMessageIDs(env.Ctx, []int64{1, 999999})
+	targets, err = env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, []int64{1, 999999})
 	require.NoError(err, "unknown id")
+	ids, err = deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
 	assert.ElementsMatch([]string{"msg1"}, ids)
 
 	// Empty input: no query, no results.
-	ids, err = env.Engine.GetGmailIDsByMessageIDs(env.Ctx, nil)
+	targets, err = env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, nil)
 	require.NoError(err, "empty input")
-	assert.Empty(ids)
+	assert.Empty(targets)
 }
 
-func TestGetGmailIDsByMessageIDs_ExcludesNonQualifying(t *testing.T) {
+func TestGetDeletionTargetsByMessageIDsPreservesDuplicateGmailIDSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	env := newTestEnv(t)
+
+	sourceID := env.AddSource(dbtest.SourceOpts{Type: "gmail", Identifier: "other@example.invalid", DisplayName: "Other"})
+	conversationID := env.AddConversation(dbtest.ConversationOpts{SourceID: sourceID, Title: "Other thread"})
+	messageID := env.AddMessage(dbtest.MessageOpts{
+		SourceID: sourceID, ConversationID: conversationID,
+		Subject: "Same remote ID", SentAt: "2024-06-01 12:00:00",
+	})
+	_, err := env.DB.Exec(`UPDATE messages SET source_message_id = 'msg1' WHERE id = ?`, messageID)
+	require.NoError(err)
+
+	targets, err := env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, []int64{messageID})
+	require.NoError(err)
+	require.Len(targets, 1)
+	assert.Equal(DeletionTarget{
+		MessageID: messageID, SourceID: sourceID, SourceType: "gmail",
+		SourceIdentifier: "other@example.invalid", SourceMessageID: "msg1",
+	}, targets[0])
+}
+
+func TestGetDeletionTargetsByFilterPreservesSource(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	env := newTestEnv(t)
+	sourceID := int64(1)
+
+	targets, err := env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{SourceID: &sourceID})
+	require.NoError(err)
+	require.NotEmpty(targets)
+	for _, target := range targets {
+		assert.Equal(sourceID, target.SourceID)
+		assert.Equal("gmail", target.SourceType)
+		assert.Equal("test@gmail.com", target.SourceIdentifier)
+		assert.NotZero(target.MessageID)
+		assert.NotEmpty(target.SourceMessageID)
+	}
+}
+
+func TestGetDeletionTargetsByMessageIDs_ExcludesNonQualifying(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -1797,12 +1848,14 @@ func TestGetGmailIDsByMessageIDs_ExcludesNonQualifying(t *testing.T) {
 	_, err = env.DB.Exec(`INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at, deleted_at) VALUES (903, 1, 1, 'dedup-1', 'email', '2024-01-03', '2024-06-01')`)
 	require.NoError(err, "insert dedup-deleted message")
 
-	ids, err := env.Engine.GetGmailIDsByMessageIDs(env.Ctx, []int64{1, 901, 902, 903})
+	targets, err := env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, []int64{1, 901, 902, 903})
 	require.NoError(err, "resolve mixed ids")
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
 	assert.ElementsMatch([]string{"msg1"}, ids, "non-Gmail, source-deleted, and dedup-deleted must be dropped")
 }
 
-func TestGetGmailIDsByMessageIDs_LargeSelectionExceedsSingleQueryLimit(t *testing.T) {
+func TestGetDeletionTargetsByMessageIDs_LargeSelectionExceedsSingleQueryLimit(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -1820,89 +1873,10 @@ func TestGetGmailIDsByMessageIDs_LargeSelectionExceedsSingleQueryLimit(t *testin
 	}
 	ids = append(ids, 5, 1)
 
-	gmailIDs, err := env.Engine.GetGmailIDsByMessageIDs(env.Ctx, ids)
+	targets, err := env.Engine.GetDeletionTargetsByMessageIDs(env.Ctx, ids)
 	require.NoError(err, "large selection must stay under bind-parameter limits")
+	gmailIDs, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
 	assert.Equal([]string{"msg5", "msg1"}, gmailIDs,
 		"newest-first order restored across chunks; duplicate input deduped")
-}
-
-func TestGetAccountsByGmailIDs(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	env := newTestEnv(t)
-
-	// Fixture messages all belong to the single Gmail source.
-	accounts, err := env.Engine.GetAccountsByGmailIDs(env.Ctx, []string{"msg1", "msg2"})
-	require.NoError(err, "resolve fixture accounts")
-	assert.Equal([]string{"test@gmail.com"}, accounts)
-
-	// Unknown IDs resolve to no account.
-	accounts, err = env.Engine.GetAccountsByGmailIDs(env.Ctx, []string{"does-not-exist"})
-	require.NoError(err, "unknown id")
-	assert.Empty(accounts)
-
-	// Empty input: no query, no results.
-	accounts, err = env.Engine.GetAccountsByGmailIDs(env.Ctx, nil)
-	require.NoError(err, "empty input")
-	assert.Empty(accounts)
-}
-
-func TestGetAccountsByGmailIDs_MultipleAndNonQualifying(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	env := newTestEnv(t)
-
-	// Second Gmail source with a live message.
-	_, err := env.DB.Exec(`INSERT INTO sources (id, source_type, identifier) VALUES (98, 'gmail', 'second@gmail.com')`)
-	require.NoError(err, "insert second gmail source")
-	_, err = env.DB.Exec(`INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at) VALUES (911, 1, 98, 'other-1', 'email', '2024-01-05')`)
-	require.NoError(err, "insert second-account message")
-
-	// Non-Gmail source and a source-deleted Gmail message must not
-	// contribute accounts.
-	_, err = env.DB.Exec(`INSERT INTO sources (id, source_type, identifier) VALUES (99, 'whatsapp', 'wa@example.com')`)
-	require.NoError(err, "insert whatsapp source")
-	_, err = env.DB.Exec(`INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at) VALUES (912, 1, 99, 'wa-1', 'whatsapp', '2024-01-06')`)
-	require.NoError(err, "insert whatsapp message")
-	_, err = env.DB.Exec(`INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at, deleted_from_source_at) VALUES (913, 1, 98, 'gone-1', 'email', '2024-01-07', '2024-06-01')`)
-	require.NoError(err, "insert source-deleted message")
-
-	accounts, err := env.Engine.GetAccountsByGmailIDs(env.Ctx, []string{"msg1", "other-1", "wa-1"})
-	require.NoError(err, "resolve mixed accounts")
-	assert.Equal([]string{"second@gmail.com", "test@gmail.com"}, accounts,
-		"both gmail accounts, sorted; whatsapp excluded")
-
-	accounts, err = env.Engine.GetAccountsByGmailIDs(env.Ctx, []string{"gone-1", "wa-1"})
-	require.NoError(err, "resolve non-qualifying")
-	assert.Empty(accounts, "deleted and non-Gmail messages contribute no account")
-}
-
-func TestGetAccountsByGmailIDs_LargeSelectionExceedsSingleQueryLimit(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-
-	env := newTestEnv(t)
-
-	_, err := env.DB.Exec(`INSERT INTO sources (id, source_type, identifier) VALUES (98, 'gmail', 'second@gmail.com')`)
-	require.NoError(err, "insert second gmail source")
-	_, err = env.DB.Exec(`INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at) VALUES (911, 1, 98, 'other-1', 'email', '2024-01-05')`)
-	require.NoError(err, "insert second-account message")
-
-	// 33k IDs exceed SQLITE_MAX_VARIABLE_NUMBER (32766) as a single IN
-	// list, so an unchunked lookup fails with "too many SQL variables".
-	// The two real IDs sit in the first and last chunk to exercise the
-	// cross-chunk account union.
-	ids := make([]string, 0, 33000)
-	ids = append(ids, "msg1")
-	for len(ids) < 32999 {
-		ids = append(ids, fmt.Sprintf("missing-%d", len(ids)))
-	}
-	ids = append(ids, "other-1")
-
-	accounts, err := env.Engine.GetAccountsByGmailIDs(env.Ctx, ids)
-	require.NoError(err, "large selection must stay under bind-parameter limits")
-	assert.Equal([]string{"second@gmail.com", "test@gmail.com"}, accounts,
-		"accounts from different chunks must be unioned and sorted")
 }

--- a/internal/sourceops/sourceops.go
+++ b/internal/sourceops/sourceops.go
@@ -1,0 +1,210 @@
+// Package sourceops resolves user-facing source selectors with explicit
+// cardinality. Callers choose whether a selector must name exactly one source,
+// an account plus its related sources, or every matching source.
+package sourceops
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/gcal"
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// Store is the source catalog used by the resolvers.
+type Store interface {
+	GetSourceByID(sourceID int64) (*store.Source, error)
+	GetSourcesByIdentifierOrDisplayName(identifier string) ([]*store.Source, error)
+	GetSourcesByTypeAndAccount(sourceType, account string) ([]*store.Source, error)
+}
+
+// Selector identifies a source either by its exact database ID or by a
+// user-facing account token. SourceType is a compatibility filter for callers
+// that already expose one; it never makes a non-unique token exact.
+type Selector struct {
+	Account     string `json:"account,omitempty"`
+	SourceID    int64  `json:"source_id,omitempty"`
+	SourceIDSet bool   `json:"-"`
+	SourceType  string `json:"-"`
+}
+
+// Selection reports the normalized input, optional primary account source,
+// and every source selected by the chosen cardinality policy.
+type Selection struct {
+	Input   string
+	Primary *store.Source
+	Sources []*store.Source
+}
+
+// ResolveExactOne resolves exactly one source and rejects ambiguous tokens.
+func ResolveExactOne(st Store, selector Selector) (*store.Source, error) {
+	input, source, err := resolveSelector(st, selector)
+	if err != nil || source != nil {
+		return source, err
+	}
+
+	sources, err := lookupToken(st, input, selector.SourceType)
+	if err != nil {
+		return nil, err
+	}
+	switch len(sources) {
+	case 0:
+		return nil, sourceNotFound(input)
+	case 1:
+		return sources[0], nil
+	default:
+		return nil, ambiguous(input, sources)
+	}
+}
+
+// ResolveAccountFamily resolves one primary account source and its related
+// Google Calendar sources. An explicit source ID always remains exact.
+func ResolveAccountFamily(st Store, selector Selector) (Selection, error) {
+	input, source, err := resolveSelector(st, selector)
+	if err != nil {
+		return Selection{}, err
+	}
+	if source != nil {
+		return Selection{Input: strconv.FormatInt(source.ID, 10), Primary: source, Sources: []*store.Source{source}}, nil
+	}
+
+	direct, err := lookupToken(st, input, selector.SourceType)
+	if err != nil {
+		return Selection{}, err
+	}
+	if len(direct) > 1 {
+		return Selection{}, ambiguous(input, direct)
+	}
+
+	calendarAccount := input
+	var primary *store.Source
+	if len(direct) == 1 {
+		primary = direct[0]
+		if primary.SourceType != gcal.SourceType && !strings.EqualFold(primary.Identifier, input) {
+			calendarAccount = primary.Identifier
+		}
+	}
+	calendars, err := st.GetSourcesByTypeAndAccount(gcal.SourceType, calendarAccount)
+	if err != nil {
+		return Selection{}, opserr.Internal(fmt.Errorf("resolve calendar sources: %w", err))
+	}
+
+	sources := make([]*store.Source, 0, len(calendars)+1)
+	seen := make(map[int64]struct{}, len(calendars)+1)
+	if primary != nil {
+		sources = append(sources, primary)
+		seen[primary.ID] = struct{}{}
+	}
+	for _, calendar := range calendars {
+		if _, ok := seen[calendar.ID]; ok {
+			continue
+		}
+		sources = append(sources, calendar)
+		seen[calendar.ID] = struct{}{}
+	}
+	if len(sources) == 0 {
+		return Selection{}, sourceNotFound(input)
+	}
+	return Selection{Input: input, Primary: primary, Sources: sources}, nil
+}
+
+// ResolveAllMatches resolves every source matching an account token. An
+// explicit source ID always remains exact.
+func ResolveAllMatches(st Store, selector Selector) (Selection, error) {
+	input, source, err := resolveSelector(st, selector)
+	if err != nil {
+		return Selection{}, err
+	}
+	if source != nil {
+		return Selection{Input: strconv.FormatInt(source.ID, 10), Primary: source, Sources: []*store.Source{source}}, nil
+	}
+
+	sources, err := lookupToken(st, input, selector.SourceType)
+	if err != nil {
+		return Selection{}, err
+	}
+	if len(sources) == 0 {
+		return Selection{}, sourceNotFound(input)
+	}
+	primary := sources[0]
+	return Selection{Input: input, Primary: primary, Sources: sources}, nil
+}
+
+func resolveSelector(st Store, selector Selector) (string, *store.Source, error) {
+	input := strings.TrimSpace(selector.Account)
+	sourceType := strings.TrimSpace(selector.SourceType)
+	idSet := selector.SourceIDSet || selector.SourceID != 0
+	switch {
+	case idSet && selector.SourceID <= 0:
+		return "", nil, opserr.Invalid(errors.New("source ID must be positive"))
+	case idSet && input != "":
+		return "", nil, opserr.Invalid(errors.New("account and source ID are mutually exclusive"))
+	case idSet && sourceType != "":
+		return "", nil, opserr.Invalid(errors.New("source type and source ID are mutually exclusive"))
+	case idSet:
+		source, err := st.GetSourceByID(selector.SourceID)
+		if errors.Is(err, store.ErrSourceNotFound) {
+			return "", nil, opserr.NotFound(err)
+		}
+		if err != nil {
+			return "", nil, opserr.Internal(fmt.Errorf("resolve source ID: %w", err))
+		}
+		return "", source, nil
+	case input == "":
+		return "", nil, opserr.Invalid(errors.New("account or source ID is required"))
+	default:
+		return input, nil, nil
+	}
+}
+
+func lookupToken(st Store, input, sourceType string) ([]*store.Source, error) {
+	sources, err := st.GetSourcesByIdentifierOrDisplayName(input)
+	if err != nil {
+		return nil, opserr.Internal(fmt.Errorf("resolve source token: %w", err))
+	}
+	if sourceType == "" {
+		return uniqueSources(sources), nil
+	}
+	filtered := sources[:0]
+	for _, source := range sources {
+		if source.SourceType == sourceType {
+			filtered = append(filtered, source)
+		}
+	}
+	return uniqueSources(filtered), nil
+}
+
+func uniqueSources(sources []*store.Source) []*store.Source {
+	unique := make([]*store.Source, 0, len(sources))
+	seen := make(map[int64]struct{}, len(sources))
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		if _, ok := seen[source.ID]; ok {
+			continue
+		}
+		seen[source.ID] = struct{}{}
+		unique = append(unique, source)
+	}
+	return unique
+}
+
+func ambiguous(input string, sources []*store.Source) error {
+	details := make([]string, 0, len(sources))
+	for _, source := range sources {
+		details = append(details, fmt.Sprintf("%s (%s, id=%d)", source.Identifier, source.SourceType, source.ID))
+	}
+	return opserr.Invalid(fmt.Errorf(
+		"ambiguous source selector %q matches multiple sources: %s",
+		input,
+		strings.Join(details, ", "),
+	))
+}
+
+func sourceNotFound(input string) error {
+	return opserr.NotFound(fmt.Errorf("no account found for %q", input))
+}

--- a/internal/sourceops/sourceops_test.go
+++ b/internal/sourceops/sourceops_test.go
@@ -1,0 +1,193 @@
+package sourceops_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/opserr"
+	"go.kenn.io/msgvault/internal/sourceops"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestResolveExactOneRequiresExactlyOneSelector(t *testing.T) {
+	f := storetest.New(t)
+
+	tests := []struct {
+		name     string
+		selector sourceops.Selector
+		want     string
+	}{
+		{name: "missing", selector: sourceops.Selector{}, want: "account or source ID is required"},
+		{name: "negative ID", selector: sourceops.Selector{SourceID: -1}, want: "source ID must be positive"},
+		{name: "explicit zero ID", selector: sourceops.Selector{SourceIDSet: true}, want: "source ID must be positive"},
+		{
+			name: "account and ID",
+			selector: sourceops.Selector{
+				Account: "test@example.com", SourceID: f.Source.ID,
+			},
+			want: "mutually exclusive",
+		},
+		{
+			name: "ID and type",
+			selector: sourceops.Selector{
+				SourceID: f.Source.ID, SourceType: "gmail",
+			},
+			want: "mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sourceops.ResolveExactOne(f.Store, tt.selector)
+			require.Error(t, err)
+			assert.Equal(t, opserr.KindInvalid, opserr.KindOf(err))
+			assert.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestResolveExactOneTreatsNumericAccountAsToken(t *testing.T) {
+	f := storetest.New(t)
+	numeric, err := f.Store.GetOrCreateSource("synctech-sms", "15551234567")
+	require.NoError(t, err)
+
+	got, err := sourceops.ResolveExactOne(f.Store, sourceops.Selector{Account: "15551234567"})
+	require.NoError(t, err)
+	assert.Equal(t, numeric.ID, got.ID)
+}
+
+func TestResolveExactOneRejectsAmbiguityWithoutFirstMatch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	gmail, err := f.Store.GetOrCreateSource("gmail", "shared@example.com")
+	require.NoError(err)
+	_, err = f.Store.GetOrCreateSource("imap", "shared@example.com")
+	require.NoError(err)
+
+	_, err = sourceops.ResolveExactOne(f.Store, sourceops.Selector{Account: "shared@example.com"})
+	require.ErrorContains(err, "ambiguous")
+	assert.Equal(opserr.KindInvalid, opserr.KindOf(err))
+
+	got, err := sourceops.ResolveExactOne(f.Store, sourceops.Selector{SourceID: gmail.ID})
+	require.NoError(err)
+	assert.Equal(gmail.ID, got.ID)
+}
+
+func TestResolveExactOneTypeFilterStillRejectsSameTypeDisplayCollision(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	first, err := f.Store.GetOrCreateSource("gmail", "first@example.com")
+	require.NoError(err)
+	second, err := f.Store.GetOrCreateSource("gmail", "second@example.com")
+	require.NoError(err)
+	require.NoError(f.Store.UpdateSourceDisplayName(first.ID, "Work"))
+	require.NoError(f.Store.UpdateSourceDisplayName(second.ID, "Work"))
+
+	_, err = sourceops.ResolveExactOne(f.Store, sourceops.Selector{
+		Account: "Work", SourceType: "gmail",
+	})
+	require.Error(err)
+	assert.Equal(opserr.KindInvalid, opserr.KindOf(err))
+	assert.ErrorContains(err, "ambiguous")
+}
+
+func TestResolveAccountFamilyExpandsRelatedCalendars(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	primary, err := f.Store.GetOrCreateSource("gmail", "family@example.com")
+	require.NoError(err)
+	require.NoError(f.Store.UpdateSourceDisplayName(primary.ID, "Family"))
+	related := createCalendarSource(t, f, "family@example.com/primary", "family@example.com")
+	other := createCalendarSource(t, f, "other@example.com/primary", "other@example.com")
+
+	selection, err := sourceops.ResolveAccountFamily(f.Store, sourceops.Selector{Account: "Family"})
+	require.NoError(err)
+	require.NotNil(selection.Primary)
+	assert.Equal(primary.ID, selection.Primary.ID)
+	assert.ElementsMatch([]int64{primary.ID, related.ID}, sourceIDs(selection.Sources))
+	assert.NotContains(sourceIDs(selection.Sources), other.ID)
+}
+
+func TestResolveAccountFamilySupportsCalendarOnlyAccount(t *testing.T) {
+	f := storetest.New(t)
+	calendar := createCalendarSource(t, f, "calendar-only/primary", "calendar.only@example.com")
+
+	selection, err := sourceops.ResolveAccountFamily(f.Store, sourceops.Selector{
+		Account: "Calendar.Only@Example.com",
+	})
+	require.NoError(t, err)
+	assert.Nil(t, selection.Primary)
+	assert.Equal(t, []int64{calendar.ID}, sourceIDs(selection.Sources))
+}
+
+func TestResolveAllMatchesPreservesIntentionalFanout(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	gmail, err := f.Store.GetOrCreateSource("gmail", "fanout@example.com")
+	require.NoError(err)
+	imap, err := f.Store.GetOrCreateSource("imap", "fanout@example.com")
+	require.NoError(err)
+
+	selection, err := sourceops.ResolveAllMatches(f.Store, sourceops.Selector{Account: "fanout@example.com"})
+	require.NoError(err)
+	assert.ElementsMatch([]int64{gmail.ID, imap.ID}, sourceIDs(selection.Sources))
+}
+
+func TestExplicitSourceIDIsExactForEveryCardinality(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	primary, err := f.Store.GetOrCreateSource("gmail", "exact@example.com")
+	require.NoError(err)
+	_ = createCalendarSource(t, f, "exact@example.com/primary", "exact@example.com")
+
+	exact, err := sourceops.ResolveExactOne(f.Store, sourceops.Selector{SourceID: primary.ID})
+	require.NoError(err)
+	assert.Equal(primary.ID, exact.ID)
+
+	family, err := sourceops.ResolveAccountFamily(f.Store, sourceops.Selector{SourceID: primary.ID})
+	require.NoError(err)
+	assert.Equal([]int64{primary.ID}, sourceIDs(family.Sources))
+
+	all, err := sourceops.ResolveAllMatches(f.Store, sourceops.Selector{SourceID: primary.ID})
+	require.NoError(err)
+	assert.Equal([]int64{primary.ID}, sourceIDs(all.Sources))
+}
+
+func createCalendarSource(
+	t *testing.T,
+	f *storetest.Fixture,
+	identifier string,
+	account string,
+) *store.Source {
+	t.Helper()
+	source, err := f.Store.GetOrCreateSource("gcal", identifier)
+	require.NoError(t, err)
+	config, err := json.Marshal(map[string]string{
+		"account_email": account,
+		"calendar_id":   identifier,
+	})
+	require.NoError(t, err)
+	require.NoError(t, f.Store.UpdateSourceSyncConfig(source.ID, string(config)))
+	return source
+}
+
+func sourceIDs(sources []*store.Source) []int64 {
+	ids := make([]int64, 0, len(sources))
+	for _, source := range sources {
+		ids = append(ids, source.ID)
+	}
+	return ids
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2321,28 +2321,32 @@ func (s *Store) MarkMessagesDeletedFromReader(sourceID int64, reader io.Reader, 
 // When permanent is true, the message row is deleted entirely; otherwise it is
 // soft-deleted by setting deleted_from_source_at.
 //
-// A2 (deferred): the match is NOT scoped by source_id, so a Gmail-ID collision
-// across two accounts would delete/soft-delete the wrong account's row (blast
-// radius: one row in the colliding account). This is deferred rather than fixed
-// because the deletion Manifest carries only a flat []GmailIDs with no per-id
-// source_id (internal/deletion/manifest.go), and a single manifest can legitimately
-// span multiple accounts (see internal/tui/actions.go resolveGmailIDs /
-// internal/mcp/handlers.go, where the account filter is optional), so a single
-// Filters.Account cannot scope every id correctly. Properly scoping this needs a
-// manifest schema/version change (out of scope). Gmail IDs are random enough that
-// a cross-account collision is astronomically unlikely. See docs/internal/PG_STATUS.md.
+// This compatibility entry point is intentionally unscoped. New deletion
+// execution resolves a manifest source and uses
+// MarkMessageDeletedBySourceMessageID instead.
 func (s *Store) MarkMessageDeletedByGmailID(permanent bool, gmailID string) error {
+	return s.MarkMessageDeletedBySourceMessageID(0, permanent, gmailID)
+}
+
+// MarkMessageDeletedBySourceMessageID marks only the message belonging to
+// sourceID. A zero sourceID retains the legacy unscoped behavior for version-1
+// deletion manifests.
+func (s *Store) MarkMessageDeletedBySourceMessageID(sourceID int64, permanent bool, gmailID string) error {
+	sourceClause := ""
+	args := []any{gmailID}
+	if sourceID > 0 {
+		sourceClause = " AND source_id = ?"
+		args = append(args, sourceID)
+	}
 	if permanent {
-		// A2 (deferred): unscoped by source_id — see function doc.
-		_, err := s.db.Exec(`DELETE FROM messages WHERE source_message_id = ?`, gmailID)
+		_, err := s.db.Exec(`DELETE FROM messages WHERE source_message_id = ?`+sourceClause, args...)
 		return err
 	}
-	// A2 (deferred): unscoped by source_id — see function doc.
 	_, err := s.db.Exec(fmt.Sprintf(`
 		UPDATE messages
 		SET deleted_from_source_at = %s
-		WHERE source_message_id = ? AND deleted_from_source_at IS NULL
-	`, s.dialect.Now()), gmailID)
+		WHERE source_message_id = ?%s AND deleted_from_source_at IS NULL
+	`, s.dialect.Now(), sourceClause), args...)
 	return err
 }
 
@@ -2354,11 +2358,15 @@ func (s *Store) MarkMessageDeletedByGmailID(permanent bool, gmailID string) erro
 // for that chunk and continues with remaining chunks. Returns the first error encountered
 // (if any) after processing all IDs.
 //
-// A2 (deferred): the IN (...) match is NOT scoped by source_id — same unscoped
-// collision caveat as MarkMessageDeletedByGmailID; see that function's doc and
-// docs/internal/PG_STATUS.md for why it is deferred (manifest lacks per-id source_id and
-// can span multiple accounts; collision astronomically unlikely).
+// This compatibility entry point is intentionally unscoped. New deletion
+// execution uses MarkMessagesDeletedBySourceMessageIDBatch.
 func (s *Store) MarkMessagesDeletedByGmailIDBatch(gmailIDs []string) error {
+	return s.MarkMessagesDeletedBySourceMessageIDBatch(0, gmailIDs)
+}
+
+// MarkMessagesDeletedBySourceMessageIDBatch scopes batch archive marking to
+// sourceID. A zero sourceID preserves legacy version-1 behavior.
+func (s *Store) MarkMessagesDeletedBySourceMessageIDBatch(sourceID int64, gmailIDs []string) error {
 	if len(gmailIDs) == 0 {
 		return nil
 	}
@@ -2371,16 +2379,20 @@ func (s *Store) MarkMessagesDeletedByGmailIDBatch(gmailIDs []string) error {
 		chunk := gmailIDs[i:end]
 
 		placeholders := make([]string, len(chunk))
-		args := make([]any, len(chunk))
+		args := make([]any, 0, len(chunk)+1)
 		for j, id := range chunk {
 			placeholders[j] = "?"
-			args[j] = id
+			args = append(args, id)
+		}
+		sourceClause := ""
+		if sourceID > 0 {
+			sourceClause = " AND source_id = ?"
+			args = append(args, sourceID)
 		}
 
-		// A2 (deferred): unscoped by source_id — see function doc.
 		query := fmt.Sprintf(
-			`UPDATE messages SET deleted_from_source_at = %s WHERE source_message_id IN (%s) AND deleted_from_source_at IS NULL`,
-			s.dialect.Now(), strings.Join(placeholders, ","))
+			`UPDATE messages SET deleted_from_source_at = %s WHERE source_message_id IN (%s)%s AND deleted_from_source_at IS NULL`,
+			s.dialect.Now(), strings.Join(placeholders, ","), sourceClause)
 
 		if _, err := s.db.Exec(query, args...); err != nil {
 			if firstErr == nil {
@@ -2388,7 +2400,7 @@ func (s *Store) MarkMessagesDeletedByGmailIDBatch(gmailIDs []string) error {
 			}
 			// Fall back to individual updates for this chunk
 			for _, id := range chunk {
-				s.MarkMessageDeletedByGmailID(false, id) //nolint:errcheck,gosec // best-effort
+				s.MarkMessageDeletedBySourceMessageID(sourceID, false, id) //nolint:errcheck,gosec // best-effort
 			}
 		}
 	}

--- a/internal/store/sources.go
+++ b/internal/store/sources.go
@@ -41,6 +41,25 @@ func (s *Store) GetSourceByIDContext(ctx context.Context, id int64) (*Source, er
 	return source, nil
 }
 
+// GetSourceByTypeAndIdentifier resolves a source by its portable stable tuple.
+func (s *Store) GetSourceByTypeAndIdentifier(sourceType, identifier string) (*Source, error) {
+	row := s.db.QueryRow(`
+		SELECT id, source_type, identifier, display_name, google_user_id,
+		       last_sync_at, sync_cursor, sync_config, oauth_app,
+		       created_at, updated_at
+		FROM sources
+		WHERE source_type = ? AND identifier = ?
+	`, sourceType, identifier)
+	source, err := scanSource(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("source %s/%s: %w", sourceType, identifier, ErrSourceNotFound)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get source by type and identifier: %w", err)
+	}
+	return source, nil
+}
+
 // GetSourcesByIdentifier returns all sources matching an identifier,
 // regardless of source_type. Use this when the identifier may be
 // shared across source types (e.g., gmail + mbox import).

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -863,6 +863,49 @@ func TestStore_MarkMessagesDeletedByGmailIDBatch(t *testing.T) {
 	require.NoError(err, "MarkMessagesDeletedByGmailIDBatch(nil)")
 }
 
+func TestStore_SourceScopedRemoteIDDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := storetest.New(t)
+	other, err := f.Store.GetOrCreateSource("gmail", "other@example.invalid")
+	require.NoError(err)
+	otherConversationID, err := f.Store.EnsureConversation(other.ID, "other-thread", "Other")
+	require.NoError(err)
+
+	const remoteID = "shared-remote-id"
+	firstID := f.CreateMessage(remoteID)
+	secondID := storetest.NewMessage(other.ID, otherConversationID).WithSourceMessageID(remoteID).Create(t, f.Store)
+
+	require.NoError(f.Store.MarkMessageDeletedBySourceMessageID(f.Source.ID, false, remoteID))
+	var firstDeleted, secondDeleted sql.NullTime
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind(`SELECT deleted_from_source_at FROM messages WHERE id = ?`), firstID,
+	).Scan(&firstDeleted))
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind(`SELECT deleted_from_source_at FROM messages WHERE id = ?`), secondID,
+	).Scan(&secondDeleted))
+	assert.True(firstDeleted.Valid)
+	assert.False(secondDeleted.Valid)
+
+	require.NoError(f.Store.MarkMessagesDeletedBySourceMessageIDBatch(other.ID, []string{remoteID}))
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind(`SELECT deleted_from_source_at FROM messages WHERE id = ?`), secondID,
+	).Scan(&secondDeleted))
+	assert.True(secondDeleted.Valid)
+
+	require.NoError(f.Store.MarkMessageDeletedBySourceMessageID(f.Source.ID, true, remoteID))
+	var count int
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind(`SELECT COUNT(*) FROM messages WHERE id = ?`), firstID,
+	).Scan(&count))
+	assert.Zero(count)
+	require.NoError(f.Store.DB().QueryRow(
+		f.Store.Rebind(`SELECT COUNT(*) FROM messages WHERE id = ?`), secondID,
+	).Scan(&count))
+	assert.Equal(1, count)
+}
+
 func TestStore_GetMessageRaw_NotFound(t *testing.T) {
 	f := storetest.New(t)
 

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -98,17 +98,25 @@ func (c *ActionController) SaveManifest(manifest *deletion.Manifest) error {
 
 // StageForDeletion prepares messages for deletion based on selection.
 func (c *ActionController) StageForDeletion(ctx DeletionContext) (*deletion.Manifest, error) {
-	gmailIDs, err := c.resolveGmailIDs(ctx)
+	targets, err := c.resolveDeletionTargets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(gmailIDs) == 0 {
+	if len(targets) == 0 {
 		return nil, errors.New("no messages selected")
 	}
+	source, err := deletion.SourceReferenceForTargets(targets)
+	if errors.Is(err, deletion.ErrMultipleDeletionSources) {
+		return nil, errors.New("selected messages span multiple sources; press 'a' to filter by account, then stage again")
+	}
+	if err != nil {
+		return nil, err
+	}
+	gmailIDs := deletion.SourceMessageIDs(targets)
 
 	description := c.buildManifestDescription(ctx)
-	manifest := deletion.NewManifest(description, gmailIDs)
+	manifest := deletion.NewManifestForSource(description, gmailIDs, source)
 	manifest.CreatedBy = "tui"
 
 	c.applyManifestFilters(manifest, ctx)
@@ -117,8 +125,8 @@ func (c *ActionController) StageForDeletion(ctx DeletionContext) (*deletion.Mani
 }
 
 // resolveGmailIDs converts selections (aggregate keys and message IDs) into Gmail IDs.
-func (c *ActionController) resolveGmailIDs(dctx DeletionContext) ([]string, error) {
-	gmailIDSet := make(map[string]bool)
+func (c *ActionController) resolveDeletionTargets(dctx DeletionContext) ([]query.DeletionTarget, error) {
+	targetsByMessageID := make(map[int64]query.DeletionTarget)
 	ctx := context.Background()
 
 	// From selected aggregates - resolve to Gmail IDs via query engine
@@ -126,30 +134,42 @@ func (c *ActionController) resolveGmailIDs(dctx DeletionContext) ([]string, erro
 		for key := range dctx.AggregateSelection {
 			filter := c.buildFilterForAggregate(key, dctx)
 
-			ids, err := c.queries.GetGmailIDsByFilter(ctx, filter)
+			targets, err := c.queries.GetDeletionTargetsByFilter(ctx, filter)
 			if err != nil {
 				return nil, fmt.Errorf("error loading messages: %w", err)
 			}
-			for _, id := range ids {
-				gmailIDSet[id] = true
+			for _, target := range targets {
+				targetsByMessageID[target.MessageID] = target
 			}
 		}
 	}
 
 	// From selected message IDs
 	if len(dctx.MessageSelection) > 0 {
+		accounts := make(map[int64]query.AccountInfo, len(dctx.Accounts))
+		for _, account := range dctx.Accounts {
+			accounts[account.ID] = account
+		}
 		for _, msg := range dctx.Messages {
 			if dctx.MessageSelection[msg.ID] {
-				gmailIDSet[msg.SourceMessageID] = true
+				account, ok := accounts[msg.SourceID]
+				if !ok {
+					return nil, fmt.Errorf("selected message %d has no source metadata", msg.ID)
+				}
+				targetsByMessageID[msg.ID] = query.DeletionTarget{
+					MessageID: msg.ID, SourceID: msg.SourceID, SourceType: account.SourceType,
+					SourceIdentifier: account.Identifier, SourceMessageID: msg.SourceMessageID,
+				}
 			}
 		}
 	}
 
-	gmailIDs := make([]string, 0, len(gmailIDSet))
-	for id := range gmailIDSet {
-		gmailIDs = append(gmailIDs, id)
+	targets := make([]query.DeletionTarget, 0, len(targetsByMessageID))
+	for _, target := range targetsByMessageID {
+		targets = append(targets, target)
 	}
-	return gmailIDs, nil
+	sort.Slice(targets, func(i, j int) bool { return targets[i].MessageID < targets[j].MessageID })
+	return targets, nil
 }
 
 // buildFilterForAggregate constructs a MessageFilter for a single aggregate key.

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -90,12 +90,16 @@ func (e *ControllerTestEnv) StageForDeletion(args stageArgs) *deletion.Manifest 
 	if granularity == 0 {
 		granularity = query.TimeYear
 	}
+	accounts := args.accounts
+	if accounts == nil {
+		accounts = []query.AccountInfo{{ID: 1, SourceType: "gmail", Identifier: "test@gmail.com"}}
+	}
 	manifest, err := e.Ctrl.StageForDeletion(DeletionContext{
 		AggregateSelection: args.aggregates,
 		MessageSelection:   args.selection,
 		AggregateViewType:  args.view,
 		AccountFilter:      args.accountID,
-		Accounts:           args.accounts,
+		Accounts:           accounts,
 		TimeGranularity:    granularity,
 		Messages:           args.messages,
 		DrillFilter:        args.drillFilter,
@@ -105,10 +109,13 @@ func (e *ControllerTestEnv) StageForDeletion(args stageArgs) *deletion.Manifest 
 }
 
 func msgSummary(id int64, sourceID string) query.MessageSummary {
-	return query.MessageSummary{ID: id, SourceMessageID: sourceID}
+	return query.MessageSummary{ID: id, SourceID: 1, SourceMessageID: sourceID}
 }
 
 func TestStageForDeletion_FromAggregateSelection(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
 	env := newTestEnv(t, "gid1", "gid2", "gid3")
 
 	manifest := env.StageForDeletion(stageArgs{
@@ -116,9 +123,24 @@ func TestStageForDeletion_FromAggregateSelection(t *testing.T) {
 		view:       query.ViewSenders,
 	})
 
-	assert.Len(t, manifest.GmailIDs, 3)
-	assert.Equal(t, []string{"alice@example.com"}, manifest.Filters.Senders)
-	assert.Equal(t, "tui", manifest.CreatedBy)
+	assert.Len(manifest.GmailIDs, 3)
+	assert.Equal(2, manifest.Version)
+	require.NotNil(manifest.Source)
+	assert.Equal(deletion.SourceReference{ID: 1, Type: "gmail", Identifier: "test@gmail.com"}, *manifest.Source)
+	assert.Equal([]string{"alice@example.com"}, manifest.Filters.Senders)
+	assert.Equal("tui", manifest.CreatedBy)
+}
+
+func TestStageForDeletionRejectsMultipleSources(t *testing.T) {
+	engine := &querytest.MockEngine{DeletionTargets: []query.DeletionTarget{
+		{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "one@example.invalid", SourceMessageID: "gm-1"},
+		{MessageID: 2, SourceID: 2, SourceType: "gmail", SourceIdentifier: "two@example.invalid", SourceMessageID: "gm-2"},
+	}}
+	controller := NewActionController(engine, t.TempDir(), nil)
+	_, err := controller.StageForDeletion(DeletionContext{
+		AggregateSelection: map[string]bool{"example.invalid": true}, AggregateViewType: query.ViewDomains,
+	})
+	require.ErrorContains(t, err, "press 'a' to filter by account")
 }
 
 func TestStageForDeletion_StoresFullDescription(t *testing.T) {
@@ -236,9 +258,12 @@ func TestStageForDeletion_DrillFilterApplied(t *testing.T) {
 	// select "2024-01". The filter should include both sender AND time period.
 	var capturedFilter query.MessageFilter
 	engine := &querytest.MockEngine{
-		GetGmailIDsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]string, error) {
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]query.DeletionTarget, error) {
 			capturedFilter = f
-			return []string{"gid1", "gid2"}, nil
+			return []query.DeletionTarget{
+				{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "test@gmail.com", SourceMessageID: "gid1"},
+				{MessageID: 2, SourceID: 1, SourceType: "gmail", SourceIdentifier: "test@gmail.com", SourceMessageID: "gid2"},
+			}, nil
 		},
 	}
 	env := NewControllerTestEnv(t, engine)
@@ -263,9 +288,12 @@ func TestStageForDeletion_NoDrillFilter(t *testing.T) {
 	// Without drill filter, only the aggregate selection filter is applied.
 	var capturedFilter query.MessageFilter
 	engine := &querytest.MockEngine{
-		GetGmailIDsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]string, error) {
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, f query.MessageFilter) ([]query.DeletionTarget, error) {
 			capturedFilter = f
-			return []string{"gid1"}, nil
+			return []query.DeletionTarget{{
+				MessageID: 1, SourceID: 1, SourceType: "gmail",
+				SourceIdentifier: "test@gmail.com", SourceMessageID: "gid1",
+			}}, nil
 		},
 	}
 	env := NewControllerTestEnv(t, engine)

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -300,11 +300,11 @@ func TestDKeyWithExistingSelection(t *testing.T) {
 func TestMessageListDKeyAutoSelectsCurrentMessage(t *testing.T) {
 	model := NewBuilder().
 		WithMessages(
-			query.MessageSummary{ID: 1, SourceMessageID: "msg1", Subject: "Hello"},
-			query.MessageSummary{ID: 2, SourceMessageID: "msg2", Subject: "World"},
+			query.MessageSummary{ID: 1, SourceID: 1, SourceMessageID: "msg1", Subject: "Hello"},
+			query.MessageSummary{ID: 2, SourceID: 1, SourceMessageID: "msg2", Subject: "World"},
 		).
 		WithLevel(levelMessageList).
-		WithAccounts(query.AccountInfo{ID: 1, Identifier: "test@gmail.com"}).
+		WithAccounts(query.AccountInfo{ID: 1, SourceType: "gmail", Identifier: "test@gmail.com"}).
 		Build()
 
 	assertHasSelection(t, model, false)

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -212,6 +212,9 @@ type SyncCLIQuery struct {
 	// Email Account email or display name to sync
 	Email *string `json:"email,omitempty"`
 
+	// SourceID Exact source ID to sync
+	SourceID *int64 `json:"source_id,omitempty"`
+
 	// Folder IMAP folder names to include (repeatable)
 	Folder []string `json:"folder,omitempty"`
 
@@ -222,6 +225,9 @@ type SyncCLIQuery struct {
 type SyncFullCLIQuery struct {
 	// Email Account email or display name to sync
 	Email *string `json:"email,omitempty"`
+
+	// SourceID Exact source ID to sync
+	SourceID *int64 `json:"source_id,omitempty"`
 
 	// Query Gmail search query
 	Query *string `json:"query,omitempty"`

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -474,6 +474,7 @@ type CLIDeleteStagedPlanRequest struct {
 	List                *bool   `json:"list,omitempty"`
 	Permanent           *bool   `json:"permanent,omitempty"`
 	RemoteDeleteEnabled *bool   `json:"remote_delete_enabled,omitempty"`
+	SourceID            *int64  `json:"source_id,omitempty"`
 	Yes                 *bool   `json:"yes,omitempty"`
 }
 
@@ -486,6 +487,7 @@ type CLIDeleteStagedPlanResponse struct {
 	PlanFingerprint           *string  `json:"plan_fingerprint,omitempty"`
 	PlannedBatchIds           []string `json:"planned_batch_ids,omitempty"`
 	RemoteDeleteEnvVar        *string  `json:"remote_delete_env_var,omitempty"`
+	ResolvedSourceID          *int64   `json:"resolved_source_id,omitempty"`
 	ScopeEscalationAccount    *string  `json:"scope_escalation_account,omitempty"`
 	ScopeEscalationBodyLines  []string `json:"scope_escalation_body_lines,omitempty"`
 	ScopeEscalationCancelHint *string  `json:"scope_escalation_cancel_hint,omitempty"`
@@ -1597,15 +1599,16 @@ func (d DeepSearchResponse) Validate() error {
 }
 
 type DeletionManifestDetail struct {
-	Account      *string    `json:"account,omitempty"`
-	CreatedAt    time.Time  `json:"created_at" validate:"required"`
-	CreatedBy    string     `json:"created_by" validate:"required"`
-	Description  string     `json:"description" validate:"required"`
-	Execution    *Execution `json:"execution,omitempty"`
-	ID           string     `json:"id" validate:"required"`
-	MessageCount int64      `json:"message_count"`
-	Status       string     `json:"status" validate:"required"`
-	Summary      *Summary   `json:"summary,omitempty"`
+	Account      *string          `json:"account,omitempty"`
+	CreatedAt    time.Time        `json:"created_at" validate:"required"`
+	CreatedBy    string           `json:"created_by" validate:"required"`
+	Description  string           `json:"description" validate:"required"`
+	Execution    *Execution       `json:"execution,omitempty"`
+	ID           string           `json:"id" validate:"required"`
+	MessageCount int64            `json:"message_count"`
+	Source       *SourceReference `json:"source,omitempty"`
+	Status       string           `json:"status" validate:"required"`
+	Summary      *Summary         `json:"summary,omitempty"`
 }
 
 func (d DeletionManifestDetail) Validate() error {
@@ -1628,6 +1631,13 @@ func (d DeletionManifestDetail) Validate() error {
 	}
 	if err := typesValidator.Var(d.ID, "required"); err != nil {
 		errors = errors.Append("ID", err)
+	}
+	if d.Source != nil {
+		if v, ok := any(d.Source).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Source", err)
+			}
+		}
 	}
 	if err := typesValidator.Var(d.Status, "required"); err != nil {
 		errors = errors.Append("Status", err)
@@ -1655,6 +1665,18 @@ type DeletionManifestSummary struct {
 }
 
 func (d DeletionManifestSummary) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(d))
+}
+
+type DeletionTarget struct {
+	MessageID        int64  `json:"message_id"`
+	SourceID         int64  `json:"source_id"`
+	SourceIdentifier string `json:"source_identifier" validate:"required"`
+	SourceMessageID  string `json:"source_message_id" validate:"required"`
+	SourceType       string `json:"source_type" validate:"required"`
+}
+
+func (d DeletionTarget) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(d))
 }
 
@@ -3075,11 +3097,26 @@ func (g GenerationSummary) Validate() error {
 }
 
 type GmailIDsResponse struct {
-	GmailIds []string `json:"gmail_ids,omitempty" validate:"required"`
+	GmailIds []string         `json:"gmail_ids,omitempty" validate:"required"`
+	Targets  []DeletionTarget `json:"targets,omitempty"`
 }
 
 func (g GmailIDsResponse) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(g.GmailIds, "required"); err != nil {
+		errors = errors.Append("GmailIds", err)
+	}
+	for i, item := range g.Targets {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Targets[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type HealthResponse struct {
@@ -3559,17 +3596,18 @@ func (l ListDeletionsResponse) Validate() error {
 }
 
 type Manifest struct {
-	CreatedAt   time.Time  `json:"created_at" validate:"required"`
-	CreatedBy   string     `json:"created_by" validate:"required"`
-	Description string     `json:"description" validate:"required"`
-	Execution   *Execution `json:"execution,omitempty"`
-	Filters     Filters    `json:"filters"`
-	GmailIds    []string   `json:"gmail_ids,omitempty" validate:"required"`
-	ID          string     `json:"id" validate:"required"`
-	RawFilter   *struct{}  `json:"raw_filter,omitempty"`
-	Status      string     `json:"status" validate:"required"`
-	Summary     *Summary   `json:"summary,omitempty"`
-	Version     int64      `json:"version"`
+	CreatedAt   time.Time        `json:"created_at" validate:"required"`
+	CreatedBy   string           `json:"created_by" validate:"required"`
+	Description string           `json:"description" validate:"required"`
+	Execution   *Execution       `json:"execution,omitempty"`
+	Filters     Filters          `json:"filters"`
+	GmailIds    []string         `json:"gmail_ids,omitempty" validate:"required"`
+	ID          string           `json:"id" validate:"required"`
+	RawFilter   *struct{}        `json:"raw_filter,omitempty"`
+	Source      *SourceReference `json:"source,omitempty"`
+	Status      string           `json:"status" validate:"required"`
+	Summary     *Summary         `json:"summary,omitempty"`
+	Version     int64            `json:"version"`
 }
 
 func (m Manifest) Validate() error {
@@ -3600,6 +3638,13 @@ func (m Manifest) Validate() error {
 	}
 	if err := typesValidator.Var(m.ID, "required"); err != nil {
 		errors = errors.Append("ID", err)
+	}
+	if m.Source != nil {
+		if v, ok := any(m.Source).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Source", err)
+			}
+		}
 	}
 	if err := typesValidator.Var(m.Status, "required"); err != nil {
 		errors = errors.Append("Status", err)
@@ -7088,6 +7133,16 @@ func (s SourceIdentityResponse) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(s))
 }
 
+type SourceReference struct {
+	ID         int64  `json:"id"`
+	Identifier string `json:"identifier" validate:"required"`
+	Type       string `json:"type" validate:"required"`
+}
+
+func (s SourceReference) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(s))
+}
+
 type SourceStatus struct {
 	ActiveSync            *SyncRunStatus `json:"active_sync,omitempty"`
 	CanSync               bool           `json:"can_sync"`
@@ -7230,12 +7285,28 @@ func (s StageDeletionRequest) Validate() error {
 }
 
 type StageDeletionResponse struct {
-	Account        *string  `json:"account,omitempty"`
-	DryRun         bool     `json:"dry_run"`
-	ID             *string  `json:"id,omitempty"`
-	MessageCount   int64    `json:"message_count"`
-	SampleGmailIds []string `json:"sample_gmail_ids,omitempty"`
-	Status         *string  `json:"status,omitempty"`
+	Account        *string          `json:"account,omitempty"`
+	DryRun         bool             `json:"dry_run"`
+	ID             *string          `json:"id,omitempty"`
+	MessageCount   int64            `json:"message_count"`
+	SampleGmailIds []string         `json:"sample_gmail_ids,omitempty"`
+	Source         *SourceReference `json:"source,omitempty"`
+	Status         *string          `json:"status,omitempty"`
+}
+
+func (s StageDeletionResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if s.Source != nil {
+		if v, ok := any(s.Source).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Source", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type StatsResponse struct {
@@ -7737,8 +7808,10 @@ func (t TranscriptSegment) Validate() error {
 }
 
 type UpdateRequest struct {
-	DisplayName string `json:"display_name" validate:"required"`
-	Email       string `json:"email" validate:"required"`
+	Account     *string `json:"account,omitempty"`
+	DisplayName string  `json:"display_name" validate:"required"`
+	Email       *string `json:"email,omitempty"`
+	SourceID    *int64  `json:"source_id,omitempty"`
 }
 
 func (u UpdateRequest) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -557,6 +557,9 @@ components:
           type: boolean
         remote_delete_enabled:
           type: boolean
+        source_id:
+          format: int64
+          type: integer
         "yes":
           type: boolean
       type: object
@@ -581,6 +584,9 @@ components:
           type: array
         remote_delete_env_var:
           type: string
+        resolved_source_id:
+          format: int64
+          type: integer
         scope_escalation_account:
           type: string
         scope_escalation_body_lines:
@@ -1885,6 +1891,8 @@ components:
         message_count:
           format: int64
           type: integer
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
         summary:
@@ -1920,6 +1928,27 @@ components:
         - created_by
         - description
         - message_count
+      type: object
+    DeletionTarget:
+      properties:
+        message_id:
+          format: int64
+          type: integer
+        source_id:
+          format: int64
+          type: integer
+        source_identifier:
+          type: string
+        source_message_id:
+          type: string
+        source_type:
+          type: string
+      required:
+        - message_id
+        - source_id
+        - source_type
+        - source_identifier
+        - source_message_id
       type: object
     DiscoverError:
       properties:
@@ -3500,6 +3529,11 @@ components:
             type: string
           nullable: true
           type: array
+        targets:
+          items:
+            $ref: "#/components/schemas/DeletionTarget"
+          nullable: true
+          type: array
       required:
         - gmail_ids
       type: object
@@ -3986,6 +4020,8 @@ components:
         id:
           type: string
         raw_filter: {}
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
         summary:
@@ -7492,6 +7528,21 @@ components:
         - signals
         - confirmed_at
       type: object
+    SourceReference:
+      additionalProperties: false
+      properties:
+        id:
+          format: int64
+          type: integer
+        identifier:
+          type: string
+        type:
+          type: string
+      required:
+        - id
+        - type
+        - identifier
+      type: object
     SourceStatus:
       properties:
         active_sync:
@@ -7625,6 +7676,8 @@ components:
             type: string
           nullable: true
           type: array
+        source:
+          $ref: "#/components/schemas/SourceReference"
         status:
           type: string
       required:
@@ -8205,12 +8258,16 @@ components:
     UpdateRequest:
       additionalProperties: false
       properties:
+        account:
+          type: string
         display_name:
           type: string
         email:
           type: string
+        source_id:
+          format: int64
+          type: integer
       required:
-        - email
         - display_name
       type: object
     UpdateResult:
@@ -8345,7 +8402,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.3.0
+  version: 2.4.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -10340,6 +10397,12 @@ paths:
           name: email
           schema:
             type: string
+        - description: Exact source ID to sync
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: IMAP folder names to include (repeatable)
           in: query
           name: folder
@@ -10381,6 +10444,12 @@ paths:
           name: email
           schema:
             type: string
+        - description: Exact source ID to sync
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: Gmail search query
           in: query
           name: query

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -2829,6 +2829,8 @@ export interface components {
             list?: boolean;
             permanent?: boolean;
             remote_delete_enabled?: boolean;
+            /** Format: int64 */
+            source_id?: number;
             yes?: boolean;
         };
         CLIDeleteStagedPlanResponse: {
@@ -2840,6 +2842,8 @@ export interface components {
             plan_fingerprint?: string;
             planned_batch_ids?: string[] | null;
             remote_delete_env_var?: string;
+            /** Format: int64 */
+            resolved_source_id?: number;
             scope_escalation_account?: string;
             scope_escalation_body_lines?: string[] | null;
             scope_escalation_cancel_hint?: string;
@@ -3454,6 +3458,7 @@ export interface components {
             id: string;
             /** Format: int64 */
             message_count: number;
+            source?: components["schemas"]["SourceReference"];
             status: string;
             summary?: components["schemas"]["Summary"];
         } & {
@@ -3468,6 +3473,17 @@ export interface components {
             /** Format: int64 */
             message_count: number;
             status: string;
+        } & {
+            [key: string]: unknown;
+        };
+        DeletionTarget: {
+            /** Format: int64 */
+            message_id: number;
+            /** Format: int64 */
+            source_id: number;
+            source_identifier: string;
+            source_message_id: string;
+            source_type: string;
         } & {
             [key: string]: unknown;
         };
@@ -4131,6 +4147,7 @@ export interface components {
         };
         GmailIDsResponse: {
             gmail_ids: string[] | null;
+            targets?: components["schemas"]["DeletionTarget"][] | null;
         } & {
             [key: string]: unknown;
         };
@@ -4356,6 +4373,7 @@ export interface components {
             gmail_ids: string[] | null;
             id: string;
             raw_filter?: unknown;
+            source?: components["schemas"]["SourceReference"];
             status: string;
             summary?: components["schemas"]["Summary"];
             /** Format: int64 */
@@ -5862,6 +5880,12 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        SourceReference: {
+            /** Format: int64 */
+            id: number;
+            identifier: string;
+            type: string;
+        };
         SourceStatus: {
             active_sync: components["schemas"]["SyncRunStatus"] | null;
             can_sync: boolean;
@@ -5917,6 +5941,7 @@ export interface components {
             /** Format: int64 */
             message_count: number;
             sample_gmail_ids?: string[] | null;
+            source?: components["schemas"]["SourceReference"];
             status?: string;
         } & {
             [key: string]: unknown;
@@ -6187,8 +6212,11 @@ export interface components {
             text: string;
         };
         UpdateRequest: {
+            account?: string;
             display_name: string;
-            email: string;
+            email?: string;
+            /** Format: int64 */
+            source_id?: number;
         };
         UpdateResult: {
             display_name: string;
@@ -8603,6 +8631,8 @@ export interface operations {
             query?: {
                 /** @description Account email or display name to sync */
                 email?: string;
+                /** @description Exact source ID to sync */
+                source_id?: number;
                 /** @description IMAP folder names to include (repeatable) */
                 folder?: string[];
                 /** @description IMAP folder names to exclude (repeatable) */
@@ -8639,6 +8669,8 @@ export interface operations {
             query?: {
                 /** @description Account email or display name to sync */
                 email?: string;
+                /** @description Exact source ID to sync */
+                source_id?: number;
                 /** @description Gmail search query */
                 query?: string;
                 /** @description Only messages on or after this YYYY-MM-DD date */


### PR DESCRIPTION
## What changed

- Add one shared source-selector contract with explicit exact-one, account-family, and all-matches semantics. Bare numeric account tokens stay account tokens; only `--source-id` selects by archive-local ID.
- Expose exact source selection through CLI and daemon transports for sync, full sync, account updates/removal, and staged deletion, and move identity operations onto the same shared selector. Existing unambiguous account arguments and intentional sync fan-out stay compatible.
- Persist staged deletion provenance as a stable source type plus identifier, with the source ID retained as a snapshot. Execution resolves the current source from that stable tuple, scopes local archive updates to it, and rejects ambiguous, cross-source, or unsupported targets before claiming a batch.
- Keep SQLite, PostgreSQL, DuckDB, API, TUI, and MCP behavior aligned. Existing version-1 deletion manifests remain readable and can be bound explicitly at execution; there is no database schema or migration change.

## Why

Msgvault already had exact source IDs internally, but most account-scoped operations could only submit an identifier or display name. Ambiguous layouts therefore either had no safe escape hatch or risked losing exact source provenance between planning and execution. This makes cardinality explicit at each call site while preserving the account-family and fan-out behavior that is intentional.

## Usage

List sources to find the exact ID, then pass it explicitly:

```console
msgvault list-accounts --json
msgvault sync --source-id 42
msgvault sync-full --source-id 42
msgvault update-account --source-id 42 --display-name "Work"
msgvault remove-account --source-id 42 --yes
msgvault delete-staged <batch-id> --source-id 42 --yes
```

`--source-id` is mutually exclusive with the existing account token. New staged-deletion manifests retain their source automatically; the explicit deletion flag is mainly the safe binding path for legacy manifests.

Closes #499
