### PR TITLE
feat(carddav): add bidirectional client sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Archive a lifetime of email, messages, meetings. Analytics and search in millise
 
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
-Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack,
+Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, CardDAV,
 Granola, Circleback, Beeper Desktop, and IMAP sync, plus offline imports from MBOX
 exports, Apple Mail (`.emlx`) directories, PST archives, and common chat/text
 export formats.
@@ -40,6 +40,7 @@ export formats.
 - **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
 - **Beeper Desktop sync**: archive chats and media from every network connected to Beeper, including iMessage, through its local API
 - **IMAP sync**: archive mail from any standard IMAP server
+- **CardDAV contacts**: pull address books, explicitly publish curated people, and resolve conflicts without losing remote card data
 - **Incremental backup snapshots**: verifiable `msgvault backup` repositories for the SQLite archive and attachments
 - **MBOX / Apple Mail / PST import**: import email from local export formats
 - **First-party web UI**: dense, keyboard-driven search, grouping, people/domain, file, source, and deletion workspaces served directly by the daemon
@@ -123,6 +124,8 @@ available with `msgvault tui`.
 | `sync-teams EMAIL` | Sync Microsoft Teams chats and channels |
 | `add-discord` / `sync-discord` | Register a read-only bot and sync Discord guild channels and threads |
 | `add-slack` / `sync-slack` | Register and archive a Slack workspace, including threads and media |
+| `add-carddav` / `sync-carddav` | Discover and sync a CardDAV account; passwords are read from stdin, never argv |
+| `carddav` | Manage address-book roles and resolve retained conflicts |
 | `export-messages` | Stream a bounded, provider-neutral archive window as versioned JSONL |
 | `export-discord` | Temporary compatibility export for bounded Discord history |
 | `backfill-discord-media` | Retry incomplete Discord attachment downloads |
@@ -359,7 +362,17 @@ client_secrets = "/path/to/client_secret.json"
 
 [sync]
 rate_limit_qps = 5
+
+[carddav]
+base_url = "https://contacts.example/dav"
+username = "alice"
+enabled = true
+schedule = "0 */6 * * *"
 ```
+
+Run `msgvault add-carddav <base-url> <username>` instead of placing the
+password in this file. Msgvault validates discovery first, then stores the
+password in an owner-only token file below `~/.msgvault/tokens/`.
 
 See the [Configuration Guide](https://msgvault.io/configuration/) for all options.
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -978,6 +978,209 @@ components:
         - first_seen_at
         - last_seen_at
       type: object
+    CardDAVAccountRequest:
+      additionalProperties: false
+      properties:
+        base_url:
+          type: string
+        enabled:
+          type: boolean
+        password:
+          type: string
+          writeOnly: true
+        schedule:
+          type: string
+        username:
+          type: string
+      required:
+        - base_url
+        - username
+        - enabled
+      type: object
+    CardDAVAccountResponse:
+      additionalProperties: true
+      properties:
+        base_url:
+          type: string
+        books:
+          format: int64
+          type: integer
+        enabled:
+          type: boolean
+        schedule:
+          type: string
+        username:
+          type: string
+      required:
+        - base_url
+        - username
+        - enabled
+        - books
+      type: object
+    CardDAVBookResponse:
+      additionalProperties: true
+      properties:
+        id:
+          format: int64
+          type: integer
+        lookup_source:
+          type: boolean
+        name:
+          type: string
+        needs_full_reconcile:
+          type: boolean
+        subscribed:
+          type: boolean
+        url:
+          type: string
+        write_target:
+          type: boolean
+      required:
+        - id
+        - name
+        - url
+        - write_target
+        - subscribed
+        - lookup_source
+        - needs_full_reconcile
+      type: object
+    CardDAVBookRolesRequest:
+      additionalProperties: false
+      properties:
+        lookup_source:
+          type: boolean
+        subscribed:
+          type: boolean
+        write_target:
+          type: boolean
+      required:
+        - write_target
+        - subscribed
+        - lookup_source
+      type: object
+    CardDAVBooksResponse:
+      additionalProperties: true
+      properties:
+        books:
+          items:
+            $ref: "#/components/schemas/CardDAVBookResponse"
+          type:
+            - array
+            - "null"
+      required:
+        - books
+      type: object
+    CardDAVConflictDetailResponse:
+      additionalProperties: true
+      properties:
+        address_book_id:
+          format: int64
+          type: integer
+        href:
+          type: string
+        id:
+          format: int64
+          type: integer
+        local_tombstone:
+          type: boolean
+        local_vcard:
+          type: string
+        remote_tombstone:
+          type: boolean
+        remote_vcard:
+          type: string
+        status:
+          type: string
+      required:
+        - id
+        - address_book_id
+        - href
+        - local_tombstone
+        - remote_tombstone
+        - status
+      type: object
+    CardDAVConflictResolutionResponse:
+      additionalProperties: true
+      properties:
+        id:
+          format: int64
+          type: integer
+        status:
+          type: string
+      required:
+        - id
+        - status
+      type: object
+    CardDAVConflictResponse:
+      additionalProperties: true
+      properties:
+        address_book_id:
+          format: int64
+          type: integer
+        href:
+          type: string
+        id:
+          format: int64
+          type: integer
+        local_tombstone:
+          type: boolean
+        remote_tombstone:
+          type: boolean
+        status:
+          type: string
+      required:
+        - id
+        - address_book_id
+        - href
+        - local_tombstone
+        - remote_tombstone
+        - status
+      type: object
+    CardDAVConflictsResponse:
+      additionalProperties: true
+      properties:
+        conflicts:
+          items:
+            $ref: "#/components/schemas/CardDAVConflictResponse"
+          type:
+            - array
+            - "null"
+      required:
+        - conflicts
+      type: object
+    CardDAVPublicationResponse:
+      additionalProperties: true
+      properties:
+        desired:
+          type: boolean
+        href:
+          type: string
+        pending_operation:
+          type: string
+        person_id:
+          format: int64
+          type: integer
+      required:
+        - person_id
+        - desired
+      type: object
+    CardDAVResolveRequest:
+      additionalProperties: false
+      properties:
+        choice:
+          enum:
+            - keep_local
+            - keep_remote
+          type: string
+      required:
+        - choice
+      type: object
+    CardDAVSyncRequest:
+      additionalProperties: false
+      properties:
+        full:
+          type: boolean
+      type: object
     ChangedMessageJSON:
       additionalProperties: true
       properties:
@@ -8635,6 +8838,27 @@ components:
         - accounts
         - top_senders
       type: object
+    SyncResult:
+      additionalProperties: true
+      properties:
+        books:
+          format: int64
+          type: integer
+        created:
+          format: int64
+          type: integer
+        removed:
+          format: int64
+          type: integer
+        updated:
+          format: int64
+          type: integer
+      required:
+        - books
+        - created
+        - updated
+        - removed
+      type: object
     SyncRunItemStatus:
       additionalProperties: true
       properties:
@@ -9356,7 +9580,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.7.0
+  version: 2.8.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -10148,6 +10372,684 @@ paths:
       security:
         - apiKey: []
       summary: End a backup freeze window
+      tags:
+        - API
+  /api/v1/carddav/account:
+    put:
+      operationId: saveCardDAVAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVAccountRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVAccountResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Discover and save a CardDAV account
+      tags:
+        - API
+  /api/v1/carddav/account/test:
+    post:
+      operationId: testCardDAVAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVAccountRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVAccountResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Test a CardDAV account
+      tags:
+        - API
+  /api/v1/carddav/books:
+    get:
+      operationId: listCardDAVBooks
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVBooksResponse"
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List CardDAV address books
+      tags:
+        - API
+  /api/v1/carddav/books/{id}:
+    patch:
+      operationId: updateCardDAVBookRoles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVBookRolesRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVBookResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Update CardDAV address book roles
+      tags:
+        - API
+  /api/v1/carddav/conflicts:
+    get:
+      operationId: listCardDAVConflicts
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictsResponse"
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List unresolved CardDAV conflicts
+      tags:
+        - API
+  /api/v1/carddav/conflicts/{id}:
+    get:
+      operationId: getCardDAVConflict
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictDetailResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Inspect a CardDAV conflict
+      tags:
+        - API
+  /api/v1/carddav/conflicts/{id}/resolve:
+    post:
+      operationId: resolveCardDAVConflict
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVResolveRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictResolutionResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Resolve a CardDAV conflict
+      tags:
+        - API
+  /api/v1/carddav/publications/{person_id}:
+    delete:
+      operationId: unpublishCardDAVPerson
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Unpublish a person from CardDAV
+      tags:
+        - API
+    get:
+      operationId: getCardDAVPublication
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get CardDAV publication state
+      tags:
+        - API
+    post:
+      operationId: publishCardDAVPerson
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Publish a person to CardDAV
+      tags:
+        - API
+  /api/v1/carddav/sync:
+    post:
+      operationId: syncCardDAV
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVSyncRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncResult"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Trigger CardDAV synchronization
       tags:
         - API
   /api/v1/cli/account:

--- a/cmd/msgvault/cmd/carddav.go
+++ b/cmd/msgvault/cmd/carddav.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/textutil"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+func newAddCardDAVCmd() *cobra.Command {
+	var schedule string
+	var disabled bool
+	cmd := &cobra.Command{Use: "add-carddav <base-url> <username>", Short: "Discover and configure a CardDAV account", Args: cobra.ExactArgs(2)}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		password, err := readCardDAVPassword()
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		body := generated.SaveCardDAVAccountBody{BaseURL: args[0], Username: args[1], Password: &password, Enabled: !disabled}
+		if schedule != "" {
+			body.Schedule = &schedule
+		}
+		resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.SaveCardDAVAccountResp, error) {
+			return api.SaveCardDAVAccountWithResponse(cmd.Context(), &generated.SaveCardDAVAccountRequestOptions{Body: &body})
+		})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Configured CardDAV account %s with %d discovered address books\n",
+			textutil.SanitizeTerminal(resp.JSON200.Username), resp.JSON200.Books)
+		return nil
+	}
+	cmd.Flags().StringVar(&schedule, "schedule", "", "cron schedule for background synchronization")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "save the connection without enabling synchronization")
+	return cmd
+}
+
+func readCardDAVPassword() (string, error) {
+	method, promptOut := choosePasswordStrategy(isatty.IsTerminal(os.Stdin.Fd()), isatty.IsCygwinTerminal(os.Stdin.Fd()), isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd()), isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))
+	var password string
+	var err error
+	switch method {
+	case passwordInteractive:
+		password, err = readPasswordInteractive("CardDAV password:", promptOut)
+	case passwordPipe:
+		password, err = readPasswordFromPipe(os.Stdin)
+	default:
+		return "", errors.New("cannot read CardDAV password: no terminal or piped stdin available")
+	}
+	if err != nil {
+		return "", err
+	}
+	if password == "" {
+		return "", errors.New("CardDAV password must not be empty")
+	}
+	return password, nil
+}
+
+func newSyncCardDAVCmd() *cobra.Command {
+	var full bool
+	cmd := &cobra.Command{Use: "sync-carddav", Short: "Synchronize the configured CardDAV account", Args: cobra.NoArgs}
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		body := generated.SyncCardDAVBody{Full: &full}
+		resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.SyncCardDAVResp, error) {
+			return api.SyncCardDAVWithResponse(cmd.Context(), &generated.SyncCardDAVRequestOptions{Body: &body})
+		})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "CardDAV sync: %d books, %d created, %d updated, %d removed\n", resp.JSON200.Books, resp.JSON200.Created, resp.JSON200.Updated, resp.JSON200.Removed)
+		return nil
+	}
+	cmd.Flags().BoolVar(&full, "full", false, "force a full address-book reconciliation")
+	return cmd
+}
+
+func newCardDAVCmd() *cobra.Command {
+	root := &cobra.Command{Use: "carddav", Short: "Inspect CardDAV books and conflicts"}
+	books := &cobra.Command{Use: "books", Short: "List discovered CardDAV address books", Args: cobra.NoArgs, RunE: runCardDAVBooks}
+	var writeTarget, subscribed, lookup bool
+	setRole := &cobra.Command{Use: "set-role <book-id>", Short: "Set all roles for a CardDAV address book", Args: cobra.ExactArgs(1)}
+	setRole.RunE = func(cmd *cobra.Command, args []string) error {
+		id, err := cardDAVCLIPositiveID(cmd, args[0])
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		body := generated.UpdateCardDAVBookRolesBody{WriteTarget: writeTarget, Subscribed: subscribed, LookupSource: lookup}
+		resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.UpdateCardDAVBookRolesResp, error) {
+			return api.UpdateCardDAVBookRolesWithResponse(cmd.Context(), &generated.UpdateCardDAVBookRolesRequestOptions{PathParams: &generated.UpdateCardDAVBookRolesPath{ID: id}, Body: &body})
+		})
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(resp.JSON200)
+	}
+	setRole.Flags().BoolVar(&writeTarget, "write-target", false, "make this the subscribed publication target")
+	setRole.Flags().BoolVar(&subscribed, "subscribed", false, "import unbound cards and synchronize changes")
+	setRole.Flags().BoolVar(&lookup, "lookup-source", false, "retain cards for identity lookup")
+	books.AddCommand(setRole)
+	conflicts := &cobra.Command{Use: "conflicts", Short: "Inspect and resolve CardDAV conflicts"}
+	conflicts.AddCommand(&cobra.Command{Use: cmdUseList, Short: "List unresolved CardDAV conflicts", Args: cobra.NoArgs, RunE: runCardDAVConflicts})
+	conflicts.AddCommand(&cobra.Command{Use: "show <conflict-id>", Short: "Show retained local and remote versions of a CardDAV conflict", Args: cobra.ExactArgs(1), RunE: runCardDAVConflictShow})
+	resolve := &cobra.Command{Use: "resolve <conflict-id> <keep_local|keep_remote>", Short: "Resolve one CardDAV conflict", Args: cobra.ExactArgs(2), RunE: runCardDAVResolve}
+	conflicts.AddCommand(resolve)
+	root.AddCommand(books, conflicts)
+	return root
+}
+
+func runCardDAVBooks(cmd *cobra.Command, _ []string) error {
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.ListCardDAVBooksResp, error) {
+		return api.ListCardDAVBooksWithResponse(cmd.Context())
+	})
+	if err != nil {
+		return err
+	}
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tNAME\tWRITE\tSUBSCRIBED\tLOOKUP\tRECONCILE")
+	for _, b := range resp.JSON200.Books {
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%t\t%t\t%t\t%t\n", b.ID,
+			textutil.SanitizeTerminal(b.Name), b.WriteTarget, b.Subscribed,
+			b.LookupSource, b.NeedsFullReconcile)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flush CardDAV address books: %w", err)
+	}
+	return nil
+}
+func runCardDAVConflicts(cmd *cobra.Command, _ []string) error {
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.ListCardDAVConflictsResp, error) {
+		return api.ListCardDAVConflictsWithResponse(cmd.Context())
+	})
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(resp.JSON200)
+}
+func runCardDAVConflictShow(cmd *cobra.Command, args []string) error {
+	id, err := cardDAVCLIPositiveID(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	resp, err := daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.GetCardDAVConflictResp, error) {
+		return api.GetCardDAVConflictWithResponse(cmd.Context(), &generated.GetCardDAVConflictRequestOptions{PathParams: &generated.GetCardDAVConflictPath{ID: id}})
+	})
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(resp.JSON200)
+}
+func runCardDAVResolve(cmd *cobra.Command, args []string) error {
+	id, err := cardDAVCLIPositiveID(cmd, args[0])
+	if err != nil {
+		return err
+	}
+	choice := generated.CardDAVResolveRequestChoice(args[1])
+	if err = choice.Validate(); err != nil {
+		return usageErr(cmd, err)
+	}
+	client, _, err := OpenHTTPStore(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+	body := generated.ResolveCardDAVConflictBody{Choice: choice}
+	_, err = daemonclient.APIResponseWithStatuses(client, []int{http.StatusOK}, func(api *apiclient.Client) (*generated.ResolveCardDAVConflictResp, error) {
+		return api.ResolveCardDAVConflictWithResponse(cmd.Context(), &generated.ResolveCardDAVConflictRequestOptions{PathParams: &generated.ResolveCardDAVConflictPath{ID: id}, Body: &body})
+	})
+	return err
+}
+func cardDAVCLIPositiveID(cmd *cobra.Command, raw string) (int64, error) {
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return 0, usageErr(cmd, errors.New("ID must be a positive integer"))
+	}
+	return id, nil
+}
+
+func newPersonCardDAVCommand(action string, publish bool) *cobra.Command {
+	direction := "from"
+	if publish {
+		direction = "to"
+	}
+	cmd := &cobra.Command{Use: action + " <person-id>", Short: action + " a person " + direction + " CardDAV", Args: cobra.ExactArgs(1)}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		id, err := cardDAVCLIPositiveID(cmd, args[0])
+		if err != nil {
+			return err
+		}
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+		if publish {
+			_, err = daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.PublishCardDAVPersonResp, error) {
+				return api.PublishCardDAVPersonWithResponse(cmd.Context(), &generated.PublishCardDAVPersonRequestOptions{PathParams: &generated.PublishCardDAVPersonPath{PersonID: id}})
+			})
+		} else {
+			_, err = daemonclient.APIResponse(client, func(api *apiclient.Client) (*generated.UnpublishCardDAVPersonResp, error) {
+				return api.UnpublishCardDAVPersonWithResponse(cmd.Context(), &generated.UnpublishCardDAVPersonRequestOptions{PathParams: &generated.UnpublishCardDAVPersonPath{PersonID: id}})
+			})
+		}
+		if err == nil {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Person %d CardDAV publication updated\n", id)
+		}
+		return err
+	}
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newAddCardDAVCmd(), newSyncCardDAVCmd(), newCardDAVCmd())
+	personCmd.AddCommand(newPersonCardDAVCommand("publish", true), newPersonCardDAVCommand("unpublish", false))
+}

--- a/cmd/msgvault/cmd/carddav_test.go
+++ b/cmd/msgvault/cmd/carddav_test.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+func TestCardDAVCommandsExposeSafeOperatorSurface(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	add := newAddCardDAVCmd()
+	assert.Nil(add.Flags().Lookup("password"), "passwords must never be accepted on argv")
+	assert.Equal("add-carddav", add.Name())
+
+	root := newCardDAVCmd()
+	books, _, err := root.Find([]string{"books"})
+	require.NoError(err)
+	assert.Equal("books", books.Name())
+	setRole, _, err := root.Find([]string{"books", "set-role"})
+	require.NoError(err)
+	assert.Equal("set-role", setRole.Name())
+	resolve, _, err := root.Find([]string{"conflicts", "resolve"})
+	require.NoError(err)
+	assert.Equal("resolve", resolve.Name())
+	show, _, err := root.Find([]string{"conflicts", "show"})
+	require.NoError(err)
+	assert.Equal("show", show.Name())
+}
+
+func TestCardDAVCLIProductionRoutes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	requests := make([]string, 0, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "PUT /api/v1/carddav/account":
+			var body map[string]any
+			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal("https://contacts.example/dav", body["base_url"])
+			assert.Equal("alice", body["username"])
+			assert.Equal("synthetic-password", body["password"])
+			assert.Equal("0 3 * * *", body["schedule"])
+			_, _ = w.Write([]byte(`{"base_url":"https://contacts.example/dav","username":"alice","enabled":true,"schedule":"0 3 * * *","books":1}`))
+		case "GET /api/v1/carddav/books":
+			_, _ = w.Write([]byte(`{"books":[{"id":9,"name":"Personal","url":"https://contacts.example/books/personal/","write_target":true,"subscribed":true,"lookup_source":false,"needs_full_reconcile":false}]}`))
+		case "PATCH /api/v1/carddav/books/9":
+			var body map[string]bool
+			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(map[string]bool{"write_target": true, "subscribed": true, "lookup_source": true}, body)
+			_, _ = w.Write([]byte(`{"id":9,"name":"Personal","url":"https://contacts.example/books/personal/","write_target":true,"subscribed":true,"lookup_source":true,"needs_full_reconcile":false}`))
+		case "GET /api/v1/carddav/conflicts":
+			_, _ = w.Write([]byte(`{"conflicts":[]}`))
+		case "GET /api/v1/carddav/conflicts/7":
+			_, _ = w.Write([]byte(`{"id":7,"address_book_id":9,"href":"/alice.vcf","local_tombstone":false,"local_vcard":"BEGIN:VCARD\\r\\nFN:Local Alice\\r\\nEND:VCARD\\r\\n","remote_tombstone":false,"remote_vcard":"BEGIN:VCARD\\r\\nFN:Remote Alice\\r\\nEND:VCARD\\r\\n","status":"open"}`))
+		case "POST /api/v1/carddav/conflicts/7/resolve":
+			var body map[string]string
+			assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal("keep_remote", body["choice"])
+			_, _ = w.Write([]byte(`{"id":7,"address_book_id":9,"href":"/alice.vcf","local_tombstone":false,"remote_tombstone":false,"status":"resolved"}`))
+		case "POST /api/v1/carddav/publications/11":
+			_, _ = w.Write([]byte(`{"person_id":11,"desired":true}`))
+		case "DELETE /api/v1/carddav/publications/11":
+			_, _ = w.Write([]byte(`{"person_id":11,"desired":false}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	home := t.TempDir()
+	withStoreResolverConfig(t, &config.Config{HomeDir: home, Data: config.DataConfig{DataDir: home}, Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true}})
+
+	readEnd, writeEnd, err := os.Pipe()
+	require.NoError(err)
+	_, err = writeEnd.WriteString("synthetic-password\n")
+	require.NoError(err)
+	require.NoError(writeEnd.Close())
+	originalStdin := os.Stdin
+	os.Stdin = readEnd
+	t.Cleanup(func() { os.Stdin = originalStdin; _ = readEnd.Close() })
+	add := newAddCardDAVCmd()
+	add.SetOut(&bytes.Buffer{})
+	add.SetArgs([]string{"https://contacts.example/dav", "alice", "--schedule", "0 3 * * *"})
+	require.NoError(add.Execute())
+	os.Stdin = originalStdin
+
+	for _, invocation := range []struct {
+		cmd  *cobra.Command
+		args []string
+	}{
+		{cmd: newCardDAVCmd(), args: []string{"books"}},
+		{cmd: newCardDAVCmd(), args: []string{"books", "set-role", "9", "--write-target", "--subscribed", "--lookup-source"}},
+		{cmd: newCardDAVCmd(), args: []string{"conflicts", "list"}},
+		{cmd: newCardDAVCmd(), args: []string{"conflicts", "show", "7"}},
+		{cmd: newCardDAVCmd(), args: []string{"conflicts", "resolve", "7", "keep_remote"}},
+		{cmd: newPersonCardDAVCommand("publish", true), args: []string{"11"}},
+		{cmd: newPersonCardDAVCommand("unpublish", false), args: []string{"11"}},
+	} {
+		invocation.cmd.SetOut(&bytes.Buffer{})
+		invocation.cmd.SetErr(&bytes.Buffer{})
+		invocation.cmd.SetArgs(invocation.args)
+		require.NoError(invocation.cmd.Execute())
+	}
+
+	assert.Equal([]string{
+		"PUT /api/v1/carddav/account",
+		"GET /api/v1/carddav/books",
+		"PATCH /api/v1/carddav/books/9",
+		"GET /api/v1/carddav/conflicts",
+		"GET /api/v1/carddav/conflicts/7",
+		"POST /api/v1/carddav/conflicts/7/resolve",
+		"POST /api/v1/carddav/publications/11",
+		"DELETE /api/v1/carddav/publications/11",
+	}, requests)
+	assert.NotContains(strings.Join(requests, "\n"), "synthetic-password")
+}
+
+func TestCardDAVConflictShowPrintsSnapshotsAsSafeJSON(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	localVCard := "BEGIN:VCARD\r\nFN:\x1b[31mLocal Alice\x1b[0m\r\nEND:VCARD\r\n"
+	remoteVCard := "BEGIN:VCARD\r\nFN:Remote Alice\r\nEND:VCARD\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v1/carddav/conflicts/7", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id": 7, "address_book_id": 9, "href": "/alice.vcf",
+			"local_tombstone": false, "local_vcard": localVCard,
+			"remote_tombstone": false, "remote_vcard": remoteVCard, "status": "open",
+		}))
+	}))
+	t.Cleanup(server.Close)
+	home := t.TempDir()
+	withStoreResolverConfig(t, &config.Config{
+		HomeDir: home, Data: config.DataConfig{DataDir: home},
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newCardDAVCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"conflicts", "show", "7"})
+	require.NoError(cmd.Execute())
+	assert.NotContains(stdout.String(), "\x1b")
+	var got struct {
+		LocalVCard  *string `json:"local_vcard"`
+		RemoteVCard *string `json:"remote_vcard"`
+	}
+	require.NoError(json.Unmarshal(stdout.Bytes(), &got))
+	require.NotNil(got.LocalVCard)
+	require.NotNil(got.RemoteVCard)
+	assert.Equal(localVCard, *got.LocalVCard)
+	assert.Equal(remoteVCard, *got.RemoteVCard)
+}
+
+func TestCardDAVBooksSanitizesTerminalControls(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	type bookResponse struct {
+		ID                 int64  `json:"id"`
+		Name               string `json:"name"`
+		URL                string `json:"url"`
+		WriteTarget        bool   `json:"write_target"`
+		Subscribed         bool   `json:"subscribed"`
+		LookupSource       bool   `json:"lookup_source"`
+		NeedsFullReconcile bool   `json:"needs_full_reconcile"`
+	}
+	malicious := "\x1b[31mPersonal\x1b[0m \x1b]8;;https://attacker.test\x07link\x1b]8;;\x07"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodGet, r.Method)
+		assert.Equal("/api/v1/carddav/books", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(struct {
+			Books []bookResponse `json:"books"`
+		}{
+			Books: []bookResponse{{
+				ID: 9, Name: malicious, URL: "https://contacts.example/books/personal/",
+				WriteTarget: true, Subscribed: true,
+			}},
+		}))
+	}))
+	t.Cleanup(server.Close)
+	home := t.TempDir()
+	withStoreResolverConfig(t, &config.Config{
+		HomeDir: home, Data: config.DataConfig{DataDir: home},
+		Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+
+	var stdout bytes.Buffer
+	cmd := newCardDAVCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"books"})
+	require.NoError(cmd.Execute())
+	assert.NotContains(stdout.String(), "\x1b")
+	assert.NotContains(stdout.String(), "https://attacker.test")
+	assert.Contains(stdout.String(), "Personal link")
+}
+
+func TestSyncCardDAVUsesTheDaemonServiceRoute(t *testing.T) {
+	var full bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/carddav/sync", r.URL.Path)
+		var body struct {
+			Full bool `json:"full"`
+		}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		full = body.Full
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"books":1,"created":2,"updated":3,"removed":4}`))
+	}))
+	t.Cleanup(server.Close)
+
+	home := t.TempDir()
+	withStoreResolverConfig(t, &config.Config{
+		HomeDir: home,
+		Data:    config.DataConfig{DataDir: home},
+		Remote:  config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+	})
+	var stdout bytes.Buffer
+	cmd := newSyncCardDAVCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--full"})
+	require.NoError(t, cmd.Execute())
+	assert.True(t, full)
+	assert.Equal(t, "CardDAV sync: 1 books, 2 created, 3 updated, 4 removed\n", stdout.String())
+}

--- a/cmd/msgvault/cmd/person.go
+++ b/cmd/msgvault/cmd/person.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/textutil"
 	apiclient "go.kenn.io/msgvault/pkg/client"
 	"go.kenn.io/msgvault/pkg/client/generated"
 )
@@ -106,7 +107,7 @@ var personListCmd = &cobra.Command{
 		_, _ = fmt.Fprintln(w, "ID\tDISPLAY NAME\tVCARD UID\tPARTICIPANTS\tREVISION")
 		for _, person := range resp.JSON200.People {
 			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\n", person.ID,
-				personDisplayName(person.DisplayName), person.VcardUID,
+				personDisplayName(person.DisplayName), textutil.SanitizeTerminal(person.VcardUID),
 				len(person.ParticipantIds), person.Revision)
 		}
 		return w.Flush()
@@ -228,7 +229,7 @@ func writeCLIPerson(cmd *cobra.Command, person *generated.Person) error {
 	}
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
 		"Person: %d\nDisplay name: %s\nvCard UID: %s\nParticipants: %v\nRevision: %d\n",
-		person.ID, personDisplayName(person.DisplayName), person.VcardUID,
+		person.ID, personDisplayName(person.DisplayName), textutil.SanitizeTerminal(person.VcardUID),
 		person.ParticipantIds, person.Revision)
 	return nil
 }
@@ -237,7 +238,11 @@ func personDisplayName(name *string) string {
 	if name == nil {
 		return "-"
 	}
-	return *name
+	safe := textutil.SanitizeTerminal(*name)
+	if strings.TrimSpace(safe) == "" {
+		return "-"
+	}
+	return safe
 }
 
 func positivePersonCLIArg(cmd *cobra.Command, raw, kind string) (int64, error) {

--- a/cmd/msgvault/cmd/person_relationship.go
+++ b/cmd/msgvault/cmd/person_relationship.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/textutil"
 	apiclient "go.kenn.io/msgvault/pkg/client"
 	"go.kenn.io/msgvault/pkg/client/generated"
 )
@@ -536,10 +537,14 @@ func formatCLIPartialDate(value *generated.PartialDate) string {
 
 func formatCLIRelationshipCounterpart(id int64, displayName *string, vcardUID string) string {
 	if displayName != nil && strings.TrimSpace(*displayName) != "" {
-		return fmt.Sprintf("%d (%s)", id, *displayName)
+		if safe := textutil.SanitizeTerminal(*displayName); strings.TrimSpace(safe) != "" {
+			return fmt.Sprintf("%d (%s)", id, safe)
+		}
 	}
 	if strings.TrimSpace(vcardUID) != "" {
-		return fmt.Sprintf("%d (%s)", id, vcardUID)
+		if safe := textutil.SanitizeTerminal(vcardUID); strings.TrimSpace(safe) != "" {
+			return fmt.Sprintf("%d (%s)", id, safe)
+		}
 	}
 	return strconv.FormatInt(id, 10)
 }

--- a/cmd/msgvault/cmd/person_test.go
+++ b/cmd/msgvault/cmd/person_test.go
@@ -12,7 +12,27 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
+
+func TestWriteCLIPersonSanitizesTerminalControls(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	malicious := "\x1b[31mAlice\x1b[0m \x1b]8;;https://attacker.test\x07Example\x1b]8;;\x07"
+	savedJSON := personJSON
+	personJSON = false
+	t.Cleanup(func() { personJSON = savedJSON })
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	require.NoError(writeCLIPerson(cmd, &generated.Person{
+		ID: 7, DisplayName: &malicious, VcardUID: malicious,
+	}))
+	assert.NotContains(stdout.String(), "\x1b")
+	assert.NotContains(stdout.String(), "https://attacker.test")
+	assert.Contains(stdout.String(), "Alice Example")
+}
 
 func TestPersonPromoteAcceptsCreatedResponse(t *testing.T) {
 	assert := assert.New(t)

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/carddav"
 	"go.kenn.io/msgvault/internal/circleback"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/deletion"
@@ -328,6 +330,16 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// Create and configure scheduler
 	sched := scheduler.New(syncFunc).WithLogger(logger).
 		WithWorkTracker(combineWorkTrackers(idleTracker, labelWorkTracker(operationGate, "a scheduled sync")))
+	cardDAVController, err := api.NewCardDAVController(cfg, s)
+	if err != nil {
+		return fmt.Errorf("configure CardDAV: %w", err)
+	}
+	cardDAVController.SetScheduleReconciler(func(cardDAVConfig config.CardDAVConfig, service api.CardDAVOperations) error {
+		return reconcileCardDAVSchedulerJob(sched, cardDAVConfig, service, logger)
+	})
+	if err := reconcileCardDAVSchedulerJob(sched, cfg.CardDAV, cardDAVController.Current(), logger); err != nil {
+		return err
+	}
 
 	// Add all scheduled accounts
 	count, errs := sched.AddAccountsFromConfig(cfg)
@@ -548,6 +560,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		ShutdownToken:                 ownership.shutdownToken,
 		ShutdownFunc:                  cancel,
 		Scheduler:                     schedAdapter,
+		CardDAV:                       cardDAVController,
 		Logger:                        logger,
 		DaemonVersion:                 Version,
 		AnalyticsMode:                 analyticsMode,
@@ -698,6 +711,33 @@ func runServe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API server: %w", serverStartupErr)
 	}
 
+	return nil
+}
+
+func reconcileCardDAVSchedulerJob(sched *scheduler.Scheduler, cardDAVConfig config.CardDAVConfig, service api.CardDAVOperations, logger *slog.Logger) error {
+	if !cardDAVConfig.Enabled || cardDAVConfig.Schedule == "" {
+		sched.RemoveJob(api.CardDAVJobName)
+		if cardDAVConfig.Enabled && cardDAVConfig.Schedule == "" {
+			logger.Warn("carddav is enabled but has no schedule — the daemon will not sync it",
+				"hint", `set a cron schedule (e.g. "0 */6 * * *") in [carddav]`)
+		}
+		return nil
+	}
+	if service == nil {
+		sched.RemoveJob(api.CardDAVJobName)
+		logger.Warn("carddav credentials are unavailable or do not match saved discovery; skipping scheduled sync",
+			"hint", "save the CardDAV account with its password to repair the connection")
+		return nil
+	}
+	if err := sched.AddJob(scheduler.Job{
+		Name: api.CardDAVJobName, Schedule: cardDAVConfig.Schedule,
+		Run: func(ctx context.Context) error {
+			_, err := service.Sync(ctx, carddav.SyncOptions{})
+			return err
+		},
+	}); err != nil {
+		return fmt.Errorf("schedule CardDAV sync: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/msgvault/cmd/serve_carddav_test.go
+++ b/cmd/msgvault/cmd/serve_carddav_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/carddav"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type scheduledCardDAVFixture struct{ syncs int }
+
+func (f *scheduledCardDAVFixture) Sync(context.Context, carddav.SyncOptions) (carddav.SyncResult, error) {
+	f.syncs++
+	return carddav.SyncResult{}, nil
+}
+func (f *scheduledCardDAVFixture) ListBooks(context.Context) ([]store.CardDAVAddressBook, error) {
+	return nil, nil
+}
+func (f *scheduledCardDAVFixture) SetBookRoles(context.Context, int64, carddav.BookRoles) error {
+	return nil
+}
+func (f *scheduledCardDAVFixture) Publication(context.Context, int64) (*store.CardDAVPublication, error) {
+	return &store.CardDAVPublication{}, nil
+}
+func (f *scheduledCardDAVFixture) PublishPerson(context.Context, int64) error   { return nil }
+func (f *scheduledCardDAVFixture) UnpublishPerson(context.Context, int64) error { return nil }
+func (f *scheduledCardDAVFixture) ListConflicts(context.Context) ([]store.CardDAVConflict, error) {
+	return nil, nil
+}
+func (f *scheduledCardDAVFixture) GetConflict(context.Context, int64) (*store.CardDAVConflict, error) {
+	return nil, store.ErrCardDAVConflictNotFound
+}
+func (f *scheduledCardDAVFixture) ResolveConflict(context.Context, int64, carddav.ResolutionChoice) error {
+	return nil
+}
+
+func TestRegisterCardDAVSchedulerJobRequiresEnabledSchedule(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     config.CardDAVConfig
+		wantStatus []scheduler.JobStatus
+	}{
+		{name: "disabled with schedule", config: config.CardDAVConfig{Schedule: "0 */6 * * *"}},
+		{name: "enabled without schedule", config: config.CardDAVConfig{Enabled: true}},
+		{name: "enabled and scheduled", config: config.CardDAVConfig{Enabled: true, Schedule: "0 */6 * * *"}, wantStatus: []scheduler.JobStatus{{Name: api.CardDAVJobName, Schedule: "0 */6 * * *"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			sched := scheduler.New(nil)
+			t.Cleanup(func() { sched.Stop() })
+			service := &scheduledCardDAVFixture{}
+			logger := slog.New(slog.DiscardHandler)
+			require.NoError(reconcileCardDAVSchedulerJob(sched, tt.config, service, logger))
+			status := sched.JobStatus()
+			if len(tt.wantStatus) == 0 {
+				assert.Empty(status)
+				return
+			}
+			require.Len(status, 1)
+			assert.Equal(tt.wantStatus[0].Name, status[0].Name)
+			assert.Equal(tt.wantStatus[0].Schedule, status[0].Schedule)
+		})
+	}
+}
+
+func TestRegisterCardDAVSchedulerJobSkipsUnavailableService(t *testing.T) {
+	sched := scheduler.New(nil)
+	t.Cleanup(func() { sched.Stop() })
+
+	require.NoError(t, reconcileCardDAVSchedulerJob(sched,
+		config.CardDAVConfig{Enabled: true, Schedule: "0 */6 * * *"}, nil,
+		slog.New(slog.DiscardHandler)))
+	assert.False(t, sched.IsJobScheduled(api.CardDAVJobName))
+}
+
+func TestReconcileCardDAVSchedulerJobUpdatesRunsAndRemovesStableJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	tracker := &fakeDaemonWorkTracker{allow: true}
+	sched := scheduler.New(nil).WithWorkTracker(tracker)
+	t.Cleanup(func() { sched.Stop() })
+	service := &scheduledCardDAVFixture{}
+	logger := slog.New(slog.DiscardHandler)
+
+	require.NoError(reconcileCardDAVSchedulerJob(sched, config.CardDAVConfig{Enabled: true, Schedule: "0 1 * * *"}, service, logger))
+	require.NoError(sched.TriggerJob(api.CardDAVJobName))
+	assert.Equal(1, service.syncs)
+	begin, done := tracker.counts()
+	assert.Equal(1, begin)
+	assert.Equal(1, done)
+
+	require.NoError(reconcileCardDAVSchedulerJob(sched, config.CardDAVConfig{Enabled: true, Schedule: "0 2 * * *"}, service, logger))
+	status := sched.JobStatus()
+	require.Len(status, 1)
+	assert.Equal("0 2 * * *", status[0].Schedule)
+	require.NoError(sched.TriggerJob(api.CardDAVJobName))
+	assert.Equal(2, service.syncs)
+
+	require.NoError(reconcileCardDAVSchedulerJob(sched, config.CardDAVConfig{Enabled: false, Schedule: "0 2 * * *"}, service, logger))
+	assert.False(sched.IsJobScheduled(api.CardDAVJobName))
+}

--- a/internal/api/carddav.go
+++ b/internal/api/carddav.go
@@ -1,0 +1,919 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/carddav"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/scheduler"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	errCardDAVValidation = errors.New("invalid CardDAV request")
+	errCardDAVUpstream   = errors.New("CardDAV upstream failure")
+	errCardDAVStorage    = errors.New("CardDAV storage failure")
+)
+
+type CardDAVOperations interface {
+	Sync(ctx context.Context, options carddav.SyncOptions) (carddav.SyncResult, error)
+	ListBooks(ctx context.Context) ([]store.CardDAVAddressBook, error)
+	SetBookRoles(ctx context.Context, bookID int64, roles carddav.BookRoles) error
+	Publication(ctx context.Context, personID int64) (*store.CardDAVPublication, error)
+	PublishPerson(ctx context.Context, personID int64) error
+	UnpublishPerson(ctx context.Context, personID int64) error
+	ListConflicts(ctx context.Context) ([]store.CardDAVConflict, error)
+	GetConflict(ctx context.Context, conflictID int64) (*store.CardDAVConflict, error)
+	ResolveConflict(ctx context.Context, conflictID int64, choice carddav.ResolutionChoice) error
+}
+
+type cardDAVCandidate interface {
+	CardDAVOperations
+	DiscoverConnection(ctx context.Context, baseURL string) (carddav.Discovery, error)
+	PersistDiscovery(ctx context.Context, baseURL, username string, discovery carddav.Discovery, credentialsChanged bool) error
+}
+
+type cardDAVServiceFactory func(*store.Store, string, string, string) (cardDAVCandidate, error)
+
+// CardDAVController owns the currently configured shared service and the
+// discovery-first account setup transaction.
+type CardDAVController struct {
+	mu                 sync.RWMutex
+	saveMu             sync.Mutex
+	cfg                *config.Config
+	store              *store.Store
+	service            CardDAVOperations
+	factory            cardDAVServiceFactory
+	persistDiscovery   func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error
+	saveConfig         func(*config.CardDAVConfig, config.CardDAVConfig) (config.CardDAVConfig, error)
+	saveCredential     func(string, carddav.Credential) error
+	loadCredential     func(string) (carddav.Credential, error)
+	saveLegacyPassword func(string, string) error
+	loadLegacyPassword func(string) (string, error)
+	removeCredential   func(string) error
+	reconcileSchedule  func(config.CardDAVConfig, CardDAVOperations) error
+}
+
+// SetScheduleReconciler wires the daemon's live scheduler into successful
+// account saves. The callback receives the newly persisted config and service.
+func (c *CardDAVController) SetScheduleReconciler(reconcile func(config.CardDAVConfig, CardDAVOperations) error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reconcileSchedule = reconcile
+}
+
+func NewCardDAVController(cfg *config.Config, st *store.Store) (*CardDAVController, error) {
+	c := &CardDAVController{cfg: cfg, store: st, factory: newCardDAVService}
+	c.saveCredential = carddav.SaveCredential
+	c.loadCredential = carddav.LoadCredential
+	c.saveLegacyPassword = carddav.SavePassword
+	c.loadLegacyPassword = carddav.LoadLegacyPassword
+	c.removeCredential = carddav.RemoveCredential
+	c.persistDiscovery = func(ctx context.Context, service cardDAVCandidate, baseURL, username string, discovery carddav.Discovery, credentialsChanged bool) error {
+		return service.PersistDiscovery(ctx, baseURL, username, discovery, credentialsChanged)
+	}
+	if cfg != nil {
+		c.saveConfig = c.saveCardDAVConfig
+	}
+	configured := c.cardDAVConfigSnapshot()
+	if cfg == nil || st == nil || strings.TrimSpace(configured.BaseURL) == "" {
+		return c, nil
+	}
+	account, err := st.GetCardDAVAccountContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	tokenDir := cfg.TokensDir()
+	credential, err := c.loadCredential(tokenDir)
+	if errors.Is(err, carddav.ErrCredentialNotBound) {
+		legacyPassword, legacyErr := carddav.LoadLegacyPassword(tokenDir)
+		if errors.Is(legacyErr, os.ErrNotExist) {
+			return c, nil
+		}
+		if legacyErr != nil {
+			return nil, legacyErr
+		}
+		if account == nil || account.ConnectionGeneration <= 0 ||
+			configured.BaseURL != account.BaseURL || configured.Username != account.Username {
+			return c, nil
+		}
+		credential = carddav.Credential{
+			Password: legacyPassword, BaseURL: account.BaseURL, Username: account.Username,
+			ConnectionGeneration: account.ConnectionGeneration,
+		}
+		if err := c.saveCredential(tokenDir, credential); err != nil {
+			return nil, err
+		}
+	} else if errors.Is(err, os.ErrNotExist) {
+		return c, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if account == nil || credential.BaseURL != configured.BaseURL || credential.Username != configured.Username ||
+		credential.BaseURL != account.BaseURL || credential.Username != account.Username ||
+		credential.ConnectionGeneration != account.ConnectionGeneration {
+		return c, nil
+	}
+	service, err := newCardDAVService(st, configured.BaseURL, configured.Username, credential.Password)
+	if err != nil {
+		return nil, err
+	}
+	c.service = service
+	return c, nil
+}
+
+func newCardDAVService(st *store.Store, baseURL, username, password string) (cardDAVCandidate, error) {
+	origin, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || origin.Scheme == "" || origin.Host == "" {
+		return nil, errors.New("CardDAV base URL must be an absolute HTTP(S) URL")
+	}
+	client, err := carddav.NewClient(carddav.ClientOptions{CredentialOrigin: origin, Username: username, Password: password})
+	if err != nil {
+		return nil, err
+	}
+	return carddav.NewService(st, client), nil
+}
+
+func (c *CardDAVController) Current() CardDAVOperations {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.service
+}
+
+func (c *CardDAVController) cardDAVConfigSnapshot() config.CardDAVConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.cfg == nil {
+		return config.CardDAVConfig{}
+	}
+	return c.cfg.CardDAV
+}
+
+func (c *CardDAVController) publishCardDAVConfig(next config.CardDAVConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cfg != nil {
+		c.cfg.CardDAV = next
+	}
+}
+
+func (c *CardDAVController) ensureDependencies() {
+	if c.factory == nil {
+		c.factory = newCardDAVService
+	}
+	if c.persistDiscovery == nil {
+		c.persistDiscovery = func(ctx context.Context, service cardDAVCandidate, baseURL, username string, discovery carddav.Discovery, credentialsChanged bool) error {
+			return service.PersistDiscovery(ctx, baseURL, username, discovery, credentialsChanged)
+		}
+	}
+	if c.cfg != nil && c.saveConfig == nil {
+		c.saveConfig = c.saveCardDAVConfig
+	}
+	if c.saveCredential == nil {
+		c.saveCredential = carddav.SaveCredential
+	}
+	if c.loadCredential == nil {
+		c.loadCredential = carddav.LoadCredential
+	}
+	if c.saveLegacyPassword == nil {
+		c.saveLegacyPassword = carddav.SavePassword
+	}
+	if c.loadLegacyPassword == nil {
+		c.loadLegacyPassword = carddav.LoadLegacyPassword
+	}
+	if c.removeCredential == nil {
+		c.removeCredential = carddav.RemoveCredential
+	}
+}
+
+func (c *CardDAVController) saveCardDAVConfig(
+	expected *config.CardDAVConfig, next config.CardDAVConfig,
+) (config.CardDAVConfig, error) {
+	path := c.cfg.ConfigFilePath()
+	before, err := config.ReadConfigFile(path)
+	if err != nil {
+		return config.CardDAVConfig{}, err
+	}
+	latest, err := config.LoadConfigFile(before, "")
+	if err != nil {
+		return config.CardDAVConfig{}, err
+	}
+	previous := latest.CardDAV
+	if expected != nil && previous != *expected {
+		return previous, fmt.Errorf("%w: CardDAV settings changed", config.ErrConfigConflict)
+	}
+	after, err := config.EditConfigFile(path, before.ETag, []config.Edit{
+		{Key: "carddav.base_url", Value: next.BaseURL},
+		{Key: "carddav.username", Value: next.Username},
+		{Key: "carddav.schedule", Value: next.Schedule},
+		{Key: "carddav.enabled", Value: next.Enabled},
+	})
+	if err != nil {
+		return previous, err
+	}
+	published, err := config.LoadConfigFile(after, "")
+	if err != nil {
+		return previous, err
+	}
+	c.publishCardDAVConfig(published.CardDAV)
+	return previous, nil
+}
+
+func (c *CardDAVController) Test(ctx context.Context, req CardDAVAccountRequest) (CardDAVAccountResponse, error) {
+	c.ensureDependencies()
+	if err := validateCardDAVAccountRequest(req); err != nil {
+		return CardDAVAccountResponse{}, err
+	}
+	password, err := c.passwordForRequest(ctx, req)
+	if err != nil {
+		return CardDAVAccountResponse{}, err
+	}
+	service, err := c.factory(c.store, req.BaseURL, req.Username, password)
+	if err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVValidation, err)
+	}
+	// Testing is deliberately non-persistent.
+	discovery, err := service.DiscoverConnection(ctx, req.BaseURL)
+	if err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVUpstream, err)
+	}
+	return CardDAVAccountResponse{BaseURL: req.BaseURL, Username: req.Username, Enabled: *req.Enabled, Schedule: req.Schedule, Books: len(discovery.Books)}, nil
+}
+
+func (c *CardDAVController) Save(ctx context.Context, req CardDAVAccountRequest) (CardDAVAccountResponse, error) {
+	c.saveMu.Lock()
+	defer c.saveMu.Unlock()
+	c.ensureDependencies()
+	if err := validateCardDAVAccountRequest(req); err != nil {
+		return CardDAVAccountResponse{}, err
+	}
+	password, err := c.passwordForRequest(ctx, req)
+	if err != nil {
+		return CardDAVAccountResponse{}, err
+	}
+	account, err := c.store.GetCardDAVAccountContext(ctx)
+	if err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err)
+	}
+	tokenDir := c.cfg.TokensDir()
+	previousCredential, previousCredentialErr := c.loadCredential(tokenDir)
+	hadPreviousCredential := previousCredentialErr == nil
+	previousLegacyPassword := ""
+	hadPreviousLegacyCredential := false
+	if req.Password != "" && errors.Is(previousCredentialErr, carddav.ErrCredentialNotBound) {
+		previousLegacyPassword, err = c.loadLegacyPassword(tokenDir)
+		if err != nil {
+			return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err)
+		}
+		hadPreviousLegacyCredential = true
+	} else if previousCredentialErr != nil && !errors.Is(previousCredentialErr, os.ErrNotExist) {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, previousCredentialErr)
+	}
+	credentialsChanged := !hadPreviousCredential || previousCredential.Password != password ||
+		previousCredential.BaseURL != req.BaseURL || previousCredential.Username != req.Username
+	if err := c.store.ValidateCardDAVConnectionChangeContext(
+		ctx, req.BaseURL, req.Username, credentialsChanged,
+	); err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err)
+	}
+	next := config.CardDAVConfig{
+		BaseURL: req.BaseURL, Username: req.Username, Enabled: *req.Enabled, Schedule: req.Schedule,
+	}
+	connectionUnchanged := account != nil && account.BaseURL == req.BaseURL &&
+		account.Username == req.Username && !credentialsChanged && req.Password == ""
+	if connectionUnchanged {
+		books, err := c.store.ListCardDAVAddressBooksContext(ctx)
+		if err != nil {
+			return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err)
+		}
+		c.mu.RLock()
+		service := c.service
+		reconcileSchedule := c.reconcileSchedule
+		c.mu.RUnlock()
+		if service == nil {
+			return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage,
+				errors.New("CardDAV service is unavailable for saved account"))
+		}
+		previous, err := c.saveConfig(nil, next)
+		if err != nil {
+			var rollbackConfigErr error
+			if errors.Is(err, config.ErrConfigChanged) {
+				_, rollbackConfigErr = c.saveConfig(&next, previous)
+			}
+			return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err, rollbackConfigErr)
+		}
+		if reconcileSchedule != nil {
+			if err := reconcileSchedule(next, service); err != nil {
+				return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage,
+					fmt.Errorf("reconcile CardDAV schedule: %w", err))
+			}
+		}
+		return CardDAVAccountResponse{
+			BaseURL: req.BaseURL, Username: req.Username, Enabled: *req.Enabled,
+			Schedule: req.Schedule, Books: len(books),
+		}, nil
+	}
+	service, err := c.factory(c.store, req.BaseURL, req.Username, password)
+	if err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVValidation, err)
+	}
+	discovery, err := service.DiscoverConnection(ctx, req.BaseURL)
+	if err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVUpstream, err)
+	}
+	generation := int64(1)
+	if account != nil {
+		generation = account.ConnectionGeneration
+		if account.BaseURL != req.BaseURL || account.Username != req.Username || credentialsChanged {
+			generation++
+		}
+	}
+	rollbackCredential := func() error {
+		if hadPreviousCredential {
+			return c.saveCredential(tokenDir, previousCredential)
+		}
+		if hadPreviousLegacyCredential {
+			return c.saveLegacyPassword(tokenDir, previousLegacyPassword)
+		}
+		return c.removeCredential(tokenDir)
+	}
+	if err := c.saveCredential(tokenDir, carddav.Credential{
+		Password: password, BaseURL: req.BaseURL, Username: req.Username, ConnectionGeneration: generation,
+	}); err != nil {
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err)
+	}
+	previous, err := c.saveConfig(nil, next)
+	if err != nil {
+		var rollbackConfigErr error
+		if errors.Is(err, config.ErrConfigChanged) {
+			_, rollbackConfigErr = c.saveConfig(&next, previous)
+		}
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err, rollbackConfigErr, rollbackCredential())
+	}
+	if err := c.persistDiscovery(ctx, service, req.BaseURL, req.Username, discovery, credentialsChanged); err != nil {
+		_, rollbackConfigErr := c.saveConfig(&next, previous)
+		return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, err, rollbackConfigErr, rollbackCredential())
+	}
+	c.mu.Lock()
+	c.service = service
+	reconcileSchedule := c.reconcileSchedule
+	c.mu.Unlock()
+	if reconcileSchedule != nil {
+		if err := reconcileSchedule(next, service); err != nil {
+			return CardDAVAccountResponse{}, errors.Join(errCardDAVStorage, fmt.Errorf("reconcile CardDAV schedule: %w", err))
+		}
+	}
+	return CardDAVAccountResponse{BaseURL: req.BaseURL, Username: req.Username, Enabled: *req.Enabled, Schedule: req.Schedule, Books: len(discovery.Books)}, nil
+}
+
+func (c *CardDAVController) passwordForRequest(ctx context.Context, req CardDAVAccountRequest) (string, error) {
+	if req.Password != "" {
+		return req.Password, nil
+	}
+	credential, err := c.reusableCredential(ctx, req.BaseURL, req.Username)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("%w: CardDAV password is required for a new connection", errCardDAVValidation)
+		}
+		if errors.Is(err, carddav.ErrCredentialNotBound) {
+			return "", fmt.Errorf("%w: CardDAV password is required because the saved connection identity does not match", errCardDAVValidation)
+		}
+		return "", errors.Join(errCardDAVStorage, err)
+	}
+	return credential.Password, nil
+}
+
+func (c *CardDAVController) reusableCredential(
+	ctx context.Context, baseURL, username string,
+) (carddav.Credential, error) {
+	if c == nil {
+		return carddav.Credential{}, carddav.ErrCredentialNotBound
+	}
+	configured := c.cardDAVConfigSnapshot()
+	if c.cfg == nil || c.store == nil || configured.BaseURL != baseURL || configured.Username != username {
+		return carddav.Credential{}, carddav.ErrCredentialNotBound
+	}
+	loadCredential := c.loadCredential
+	if loadCredential == nil {
+		loadCredential = carddav.LoadCredential
+	}
+	credential, err := loadCredential(c.cfg.TokensDir())
+	if err != nil {
+		return carddav.Credential{}, err
+	}
+	account, err := c.store.GetCardDAVAccountContext(ctx)
+	if err != nil {
+		return carddav.Credential{}, err
+	}
+	if account == nil || credential.BaseURL != baseURL || credential.Username != username ||
+		account.BaseURL != baseURL || account.Username != username ||
+		credential.ConnectionGeneration != account.ConnectionGeneration {
+		return carddav.Credential{}, carddav.ErrCredentialNotBound
+	}
+	return credential, nil
+}
+
+func (c *CardDAVController) passwordConfigured(ctx context.Context, baseURL, username string) bool {
+	_, err := c.reusableCredential(ctx, baseURL, username)
+	return err == nil
+}
+
+func validateCardDAVAccountRequest(req CardDAVAccountRequest) error {
+	if strings.TrimSpace(req.BaseURL) == "" || strings.TrimSpace(req.Username) == "" {
+		return fmt.Errorf("%w: CardDAV base URL and username are required", errCardDAVValidation)
+	}
+	if req.Enabled == nil {
+		return fmt.Errorf("%w: CardDAV enabled is required", errCardDAVValidation)
+	}
+	origin, err := url.Parse(strings.TrimSpace(req.BaseURL))
+	if err != nil || origin.User != nil || origin.Host == "" || (origin.Scheme != "http" && origin.Scheme != "https") {
+		return fmt.Errorf("%w: CardDAV base URL must be an absolute HTTP(S) URL", errCardDAVValidation)
+	}
+	if req.Schedule != "" {
+		if err := scheduler.ValidateCronExpr(req.Schedule); err != nil {
+			return errors.Join(errCardDAVValidation, fmt.Errorf("invalid CardDAV schedule: %w", err))
+		}
+	}
+	return nil
+}
+
+type CardDAVAccountRequest struct {
+	BaseURL  string `json:"base_url"`
+	Username string `json:"username"`
+	Password string `json:"password,omitempty" writeOnly:"true"`
+	Schedule string `json:"schedule,omitempty"`
+	Enabled  *bool  `json:"enabled" nullable:"false"`
+}
+type CardDAVAccountResponse struct {
+	BaseURL  string `json:"base_url"`
+	Username string `json:"username"`
+	Schedule string `json:"schedule,omitempty"`
+	Enabled  bool   `json:"enabled"`
+	Books    int    `json:"books"`
+}
+type CardDAVBookResponse struct {
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
+	URL                string `json:"url"`
+	WriteTarget        bool   `json:"write_target"`
+	Subscribed         bool   `json:"subscribed"`
+	LookupSource       bool   `json:"lookup_source"`
+	NeedsFullReconcile bool   `json:"needs_full_reconcile"`
+}
+type CardDAVBooksResponse struct {
+	Books []CardDAVBookResponse `json:"books"`
+}
+type CardDAVBookRolesRequest struct {
+	WriteTarget  *bool `json:"write_target" nullable:"false"`
+	Subscribed   *bool `json:"subscribed" nullable:"false"`
+	LookupSource *bool `json:"lookup_source" nullable:"false"`
+}
+type CardDAVPublicationResponse struct {
+	PersonID         int64  `json:"person_id"`
+	Desired          bool   `json:"desired"`
+	PendingOperation string `json:"pending_operation,omitempty"`
+	Href             string `json:"href,omitempty"`
+}
+type CardDAVConflictResponse struct {
+	ID              int64  `json:"id"`
+	AddressBookID   int64  `json:"address_book_id"`
+	Href            string `json:"href"`
+	LocalTombstone  bool   `json:"local_tombstone"`
+	RemoteTombstone bool   `json:"remote_tombstone"`
+	Status          string `json:"status"`
+}
+type CardDAVConflictDetailResponse struct {
+	ID              int64  `json:"id"`
+	AddressBookID   int64  `json:"address_book_id"`
+	Href            string `json:"href"`
+	LocalVCard      string `json:"local_vcard,omitempty"`
+	RemoteVCard     string `json:"remote_vcard,omitempty"`
+	LocalTombstone  bool   `json:"local_tombstone"`
+	RemoteTombstone bool   `json:"remote_tombstone"`
+	Status          string `json:"status"`
+}
+type CardDAVConflictResolutionResponse struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+}
+type CardDAVConflictsResponse struct {
+	Conflicts []CardDAVConflictResponse `json:"conflicts"`
+}
+type CardDAVResolveRequest struct {
+	Choice carddav.ResolutionChoice `json:"choice" enum:"keep_local,keep_remote"`
+}
+type CardDAVSyncRequest struct {
+	Full bool `json:"full,omitempty"`
+}
+
+func (s *Server) registerCardDAVRoutes(api huma.API) {
+	registerCardDAVJSONRouteWithRequest[CardDAVAccountRequest, CardDAVAccountResponse](api, "testCardDAVAccount", http.MethodPost, "/carddav/account/test", "Test a CardDAV account", s.handleCardDAVAccountTest, http.StatusBadRequest, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+	registerCardDAVJSONRouteWithRequest[CardDAVAccountRequest, CardDAVAccountResponse](api, "saveCardDAVAccount", http.MethodPut, "/carddav/account", "Discover and save a CardDAV account", s.handleCardDAVAccountSave, http.StatusBadRequest, http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+	registerCardDAVJSONRoute[CardDAVBooksResponse](api, "listCardDAVBooks", http.MethodGet, "/carddav/books", "List CardDAV address books", s.handleCardDAVBooks, http.StatusInternalServerError, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRouteWithRequest[CardDAVBookRolesRequest, CardDAVBookResponse](api, "updateCardDAVBookRoles", http.MethodPatch, "/carddav/books/{id}", "id", "Update CardDAV address book roles", s.handleCardDAVBookRoles, http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusInternalServerError, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRoute[CardDAVPublicationResponse](api, "getCardDAVPublication", http.MethodGet, "/carddav/publications/{person_id}", "person_id", "Get CardDAV publication state", s.handleCardDAVPublication, http.StatusBadRequest, http.StatusNotFound, http.StatusInternalServerError, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRoute[CardDAVPublicationResponse](api, "publishCardDAVPerson", http.MethodPost, "/carddav/publications/{person_id}", "person_id", "Publish a person to CardDAV", s.handleCardDAVPublish, http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRoute[CardDAVPublicationResponse](api, "unpublishCardDAVPerson", http.MethodDelete, "/carddav/publications/{person_id}", "person_id", "Unpublish a person from CardDAV", s.handleCardDAVUnpublish, http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+	registerCardDAVJSONRoute[CardDAVConflictsResponse](api, "listCardDAVConflicts", http.MethodGet, "/carddav/conflicts", "List unresolved CardDAV conflicts", s.handleCardDAVConflicts, http.StatusInternalServerError, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRoute[CardDAVConflictDetailResponse](api, "getCardDAVConflict", http.MethodGet, "/carddav/conflicts/{id}", "id", "Inspect a CardDAV conflict", s.handleCardDAVConflict, http.StatusBadRequest, http.StatusNotFound, http.StatusInternalServerError, http.StatusServiceUnavailable)
+	registerCardDAVIDJSONRouteWithRequest[CardDAVResolveRequest, CardDAVConflictResolutionResponse](api, "resolveCardDAVConflict", http.MethodPost, "/carddav/conflicts/{id}/resolve", "id", "Resolve a CardDAV conflict", s.handleCardDAVResolve, http.StatusBadRequest, http.StatusNotFound, http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+	registerCardDAVJSONRouteWithRequest[CardDAVSyncRequest, carddav.SyncResult](api, "syncCardDAV", http.MethodPost, "/carddav/sync", "Trigger CardDAV synchronization", s.handleCardDAVSync, http.StatusBadRequest, http.StatusConflict, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable)
+}
+
+func registerCardDAVJSONRoute[Resp any](api huma.API, operationID, method, path, summary string, handler http.HandlerFunc, errorStatuses ...int) {
+	op := rawAPIV1Operation(operationID, method, path, summary)
+	op.Responses = jsonResponsesFor[Resp](api)
+	addErrorResponses(api, op.Responses, errorStatuses...)
+	addCardDAVRetryAfterHeader(op.Responses)
+	registerRawHumaRoute(api, op, handler)
+}
+
+func registerCardDAVJSONRouteWithRequest[Req, Resp any](api huma.API, operationID, method, path, summary string, handler http.HandlerFunc, errorStatuses ...int) {
+	op := rawAPIV1Operation(operationID, method, path, summary)
+	op.RequestBody = jsonRequestBodyFor[Req](api)
+	op.Responses = jsonResponsesFor[Resp](api)
+	addErrorResponses(api, op.Responses, errorStatuses...)
+	addCardDAVRetryAfterHeader(op.Responses)
+	registerRawHumaRoute(api, op, handler)
+}
+
+func cardDAVIDOperation(operationID, method, path, parameter, summary string) huma.Operation {
+	op := rawAPIV1Operation(operationID, method, path, summary)
+	minimum := float64(1)
+	op.Parameters = append(op.Parameters, &huma.Param{Name: parameter, In: "path", Required: true,
+		Schema: &huma.Schema{Type: huma.TypeInteger, Format: formatInt64, Minimum: &minimum}})
+	return op
+}
+
+func registerCardDAVIDJSONRoute[Resp any](api huma.API, operationID, method, path, parameter, summary string, handler http.HandlerFunc, errorStatuses ...int) {
+	op := cardDAVIDOperation(operationID, method, path, parameter, summary)
+	op.Responses = jsonResponsesFor[Resp](api)
+	addErrorResponses(api, op.Responses, errorStatuses...)
+	addCardDAVRetryAfterHeader(op.Responses)
+	registerRawHumaRoute(api, op, handler)
+}
+
+func registerCardDAVIDJSONRouteWithRequest[Req, Resp any](api huma.API, operationID, method, path, parameter, summary string, handler http.HandlerFunc, errorStatuses ...int) {
+	op := cardDAVIDOperation(operationID, method, path, parameter, summary)
+	op.RequestBody = jsonRequestBodyFor[Req](api)
+	op.Responses = jsonResponsesFor[Resp](api)
+	addErrorResponses(api, op.Responses, errorStatuses...)
+	addCardDAVRetryAfterHeader(op.Responses)
+	registerRawHumaRoute(api, op, handler)
+}
+
+func addCardDAVRetryAfterHeader(responses map[string]*huma.Response) {
+	response := responses[httpStatusKey(http.StatusServiceUnavailable)]
+	if response == nil {
+		return
+	}
+	if response.Headers == nil {
+		response.Headers = make(map[string]*huma.Param)
+	}
+	minimum := float64(0)
+	response.Headers["Retry-After"] = &huma.Param{
+		Description: "Seconds until CardDAV retry is safe",
+		Schema: &huma.Schema{
+			Type: huma.TypeInteger, Format: formatInt64, Minimum: &minimum,
+		},
+	}
+}
+
+func decodeCardDAV(w http.ResponseWriter, r *http.Request, dst any) bool {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		writeError(w, 400, "bad_request", "Invalid JSON request")
+		return false
+	}
+	return true
+}
+func (s *Server) cardDAVService(w http.ResponseWriter) CardDAVOperations {
+	if s.cardDAV == nil {
+		writeError(w, 503, "carddav_unavailable", "CardDAV is not configured")
+		return nil
+	}
+	service := s.cardDAV.Current()
+	if service == nil {
+		writeError(w, 503, "carddav_unavailable", "CardDAV is not configured")
+		return nil
+	}
+	return service
+}
+func (s *Server) handleCardDAVAccountTest(w http.ResponseWriter, r *http.Request) {
+	if s.cardDAV == nil {
+		writeError(w, http.StatusServiceUnavailable, "carddav_unavailable", "CardDAV setup is unavailable")
+		return
+	}
+	var req CardDAVAccountRequest
+	if !decodeCardDAV(w, r, &req) {
+		return
+	}
+	result, err := s.cardDAV.Test(r.Context(), req)
+	if err != nil {
+		s.writeCardDAVAccountError(r.Context(), w, err, "CardDAV discovery failed")
+		return
+	}
+	writeJSON(w, 200, result)
+}
+func (s *Server) handleCardDAVAccountSave(w http.ResponseWriter, r *http.Request) {
+	if s.cardDAV == nil {
+		writeError(w, http.StatusServiceUnavailable, "carddav_unavailable", "CardDAV setup is unavailable")
+		return
+	}
+	var req CardDAVAccountRequest
+	if !decodeCardDAV(w, r, &req) {
+		return
+	}
+	result, err := s.cardDAV.Save(r.Context(), req)
+	if err != nil {
+		s.writeCardDAVAccountError(r.Context(), w, err, "CardDAV discovery or save failed")
+		return
+	}
+	writeJSON(w, 200, result)
+}
+
+func (s *Server) writeCardDAVAccountError(
+	ctx context.Context, w http.ResponseWriter, err error, message string,
+) {
+	var statusErr *carddav.StatusError
+	switch {
+	case errors.Is(err, errCardDAVValidation):
+		writeError(w, http.StatusBadRequest, "bad_request", message)
+	case errors.Is(err, store.ErrCardDAVCredentialChangePending),
+		errors.Is(err, store.ErrCardDAVIdentityChangeOwned):
+		writeError(w, http.StatusConflict, "conflict", message)
+	case errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusTooManyRequests:
+		s.setCardDAVRetryAfterHeader(ctx, w, statusErr.RetryAfter)
+		writeError(w, http.StatusServiceUnavailable, "carddav_retry_after", message)
+	case errors.Is(err, errCardDAVUpstream):
+		writeError(w, http.StatusBadGateway, "carddav_upstream_failed", message)
+	default:
+		writeError(w, http.StatusInternalServerError, "carddav_storage_failed", message)
+	}
+}
+
+func (s *Server) writeCardDAVOperationError(
+	ctx context.Context, w http.ResponseWriter, err error, message string,
+) {
+	var statusErr *carddav.StatusError
+	var networkErr net.Error
+	switch {
+	case errors.Is(err, carddav.ErrInvalidResolutionChoice):
+		writeError(w, http.StatusBadRequest, "bad_request", message)
+	case errors.Is(err, store.ErrCardDAVAddressBookNotFound),
+		errors.Is(err, store.ErrCardDAVPublicationNotFound),
+		errors.Is(err, store.ErrCardDAVConflictNotFound),
+		errors.Is(err, store.ErrPersonNotFound):
+		writeError(w, http.StatusNotFound, "not_found", message)
+	case errors.Is(err, store.ErrCardDAVStalePlan),
+		errors.Is(err, store.ErrCardDAVConflictStale),
+		errors.Is(err, store.ErrCardDAVWriteTargetSubscribed),
+		errors.Is(err, store.ErrCardDAVReadOnlyAddressBook),
+		errors.Is(err, store.ErrCardDAVRoleChangePending),
+		errors.Is(err, store.ErrCardDAVPublicationPending),
+		errors.Is(err, store.ErrCardDAVPublicationMismatch),
+		errors.Is(err, store.ErrCardDAVResourceAmbiguous),
+		errors.Is(err, store.ErrCardDAVNoWriteTarget),
+		errors.Is(err, carddav.ErrCardDAVConflictPending):
+		writeError(w, http.StatusConflict, "conflict", message)
+	case errors.Is(err, store.ErrCardDAVRetryAfter):
+		s.setCardDAVRetryAfterHeader(ctx, w, 0)
+		writeError(w, http.StatusServiceUnavailable, "carddav_retry_after", message)
+	case errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusTooManyRequests:
+		s.setCardDAVRetryAfterHeader(ctx, w, statusErr.RetryAfter)
+		writeError(w, http.StatusServiceUnavailable, "carddav_retry_after", message)
+	case errors.As(err, &statusErr), errors.As(err, &networkErr):
+		writeError(w, http.StatusBadGateway, "carddav_upstream_failed", message)
+	default:
+		writeError(w, http.StatusInternalServerError, "carddav_storage_failed", message)
+	}
+}
+
+func (s *Server) setCardDAVRetryAfterHeader(
+	ctx context.Context, w http.ResponseWriter, delay time.Duration,
+) {
+	if delay <= 0 && s.cardDAV != nil && s.cardDAV.store != nil {
+		if gate, err := s.cardDAV.store.GetCardDAVRetryAfterContext(ctx); err == nil && gate != nil {
+			delay = time.Until(*gate)
+		}
+	}
+	seconds := max(int64(1), int64((delay+time.Second-1)/time.Second))
+	w.Header().Set("Retry-After", strconv.FormatInt(seconds, 10))
+}
+func bookResponse(b store.CardDAVAddressBook) CardDAVBookResponse {
+	return CardDAVBookResponse{ID: b.ID, Name: b.DisplayName, URL: b.CanonicalURL, WriteTarget: b.IsWriteTarget, Subscribed: b.IsSubscribed, LookupSource: b.IsLookupSource, NeedsFullReconcile: b.NeedsFullReconcile}
+}
+func (s *Server) handleCardDAVBooks(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	books, err := svc.ListBooks(r.Context())
+	if err != nil {
+		writeError(w, 500, "carddav_failed", "CardDAV operation failed")
+		return
+	}
+	out := CardDAVBooksResponse{Books: make([]CardDAVBookResponse, 0, len(books))}
+	for _, b := range books {
+		out.Books = append(out.Books, bookResponse(b))
+	}
+	writeJSON(w, 200, out)
+}
+func cardDAVPositivePathID(r *http.Request, name string) (int64, error) {
+	id, err := strconv.ParseInt(r.PathValue(name), 10, 64)
+	if err != nil || id <= 0 {
+		return 0, errors.New("ID must be positive")
+	}
+	return id, nil
+}
+func (s *Server) handleCardDAVBookRoles(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	id, err := cardDAVPositivePathID(r, "id")
+	if err != nil {
+		writeError(w, 400, "bad_request", err.Error())
+		return
+	}
+	var req CardDAVBookRolesRequest
+	if !decodeCardDAV(w, r, &req) {
+		return
+	}
+	if req.WriteTarget == nil || req.Subscribed == nil || req.LookupSource == nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "write_target, subscribed, and lookup_source are required")
+		return
+	}
+	if err = svc.SetBookRoles(r.Context(), id, carddav.BookRoles{WriteTarget: *req.WriteTarget, Subscribed: *req.Subscribed, LookupSource: *req.LookupSource}); err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV role update failed")
+		return
+	}
+	books, err := svc.ListBooks(r.Context())
+	if err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV book lookup failed")
+		return
+	}
+	for _, b := range books {
+		if b.ID == id {
+			writeJSON(w, 200, bookResponse(b))
+			return
+		}
+	}
+	writeError(w, 404, "not_found", "CardDAV book not found")
+}
+func publicationResponse(p *store.CardDAVPublication, id int64) CardDAVPublicationResponse {
+	if p == nil {
+		return CardDAVPublicationResponse{PersonID: id}
+	}
+	return CardDAVPublicationResponse{PersonID: id, Desired: p.Desired, PendingOperation: string(p.PendingOperation), Href: p.Href}
+}
+func (s *Server) handleCardDAVPublication(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	id, err := cardDAVPositivePathID(r, "person_id")
+	if err != nil {
+		writeError(w, 400, "bad_request", err.Error())
+		return
+	}
+	p, err := svc.Publication(r.Context(), id)
+	if errors.Is(err, store.ErrCardDAVPublicationNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "CardDAV publication not found")
+		return
+	}
+	if err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV publication lookup failed")
+		return
+	}
+	writeJSON(w, 200, publicationResponse(p, id))
+}
+func (s *Server) mutatePublication(w http.ResponseWriter, r *http.Request, publish bool) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	id, err := cardDAVPositivePathID(r, "person_id")
+	if err != nil {
+		writeError(w, 400, "bad_request", err.Error())
+		return
+	}
+	if publish {
+		err = svc.PublishPerson(r.Context(), id)
+	} else {
+		err = svc.UnpublishPerson(r.Context(), id)
+	}
+	if err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV publication failed")
+		return
+	}
+	p, err := svc.Publication(r.Context(), id)
+	if !publish && errors.Is(err, store.ErrCardDAVPublicationNotFound) {
+		writeJSON(w, http.StatusOK, CardDAVPublicationResponse{PersonID: id, Desired: false})
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "carddav_failed", "CardDAV publication lookup failed")
+		return
+	}
+	writeJSON(w, 200, publicationResponse(p, id))
+}
+func (s *Server) handleCardDAVPublish(w http.ResponseWriter, r *http.Request) {
+	s.mutatePublication(w, r, true)
+}
+func (s *Server) handleCardDAVUnpublish(w http.ResponseWriter, r *http.Request) {
+	s.mutatePublication(w, r, false)
+}
+func conflictResponse(c store.CardDAVConflict) CardDAVConflictResponse {
+	return CardDAVConflictResponse{ID: c.ID, AddressBookID: c.AddressBookID, Href: c.Href, LocalTombstone: c.LocalTombstone, RemoteTombstone: c.RemoteTombstone, Status: string(c.Status)}
+}
+func conflictDetailResponse(c store.CardDAVConflict) CardDAVConflictDetailResponse {
+	return CardDAVConflictDetailResponse{
+		ID: c.ID, AddressBookID: c.AddressBookID, Href: c.Href,
+		LocalVCard: string(c.LocalBody), RemoteVCard: string(c.RemoteBody),
+		LocalTombstone: c.LocalTombstone, RemoteTombstone: c.RemoteTombstone,
+		Status: string(c.Status),
+	}
+}
+func (s *Server) handleCardDAVConflicts(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	items, err := svc.ListConflicts(r.Context())
+	if err != nil {
+		writeError(w, 500, "carddav_failed", "CardDAV operation failed")
+		return
+	}
+	out := CardDAVConflictsResponse{Conflicts: make([]CardDAVConflictResponse, 0, len(items))}
+	for _, c := range items {
+		out.Conflicts = append(out.Conflicts, conflictResponse(c))
+	}
+	writeJSON(w, 200, out)
+}
+func (s *Server) handleCardDAVConflict(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	id, err := cardDAVPositivePathID(r, "id")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	conflict, err := svc.GetConflict(r.Context(), id)
+	if err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV conflict lookup failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, conflictDetailResponse(*conflict))
+}
+func (s *Server) handleCardDAVResolve(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	id, err := cardDAVPositivePathID(r, "id")
+	if err != nil {
+		writeError(w, 400, "bad_request", err.Error())
+		return
+	}
+	var req CardDAVResolveRequest
+	if !decodeCardDAV(w, r, &req) {
+		return
+	}
+	if err = svc.ResolveConflict(r.Context(), id, req.Choice); err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV conflict resolution failed")
+		return
+	}
+	writeJSON(w, 200, CardDAVConflictResolutionResponse{ID: id, Status: string(store.CardDAVConflictResolved)})
+}
+func (s *Server) handleCardDAVSync(w http.ResponseWriter, r *http.Request) {
+	svc := s.cardDAVService(w)
+	if svc == nil {
+		return
+	}
+	var req CardDAVSyncRequest
+	if !decodeCardDAV(w, r, &req) {
+		return
+	}
+	result, err := svc.Sync(r.Context(), carddav.SyncOptions{Full: req.Full})
+	if err != nil {
+		s.writeCardDAVOperationError(r.Context(), w, err, "CardDAV synchronization failed")
+		return
+	}
+	writeJSON(w, 200, result)
+}

--- a/internal/api/carddav_test.go
+++ b/internal/api/carddav_test.go
@@ -1,0 +1,1226 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/carddav"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestCardDAVAccountSaveDiscoversBeforePublishingConfigAndCredential(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	failing := true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("Basic YWxpY2U6c3ludGhldGljLXBhc3N3b3Jk", r.Header.Get("Authorization"))
+		if failing {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeCardDAVMultiStatus(w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop><D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeCardDAVMultiStatus(w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop><C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeCardDAVMultiStatus(w, `<D:response><D:href>/books/</D:href><D:propstat><D:prop><D:resourcetype><D:collection/></D:resourcetype></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response><D:response><D:href>/books/personal/</D:href><D:propstat><D:prop><D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Personal</D:displayname><D:current-user-privilege-set><D:privilege><D:bind/></D:privilege></D:current-user-privilege-set></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(err)
+	baseURL := "http://contacts.example:" + serverURL.Port() + "/dav"
+	home := t.TempDir()
+	dataDir := t.TempDir()
+	cfg := &config.Config{HomeDir: home, Data: config.DataConfig{DataDir: dataDir}}
+	st := testutil.NewTestStore(t)
+	controller := &CardDAVController{cfg: cfg, store: st}
+	controller.factory = fixtureCardDAVFactory(t, serverURL)
+	req := CardDAVAccountRequest{BaseURL: baseURL, Username: "alice", Password: "synthetic-password", Enabled: new(true), Schedule: "0 */6 * * *"}
+	_, err = controller.Save(t.Context(), req)
+	require.Error(err)
+	assert.NoFileExists(cfg.ConfigFilePath())
+	assert.NoFileExists(filepath.Join(cfg.TokensDir(), "carddav.json"))
+	failing = false
+	result, err := controller.Save(t.Context(), req)
+	require.NoError(err)
+	assert.Equal(1, result.Books)
+	password, err := carddav.LoadPassword(cfg.TokensDir())
+	require.NoError(err)
+	assert.Equal("synthetic-password", password)
+	if runtime.GOOS != "windows" {
+		info, statErr := os.Stat(filepath.Join(cfg.TokensDir(), "carddav.json"))
+		require.NoError(statErr)
+		assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+	}
+	assert.NoFileExists(filepath.Join(home, "tokens", "carddav.json"))
+	content, err := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(err)
+	assert.NotContains(string(content), "synthetic-password")
+}
+
+func TestNewCardDAVControllerLoadsCredentialFromConfiguredDataDir(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	dataDir := t.TempDir()
+	cfg := &config.Config{
+		HomeDir: home, Data: config.DataConfig{DataDir: dataDir},
+		CardDAV: config.CardDAVConfig{BaseURL: "https://contacts.example/dav", Username: "alice"},
+	}
+	st := testutil.NewTestStore(t)
+	_, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books:        []store.CardDAVDiscoveredBook{{CanonicalURL: "https://contacts.example/books/alice/personal/"}},
+	})
+	require.NoError(err)
+	require.NoError(carddav.SaveCredential(cfg.TokensDir(), carddav.Credential{
+		Password: "synthetic-password", BaseURL: cfg.CardDAV.BaseURL,
+		Username: cfg.CardDAV.Username, ConnectionGeneration: 1,
+	}))
+
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	assert.NotNil(controller.Current())
+	assert.FileExists(filepath.Join(cfg.TokensDir(), "carddav.json"))
+	assert.NoFileExists(filepath.Join(home, "tokens", "carddav.json"))
+}
+
+type controlledCardDAVCandidate struct {
+	cardDAVListFixture
+
+	discovery     carddav.Discovery
+	discover      error
+	discoverCalls atomic.Int32
+}
+
+func (f *controlledCardDAVCandidate) DiscoverConnection(context.Context, string) (carddav.Discovery, error) {
+	f.discoverCalls.Add(1)
+	return f.discovery, f.discover
+}
+
+func (f *controlledCardDAVCandidate) PersistDiscovery(
+	context.Context, string, string, carddav.Discovery, bool,
+) error {
+	return nil
+}
+
+func savedCardDAVFixture(t *testing.T) (*config.Config, *store.Store, *controlledCardDAVCandidate) {
+	t.Helper()
+	home := t.TempDir()
+	cfg := config.NewDefaultConfig()
+	cfg.HomeDir = home
+	cfg.Data.DataDir = home
+	cfg.CardDAV = config.CardDAVConfig{
+		BaseURL: "https://old.example/dav", Username: "old-user", Enabled: true, Schedule: "0 1 * * *",
+	}
+	require.NoError(t, cfg.Save())
+	st := testutil.NewTestStore(t)
+	_, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: "https://old.example/dav", Username: "old-user",
+		PrincipalURL: "https://old.example/principal/", HomeURL: "https://old.example/books/",
+		Books: []store.CardDAVDiscoveredBook{{CanonicalURL: "https://old.example/books/live/", DisplayName: "Old", CanCreate: new(true)}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, carddav.SaveCredential(cfg.TokensDir(), carddav.Credential{
+		Password: "old-password", BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username, ConnectionGeneration: 1,
+	}))
+	service := &controlledCardDAVCandidate{discovery: carddav.Discovery{
+		PrincipalURL: mustURL(t, "https://new.example/principal/"),
+		HomeURL:      mustURL(t, "https://new.example/books/"),
+		Books:        []carddav.DiscoveredBook{{URL: mustURL(t, "https://new.example/books/live/"), DisplayName: "New"}},
+	}}
+	return cfg, st, service
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
+}
+
+func TestCardDAVControllerConfigurationSnapshotsDoNotMixConcurrentPublications(t *testing.T) {
+	assert := assert.New(t)
+	first := config.CardDAVConfig{BaseURL: "https://first.example/dav", Username: "first", Enabled: true}
+	second := config.CardDAVConfig{BaseURL: "https://second.example/dav", Username: "second", Schedule: "0 2 * * *"}
+	cfg := &config.Config{CardDAV: first}
+	controller := &CardDAVController{cfg: cfg}
+
+	const iterations = 10_000
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range iterations {
+			controller.publishCardDAVConfig(second)
+			controller.publishCardDAVConfig(first)
+		}
+	}()
+	for range iterations {
+		got := controller.cardDAVConfigSnapshot()
+		assert.True(got == first || got == second, "configuration snapshot was mixed: %+v", got)
+	}
+	<-done
+}
+
+func TestCardDAVAccountSaveRollsBackPublishedFilesWhenDiscoveryStoreFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, oldService := savedCardDAVFixture(t)
+	newService := &controlledCardDAVCandidate{discovery: oldService.discovery}
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return newService, nil }
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error {
+		return errors.New("injected database failure")
+	}
+	beforeConfig, err := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(err)
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: "new-user", Password: "new-password", Enabled: new(true), Schedule: "0 2 * * *",
+	})
+	require.ErrorContains(err, "injected database failure")
+
+	afterConfig, readErr := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(readErr)
+	assert.Equal(beforeConfig, afterConfig)
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("old-password", credential.Password)
+	account, accountErr := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(accountErr)
+	require.NotNil(account)
+	assert.Equal("https://old.example/dav", account.BaseURL)
+	books, booksErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(booksErr)
+	require.Len(books, 1)
+	assert.Equal("Old", books[0].DisplayName)
+	assert.NotSame(newService, controller.Current())
+}
+
+func TestCardDAVAccountSavePreservesOldStateWhenConfigPublicationFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	persisted := false
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error {
+		persisted = true
+		return nil
+	}
+	controller.saveConfig = func(*config.CardDAVConfig, config.CardDAVConfig) (config.CardDAVConfig, error) {
+		return cfg.CardDAV, errors.New("injected config publication failure")
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: "new-user", Password: "new-password", Enabled: new(true),
+	})
+	require.ErrorContains(err, "injected config publication failure")
+	assert.False(persisted)
+	assert.Equal(config.CardDAVConfig{BaseURL: "https://old.example/dav", Username: "old-user", Enabled: true, Schedule: "0 1 * * *"}, cfg.CardDAV)
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("old-password", credential.Password)
+}
+
+func TestCardDAVAccountSaveRepublishesPreviousConfigAfterPublishThenError(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	persisted := false
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error {
+		persisted = true
+		return nil
+	}
+	beforeConfig, err := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(err)
+	saveCalls := 0
+	controller.saveConfig = func(expected *config.CardDAVConfig, next config.CardDAVConfig) (config.CardDAVConfig, error) {
+		saveCalls++
+		previous, publishErr := controller.saveCardDAVConfig(expected, next)
+		require.NoError(publishErr, "exercise the real atomic config publication path")
+		if saveCalls == 1 {
+			return previous, errors.Join(config.ErrConfigChanged, errors.New("injected displaced-file retirement failure"))
+		}
+		return previous, errors.New("injected rollback retirement failure")
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: "new-user", Password: "new-password", Enabled: new(true),
+	})
+	require.ErrorContains(err, "injected displaced-file retirement failure")
+	require.ErrorContains(err, "injected rollback retirement failure")
+	assert.Equal(2, saveCalls)
+	assert.False(persisted)
+	assert.Equal(config.CardDAVConfig{BaseURL: "https://old.example/dav", Username: "old-user", Enabled: true, Schedule: "0 1 * * *"}, cfg.CardDAV)
+	afterConfig, readErr := os.ReadFile(cfg.ConfigFilePath())
+	require.NoError(readErr)
+	assert.Equal(beforeConfig, afterConfig)
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("old-password", credential.Password)
+	assert.NotSame(candidate, controller.Current())
+}
+
+func TestCardDAVAccountSavePreservesConcurrentNonCardDAVConfigEdits(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error { return nil }
+
+	before, err := config.ReadConfigFile(cfg.ConfigFilePath())
+	require.NoError(err)
+	_, err = config.EditConfigFile(cfg.ConfigFilePath(), before.ETag, []config.Edit{{Key: "web.theme", Value: "dark"}})
+	require.NoError(err)
+	assert.Equal(config.WebThemeSystem, cfg.Web.Theme, "the daemon snapshot should remain stale for this regression")
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: "new-user", Password: "new-password",
+		Enabled: new(false), Schedule: "0 4 * * *",
+	})
+	require.NoError(err)
+
+	persisted, err := config.Load(cfg.ConfigFilePath(), "")
+	require.NoError(err)
+	assert.Equal(config.WebThemeDark, persisted.Web.Theme)
+	assert.Equal(config.CardDAVConfig{
+		BaseURL: "https://new.example/dav", Username: "new-user", Enabled: false, Schedule: "0 4 * * *",
+	}, persisted.CardDAV)
+}
+
+func TestCardDAVAccountSavePreservesOldStateWhenCredentialPublicationFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	persisted := false
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error {
+		persisted = true
+		return nil
+	}
+	controller.saveCredential = func(_ string, credential carddav.Credential) error {
+		if credential.Password == "new-password" {
+			return errors.New("injected credential publication failure")
+		}
+		return carddav.SaveCredential(cfg.TokensDir(), credential)
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: "new-user", Password: "new-password", Enabled: new(true),
+	})
+	require.ErrorContains(err, "injected credential publication failure")
+	assert.False(persisted)
+	assert.Equal("https://old.example/dav", cfg.CardDAV.BaseURL)
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("old-password", credential.Password)
+}
+
+func TestCardDAVControllerKeepsSetupAvailableForCredentialMismatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cfg, st, _ := savedCardDAVFixture(t)
+	require.NoError(carddav.SaveCredential(cfg.TokensDir(), carddav.Credential{
+		Password: "wrong-origin-password", BaseURL: "https://different.example/dav",
+		Username: cfg.CardDAV.Username, ConnectionGeneration: 1,
+	}))
+
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	assert.NotNil(controller)
+	assert.Nil(controller.Current())
+}
+
+func TestCardDAVControllerMigratesLegacyPasswordWhenDurableIdentityMatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, _ := savedCardDAVFixture(t)
+	require.NoError(carddav.SavePassword(cfg.TokensDir(), "legacy-password"))
+	tokenPath := filepath.Join(cfg.HomeDir, "tokens", "carddav.json")
+	before, err := os.Stat(tokenPath)
+	require.NoError(err)
+
+	controller, err := NewCardDAVController(cfg, st)
+
+	require.NoError(err)
+	assert.NotNil(controller.Current())
+	credential, err := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(err)
+	assert.Equal(carddav.Credential{
+		Password: "legacy-password", BaseURL: cfg.CardDAV.BaseURL,
+		Username: cfg.CardDAV.Username, ConnectionGeneration: 1,
+	}, credential)
+	after, err := os.Stat(tokenPath)
+	require.NoError(err)
+	assert.Equal(before.Mode().Perm(), after.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		assert.Equal(os.FileMode(0o600), after.Mode().Perm())
+	}
+}
+
+func TestCardDAVControllerLeavesLegacyPasswordUnboundWhenIdentityDoesNotMatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, _ := savedCardDAVFixture(t)
+	require.NoError(carddav.SavePassword(cfg.TokensDir(), "legacy-password"))
+	cfg.CardDAV.Username = "different-user"
+	require.NoError(cfg.Save())
+
+	controller, err := NewCardDAVController(cfg, st)
+
+	require.NoError(err)
+	assert.NotNil(controller)
+	assert.Nil(controller.Current())
+	password, loadErr := carddav.LoadPassword(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("legacy-password", password)
+	_, loadErr = carddav.LoadCredential(cfg.TokensDir())
+	require.ErrorContains(loadErr, "not bound")
+}
+
+func TestCardDAVAccountSaveRepairsUnboundLegacyCredentialWithExplicitPassword(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	require.NoError(carddav.SavePassword(cfg.TokensDir(), "legacy-password"))
+	cfg.CardDAV.Username = "replacement-user"
+	require.NoError(cfg.Save())
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	require.Nil(controller.Current())
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+		return candidate, nil
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		Password: "replacement-password", Enabled: new(true),
+	})
+	require.NoError(err)
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("replacement-password", credential.Password)
+	assert.Equal("replacement-user", credential.Username)
+	assert.Same(candidate, controller.Current())
+}
+
+func TestCardDAVAccountSaveRestoresUnboundLegacyCredentialOnRollback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	require.NoError(carddav.SavePassword(cfg.TokensDir(), "legacy-password"))
+	cfg.CardDAV.Username = "replacement-user"
+	require.NoError(cfg.Save())
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+		return candidate, nil
+	}
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error {
+		return errors.New("injected discovery persistence failure")
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		Password: "replacement-password", Enabled: new(true),
+	})
+	require.ErrorContains(err, "injected discovery persistence failure")
+	password, loadErr := carddav.LoadLegacyPassword(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("legacy-password", password)
+	_, loadErr = carddav.LoadCredential(cfg.TokensDir())
+	require.ErrorIs(loadErr, carddav.ErrCredentialNotBound)
+}
+
+func TestCardDAVControllerConstructsManualServiceWhenSchedulingDisabled(t *testing.T) {
+	cfg, st, _ := savedCardDAVFixture(t)
+	cfg.CardDAV.Enabled = false
+	require.NoError(t, cfg.Save())
+
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(t, err)
+	assert.NotNil(t, controller.Current())
+}
+
+func TestCardDAVAccountSaveUpdatesSchedulingWithoutDiscovery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	candidate.discover = errors.New("injected upstream outage")
+	controller.service = candidate
+	factoryCalled := false
+	controller.factory = func(_ *store.Store, _, _, password string) (cardDAVCandidate, error) {
+		factoryCalled = true
+		return candidate, nil
+	}
+	controller.saveCredential = func(string, carddav.Credential) error {
+		return errors.New("unchanged credential must not be rewritten")
+	}
+	var scheduledConfig config.CardDAVConfig
+	var scheduledService CardDAVOperations
+	controller.SetScheduleReconciler(func(cfg config.CardDAVConfig, service CardDAVOperations) error {
+		scheduledConfig, scheduledService = cfg, service
+		return nil
+	})
+
+	response, err := controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username, Enabled: new(false), Schedule: "0 3 * * *",
+	})
+	require.NoError(err)
+	assert.False(factoryCalled)
+	assert.Equal(int32(0), candidate.discoverCalls.Load())
+	assert.Equal(1, response.Books)
+	assert.Equal(config.CardDAVConfig{BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username, Enabled: false, Schedule: "0 3 * * *"}, scheduledConfig)
+	assert.Same(candidate, scheduledService)
+	assert.Same(candidate, controller.Current())
+	credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(loadErr)
+	assert.Equal("old-password", credential.Password)
+}
+
+func TestCardDAVAccountSaveExplicitPasswordRefreshesDiscovery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+		return candidate, nil
+	}
+
+	response, err := controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		Password: "old-password", Enabled: new(true), Schedule: cfg.CardDAV.Schedule,
+	})
+	require.NoError(err)
+	assert.Equal(int32(1), candidate.discoverCalls.Load())
+	assert.Equal(len(candidate.discovery.Books), response.Books)
+	assert.Same(candidate, controller.Current())
+}
+
+func TestCardDAVAccountSaveRepairsMissingCredentialAfterStartup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	require.NoError(carddav.RemoveCredential(cfg.TokensDir()))
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	assert.Nil(controller.Current())
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+		return candidate, nil
+	}
+	controller.persistDiscovery = func(
+		ctx context.Context, _ cardDAVCandidate, baseURL, username string,
+		discovery carddav.Discovery, credentialsChanged bool,
+	) error {
+		_, _, persistErr := st.ReplaceCardDAVDiscoveryContext(ctx, store.CardDAVDiscoveryInput{
+			BaseURL: baseURL, Username: username, CredentialsChanged: credentialsChanged,
+			PrincipalURL: discovery.PrincipalURL.String(), HomeURL: discovery.HomeURL.String(),
+			Books: []store.CardDAVDiscoveredBook{{
+				CanonicalURL: discovery.Books[0].URL.String(),
+				DisplayName:  discovery.Books[0].DisplayName,
+			}},
+		})
+		return persistErr
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		Password: "replacement-password", Enabled: new(true), Schedule: cfg.CardDAV.Schedule,
+	})
+	require.NoError(err)
+	assert.Same(candidate, controller.Current())
+	credential, err := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(err)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(account)
+	assert.Equal(account.ConnectionGeneration, credential.ConnectionGeneration)
+}
+
+func TestCardDAVAccountSavePasswordChangeAdvancesConnectionGeneration(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, candidate := savedCardDAVFixture(t)
+	before, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(before)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	controller.persistDiscovery = func(ctx context.Context, _ cardDAVCandidate, baseURL, username string, discovery carddav.Discovery, credentialsChanged bool) error {
+		_, _, persistErr := st.ReplaceCardDAVDiscoveryContext(ctx, store.CardDAVDiscoveryInput{
+			BaseURL: baseURL, Username: username, CredentialsChanged: credentialsChanged,
+			PrincipalURL: discovery.PrincipalURL.String(), HomeURL: discovery.HomeURL.String(),
+			Books: []store.CardDAVDiscoveredBook{{
+				CanonicalURL: discovery.Books[0].URL.String(), DisplayName: discovery.Books[0].DisplayName,
+			}},
+		})
+		return persistErr
+	}
+
+	_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+		BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+		Password: "replacement-password", Enabled: new(true),
+	})
+	require.NoError(err)
+	saved, err := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(err)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(account)
+	assert.Equal(int64(2), saved.ConnectionGeneration)
+	assert.Equal(saved.ConnectionGeneration, account.ConnectionGeneration)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: books[0].ID, ConnectionGeneration: before.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision,
+	})
+	require.ErrorIs(err, store.ErrCardDAVStalePlan,
+		"work authenticated with the prior password must fail the advanced connection fence")
+}
+
+func TestCardDAVAccountSaveRejectsCredentialRotationBeforeDiscoveryWhenIntentIsPending(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed func(*testing.T, *store.Store, store.CardDAVAddressBook)
+	}{
+		{name: "publication", seed: func(t *testing.T, st *store.Store, book store.CardDAVAddressBook) {
+			t.Helper()
+			var personID int64
+			require.NoError(t, st.DB().QueryRow(st.Rebind(`INSERT INTO persons (vcard_uid, display_name)
+				VALUES (?, ?) RETURNING id`), "api-rotation-publication", "API Rotation").Scan(&personID))
+			snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+			require.NoError(t, err)
+			_, err = st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+				PersonID: personID, Desired: true, AddressBookID: book.ID,
+				Href:                 book.CanonicalURL + "api-rotation-publication.vcf",
+				OutgoingBody:         []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:api-rotation-publication\r\nFN:API Rotation\r\nEND:VCARD\r\n"),
+				OutgoingSemanticHash: "semantic-api-rotation", LocalHash: snapshot.Fingerprint,
+			})
+			require.NoError(t, err)
+		}},
+		{name: "conflict", seed: func(t *testing.T, st *store.Store, book store.CardDAVAddressBook) {
+			t.Helper()
+			_, err := st.DB().Exec(st.Rebind(`INSERT INTO carddav_conflicts (
+				address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+				base_remote_etag, remote_etag, mapping_revision, local_body, remote_body,
+				local_tombstone, remote_tombstone, pending_operation, connection_generation,
+				book_sync_revision, previous_mapping_revision, pending_started_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, TRUE, FALSE, 'delete', 1, ?, ?, ?)`),
+				book.ID, book.CanonicalURL+"pending-conflict.vcf", "local", "local", "remote",
+				`"one"`, `"two"`, int64(2), []byte("remote-body"), book.SyncRevision, int64(1), time.Now().UTC())
+			require.NoError(t, err)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			cfg, st, candidate := savedCardDAVFixture(t)
+			books, err := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(err)
+			require.Len(books, 1)
+			tc.seed(t, st, books[0])
+			controller, err := NewCardDAVController(cfg, st)
+			require.NoError(err)
+			oldService := controller.Current()
+			controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+				return candidate, nil
+			}
+			beforeConfig, err := os.ReadFile(cfg.ConfigFilePath())
+			require.NoError(err)
+
+			_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+				BaseURL: cfg.CardDAV.BaseURL, Username: cfg.CardDAV.Username,
+				Password: "replacement-password", Enabled: new(true),
+			})
+
+			require.ErrorIs(err, store.ErrCardDAVCredentialChangePending)
+			assert.Zero(candidate.discoverCalls.Load(), "blocked rotation must make no network discovery")
+			afterConfig, readErr := os.ReadFile(cfg.ConfigFilePath())
+			require.NoError(readErr)
+			assert.Equal(beforeConfig, afterConfig)
+			credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+			require.NoError(loadErr)
+			assert.Equal("old-password", credential.Password)
+			account, getErr := st.GetCardDAVAccountContext(t.Context())
+			require.NoError(getErr)
+			require.NotNil(account)
+			assert.Equal(int64(1), account.ConnectionGeneration)
+			assert.Same(oldService, controller.Current())
+		})
+	}
+}
+
+func TestCardDAVAccountSaveRejectsIdentityChangeBeforeDiscoveryWhenRemoteStateIsOwned(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed func(*testing.T, *store.Store, store.CardDAVAddressBook)
+	}{
+		{name: "publication", seed: func(t *testing.T, st *store.Store, book store.CardDAVAddressBook) {
+			t.Helper()
+			var personID int64
+			require.NoError(t, st.DB().QueryRow(st.Rebind(`INSERT INTO persons (vcard_uid, display_name)
+				VALUES (?, ?) RETURNING id`), "api-identity-publication", "API Identity").Scan(&personID))
+			_, err := st.DB().Exec(st.Rebind(`INSERT INTO carddav_publications
+				(person_id, desired, address_book_id, href) VALUES (?, TRUE, ?, ?)`),
+				personID, book.ID, book.CanonicalURL+"api-identity-publication.vcf")
+			require.NoError(t, err)
+		}},
+		{name: "conflict", seed: func(t *testing.T, st *store.Store, book store.CardDAVAddressBook) {
+			t.Helper()
+			_, err := st.DB().Exec(st.Rebind(`INSERT INTO carddav_conflicts (
+				address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+				base_remote_etag, remote_etag, mapping_revision, local_body, remote_body,
+				local_tombstone, remote_tombstone
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE, FALSE)`),
+				book.ID, book.CanonicalURL+"unresolved-conflict.vcf", "local", "local", "remote",
+				`"one"`, `"two"`, int64(1), []byte("local-body"), []byte("remote-body"))
+			require.NoError(t, err)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			cfg, st, candidate := savedCardDAVFixture(t)
+			books, err := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(err)
+			require.Len(books, 1)
+			tc.seed(t, st, books[0])
+			controller, err := NewCardDAVController(cfg, st)
+			require.NoError(err)
+			oldService := controller.Current()
+			controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+				return candidate, nil
+			}
+			beforeConfig, err := os.ReadFile(cfg.ConfigFilePath())
+			require.NoError(err)
+
+			_, err = controller.Save(t.Context(), CardDAVAccountRequest{
+				BaseURL: cfg.CardDAV.BaseURL, Username: "different-user",
+				Password: "replacement-password", Enabled: new(true),
+			})
+
+			require.ErrorIs(err, store.ErrCardDAVIdentityChangeOwned)
+			assert.Zero(candidate.discoverCalls.Load(), "blocked identity change must make no network discovery")
+			credential, loadErr := carddav.LoadCredential(cfg.TokensDir())
+			require.NoError(loadErr)
+			assert.Equal("old-password", credential.Password)
+			afterConfig, readErr := os.ReadFile(cfg.ConfigFilePath())
+			require.NoError(readErr)
+			assert.Equal(beforeConfig, afterConfig)
+			account, getErr := st.GetCardDAVAccountContext(t.Context())
+			require.NoError(getErr)
+			require.NotNil(account)
+			assert.Equal("old-user", account.Username)
+			assert.Same(oldService, controller.Current())
+		})
+	}
+}
+
+type blockingCardDAVCandidate struct {
+	cardDAVListFixture
+
+	discovery carddav.Discovery
+	started   chan<- struct{}
+	release   <-chan struct{}
+}
+
+func (f *blockingCardDAVCandidate) DiscoverConnection(ctx context.Context, _ string) (carddav.Discovery, error) {
+	select {
+	case f.started <- struct{}{}:
+	case <-ctx.Done():
+		return carddav.Discovery{}, ctx.Err()
+	}
+	select {
+	case <-f.release:
+		return f.discovery, nil
+	case <-ctx.Done():
+		return carddav.Discovery{}, ctx.Err()
+	}
+}
+
+func (f *blockingCardDAVCandidate) PersistDiscovery(context.Context, string, string, carddav.Discovery, bool) error {
+	return nil
+}
+
+func TestCardDAVAccountSaveSerializesCompleteCredentialTransition(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cfg, st, fixture := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(err)
+	firstStarted := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	secondFactoryCalled := make(chan struct{}, 1)
+	first := &blockingCardDAVCandidate{discovery: fixture.discovery, started: firstStarted, release: firstRelease}
+	var factoryCalls atomic.Int32
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) {
+		if factoryCalls.Add(1) == 1 {
+			return first, nil
+		}
+		secondFactoryCalled <- struct{}{}
+		return fixture, nil
+	}
+	controller.persistDiscovery = func(context.Context, cardDAVCandidate, string, string, carddav.Discovery, bool) error { return nil }
+	baseURL, username := cfg.CardDAV.BaseURL, cfg.CardDAV.Username
+
+	results := make(chan error, 2)
+	go func() {
+		_, saveErr := controller.Save(t.Context(), CardDAVAccountRequest{
+			BaseURL: baseURL, Username: username,
+			Password: "first-password", Enabled: new(true),
+		})
+		results <- saveErr
+	}()
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		require.FailNow("first save did not enter discovery")
+	}
+	go func() {
+		_, saveErr := controller.Save(t.Context(), CardDAVAccountRequest{
+			BaseURL: baseURL, Username: username,
+			Password: "second-password", Enabled: new(true),
+		})
+		results <- saveErr
+	}()
+	select {
+	case <-secondFactoryCalled:
+		assert.Fail("second save entered the transition while the first save was in discovery")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(firstRelease)
+	for range 2 {
+		require.NoError(<-results)
+	}
+	credential, err := carddav.LoadCredential(cfg.TokensDir())
+	require.NoError(err)
+	assert.Equal("second-password", credential.Password)
+}
+
+func TestCardDAVAccountRequiresPasswordWhenConnectionIdentityChanges(t *testing.T) {
+	cfg, st, _ := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(t, err)
+
+	_, err = controller.Test(t.Context(), CardDAVAccountRequest{
+		BaseURL: "https://new.example/dav", Username: cfg.CardDAV.Username, Enabled: new(true),
+	})
+	require.ErrorIs(t, err, errCardDAVValidation)
+	assert.ErrorContains(t, err, "password")
+}
+
+func writeCardDAVMultiStatus(w http.ResponseWriter, body string) {
+	_, _ = w.Write([]byte(`<?xml version="1.0"?><D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">` + body + `</D:multistatus>`))
+}
+
+func fixtureCardDAVFactory(t *testing.T, target *url.URL) cardDAVServiceFactory {
+	t.Helper()
+	resolver := fixtureCardDAVResolver(t, netip.MustParseAddr("203.0.113.9"))
+	dialer := net.Dialer{}
+	return func(st *store.Store, baseURL, username, password string) (cardDAVCandidate, error) {
+		origin, err := url.Parse(baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse fixture CardDAV base URL: %w", err)
+		}
+		client, err := carddav.NewClient(carddav.ClientOptions{CredentialOrigin: origin, Username: username, Password: password, Resolver: resolver, AllowInsecureCredentials: true, DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, target.Host)
+		}})
+		if err != nil {
+			return nil, err
+		}
+		return carddav.NewService(st, client), nil
+	}
+}
+
+func fixtureCardDAVResolver(t *testing.T, address netip.Addr) *net.Resolver {
+	t.Helper()
+	listener, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		buffer := make([]byte, 512)
+		for {
+			n, remote, readErr := listener.ReadFrom(buffer)
+			if readErr != nil {
+				return
+			}
+			_, _ = listener.WriteTo(fixtureCardDAVDNSResponse(buffer[:n], address), remote)
+		}
+	}()
+	dialer := net.Dialer{}
+	return &net.Resolver{PreferGo: true, Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, listener.LocalAddr().String())
+	}}
+}
+func fixtureCardDAVDNSResponse(request []byte, address netip.Addr) []byte {
+	questionEnd := 12
+	for questionEnd < len(request) && request[questionEnd] != 0 {
+		questionEnd += int(request[questionEnd]) + 1
+	}
+	questionEnd += 5
+	response := append([]byte{}, request[:2]...)
+	response = append(response, 0x81, 0x80, 0x00, 0x01)
+	// #nosec G602 -- questionEnd >= 4 proves both question-type indexes are in bounds.
+	if address.Is4() && questionEnd >= 4 && request[questionEnd-4] == 0 && request[questionEnd-3] == 1 {
+		response = append(response, 0x00, 0x01)
+	} else {
+		response = append(response, 0, 0)
+	}
+	response = append(response, 0, 0, 0, 0)
+	response = append(response, request[12:questionEnd]...)
+	// #nosec G602 -- questionEnd >= 4 proves both question-type indexes are in bounds.
+	if address.Is4() && questionEnd >= 4 && request[questionEnd-4] == 0 && request[questionEnd-3] == 1 {
+		response = append(response, 0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 0x3c, 0, 4)
+		response = append(response, address.AsSlice()...)
+	}
+	return response
+}
+
+type cardDAVListFixture struct{ conflict store.CardDAVConflict }
+
+func (f cardDAVListFixture) Sync(context.Context, carddav.SyncOptions) (carddav.SyncResult, error) {
+	return carddav.SyncResult{}, nil
+}
+func (f cardDAVListFixture) ListBooks(context.Context) ([]store.CardDAVAddressBook, error) {
+	return nil, nil
+}
+func (f cardDAVListFixture) SetBookRoles(context.Context, int64, carddav.BookRoles) error { return nil }
+func (f cardDAVListFixture) Publication(context.Context, int64) (*store.CardDAVPublication, error) {
+	return nil, store.ErrCardDAVPublicationNotFound
+}
+func (f cardDAVListFixture) PublishPerson(context.Context, int64) error   { return nil }
+func (f cardDAVListFixture) UnpublishPerson(context.Context, int64) error { return nil }
+func (f cardDAVListFixture) ListConflicts(context.Context) ([]store.CardDAVConflict, error) {
+	return []store.CardDAVConflict{f.conflict}, nil
+}
+func (f cardDAVListFixture) GetConflict(context.Context, int64) (*store.CardDAVConflict, error) {
+	conflict := f.conflict
+	return &conflict, nil
+}
+func (f cardDAVListFixture) ResolveConflict(context.Context, int64, carddav.ResolutionChoice) error {
+	return errors.New("unused")
+}
+
+func TestCardDAVConflictListNeverExposesSnapshots(t *testing.T) {
+	assert := assert.New(t)
+
+	controller := &CardDAVController{service: cardDAVListFixture{conflict: store.CardDAVConflict{ID: 7, AddressBookID: 2, Href: "/books/personal/alice.vcf", Status: store.CardDAVConflictUnresolved, LocalBody: []byte("private-local-card"), RemoteBody: []byte("private-remote-card")}}}
+	srv := NewServerWithOptions(ServerOptions{Config: &config.Config{}, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/carddav/conflicts", nil)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	assert.NotContains(resp.Body.String(), "private-local-card")
+	assert.NotContains(resp.Body.String(), "private-remote-card")
+	assert.Contains(resp.Body.String(), `"id":7`)
+}
+
+func TestCardDAVConflictDetailExposesOnlyRequestedSnapshots(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	conflict := store.CardDAVConflict{
+		ID: 7, AddressBookID: 2, Href: "/books/personal/alice.vcf",
+		Status:     store.CardDAVConflictUnresolved,
+		LocalBody:  []byte("BEGIN:VCARD\r\nFN:Alice Local\r\nEND:VCARD\r\n"),
+		RemoteBody: []byte("BEGIN:VCARD\r\nFN:Alice Remote\r\nEND:VCARD\r\n"),
+	}
+	resp := cardDAVRouteResponse(t, cardDAVListFixture{conflict: conflict}, http.MethodGet,
+		"/api/v1/carddav/conflicts/7", "")
+
+	require.Equal(http.StatusOK, resp.Code, resp.Body.String())
+	assert.Contains(resp.Body.String(), "Alice Local")
+	assert.Contains(resp.Body.String(), "Alice Remote")
+	assert.Contains(resp.Body.String(), `"href":"/books/personal/alice.vcf"`)
+}
+
+func TestCardDAVConflictResolutionReturnsOnlyResolvedIdentity(t *testing.T) {
+	resp := cardDAVRouteResponse(t, cardDAVErrorFixture{}, http.MethodPost,
+		"/api/v1/carddav/conflicts/7/resolve", `{"choice":"keep_remote"}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	assert.JSONEq(t, `{"id":7,"status":"resolved"}`, resp.Body.String())
+}
+
+type cardDAVErrorFixture struct {
+	cardDAVListFixture
+
+	books       []store.CardDAVAddressBook
+	booksErr    error
+	rolesErr    error
+	publication *store.CardDAVPublication
+	pubErr      error
+	mutateErr   error
+	conflictErr error
+	resolveErr  error
+	syncResult  carddav.SyncResult
+	syncErr     error
+}
+
+func (f cardDAVErrorFixture) Sync(context.Context, carddav.SyncOptions) (carddav.SyncResult, error) {
+	return f.syncResult, f.syncErr
+}
+
+func (f cardDAVErrorFixture) ListBooks(context.Context) ([]store.CardDAVAddressBook, error) {
+	return f.books, f.booksErr
+}
+func (f cardDAVErrorFixture) SetBookRoles(context.Context, int64, carddav.BookRoles) error {
+	return f.rolesErr
+}
+func (f cardDAVErrorFixture) Publication(context.Context, int64) (*store.CardDAVPublication, error) {
+	return f.publication, f.pubErr
+}
+func (f cardDAVErrorFixture) PublishPerson(context.Context, int64) error   { return f.mutateErr }
+func (f cardDAVErrorFixture) UnpublishPerson(context.Context, int64) error { return f.mutateErr }
+func (f cardDAVErrorFixture) GetConflict(context.Context, int64) (*store.CardDAVConflict, error) {
+	if f.conflictErr != nil {
+		return nil, f.conflictErr
+	}
+	conflict := f.conflict
+	return &conflict, nil
+}
+func (f cardDAVErrorFixture) ResolveConflict(context.Context, int64, carddav.ResolutionChoice) error {
+	return f.resolveErr
+}
+
+func cardDAVRouteResponse(t *testing.T, service CardDAVOperations, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	controller := &CardDAVController{service: service}
+	srv := NewServerWithOptions(ServerOptions{Config: &config.Config{}, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller})
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	return resp
+}
+
+func TestCardDAVRoutesMapValidationMissingConflictAndStorageStatuses(t *testing.T) {
+	const roles = `{"write_target":false,"subscribed":true,"lookup_source":false}`
+	tests := []struct {
+		name, method, path, body string
+		service                  CardDAVOperations
+		want                     int
+	}{
+		{name: "role required fields", method: http.MethodPatch, path: "/api/v1/carddav/books/7", body: `{"subscribed":true}`, service: cardDAVErrorFixture{}, want: http.StatusBadRequest},
+		{name: "role missing", method: http.MethodPatch, path: "/api/v1/carddav/books/7", body: roles, service: cardDAVErrorFixture{rolesErr: store.ErrCardDAVAddressBookNotFound}, want: http.StatusNotFound},
+		{name: "role conflict", method: http.MethodPatch, path: "/api/v1/carddav/books/7", body: roles, service: cardDAVErrorFixture{rolesErr: store.ErrCardDAVReadOnlyAddressBook}, want: http.StatusConflict},
+		{name: "role pending mutation", method: http.MethodPatch, path: "/api/v1/carddav/books/7", body: roles, service: cardDAVErrorFixture{rolesErr: store.ErrCardDAVRoleChangePending}, want: http.StatusConflict},
+		{name: "role follow-up storage", method: http.MethodPatch, path: "/api/v1/carddav/books/7", body: roles, service: cardDAVErrorFixture{booksErr: errors.New("database unavailable")}, want: http.StatusInternalServerError},
+		{name: "publication missing", method: http.MethodGet, path: "/api/v1/carddav/publications/7", service: cardDAVErrorFixture{pubErr: store.ErrCardDAVPublicationNotFound}, want: http.StatusNotFound},
+		{name: "person missing", method: http.MethodPost, path: "/api/v1/carddav/publications/7", service: cardDAVErrorFixture{mutateErr: store.ErrPersonNotFound}, want: http.StatusNotFound},
+		{name: "publication follow-up missing", method: http.MethodPost, path: "/api/v1/carddav/publications/7", service: cardDAVErrorFixture{pubErr: store.ErrCardDAVPublicationNotFound}, want: http.StatusInternalServerError},
+		{name: "conflict detail missing", method: http.MethodGet, path: "/api/v1/carddav/conflicts/7", service: cardDAVErrorFixture{conflictErr: store.ErrCardDAVConflictNotFound}, want: http.StatusNotFound},
+		{name: "resolution validation", method: http.MethodPost, path: "/api/v1/carddav/conflicts/7/resolve", body: `{"choice":"invalid"}`, service: cardDAVErrorFixture{resolveErr: carddav.ErrInvalidResolutionChoice}, want: http.StatusBadRequest},
+		{name: "conflict missing", method: http.MethodPost, path: "/api/v1/carddav/conflicts/7/resolve", body: `{"choice":"keep_remote"}`, service: cardDAVErrorFixture{resolveErr: store.ErrCardDAVConflictNotFound}, want: http.StatusNotFound},
+		{name: "conflict stale", method: http.MethodPost, path: "/api/v1/carddav/conflicts/7/resolve", body: `{"choice":"keep_remote"}`, service: cardDAVErrorFixture{resolveErr: store.ErrCardDAVConflictStale}, want: http.StatusConflict},
+		{name: "conflict storage", method: http.MethodPost, path: "/api/v1/carddav/conflicts/7/resolve", body: `{"choice":"keep_remote"}`, service: cardDAVErrorFixture{resolveErr: errors.New("database unavailable")}, want: http.StatusInternalServerError},
+		{name: "sync stale", method: http.MethodPost, path: "/api/v1/carddav/sync", body: `{}`, service: cardDAVErrorFixture{syncErr: store.ErrCardDAVStalePlan}, want: http.StatusConflict},
+		{name: "sync retry gate", method: http.MethodPost, path: "/api/v1/carddav/sync", body: `{}`, service: cardDAVErrorFixture{syncErr: store.ErrCardDAVRetryAfter}, want: http.StatusServiceUnavailable},
+		{name: "sync storage", method: http.MethodPost, path: "/api/v1/carddav/sync", body: `{}`, service: cardDAVErrorFixture{syncErr: errors.New("database unavailable")}, want: http.StatusInternalServerError},
+		{name: "sync upstream", method: http.MethodPost, path: "/api/v1/carddav/sync", body: `{}`, service: cardDAVErrorFixture{syncErr: &carddav.StatusError{StatusCode: http.StatusBadGateway}}, want: http.StatusBadGateway},
+		{name: "sync upstream rate limit", method: http.MethodPost, path: "/api/v1/carddav/sync", body: `{}`, service: cardDAVErrorFixture{syncErr: &carddav.StatusError{StatusCode: http.StatusTooManyRequests, RetryAfter: 17 * time.Second}}, want: http.StatusServiceUnavailable},
+		{name: "zero id", method: http.MethodGet, path: "/api/v1/carddav/publications/0", service: cardDAVErrorFixture{}, want: http.StatusBadRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := cardDAVRouteResponse(t, tt.service, tt.method, tt.path, tt.body)
+			assert.Equal(t, tt.want, resp.Code, resp.Body.String())
+		})
+	}
+}
+
+func TestCardDAVRetryGateResponseCarriesSafeRetryAfter(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	_, st, _ := savedCardDAVFixture(t)
+	retryAt := time.Now().UTC().Add(90 * time.Second)
+	require.NoError(st.SetCardDAVRetryAfterContext(t.Context(), retryAt))
+	controller := &CardDAVController{
+		store:   st,
+		service: cardDAVErrorFixture{syncErr: store.ErrCardDAVRetryAfter},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{}, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/carddav/sync", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(resp, req)
+
+	require.Equal(http.StatusServiceUnavailable, resp.Code, resp.Body.String())
+	retrySeconds, err := strconv.ParseInt(resp.Header().Get("Retry-After"), 10, 64)
+	require.NoError(err)
+	assert.GreaterOrEqual(retrySeconds, int64(1))
+	assert.LessOrEqual(retrySeconds, int64(90))
+}
+
+func TestCardDAVFreshRateLimitsMapToServiceUnavailableWithRetryAfter(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv := &Server{}
+	statusErr := &carddav.StatusError{
+		StatusCode: http.StatusTooManyRequests, RetryAfter: 17 * time.Second,
+	}
+
+	operation := httptest.NewRecorder()
+	srv.writeCardDAVOperationError(t.Context(), operation, statusErr, "CardDAV sync failed")
+	require.Equal(http.StatusServiceUnavailable, operation.Code, operation.Body.String())
+	assert.Equal("17", operation.Header().Get("Retry-After"))
+
+	account := httptest.NewRecorder()
+	srv.writeCardDAVAccountError(t.Context(), account,
+		errors.Join(errCardDAVUpstream, statusErr), "CardDAV discovery failed")
+	require.Equal(http.StatusServiceUnavailable, account.Code, account.Body.String())
+	assert.Equal("17", account.Header().Get("Retry-After"))
+}
+
+func TestCardDAVAccountTestMapsValidationAndUpstreamFailures(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	candidate := &controlledCardDAVCandidate{discover: errors.New("remote unavailable")}
+	controller := &CardDAVController{cfg: &config.Config{HomeDir: t.TempDir()}, store: st}
+	controller.factory = func(*store.Store, string, string, string) (cardDAVCandidate, error) { return candidate, nil }
+	srv := NewServerWithOptions(ServerOptions{Config: &config.Config{}, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller})
+
+	for _, tc := range []struct {
+		name, body string
+		want       int
+	}{
+		{name: "validation", body: `{"base_url":"","username":"alice","password":"secret"}`, want: http.StatusBadRequest},
+		{name: "enabled required", body: `{"base_url":"https://contacts.example/dav","username":"alice","password":"secret"}`, want: http.StatusBadRequest},
+		{name: "upstream", body: `{"base_url":"https://contacts.example/dav","username":"alice","password":"secret","enabled":true}`, want: http.StatusBadGateway},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/carddav/account/test", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, req)
+			assert.Equal(t, tc.want, resp.Code, resp.Body.String())
+		})
+	}
+}
+
+func TestCardDAVAccountChangeOwnershipErrorsMapConflict(t *testing.T) {
+	srv := &Server{}
+	for _, err := range []error{
+		store.ErrCardDAVCredentialChangePending,
+		store.ErrCardDAVIdentityChangeOwned,
+	} {
+		resp := httptest.NewRecorder()
+		srv.writeCardDAVAccountError(t.Context(), resp, err, "CardDAV account change blocked")
+		assert.Equal(t, http.StatusConflict, resp.Code, resp.Body.String())
+	}
+}
+
+func TestCardDAVAccountTestMapsCredentialStorageFailure(t *testing.T) {
+	cfg, st, _ := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st)
+	require.NoError(t, err)
+	controller.loadCredential = func(string) (carddav.Credential, error) {
+		return carddav.Credential{}, errors.New("database-backed credential lookup unavailable")
+	}
+	srv := NewServerWithOptions(ServerOptions{Config: &config.Config{}, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/carddav/account/test", strings.NewReader(`{
+		"base_url":"https://old.example/dav","username":"old-user","enabled":true
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Code, resp.Body.String())
+}
+
+func TestCardDAVSyncResponseUsesLowercaseJSONFields(t *testing.T) {
+	resp := cardDAVRouteResponse(t, cardDAVErrorFixture{syncResult: carddav.SyncResult{
+		Books: 1, Created: 2, Updated: 3, Removed: 4,
+	}}, http.MethodPost, "/api/v1/carddav/sync", `{}`)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	assert.JSONEq(t, `{"books":1,"created":2,"updated":3,"removed":4}`, resp.Body.String())
+}
+
+func TestCardDAVPublicationStateRouteRequiresAuthAndReturnsState(t *testing.T) {
+	controller := &CardDAVController{service: cardDAVErrorFixture{publication: &store.CardDAVPublication{
+		PersonID: 11, Desired: true, PendingOperation: store.CardDAVMutationCreate, Href: "/books/personal/11.vcf",
+	}}}
+	cfg := &config.Config{Server: config.ServerConfig{APIKey: "synthetic-api-key"}}
+	srv := NewServerWithOptions(ServerOptions{Config: cfg, Store: &mockStore{}, Logger: testLogger(), CardDAV: controller})
+
+	unauthorized := httptest.NewRecorder()
+	srv.Router().ServeHTTP(unauthorized, httptest.NewRequest(http.MethodGet, "/api/v1/carddav/publications/11", nil))
+	assert.Equal(t, http.StatusUnauthorized, unauthorized.Code)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/carddav/publications/11", nil)
+	req.Header.Set("X-Api-Key", "synthetic-api-key")
+	authorized := httptest.NewRecorder()
+	srv.Router().ServeHTTP(authorized, req)
+	require.Equal(t, http.StatusOK, authorized.Code, authorized.Body.String())
+	assert.JSONEq(t, `{"person_id":11,"desired":true,"pending_operation":"create","href":"/books/personal/11.vcf"}`, authorized.Body.String())
+}
+
+func TestCardDAVUnpublishReturnsDesiredFalseWhenPublicationIsGone(t *testing.T) {
+	resp := cardDAVRouteResponse(t, cardDAVErrorFixture{
+		pubErr: store.ErrCardDAVPublicationNotFound,
+	}, http.MethodDelete, "/api/v1/carddav/publications/11", "")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	assert.JSONEq(t, `{"person_id":11,"desired":false}`, resp.Body.String())
+}

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -223,7 +223,9 @@ import (
 // time-period, and attachment filters to vector and hybrid search. Stats also
 // report the text-vector message-type scope for compatible search clients.
 // Additive (minor bump): existing unfiltered searches are unchanged.
-const APISchemaVersion = "2.7.0"
+// 2.8.0 adds CardDAV account setup, book roles, publication, conflict, and
+// sync routes. Passwords are request-only and never appear in responses.
+const APISchemaVersion = "2.8.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,7 +38,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.7.0", APISchemaVersion)
+	assert.Equal("2.8.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -60,11 +60,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.7.0", APISchemaVersion)
+	assert.Equal(t, "2.8.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.7.0", APISchemaVersion)
+	assert.Equal(t, "2.8.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -88,7 +88,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.7.0", APISchemaVersion,
+	assert.Equal(t, "2.8.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -399,7 +399,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.7.0", APISchemaVersion,
+	assert.Equal("2.8.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -472,7 +472,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.7.0", APISchemaVersion,
+	assertions.Equal("2.8.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -492,7 +492,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.7.0", APISchemaVersion,
+	assert.Equal("2.8.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -520,7 +520,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.7.0", APISchemaVersion,
+	assertions.Equal("2.8.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -564,9 +564,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// routes added in 1.42.0, cache-readiness responses added in 1.43.0,
 	// document search added in 1.44.0, participant/people separation added in
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
-	// 2.5.0. Person search in 2.6.0 and structured filters in 2.7.0 did not
-	// touch it.
-	assert.Equal("2.7.0", APISchemaVersion, "meeting import is an additive schema release")
+	// 2.5.0. Person search in 2.6.0, structured filters in 2.7.0, and CardDAV
+	// routes in 2.8.0 did not touch it.
+	assert.Equal("2.8.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]
@@ -946,6 +946,111 @@ func TestOpenAPIArtifactUpToDate(t *testing.T) {
 	want, err := os.ReadFile(openAPIArtifactPath)
 	require.NoError(t, err, "read api/openapi.yaml; run `make api-generate` to regenerate")
 	assert.Equal(t, normalizeGeneratedArtifact(want), normalizeGeneratedArtifact(got), "api/openapi.yaml is stale; run `make api-generate`")
+}
+
+func TestCardDAVOpenAPIDocumentsPositiveIDsAndOperationalErrors(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	doc := OpenAPIDocument()
+	for _, tc := range []struct {
+		path, method, parameter string
+		statuses                []string
+	}{
+		{path: "/api/v1/carddav/books/{id}", method: http.MethodPatch, parameter: "id", statuses: []string{"400", "404", "409", "500", "503"}},
+		{path: "/api/v1/carddav/conflicts/{id}", method: http.MethodGet, parameter: "id", statuses: []string{"400", "404", "500", "503"}},
+		{path: "/api/v1/carddav/conflicts/{id}/resolve", method: http.MethodPost, parameter: "id", statuses: []string{"400", "404", "409", "500", "502", "503"}},
+		{path: "/api/v1/carddav/publications/{person_id}", method: http.MethodGet, parameter: "person_id", statuses: []string{"400", "404", "500", "503"}},
+	} {
+		operation := pathOperation(doc.Paths[tc.path], tc.method)
+		require.NotNil(operation, tc.path)
+		require.NotEmpty(operation.Parameters, tc.path)
+		parameter := operation.Parameters[0]
+		assert.Equal(tc.parameter, parameter.Name)
+		require.NotNil(parameter.Schema.Minimum, tc.path)
+		assert.InDelta(float64(1), *parameter.Schema.Minimum, 0, tc.path)
+		for _, status := range tc.statuses {
+			assert.Contains(operation.Responses, status, "%s %s", tc.method, tc.path)
+		}
+	}
+
+	for _, tc := range []struct {
+		path, method string
+		statuses     []string
+	}{
+		{path: "/api/v1/carddav/account/test", method: http.MethodPost, statuses: []string{"400", "500", "502", "503"}},
+		{path: "/api/v1/carddav/account", method: http.MethodPut, statuses: []string{"400", "500", "502", "503"}},
+		{path: "/api/v1/carddav/sync", method: http.MethodPost, statuses: []string{"400", "409", "500", "502", "503"}},
+	} {
+		operation := pathOperation(doc.Paths[tc.path], tc.method)
+		require.NotNil(operation, tc.path)
+		for _, status := range tc.statuses {
+			assert.Contains(operation.Responses, status, "%s %s", tc.method, tc.path)
+		}
+	}
+}
+
+func TestCardDAVServiceUnavailableResponsesDocumentRetryAfter(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	routes := []struct{ path, method string }{
+		{path: "/api/v1/carddav/account/test", method: http.MethodPost},
+		{path: "/api/v1/carddav/account", method: http.MethodPut},
+		{path: "/api/v1/carddav/books", method: http.MethodGet},
+		{path: "/api/v1/carddav/books/{id}", method: http.MethodPatch},
+		{path: "/api/v1/carddav/publications/{person_id}", method: http.MethodGet},
+		{path: "/api/v1/carddav/publications/{person_id}", method: http.MethodPost},
+		{path: "/api/v1/carddav/publications/{person_id}", method: http.MethodDelete},
+		{path: "/api/v1/carddav/conflicts", method: http.MethodGet},
+		{path: "/api/v1/carddav/conflicts/{id}", method: http.MethodGet},
+		{path: "/api/v1/carddav/conflicts/{id}/resolve", method: http.MethodPost},
+		{path: "/api/v1/carddav/sync", method: http.MethodPost},
+	}
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		for _, route := range routes {
+			operation := pathOperation(document.Paths[route.path], route.method)
+			require.NotNil(operation, "%s %s", route.method, route.path)
+			response := operation.Responses[httpStatusKey(http.StatusServiceUnavailable)]
+			require.NotNil(response, "%s %s", route.method, route.path)
+			header := response.Headers["Retry-After"]
+			require.NotNil(header, "%s %s", route.method, route.path)
+			require.NotNil(header.Schema, "%s %s", route.method, route.path)
+			assert.Equal(huma.TypeInteger, header.Schema.Type, "%s %s", route.method, route.path)
+			assert.Equal(formatInt64, header.Schema.Format, "%s %s", route.method, route.path)
+		}
+	}
+
+	syncResponse := generated.SyncCardDAVResp{
+		Headers503: &generated.SyncCardDAVResp503Headers{RetryAfter: "17"},
+	}
+	publishResponse := generated.PublishCardDAVPersonResp{
+		Headers503: &generated.PublishCardDAVPersonResp503Headers{RetryAfter: "23"},
+	}
+	require.NotNil(syncResponse.Headers503)
+	require.NotNil(publishResponse.Headers503)
+	assert.Equal("17", syncResponse.Headers503.RetryAfter)
+	assert.Equal("23", publishResponse.Headers503.RetryAfter)
+}
+
+func pathOperation(item *huma.PathItem, method string) *huma.Operation {
+	if item == nil {
+		return nil
+	}
+	switch method {
+	case http.MethodGet:
+		return item.Get
+	case http.MethodPost:
+		return item.Post
+	case http.MethodPut:
+		return item.Put
+	case http.MethodPatch:
+		return item.Patch
+	case http.MethodDelete:
+		return item.Delete
+	default:
+		return nil
+	}
 }
 
 func TestOpenAPIClientSpecArtifactUpToDate(t *testing.T) {

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -377,13 +377,15 @@ var operationGateExemptPaths = map[string]bool{
 // registerSearchCoverageRoute (the OpenAPI "Exploration" tag), so a new
 // analytical route forces a conscious classification decision here.
 //
-// The remote-image proxy is the one non-Exploration entry: it is POST only
-// so the session CSRF middleware treats it as an unsafe method (same-origin
-// plus X-Csrf-Token), and its handler touches no archive state at all — it
-// performs one SSRF-validated outbound fetch — so it must stay available
+// The remote-image proxy and CardDAV account test are the non-Exploration
+// entries. Both perform SSRF-validated outbound reads without changing
+// archive or persistent configuration state, so they must stay available
 // while a long archive operation holds the gate.
+const cardDAVAccountTestPath = "/api/v1/carddav/account/test"
+
 var readOnlyPostRoutePatterns = []string{
 	remoteImagePath,
+	cardDAVAccountTestPath,
 	"/api/v1/explore",
 	"/api/v1/explore/groups",
 	"/api/v1/explore/preflight",

--- a/internal/api/operation_gate_test.go
+++ b/internal/api/operation_gate_test.go
@@ -706,14 +706,40 @@ func TestOperationGateMiddlewareSkipsReadOnlyAnalyticalPosts(t *testing.T) {
 	}
 }
 
+func TestOperationGateMiddlewareSkipsCardDAVAccountTestWhileGateHeld(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	oldLimit := operationGateWaitLimit
+	operationGateWaitLimit = 20 * time.Millisecond
+	t.Cleanup(func() { operationGateWaitLimit = oldLimit })
+
+	gate := NewSerialOperationGate()
+	release, ok := gate.BeginLabeledWorkContext(context.Background(), "msgvault sync")
+	require.True(ok, "occupy operation gate")
+	defer release()
+
+	called := false
+	handler := operationGateMiddleware(gate, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodPost, cardDAVAccountTestPath, strings.NewReader(`{}`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	assert.True(called, "CardDAV connection test should bypass the held operation gate")
+	assert.Equal(http.StatusNoContent, resp.Code, "status")
+}
+
 // TestReadOnlyPostRoutePatternsMatchExplorationRoutes pins the gate's
 // read-only POST table to the registered analytical routes: every POST
 // operation tagged "Exploration" (registerExploreRoute and the search
 // coverage route) must be classified read-only, and the table must not
 // carry stale entries for routes that no longer exist. The remote-image
-// proxy is the one pinned non-Exploration entry — POST purely for the CSRF
-// unsafe-method machinery, reading no archive state — and it must remain a
-// registered POST route for its table entry to stay valid.
+// proxy and CardDAV account test are the pinned non-Exploration entries;
+// both must remain registered POST routes for their table entries to stay
+// valid.
 func TestReadOnlyPostRoutePatternsMatchExplorationRoutes(t *testing.T) {
 	require := require.New(t)
 	doc := OpenAPIDocument()
@@ -721,8 +747,12 @@ func TestReadOnlyPostRoutePatternsMatchExplorationRoutes(t *testing.T) {
 	require.NotNil(remoteImage, "remote-image proxy route must exist")
 	require.NotNil(remoteImage.Post, "remote-image proxy must be registered as POST")
 	require.Nil(remoteImage.Get, "remote-image proxy must not be reachable via GET")
+	cardDAVAccountTest := doc.Paths[cardDAVAccountTestPath]
+	require.NotNil(cardDAVAccountTest, "CardDAV account test route must exist")
+	require.NotNil(cardDAVAccountTest.Post, "CardDAV account test must be registered as POST")
+	require.Nil(cardDAVAccountTest.Get, "CardDAV account test must not be reachable via GET")
 
-	expected := []string{remoteImagePath}
+	expected := []string{remoteImagePath, cardDAVAccountTestPath}
 	for path, item := range doc.Paths {
 		if item.Post != nil && slices.Contains(item.Post.Tags, "Exploration") {
 			expected = append(expected, path)
@@ -733,7 +763,7 @@ func TestReadOnlyPostRoutePatternsMatchExplorationRoutes(t *testing.T) {
 	slices.Sort(table)
 	assert.Equal(t, expected, table,
 		"readOnlyPostRoutePatterns must match the POST routes tagged Exploration plus the "+
-			"remote-image proxy; classify new analytical routes consciously in operation_gate.go")
+			"pinned read-only POSTs; classify new analytical routes consciously in operation_gate.go")
 }
 
 // gateAnalyticsEngine backs the read-only analytical routes with minimal

--- a/internal/api/person_profiles.go
+++ b/internal/api/person_profiles.go
@@ -343,6 +343,9 @@ func (s *Server) writePersonError(w http.ResponseWriter, err error) {
 	case errors.Is(err, store.ErrPersonReferenced):
 		writeError(w, http.StatusConflict, "person_referenced",
 			"Another profile still references this person")
+	case errors.Is(err, store.ErrPersonCardDAVPublished):
+		writeError(w, http.StatusConflict, "person_carddav_published",
+			"Unpublish this person from CardDAV before deleting it")
 	case errors.Is(err, store.ErrParticipantNotFound), errors.Is(err, store.ErrInvalidParticipantID):
 		writeError(w, http.StatusBadRequest, "invalid_participant_id", err.Error())
 	default:

--- a/internal/api/person_profiles_test.go
+++ b/internal/api/person_profiles_test.go
@@ -126,6 +126,16 @@ func TestPersonProfileHTTPDelete(t *testing.T) {
 	assert.Equal(http.StatusNotFound, deletedAgain.Code)
 }
 
+func TestPersonProfileHTTPDeleteReportsCardDAVPublication(t *testing.T) {
+	srv, _ := newIdentityLinkTestServer(t)
+	response := httptest.NewRecorder()
+
+	srv.writePersonError(response, store.ErrPersonCardDAVPublished)
+
+	assert.Equal(t, http.StatusConflict, response.Code)
+	assert.Contains(t, response.Body.String(), `"person_carddav_published"`)
+}
+
 func TestPersonPatchSchemaRequiresNullableDisplayName(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/api/remote_image.go
+++ b/internal/api/remote_image.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.kenn.io/msgvault/internal/netguard"
 )
 
 // POST /api/v1/content/remote-image is the SSRF-hardened proxy consented
@@ -48,159 +50,11 @@ const (
 	remoteImageErrUnsupportedType = "unsupported_type"
 )
 
-// remoteImageProhibitedSuffixes mirrors the browser-side hostname gate in
-// web/src/lib/content/url-safety.ts: reserved or conventionally-private
-// names never resolve to a legitimate public image host.
-var remoteImageProhibitedSuffixes = []string{"localhost", "local", "internal", "home.arpa"}
+// prohibitedRemoteIP and prohibitedRemoteHostname retain the package-private
+// wrappers used by the image proxy while the shared policy lives in netguard.
+func prohibitedRemoteIP(addr netip.Addr) bool { return netguard.ProhibitedIP(addr) }
 
-// remoteImageProhibitedV4 lists IPv4 ranges a proxied image fetch must never
-// reach: unspecified/"this network", RFC 1918, loopback, CGNAT, link-local
-// (cloud metadata), IETF protocol assignments, benchmarking, multicast, and
-// reserved/broadcast space.
-var remoteImageProhibitedV4 = []netip.Prefix{
-	netip.MustParsePrefix("0.0.0.0/8"),
-	netip.MustParsePrefix("10.0.0.0/8"),
-	netip.MustParsePrefix("100.64.0.0/10"),
-	netip.MustParsePrefix("127.0.0.0/8"),
-	netip.MustParsePrefix("169.254.0.0/16"),
-	netip.MustParsePrefix("172.16.0.0/12"),
-	netip.MustParsePrefix("192.0.0.0/24"),
-	netip.MustParsePrefix("192.168.0.0/16"),
-	netip.MustParsePrefix("198.18.0.0/15"),
-	netip.MustParsePrefix("224.0.0.0/4"),
-	netip.MustParsePrefix("240.0.0.0/4"),
-}
-
-// remoteImageProhibitedV6 lists the IPv6 counterparts: ULA, link-local, and
-// multicast. Loopback/unspecified and the IPv4-embedding transition forms are
-// handled in prohibitedRemoteIP by validating the embedded IPv4 address.
-var remoteImageProhibitedV6 = []netip.Prefix{
-	netip.MustParsePrefix("fc00::/7"),
-	netip.MustParsePrefix("fe80::/10"),
-	netip.MustParsePrefix("ff00::/8"),
-	// 64:ff9b:1::/48 is the RFC 8215 local-use IPv4/IPv6 translation space.
-	// Unlike the well-known NAT64 prefix, the embedded-IPv4 layout is
-	// network-specific (RFC 8215 permits several prefix lengths), so the
-	// embedded destination cannot be reliably extracted; the whole range is
-	// rejected instead.
-	netip.MustParsePrefix("64:ff9b:1::/48"),
-}
-
-// IPv6 transition mechanisms that embed an IPv4 destination at a fixed,
-// well-defined offset. A translated packet is ultimately delivered to the
-// embedded IPv4 address, so these ranges are validated against the IPv4
-// prohibited list rather than the IPv6 one.
-var (
-	// ::/96 — deprecated IPv4-compatible addresses (::a.b.c.d).
-	remoteImageV4CompatPrefix = netip.MustParsePrefix("::/96")
-	// 64:ff9b::/96 — RFC 6052 well-known NAT64/DNS64 translation prefix.
-	remoteImageNAT64Prefix = netip.MustParsePrefix("64:ff9b::/96")
-	// 2002::/16 — RFC 3056 6to4; the IPv4 address follows the prefix.
-	remoteImage6to4Prefix = netip.MustParsePrefix("2002::/16")
-	// 2001::/32 — RFC 4380 Teredo; the client IPv4 is the last four bytes,
-	// each XORed with 0xFF.
-	remoteImageTeredoPrefix = netip.MustParsePrefix("2001::/32")
-)
-
-// embeddedIPv4 extracts the IPv4 destination embedded in an IPv6 transition
-// address, reporting false for addresses that embed none.
-func embeddedIPv4(addr netip.Addr) (netip.Addr, bool) {
-	raw := addr.As16()
-	switch {
-	case remoteImageV4CompatPrefix.Contains(addr) || remoteImageNAT64Prefix.Contains(addr):
-		// The IPv4 address is the last four bytes. ::/128 and ::1/128 map to
-		// 0.0.0.0/8 here and stay prohibited.
-		return netip.AddrFrom4([4]byte{raw[12], raw[13], raw[14], raw[15]}), true
-	case remoteImage6to4Prefix.Contains(addr):
-		return netip.AddrFrom4([4]byte{raw[2], raw[3], raw[4], raw[5]}), true
-	case remoteImageTeredoPrefix.Contains(addr):
-		return netip.AddrFrom4([4]byte{
-			raw[12] ^ 0xff, raw[13] ^ 0xff, raw[14] ^ 0xff, raw[15] ^ 0xff,
-		}), true
-	default:
-		return netip.Addr{}, false
-	}
-}
-
-// prohibitedRemoteIP reports whether a resolved or literal address is a
-// destination the image proxy must never dial. IPv6 forms that embed an IPv4
-// destination — IPv4-mapped (::ffff:a.b.c.d), deprecated IPv4-compatible
-// (::a.b.c.d), NAT64 (64:ff9b::a.b.c.d), 6to4 (2002::/16), and Teredo
-// (2001::/32) — defer to the embedded IPv4 rules so an obfuscated loopback or
-// NAT64-translated private destination cannot slip through as IPv6.
-func prohibitedRemoteIP(addr netip.Addr) bool {
-	if !addr.IsValid() || addr.Zone() != "" {
-		return true
-	}
-	addr = addr.Unmap()
-	if addr.Is6() {
-		if v4, ok := embeddedIPv4(addr); ok {
-			addr = v4
-		}
-	}
-	prefixes := remoteImageProhibitedV4
-	if addr.Is6() {
-		prefixes = remoteImageProhibitedV6
-	}
-	for _, prefix := range prefixes {
-		if prefix.Contains(addr) {
-			return true
-		}
-	}
-	return false
-}
-
-// prohibitedRemoteHostname is the server-side port of the browser hostname
-// gate for non-IP-literal hosts: reserved/conventional-private suffixes,
-// unqualified single-label names, and unnormalized numeric or hex final
-// labels (an IPv4 obfuscation the platform resolver may still parse as an
-// address) are all rejected before any DNS query is made.
-func prohibitedRemoteHostname(hostname string) bool {
-	host := strings.ToLower(strings.TrimSpace(hostname))
-	host = strings.TrimSuffix(host, ".")
-	if host == "" {
-		return true
-	}
-	labels := strings.Split(host, ".")
-	if len(labels) < 2 {
-		return true
-	}
-	last := labels[len(labels)-1]
-	if isDecimalLabel(last) || isHexLabel(last) {
-		return true
-	}
-	for _, suffix := range remoteImageProhibitedSuffixes {
-		if host == suffix || strings.HasSuffix(host, "."+suffix) {
-			return true
-		}
-	}
-	return false
-}
-
-func isDecimalLabel(label string) bool {
-	if label == "" {
-		return false
-	}
-	for _, r := range label {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return true
-}
-
-func isHexLabel(label string) bool {
-	rest, ok := strings.CutPrefix(label, "0x")
-	if !ok {
-		return false
-	}
-	for _, r := range rest {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return false
-		}
-	}
-	return true
-}
+func prohibitedRemoteHostname(hostname string) bool { return netguard.ProhibitedHostname(hostname) }
 
 // remoteImageFetchError is a fetch failure mapped to an API error response.
 // The fetched bytes are never echoed on error.

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -225,6 +225,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 
 	registerAPIV1RawHumaJSONRoute[StatsResponse](apiV1, "getStats", http.MethodGet, "/stats", "Get archive statistics", s.handleStats)
 	s.registerSettingsRoutes(apiV1)
+	s.registerCardDAVRoutes(apiV1)
 	s.registerSavedViewRoutes(apiV1)
 	s.registerExploreRoutes(apiV1)
 	s.registerFilesRoutes(apiV1)

--- a/internal/api/scheduler_jobs.go
+++ b/internal/api/scheduler_jobs.go
@@ -41,6 +41,10 @@ const BeeperJobName = sourceTypeBeeper
 // Slack workspace source.
 const SlackJobName = sourceTypeSlack
 
+// CardDAVJobName is the stable singleton scheduler identity for the configured
+// CardDAV account.
+const CardDAVJobName = "carddav"
+
 // classifySourceScheduling determines which scheduler, if any, may operate a
 // store source. Account scheduling is opt-in so imported or unknown source
 // types cannot borrow a scheduled account merely by sharing its identifier.

--- a/internal/api/scheduler_jobs_test.go
+++ b/internal/api/scheduler_jobs_test.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCardDAVSchedulerJobNameIsStable(t *testing.T) {
+	assert.Equal(t, "carddav", CardDAVJobName)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -234,6 +235,7 @@ type Server struct {
 	shutdownToken  string
 	shutdownFunc   func()
 	scheduler      SyncScheduler
+	cardDAV        *CardDAVController
 	logger         *slog.Logger
 	requestTimeout time.Duration
 	// readTimeout is the ordinary connection read ceiling used by http.Server.
@@ -445,8 +447,11 @@ type ServerOptions struct {
 	// derives it: ready when Backend is non-nil, disabled otherwise. The
 	// serve daemon passes VectorStatusInitializing and installs the
 	// components later via SetVectorFeatures.
-	VectorStatus  VectorStatus
-	Scheduler     SyncScheduler
+	VectorStatus VectorStatus
+	Scheduler    SyncScheduler
+	// CardDAV owns the single configured CardDAV service used by HTTP, CLI,
+	// and scheduled synchronization.
+	CardDAV       *CardDAVController
 	Logger        *slog.Logger
 	IdleTracker   *IdleTracker
 	OperationGate OperationGate
@@ -522,6 +527,7 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		backend:                  opts.Backend,
 		personSearchEngine:       opts.PersonSearchEngine,
 		scheduler:                opts.Scheduler,
+		cardDAV:                  opts.CardDAV,
 		logger:                   opts.Logger,
 		requestTimeout:           timeout,
 		readTimeout:              daemonReadTimeout,
@@ -993,6 +999,10 @@ func (s *Server) timeoutMiddleware(next http.Handler) http.Handler {
 			serveMeetingImportWithReadDeadline(w, r, next)
 			return
 		}
+		if cardDAVRequestNeedsProtectiveCeiling(r) {
+			serveWithProtectiveRequestDeadline(w, r, next)
+			return
+		}
 		if s.requestUsesCLITimeoutPolicy(r) {
 			if cliRequestNeedsProtectiveCeiling(r) {
 				serveWithProtectiveRequestDeadline(w, r, next)
@@ -1011,6 +1021,24 @@ func (s *Server) timeoutMiddleware(next http.Handler) http.Handler {
 		defer cancel()
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// cardDAVRequestNeedsProtectiveCeiling identifies routes that may perform
+// upstream CardDAV requests. Their client has its own five-minute operation
+// budget, so the ordinary one-minute API timeout must not preempt it.
+func cardDAVRequestNeedsProtectiveCeiling(r *http.Request) bool {
+	switch r.Method + " " + r.URL.Path {
+	case "POST /api/v1/carddav/account/test",
+		"PUT /api/v1/carddav/account",
+		"POST /api/v1/carddav/sync":
+		return true
+	}
+	if strings.HasPrefix(r.URL.Path, "/api/v1/carddav/publications/") {
+		return r.Method == http.MethodPost || r.Method == http.MethodDelete
+	}
+	return r.Method == http.MethodPost &&
+		strings.HasPrefix(r.URL.Path, "/api/v1/carddav/conflicts/") &&
+		strings.HasSuffix(r.URL.Path, "/resolve")
 }
 
 // cliRequestNeedsProtectiveCeiling identifies marked CLI routes whose
@@ -1057,6 +1085,7 @@ func (s *Server) requestTimeoutForPath(path string) (time.Duration, bool) {
 func isLongDaemonRequest(path string) bool {
 	switch path {
 	case "/api/v1/cli/build-cache",
+		"/api/v1/carddav/sync",
 		"/api/v1/cli/deduplicate/plan",
 		meetingImportEndpointPath,
 		"/api/v1/cli/identities/discover",

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1216,6 +1216,46 @@ func TestTimeoutMiddlewareDeadlinePolicy(t *testing.T) {
 	}
 }
 
+func TestCardDAVNetworkRoutesReceiveProtectiveDeadline(t *testing.T) {
+	srv := NewServerWithOptions(ServerOptions{
+		Config:         &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Logger:         testLogger(),
+		RequestTimeout: 5 * time.Millisecond,
+	})
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/api/v1/carddav/account/test"},
+		{method: http.MethodPut, path: "/api/v1/carddav/account"},
+		{method: http.MethodPost, path: "/api/v1/carddav/publications/7"},
+		{method: http.MethodDelete, path: "/api/v1/carddav/publications/7"},
+		{method: http.MethodPost, path: "/api/v1/carddav/conflicts/7/resolve"},
+		{method: http.MethodPost, path: "/api/v1/carddav/sync"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			var deadline time.Time
+			var hasDeadline bool
+			handler := srv.timeoutMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				deadline, hasDeadline = r.Context().Deadline()
+			}))
+			recorder := &deadlineClearingRecorder{ResponseRecorder: httptest.NewRecorder()}
+			handler.ServeHTTP(recorder, httptest.NewRequest(route.method, route.path, nil))
+
+			require.True(hasDeadline, "network route receives a context deadline")
+			remaining := time.Until(deadline)
+			assert.Greater(remaining, DaemonLongRequestTimeout-time.Second)
+			assert.LessOrEqual(remaining, DaemonLongRequestTimeout)
+			require.Len(recorder.readDeadlines, 1, "network route extends the server read deadline")
+			assert.Empty(recorder.writeDeadlines, "network route keeps the generous server write deadline")
+		})
+	}
+}
+
 func TestCLIRequestDurationPolicy(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,10 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 )
 
-const settingsPath = "/api/v1/settings"
+const (
+	settingsPath         = "/api/v1/settings"
+	settingsGroupSources = "sources"
+)
 
 // SecretSettingState is the only representation of a secret returned to a
 // browser. The configured value never crosses the API boundary.
@@ -79,9 +83,10 @@ type settingDefinition struct {
 	// editing config.toml on the daemon host. Used for values that select
 	// daemon-side resources (such as environment variable names) which a
 	// remote session must never control.
-	localOnly bool
-	secret    func(*config.Config) bool
-	read      func(*config.Config) any
+	localOnly    bool
+	secret       func(*config.Config) bool
+	serverSecret func(context.Context, *Server, *config.Config) bool
+	read         func(*config.Config) any
 }
 
 var settingsCatalog = []settingDefinition{
@@ -143,8 +148,13 @@ var settingsCatalog = []settingDefinition{
 	intSetting("vector.search.rrf_k", "search", func(c *config.Config) int { return c.Vector.Search.RRFK }),
 	intSetting("vector.search.k_per_signal", "search", func(c *config.Config) int { return c.Vector.Search.KPerSignal }),
 	numberSetting("vector.search.subject_boost", "search", func(c *config.Config) float64 { return c.Vector.Search.SubjectBoost }),
-	boolSetting("beeper.enabled", "sources", func(c *config.Config) bool { return c.Beeper.Enabled }),
-	stringSetting("beeper.schedule", "sources", nil, func(c *config.Config) string { return c.Beeper.Schedule }),
+	boolSetting("beeper.enabled", settingsGroupSources, func(c *config.Config) bool { return c.Beeper.Enabled }),
+	stringSetting("beeper.schedule", settingsGroupSources, nil, func(c *config.Config) string { return c.Beeper.Schedule }),
+	readOnlyStringSetting("carddav.base_url", settingsGroupSources, func(c *config.Config) string { return c.CardDAV.BaseURL }),
+	readOnlyStringSetting("carddav.username", settingsGroupSources, func(c *config.Config) string { return c.CardDAV.Username }),
+	readOnlyStringSetting("carddav.schedule", settingsGroupSources, func(c *config.Config) string { return c.CardDAV.Schedule }),
+	readOnlyBoolSetting("carddav.enabled", settingsGroupSources, func(c *config.Config) bool { return c.CardDAV.Enabled }),
+	readOnlyCardDAVSecretSetting(),
 	boolSetting("integrations.tasks.enabled", "integrations", func(c *config.Config) bool { return c.Integrations.Tasks.Enabled }),
 	testableStringSetting("integrations.tasks.endpoint", "integrations", func(c *config.Config) string { return c.Integrations.Tasks.Endpoint }),
 	secretSetting("integrations.tasks.api_key", "integrations", func(c *config.Config) bool { return c.Integrations.Tasks.APIKey != "" }),
@@ -205,6 +215,26 @@ func localOnlyStringSetting(key, group string, read func(*config.Config) string)
 	return definition
 }
 
+func readOnlyStringSetting(key, group string, read func(*config.Config) string) settingDefinition {
+	return localOnlyStringSetting(key, group, read)
+}
+
+func readOnlyBoolSetting(key, group string, read func(*config.Config) bool) settingDefinition {
+	definition := boolSetting(key, group, read)
+	definition.localOnly = true
+	return definition
+}
+
+func readOnlyCardDAVSecretSetting() settingDefinition {
+	return settingDefinition{
+		key: "carddav.password", group: settingsGroupSources, kind: "secret", localOnly: true,
+		serverSecret: func(ctx context.Context, s *Server, c *config.Config) bool {
+			return s != nil && s.cardDAV != nil &&
+				s.cardDAV.passwordConfigured(ctx, c.CardDAV.BaseURL, c.CardDAV.Username)
+		},
+	}
+}
+
 func intSetting(key, group string, read func(*config.Config) int) settingDefinition {
 	return settingDefinition{key: key, group: group, kind: "integer", read: func(c *config.Config) any { return read(c) }}
 }
@@ -233,7 +263,7 @@ func settingsDefinitionByKey() map[string]settingDefinition {
 	return result
 }
 
-func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleGetSettings(w http.ResponseWriter, r *http.Request) {
 	snapshot, cfg, err := s.readPersistedSettings()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "settings_read_failed", err.Error())
@@ -241,7 +271,7 @@ func (s *Server) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 	}
 	w.Header().Set(etagHeaderName, snapshot.ETag)
 	w.Header().Set("Cache-Control", "no-store")
-	writeJSON(w, http.StatusOK, buildSettingsResponse(cfg, s.settingsPendingRestart.Load()))
+	writeJSON(w, http.StatusOK, s.buildSettingsResponse(r.Context(), cfg, s.settingsPendingRestart.Load()))
 }
 
 func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
@@ -316,7 +346,7 @@ func (s *Server) handlePatchSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set(etagHeaderName, snapshot.ETag)
 	w.Header().Set("Cache-Control", "no-store")
-	writeJSON(w, http.StatusOK, buildSettingsResponse(loaded, true))
+	writeJSON(w, http.StatusOK, s.buildSettingsResponse(r.Context(), loaded, true))
 }
 
 func (s *Server) readPersistedSettings() (config.ConfigFile, *config.Config, error) {
@@ -334,7 +364,7 @@ func (s *Server) readPersistedSettings() (config.ConfigFile, *config.Config, err
 	return snapshot, loaded, nil
 }
 
-func buildSettingsResponse(cfg *config.Config, pendingRestart bool) SettingsResponse {
+func (s *Server) buildSettingsResponse(ctx context.Context, cfg *config.Config, pendingRestart bool) SettingsResponse {
 	settings := make([]Setting, 0, len(settingsCatalog))
 	for _, definition := range settingsCatalog {
 		setting := Setting{
@@ -346,7 +376,9 @@ func buildSettingsResponse(cfg *config.Config, pendingRestart bool) SettingsResp
 			Testable:        definition.testable,
 			ReadOnly:        definition.localOnly,
 		}
-		if definition.secret != nil {
+		if definition.serverSecret != nil {
+			setting.Secret = &SecretSettingState{Configured: definition.serverSecret(ctx, s, cfg)}
+		} else if definition.secret != nil {
 			setting.Secret = &SecretSettingState{Configured: definition.secret(cfg)}
 		} else {
 			setting.Value = settingValue(definition.kind, definition.read(cfg))

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -11,11 +11,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/carddav"
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
 )
 
 func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
@@ -55,7 +59,8 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 		assert.True(setting.RestartRequired, setting.Key)
 		wantReadOnly := setting.Key == "vector.embeddings.api_key_env" ||
 			setting.Key == "vector.multimodal.api_key_env" ||
-			setting.Key == "vector.multimodal.capabilities_file"
+			setting.Key == "vector.multimodal.capabilities_file" ||
+			strings.HasPrefix(setting.Key, "carddav.")
 		assert.Equal(wantReadOnly, setting.ReadOnly, setting.Key)
 	}
 	assert.NotContains(resp.Body.String(), "test-api-key")
@@ -84,6 +89,90 @@ func TestPatchSettingsExposesCompleteSemanticPersonOptInPolicy(t *testing.T) {
 	check.Contains(string(got), "people.enabled = true")
 	check.Contains(string(got), `people.retention_posture = "zero_data_retention"`)
 	check.Contains(string(got), `people.training_posture = "no_training"`)
+}
+
+func TestGetSettingsExposesReadOnlyCardDAVAccountStateWithoutCredential(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _ := newSettingsTestServer(t, `[carddav]
+base_url = "https://contacts.example/dav"
+username = "alice"
+schedule = "0 3 * * *"
+enabled = true
+`)
+	st := testutil.NewTestStore(t)
+	account, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: srv.cfg.CardDAV.BaseURL, Username: srv.cfg.CardDAV.Username,
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+		}},
+	})
+	require.NoError(err)
+	require.NoError(carddav.SaveCredential(srv.cfg.TokensDir(), carddav.Credential{
+		Password: "must-not-cross-api", BaseURL: srv.cfg.CardDAV.BaseURL,
+		Username: srv.cfg.CardDAV.Username, ConnectionGeneration: account.ConnectionGeneration,
+	}))
+	srv.cardDAV, err = NewCardDAVController(srv.cfg, st)
+	require.NoError(err)
+
+	resp := performSettingsRequest(t, srv, http.MethodGet, settingsPath, nil, "", "")
+	require.Equal(http.StatusOK, resp.Code, resp.Body.String())
+	var body SettingsResponse
+	require.NoError(json.Unmarshal(resp.Body.Bytes(), &body))
+	byKey := settingsByKey(body.Settings)
+	for _, key := range []string{"carddav.base_url", "carddav.username", "carddav.schedule", "carddav.enabled", "carddav.password"} {
+		require.Contains(byKey, key)
+		assert.True(byKey[key].ReadOnly, key)
+	}
+	assert.Equal(&SecretSettingState{Configured: true}, byKey["carddav.password"].Secret)
+	assert.NotContains(resp.Body.String(), "must-not-cross-api")
+
+	patch := performSettingsRequest(t, srv, http.MethodPatch, settingsPath,
+		[]byte(`{"updates":[{"key":"carddav.enabled","value":{"boolean":false}}]}`),
+		resp.Header().Get("ETag"), "")
+	assert.Equal(http.StatusBadRequest, patch.Code, patch.Body.String())
+}
+
+func TestGetSettingsReportsStaleCardDAVCredentialAsNotConfigured(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _ := newSettingsTestServer(t, `[carddav]
+base_url = "https://contacts.example/dav"
+username = "alice"
+enabled = true
+`)
+	st := testutil.NewTestStore(t)
+	discovery := store.CardDAVDiscoveryInput{
+		BaseURL: srv.cfg.CardDAV.BaseURL, Username: srv.cfg.CardDAV.Username,
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+		}},
+	}
+	account, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), discovery)
+	require.NoError(err)
+	require.NoError(carddav.SaveCredential(srv.cfg.TokensDir(), carddav.Credential{
+		Password: "stale-password", BaseURL: srv.cfg.CardDAV.BaseURL,
+		Username: srv.cfg.CardDAV.Username, ConnectionGeneration: account.ConnectionGeneration,
+	}))
+	discovery.CredentialsChanged = true
+	account, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), discovery)
+	require.NoError(err)
+	assert.Equal(int64(2), account.ConnectionGeneration)
+	srv.cardDAV, err = NewCardDAVController(srv.cfg, st)
+	require.NoError(err)
+
+	resp := performSettingsRequest(t, srv, http.MethodGet, settingsPath, nil, "", "")
+	require.Equal(http.StatusOK, resp.Code, resp.Body.String())
+	var body SettingsResponse
+	require.NoError(json.Unmarshal(resp.Body.Bytes(), &body))
+	assert.Equal(&SecretSettingState{Configured: false}, settingsByKey(body.Settings)["carddav.password"].Secret)
+	assert.NotContains(resp.Body.String(), "stale-password")
 }
 
 func TestPatchSettingsSelectsVoyageContextualEmbeddingFormat(t *testing.T) {

--- a/internal/carddav/conflicts.go
+++ b/internal/carddav/conflicts.go
@@ -1,0 +1,356 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type ResolutionChoice string
+
+const (
+	ResolutionKeepLocal  ResolutionChoice = "keep_local"
+	ResolutionKeepRemote ResolutionChoice = "keep_remote"
+)
+
+var (
+	ErrInvalidResolutionChoice = errors.New("invalid CardDAV conflict resolution choice")
+	ErrCardDAVConflictPending  = errors.New("CardDAV mapping has an unresolved conflict")
+)
+
+type ConflictError struct {
+	ID int64
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("%s: conflict %d", ErrCardDAVConflictPending, e.ID)
+}
+
+func (e *ConflictError) Unwrap() error { return ErrCardDAVConflictPending }
+
+func (s *Service) ListConflicts(ctx context.Context) ([]store.CardDAVConflict, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("CardDAV service is not configured")
+	}
+	return s.store.ListCardDAVConflictsContext(ctx, true)
+}
+
+func (s *Service) GetConflict(ctx context.Context, id int64) (*store.CardDAVConflict, error) {
+	if s == nil || s.store == nil || id <= 0 {
+		return nil, errors.New("CardDAV service is not configured")
+	}
+	return s.store.GetCardDAVConflictContext(ctx, id)
+}
+
+func (s *Service) ResolveConflict(ctx context.Context, id int64, choice ResolutionChoice) error {
+	if choice != ResolutionKeepLocal && choice != ResolutionKeepRemote {
+		return ErrInvalidResolutionChoice
+	}
+	if s == nil || s.store == nil || s.client == nil || id <= 0 {
+		return errors.New("CardDAV service is not configured")
+	}
+	conflict, err := s.store.GetCardDAVConflictContext(ctx, id)
+	if err != nil {
+		return err
+	}
+	if conflict.Status != store.CardDAVConflictUnresolved {
+		return store.ErrCardDAVConflictStale
+	}
+	if choice == ResolutionKeepRemote {
+		operationCtx, cancel := context.WithTimeout(ctx, s.client.operationTimeout)
+		defer cancel()
+		remote, tombstone, fetchErr := s.fetchCanonical(operationCtx, conflict.Href)
+		if fetchErr != nil {
+			return fetchErr
+		}
+		if tombstone != conflict.RemoteTombstone ||
+			(!tombstone && remote.RemoteETag != conflict.RemoteETag) {
+			return store.ErrCardDAVConflictStale
+		}
+		_, err = s.store.ResolveCardDAVConflictRemoteContext(operationCtx, store.CardDAVConflictRemoteResolution{
+			ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+			Remote: remote, RemoteTombstone: tombstone,
+		})
+		if err != nil {
+			return err
+		}
+		_, err = s.store.SweepResolvedCardDAVConflictsContext(operationCtx, time.Now())
+		return err
+	}
+	return s.resolveConflictKeepLocal(ctx, conflict)
+}
+
+func (s *Service) prepareSyncConflicts(
+	ctx context.Context, book store.CardDAVAddressBook, plan *store.CardDAVSyncPlan,
+) error {
+	resources, err := s.store.ListCardDAVResourcesContext(ctx, book.ID)
+	if err != nil {
+		return err
+	}
+	byHref := make(map[string]store.CardDAVResource, len(resources))
+	byRemoteUID := make(map[string][]store.CardDAVResource, len(resources))
+	for _, resource := range resources {
+		byHref[resource.Href] = resource
+		if resource.RemoteUID != "" {
+			byRemoteUID[resource.RemoteUID] = append(byRemoteUID[resource.RemoteUID], resource)
+		}
+	}
+	removed := make(map[string]bool, len(plan.RemovedHrefs))
+	for _, href := range plan.RemovedHrefs {
+		removed[href] = true
+	}
+	seen := make(map[string]bool, len(plan.Upserts))
+	for _, remote := range plan.Upserts {
+		seen[remote.Href] = true
+	}
+	changed := make(map[string]*store.CardDAVRemoteResource, len(plan.Upserts))
+	claimedPreviousHrefs := make(map[string]bool)
+	for index := range plan.Upserts {
+		remote := &plan.Upserts[index]
+		if _, exists := byHref[remote.Href]; !exists && remote.RemoteUID != "" {
+			matches := byRemoteUID[remote.RemoteUID]
+			if len(matches) == 1 && !claimedPreviousHrefs[matches[0].Href] {
+				old := matches[0]
+				eligible := removed[old.Href] || plan.ReplaceAll && !seen[old.Href]
+				if eligible {
+					remote.PreviousHref = old.Href
+					claimedPreviousHrefs[old.Href] = true
+					delete(byHref, old.Href)
+					byHref[remote.Href] = old
+				}
+			}
+		}
+		changed[remote.Href] = remote
+	}
+	if plan.ReplaceAll {
+		for href := range byHref {
+			if _, exists := changed[href]; !exists {
+				removed[href] = true
+			}
+		}
+	}
+	for href, remote := range changed {
+		mapping, exists := byHref[href]
+		if !exists {
+			continue
+		}
+		capture, needed, err := s.prepareMappingConflict(ctx, book, mapping, remote, false)
+		if err != nil {
+			return err
+		}
+		if needed {
+			if remote.PreviousHref != "" {
+				capture.Href = remote.Href
+			}
+			plan.Conflicts = append(plan.Conflicts, capture)
+		}
+	}
+	for href := range removed {
+		mapping, exists := byHref[href]
+		if !exists {
+			continue
+		}
+		capture, needed, err := s.prepareMappingConflict(ctx, book, mapping, nil, true)
+		if err != nil {
+			return err
+		}
+		if needed {
+			plan.Conflicts = append(plan.Conflicts, capture)
+		}
+	}
+	return nil
+}
+
+func (s *Service) recordPublicationConflict(
+	ctx context.Context, pending *store.CardDAVPublication,
+	remote store.CardDAVRemoteResource, remoteTombstone, retainOversizeIntent bool,
+) error {
+	mapping, err := s.store.GetCardDAVResourceContext(ctx, pending.AddressBookID, pending.Href)
+	if err != nil {
+		return err
+	}
+	localBody := append([]byte(nil), pending.OutgoingBody...)
+	localHash := pending.LocalHash
+	localTombstone := pending.PendingOperation == store.CardDAVMutationDelete
+	if !localTombstone && mapping.PersonID != nil {
+		snapshot, err := s.store.LoadPersonVCardSnapshotContext(ctx, *mapping.PersonID)
+		if err != nil {
+			return err
+		}
+		if snapshot.Fingerprint != pending.LocalHash {
+			books, err := s.store.ListCardDAVAddressBooksContext(ctx)
+			if err != nil {
+				return err
+			}
+			book, ok := findCardDAVBook(books, pending.AddressBookID)
+			if !ok {
+				return store.ErrCardDAVStalePlan
+			}
+			person, err := s.store.GetPersonContext(ctx, *mapping.PersonID)
+			if err != nil {
+				return err
+			}
+			localBody, localHash, err = s.renderPublicationCard(ctx, *person, book, mapping)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	capture := store.CardDAVConflictCapture{
+		AddressBookID: mapping.AddressBookID, Href: mapping.Href,
+		ExpectedMappingRevision: mapping.MappingRevision,
+		BaseLocalHash:           mapping.LocalHash, LocalHash: localHash,
+		BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+		LocalBody: localBody, LocalTombstone: localTombstone,
+		RemoteETag: remote.RemoteETag, RemoteBody: remote.RemoteBody,
+		RemoteTombstone: remoteTombstone,
+	}
+	var conflict *store.CardDAVConflict
+	if retainOversizeIntent {
+		conflict, err = s.store.RecordCardDAVPublicationConflictRetainingIntentContext(ctx, *pending, capture)
+	} else {
+		conflict, err = s.store.RecordCardDAVPublicationConflictContext(ctx, *pending, capture)
+	}
+	if err != nil {
+		return err
+	}
+	return &ConflictError{ID: conflict.ID}
+}
+
+func (s *Service) prepareMappingConflict(
+	ctx context.Context, book store.CardDAVAddressBook, mapping store.CardDAVResource,
+	remote *store.CardDAVRemoteResource, remoteTombstone bool,
+) (store.CardDAVConflictCapture, bool, error) {
+	if mapping.MappingStatus != store.CardDAVMappingMapped {
+		return store.CardDAVConflictCapture{}, false, nil
+	}
+	existingConflict, conflictErr := s.store.GetUnresolvedCardDAVConflictForMappingContext(ctx, book.ID, mapping.Href)
+	unresolved := conflictErr == nil
+	if conflictErr != nil && !errors.Is(conflictErr, store.ErrCardDAVConflictNotFound) {
+		return store.CardDAVConflictCapture{}, false, conflictErr
+	}
+	localTombstone := mapping.PersonID == nil || (existingConflict != nil && existingConflict.LocalTombstone)
+	localHash := mapping.LocalHash
+	var localBody []byte
+	if mapping.PersonID != nil && !localTombstone {
+		person, err := s.store.GetPersonContext(ctx, *mapping.PersonID)
+		if err != nil {
+			return store.CardDAVConflictCapture{}, false, err
+		}
+		body, hash, err := s.renderPublicationCard(ctx, *person, book, &mapping)
+		if err != nil {
+			return store.CardDAVConflictCapture{}, false, err
+		}
+		localBody, localHash = body, hash
+	}
+	localChanged := localTombstone || localHash != mapping.LocalHash
+	remoteChanged := remoteTombstone || remote.SemanticHash != mapping.RemoteSemanticHash
+	if !unresolved && (!localChanged || !remoteChanged) {
+		return store.CardDAVConflictCapture{}, false, nil
+	}
+	if !unresolved && localTombstone && remoteTombstone {
+		return store.CardDAVConflictCapture{}, false, nil
+	}
+	if !unresolved && !localTombstone && !remoteTombstone {
+		localSemanticHash, err := SemanticHash(localBody)
+		if err != nil {
+			return store.CardDAVConflictCapture{}, false, err
+		}
+		if localSemanticHash == remote.SemanticHash {
+			remote.EquivalentLocalHash = localHash
+			return store.CardDAVConflictCapture{}, false, nil
+		}
+	}
+	capture := store.CardDAVConflictCapture{
+		AddressBookID: book.ID, Href: mapping.Href,
+		ExpectedMappingRevision: mapping.MappingRevision,
+		BaseLocalHash:           mapping.LocalHash, LocalHash: localHash,
+		BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+		LocalBody: localBody, LocalTombstone: localTombstone,
+		RemoteTombstone: remoteTombstone,
+	}
+	if remote != nil {
+		capture.RemoteETag = remote.RemoteETag
+		capture.RemoteBody = append([]byte(nil), remote.RemoteBody...)
+	}
+	size := 0
+	if !capture.LocalTombstone {
+		size += len(capture.LocalBody)
+	}
+	if !capture.RemoteTombstone {
+		size += len(capture.RemoteBody)
+	}
+	if size > store.MaxCardDAVConflictSnapshotBytes {
+		return store.CardDAVConflictCapture{}, false, store.ErrCardDAVConflictTooLarge
+	}
+	return capture, true, nil
+}
+
+func (s *Service) resolveConflictKeepLocal(
+	ctx context.Context, conflict *store.CardDAVConflict,
+) error {
+	operationCtx, cancel := context.WithTimeout(ctx, s.client.operationTimeout)
+	defer cancel()
+	remote, tombstone, err := s.fetchCanonical(operationCtx, conflict.Href)
+	if err != nil {
+		return err
+	}
+	if conflict.LocalTombstone {
+		if conflict.PendingOperation != "" {
+			pending := &store.CardDAVPublication{
+				AddressBookID: conflict.AddressBookID, Href: conflict.Href,
+				PendingOperation: conflict.PendingOperation, RemoteETag: conflict.RemoteETag,
+				ConnectionGeneration:    conflict.ConnectionGeneration,
+				BookSyncRevision:        conflict.BookSyncRevision,
+				MappingRevision:         conflict.MappingRevision,
+				PreviousMappingRevision: conflict.PreviousMappingRevision,
+				PendingStartedAt:        conflict.PendingStartedAt,
+				RecoveryOnly:            true, ResolutionConflictID: conflict.ID,
+			}
+			if err := s.executeMutation(operationCtx, pending); err != nil {
+				return err
+			}
+			_, err = s.store.SweepResolvedCardDAVConflictsContext(operationCtx, time.Now())
+			return err
+		}
+		if !tombstone {
+			pending, prepareErr := s.store.PrepareCardDAVConflictLocalTombstoneContext(
+				operationCtx, conflict.ID, conflict.MappingRevision, remote)
+			if prepareErr != nil {
+				return prepareErr
+			}
+			if err := s.executeMutation(operationCtx, pending); err != nil {
+				return err
+			}
+		} else {
+			_, err = s.store.ResolveCardDAVConflictLocalTombstoneContext(
+				operationCtx, conflict.ID, conflict.MappingRevision)
+			if err != nil {
+				return err
+			}
+		}
+		_, err = s.store.SweepResolvedCardDAVConflictsContext(operationCtx, time.Now())
+		return err
+	}
+	semanticHash, err := SemanticHash(conflict.LocalBody)
+	if err != nil {
+		return err
+	}
+	prepared, err := s.store.PrepareCardDAVConflictLocalContext(operationCtx,
+		store.CardDAVConflictLocalPlan{
+			ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+			RemoteETag: remote.RemoteETag, RemoteTombstone: tombstone,
+			OutgoingSemanticHash: semanticHash,
+		})
+	if err != nil {
+		return err
+	}
+	if err := s.executeMutation(operationCtx, prepared); err != nil {
+		return err
+	}
+	_, err = s.store.SweepResolvedCardDAVConflictsContext(operationCtx, time.Now())
+	return err
+}

--- a/internal/carddav/conflicts_test.go
+++ b/internal/carddav/conflicts_test.go
@@ -1,0 +1,1506 @@
+package carddav
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func conflictCard(uid, name string) []byte {
+	return []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + uid + "\r\nFN:" + name + "\r\nEND:VCARD\r\n")
+}
+
+func conflictCardWithEmail(uid, name, email string) []byte {
+	return []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + uid + "\r\nFN:" + name +
+		"\r\nEMAIL:" + email + "\r\nEND:VCARD\r\n")
+}
+
+func escapedCardData(body []byte) string {
+	value := strings.ReplaceAll(string(body), "&", "&amp;")
+	value = strings.ReplaceAll(value, "<", "&lt;")
+	return strings.ReplaceAll(value, ">", "&gt;")
+}
+
+func TestPullConflictBlocksOnlyMappingAndAdvancesBookFence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	cards := map[string]struct {
+		body []byte
+		etag string
+	}{
+		"alice": {body: conflictCard("alice", "Alice Base"), etag: `"alice-1"`},
+		"bob":   {body: conflictCard("bob", "Bob Base"), etag: `"bob-1"`},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		var events strings.Builder
+		for _, uid := range []string{"alice", "bob"} {
+			card := cards[uid]
+			events.WriteString(cardResponseRaw("/books/personal/"+uid+".vcf", card.etag, escapedCardData(card.body)))
+		}
+		writeDAVXML(t, w, syncResponse(events.String(), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	beforeRevision := books[0].SyncRevision
+	alice, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	require.NotNil(alice.PersonID)
+	bob, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/bob.vcf")
+	require.NoError(err)
+	_, err = st.AddPersonContactPointContext(t.Context(), *alice.PersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+
+	mu.Lock()
+	cards["alice"] = struct {
+		body []byte
+		etag string
+	}{body: conflictCard("alice", "Alice Remote"), etag: `"alice-2"`}
+	cards["bob"] = struct {
+		body []byte
+		etag string
+	}{body: conflictCard("bob", "Bob Remote"), etag: `"bob-2"`}
+	mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Equal(beforeRevision+1, books[0].SyncRevision)
+
+	afterAlice, err := st.GetCardDAVResourceContext(t.Context(), book.ID, alice.Href)
+	require.NoError(err)
+	assert.Equal(alice.RemoteBody, afterAlice.RemoteBody, "conflicted mapping must retain its last common remote state")
+	afterBob, err := st.GetCardDAVResourceContext(t.Context(), book.ID, bob.Href)
+	require.NoError(err)
+	assert.Equal(cards["bob"].body, afterBob.RemoteBody, "unrelated mapping must continue applying")
+
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.Equal(alice.Href, conflicts[0].Href)
+	assert.Contains(string(conflicts[0].LocalBody), "EMAIL:alice-local@example.test")
+	assert.Equal(cards["alice"].body, conflicts[0].RemoteBody)
+}
+
+func TestPullConflictCapturesLocalEditAgainstRemoteDelete(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	deleted := false
+	body := conflictCard("alice", "Alice Base")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.Method == http.MethodGet {
+			if deleted {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("ETag", `"one"`)
+			_, err := w.Write(body)
+			assert.NoError(err)
+			return
+		}
+		events := ""
+		if !deleted {
+			events = cardResponseRaw("/books/personal/alice.vcf", `"one"`, escapedCardData(body))
+		}
+		writeDAVXML(t, w, syncResponse(events, ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO carddav_publications
+		(person_id, desired, address_book_id, href) VALUES (?, TRUE, ?, ?)`),
+		*mapping.PersonID, book.ID, mapping.Href)
+	require.NoError(err)
+	_, err = st.AddPersonContactPointContext(t.Context(), *mapping.PersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	mu.Lock()
+	deleted = true
+	mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.True(conflicts[0].RemoteTombstone)
+	assert.False(conflicts[0].LocalTombstone)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err, "conflict must retain the mapping")
+	require.NoError(service.ResolveConflict(t.Context(), conflicts[0].ID, ResolutionKeepRemote))
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), *mapping.PersonID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+}
+
+func TestPullConflictCapturesLocalDeleteAgainstRemoteEdit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	body := conflictCard("alice", "Alice Base")
+	etag := `"one"`
+	remoteDeleted := false
+	deletes := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.Method {
+		case "REPORT":
+			events := ""
+			if !remoteDeleted {
+				events = cardResponseRaw("/books/personal/alice.vcf", etag, escapedCardData(body))
+			}
+			writeDAVXML(t, w, syncResponse(events, ""))
+		case http.MethodGet:
+			if remoteDeleted {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("ETag", etag)
+			_, err := w.Write(body)
+			assert.NoError(err)
+		case http.MethodDelete:
+			deletes++
+			assert.Equal(etag, r.Header.Get("If-Match"))
+			remoteDeleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+	require.NoError(err)
+	require.NoError(st.DeletePersonContext(t.Context(), person.ID, person.Revision))
+	mu.Lock()
+	body = conflictCard("alice", "Alice Remote")
+	etag = `"two"`
+	mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.True(conflicts[0].LocalTombstone)
+	assert.False(conflicts[0].RemoteTombstone)
+	assert.Equal(body, conflicts[0].RemoteBody)
+	require.NoError(service.ResolveConflict(t.Context(), conflicts[0].ID, ResolutionKeepLocal))
+	assert.Equal(1, deletes)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func TestPullAppliesEquivalentConcurrentOutcomesWithoutConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	body := conflictCard("alice", "Alice Base")
+	etag := `"one"`
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		if r.Method != "REPORT" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		responses := ""
+		if !deleted {
+			responses = cardResponseRaw("/books/personal/alice.vcf", etag, escapedCardData(body))
+		}
+		writeDAVXML(t, w, syncResponse(responses, ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+	_, err = st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	localBody, _, err := service.renderPublicationCard(t.Context(), *person, book, mapping)
+	require.NoError(err)
+	mu.Lock()
+	body, etag = localBody, `"two"`
+	mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	assert.Empty(conflicts)
+	mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(`"two"`, mapping.RemoteETag)
+	person, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NoError(st.DeletePersonContext(t.Context(), personID, person.Revision))
+	mu.Lock()
+	deleted = true
+	mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err = service.ListConflicts(t.Context())
+	require.NoError(err)
+	assert.Empty(conflicts)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func TestKeepRemoteReimportsSubscribedCardAfterLocalDeleteWithoutPublicationReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	fixture.body = conflictCard("person", "Alice Base")
+	fixture.etag = `"remote-base"`
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NoError(st.DeletePersonContext(t.Context(), personID, person.Revision))
+	latest := conflictCard("person", "Alice Retained")
+	fixture.mu.Lock()
+	fixture.body = latest
+	fixture.etag = `"remote-retained"`
+	fixture.mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	require.NoError(service.ResolveConflict(t.Context(), conflicts[0].ID, ResolutionKeepRemote))
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	assert.NotEqual(personID, *mapping.PersonID)
+	assert.Equal(store.CardDAVGovernanceRemote, mapping.Governance)
+	fixture.mu.Lock()
+	requestsBeforeReconcile := fixture.puts + fixture.deletes + fixture.gets + fixture.reports
+	fixture.mu.Unlock()
+	require.NoError(service.ReconcilePublications(t.Context()))
+	fixture.mu.Lock()
+	assert.Equal(requestsBeforeReconcile, fixture.puts+fixture.deletes+fixture.gets+fixture.reports)
+	fixture.mu.Unlock()
+}
+
+func TestKeepRemoteRebasesBoundImportedProjectionWithoutPublicationReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{
+		body: conflictCardWithEmail(
+			"person", "Alice Remote Base", "alice.base@example.test",
+		),
+		etag: `"remote-1"`,
+	}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(
+		t.Context(), book.ID, book.CanonicalURL+"person.vcf",
+	)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	_, err = st.UpdatePersonDisplayNameContext(
+		t.Context(), personID, person.Revision, new("Alice Local Label"),
+	)
+	require.NoError(err)
+	_, err = st.AddPersonNameContext(t.Context(), personID, store.PersonNameInput{
+		NameKind: store.PersonNameSort, SortAs: new("Local Sort Key"),
+		OriginalValue: "Local Sort Key",
+		Envelope:      store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO carddav_publications
+		(person_id, desired, address_book_id, href) VALUES (?, TRUE, ?, ?)`),
+		personID, book.ID, mapping.Href)
+	require.NoError(err)
+
+	retained := conflictCardWithEmail(
+		"person", "Alice Remote Retained", "alice.retained@example.test",
+	)
+	fixture.mu.Lock()
+	fixture.body = retained
+	fixture.etag = `"remote-2"`
+	fixture.mu.Unlock()
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+
+	require.NoError(service.ResolveConflict(
+		t.Context(), conflicts[0].ID, ResolutionKeepRemote,
+	))
+	person, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NotNil(person.DisplayName)
+	assert.Equal("Alice Local Label", *person.DisplayName,
+		"an explicit local display label must not be overwritten")
+	names, err := st.ListPersonNamesContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(names, 2)
+	remoteName, userName := names[0], names[1]
+	if remoteName.Envelope.Source == store.ProvenanceUser {
+		remoteName, userName = userName, remoteName
+	}
+	require.NotNil(remoteName.Formatted)
+	assert.Equal("Alice Remote Retained", *remoteName.Formatted)
+	assert.Equal(store.ProvenanceCardDAVImport, remoteName.Envelope.Source)
+	require.NotNil(userName.SortAs)
+	assert.Equal("Local Sort Key", *userName.SortAs)
+	assert.Equal(store.ProvenanceUser, userName.Envelope.Source)
+	points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(points, 1)
+	assert.Equal("alice.retained@example.test", points[0].OriginalValue)
+	assert.Equal(store.ProvenanceCardDAVImport, points[0].Envelope.Source)
+
+	mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(snapshot.Fingerprint, mapping.LocalHash)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+
+	fixture.mu.Lock()
+	putsBefore, deletesBefore := fixture.puts, fixture.deletes
+	getsBefore, reportsBefore := fixture.gets, fixture.reports
+	fixture.mu.Unlock()
+	require.NoError(service.ReconcilePublications(t.Context()))
+	fixture.mu.Lock()
+	assert.Equal(putsBefore, fixture.puts)
+	assert.Equal(deletesBefore, fixture.deletes)
+	assert.Equal(getsBefore, fixture.gets)
+	assert.Equal(reportsBefore, fixture.reports)
+	fixture.mu.Unlock()
+}
+
+func TestKeepRemoteRebasesImportedPersonCleanupBaseline(t *testing.T) {
+	tests := []struct {
+		name               string
+		makeLocalChange    func(t *testing.T, st *store.Store, personID int64)
+		wantPersonRetained bool
+	}{
+		{
+			name: "discarded imported projection edit advances cleanup baseline",
+			makeLocalChange: func(t *testing.T, st *store.Store, personID int64) {
+				t.Helper()
+				points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+				require.NoError(t, err)
+				require.Len(t, points, 1)
+				require.NoError(t, st.SupersedePersonContactPointContext(
+					t.Context(), personID, points[0].Envelope.ID, nil,
+				))
+			},
+		},
+		{
+			name: "explicit user state keeps cleanup baseline",
+			makeLocalChange: func(t *testing.T, st *store.Store, personID int64) {
+				t.Helper()
+				_, err := st.AddPersonNameContext(t.Context(), personID, store.PersonNameInput{
+					NameKind: store.PersonNameSort, SortAs: new("User Sort Key"),
+					OriginalValue: "User Sort Key",
+					Envelope:      store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+				})
+				require.NoError(t, err)
+			},
+			wantPersonRetained: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			fixture := &conflictMutationServer{
+				body: conflictCardWithEmail(
+					"person", "Alice Remote Base", "alice.base@example.test",
+				),
+				etag: `"remote-1"`,
+			}
+			server := httptest.NewServer(fixture.handler(t))
+			t.Cleanup(server.Close)
+			service, st, book := newPullService(t, server, false)
+
+			_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+			require.NoError(err)
+			mapping, err := st.GetCardDAVResourceContext(
+				t.Context(), book.ID, book.CanonicalURL+"person.vcf",
+			)
+			require.NoError(err)
+			require.NotNil(mapping.PersonID)
+			personID := *mapping.PersonID
+			tt.makeLocalChange(t, st, personID)
+
+			fixture.mu.Lock()
+			fixture.body = conflictCardWithEmail(
+				"person", "Alice Remote Retained", "alice.retained@example.test",
+			)
+			fixture.etag = `"remote-2"`
+			fixture.mu.Unlock()
+			_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+			require.NoError(err)
+			conflicts, err := service.ListConflicts(t.Context())
+			require.NoError(err)
+			require.Len(conflicts, 1)
+			require.NoError(service.ResolveConflict(
+				t.Context(), conflicts[0].ID, ResolutionKeepRemote,
+			))
+
+			fixture.mu.Lock()
+			fixture.body = nil
+			fixture.etag = ""
+			fixture.mu.Unlock()
+			_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+			require.NoError(err)
+			_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+			require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+			person, err := st.GetPersonContext(t.Context(), personID)
+			if tt.wantPersonRetained {
+				require.NoError(err)
+				assert.Equal(t, personID, person.ID)
+				return
+			}
+			require.ErrorIs(err, store.ErrPersonNotFound)
+		})
+	}
+}
+
+type conflictMutationServer struct {
+	mu                  sync.Mutex
+	body                []byte
+	etag                string
+	force412            bool
+	delete412           bool
+	deleteStatus        int
+	timeoutPut          bool
+	timeoutDelete       bool
+	puts                int
+	deletes             int
+	gets                int
+	reports             int
+	lastPutBody         []byte
+	lastIfMatch         string
+	syncToken           string
+	deleteRaceBody      []byte
+	deleteRaceETag      string
+	deleteRaceTombstone bool
+	getFailures         int
+	onGet               func(int)
+}
+
+func (f *conflictMutationServer) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		switch r.Method {
+		case http.MethodPut:
+			f.puts++
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			f.lastPutBody = append([]byte(nil), body...)
+			f.lastIfMatch = r.Header.Get("If-Match")
+			if f.force412 {
+				f.force412 = false
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			if len(f.body) == 0 {
+				assert.Equal(t, "*", r.Header.Get("If-None-Match"))
+			} else {
+				assert.Equal(t, f.etag, r.Header.Get("If-Match"))
+			}
+			f.body = append([]byte(nil), body...)
+			f.etag = `"server-` + string(rune('0'+f.puts)) + `"`
+			if f.timeoutPut {
+				f.timeoutPut = false
+				f.mu.Unlock()
+				<-r.Context().Done()
+				f.mu.Lock()
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodGet:
+			f.gets++
+			if f.onGet != nil {
+				f.onGet(f.gets)
+			}
+			if f.getFailures > 0 {
+				f.getFailures--
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			if len(f.body) == 0 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("ETag", f.etag)
+			_, err := w.Write(f.body)
+			assert.NoError(t, err)
+		case http.MethodDelete:
+			f.deletes++
+			f.lastIfMatch = r.Header.Get("If-Match")
+			if f.deleteStatus != 0 {
+				if f.deleteStatus == http.StatusTooManyRequests {
+					w.Header().Set("Retry-After", "3600")
+				}
+				w.WriteHeader(f.deleteStatus)
+				return
+			}
+			if f.delete412 {
+				f.delete412 = false
+				if f.deleteRaceTombstone {
+					f.body = nil
+					f.etag = ""
+				} else if len(f.deleteRaceBody) > 0 {
+					f.body = append([]byte(nil), f.deleteRaceBody...)
+					f.etag = f.deleteRaceETag
+				}
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+			assert.Equal(t, f.etag, r.Header.Get("If-Match"))
+			f.body = nil
+			f.etag = ""
+			if f.timeoutDelete {
+				f.timeoutDelete = false
+				f.mu.Unlock()
+				<-r.Context().Done()
+				f.mu.Lock()
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "REPORT":
+			f.reports++
+			events := ""
+			if len(f.body) > 0 {
+				events = cardResponseRaw("/books/personal/person.vcf", f.etag, escapedCardData(f.body))
+			}
+			writeDAVXML(t, w, syncResponse(events, f.syncToken))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func oversizedConflictCard(uid string) []byte {
+	prefix := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + uid + "\r\nFN:Oversized\r\n")
+	suffix := []byte("END:VCARD\r\n")
+	body := make([]byte, 0, store.MaxCardDAVConflictSnapshotBytes)
+	body = append(body, prefix...)
+	remaining := store.MaxCardDAVConflictSnapshotBytes - len(prefix) - len(suffix)
+	for remaining > 0 {
+		const overhead = len("NOTE:\r\n")
+		chunk := min(1<<20, remaining-overhead)
+		body = append(body, "NOTE:"...)
+		body = append(body, bytes.Repeat([]byte("x"), chunk)...)
+		body = append(body, '\r', '\n')
+		remaining -= overhead + chunk
+	}
+	body = append(body, suffix...)
+	return body
+}
+
+func TestConditional412CapturesConflictAndKeepLocalRefetchesCurrentETag(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	service.client.requestTimeout = 250 * time.Millisecond
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote")
+	fixture.etag = `"remote-2"`
+	fixture.force412 = true
+	fixture.mu.Unlock()
+
+	err = service.PublishPerson(t.Context(), personID)
+	var conflictErr *ConflictError
+	require.ErrorAs(err, &conflictErr)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Empty(publication.PendingOperation)
+	conflicts, getErr := service.ListConflicts(t.Context())
+	require.NoError(getErr)
+	require.Len(conflicts, 1)
+	assert.Equal(conflictErr.ID, conflicts[0].ID)
+	assert.Contains(string(conflicts[0].LocalBody), "EMAIL:alice-local@example.test")
+	assert.Equal(conflictCard("person", "Alice Remote"), conflicts[0].RemoteBody)
+	fixture.mu.Lock()
+	putsBeforeBlockedRetry := fixture.puts
+	fixture.mu.Unlock()
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, ErrCardDAVConflictPending)
+	fixture.mu.Lock()
+	assert.Equal(putsBeforeBlockedRetry, fixture.puts, "unresolved mapping must block before network")
+	fixture.mu.Unlock()
+
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Even Newer")
+	fixture.etag = `"remote-3"`
+	fixture.timeoutPut = true
+	getsBefore := fixture.gets
+	fixture.mu.Unlock()
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET
+		is_write_target = FALSE, is_subscribed = TRUE, can_update = TRUE WHERE id = ?`), book.ID)
+	require.NoError(err)
+
+	require.Error(service.ResolveConflict(t.Context(), conflictErr.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	putsAfterTimeout := fixture.puts
+	fixture.mu.Unlock()
+	require.NoError(service.ResolveConflict(t.Context(), conflictErr.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	assert.GreaterOrEqual(fixture.gets, getsBefore+3, "resolution must preflight and recover with canonical GETs")
+	assert.Equal(putsAfterTimeout, fixture.puts, "ambiguous resolution recovery must not replay PUT")
+	assert.Equal(`"remote-3"`, fixture.lastIfMatch)
+	assert.Equal(conflicts[0].LocalBody, fixture.lastPutBody)
+	fixture.mu.Unlock()
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflictErr.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepLocal, resolved.Resolution)
+}
+
+func TestSyncSkipsConflictedPublicationAndStillAdvancesToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote")
+	fixture.etag = `"remote-2"`
+	fixture.force412 = true
+	fixture.syncToken = "token-after-conflict"
+	fixture.mu.Unlock()
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET supports_sync_collection = TRUE WHERE id = ?`), book.ID)
+	require.NoError(err)
+	var conflictErr *ConflictError
+	require.ErrorAs(service.PublishPerson(t.Context(), personID), &conflictErr)
+	fixture.mu.Lock()
+	putsBeforeSync := fixture.puts
+	deletesBeforeSync := fixture.deletes
+	fixture.mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	for _, candidate := range books {
+		if candidate.ID == book.ID {
+			assert.Equal("token-after-conflict", candidate.SyncToken)
+		}
+	}
+	fixture.mu.Lock()
+	assert.Equal(putsBeforeSync, fixture.puts, "reconciliation must not replay a conflicted publication")
+	assert.Equal(deletesBeforeSync, fixture.deletes)
+	fixture.mu.Unlock()
+}
+
+func TestSyncAbortsPullAfterPendingPublicationRecoveryFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	service.client.requestTimeout = 250 * time.Millisecond
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	fixture.mu.Lock()
+	fixture.timeoutPut = true
+	fixture.mu.Unlock()
+	require.Error(service.PublishPerson(t.Context(), personID))
+	pending, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	require.Equal(store.CardDAVMutationUpdate, pending.PendingOperation)
+
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Divergent Remote")
+	fixture.etag = `"remote-divergent"`
+	fixture.getFailures = 1
+	reportsBefore := fixture.reports
+	fixture.mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusServiceUnavailable, status.StatusCode)
+	fixture.mu.Lock()
+	assert.Equal(reportsBefore, fixture.reports, "pull must not advance a mapping after recovery fails")
+	fixture.mu.Unlock()
+	stillPending, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(pending.MappingRevision, stillPending.MappingRevision)
+	assert.Equal(pending.PendingOperation, stillPending.PendingOperation)
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	fixture.mu.Lock()
+	assert.Greater(fixture.reports, reportsBefore, "a later successful recovery may proceed to pull")
+	fixture.mu.Unlock()
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	require.NoError(service.ResolveConflict(t.Context(), conflicts[0].ID, ResolutionKeepLocal))
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflicts[0].ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepLocal, resolved.Resolution)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	assert.Contains(string(resource.RemoteBody), "EMAIL:alice-local@example.test")
+}
+
+func seedLocalTombstoneConflict(
+	t *testing.T, fixture *conflictMutationServer,
+) (*Service, *store.Store, store.CardDAVAddressBook, *store.CardDAVResource, *store.CardDAVConflict) {
+	t.Helper()
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	fixture.body = conflictCard("person", "Alice Base")
+	fixture.etag = `"remote-base"`
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(t, err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(t, err)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(t, err)
+	require.NoError(t, st.DeletePersonContext(t.Context(), personID, person.Revision))
+	remoteBody := conflictCard("person", "Alice Remote")
+	fixture.mu.Lock()
+	fixture.body = append([]byte(nil), remoteBody...)
+	fixture.etag = `"remote-race"`
+	fixture.mu.Unlock()
+	capture := store.CardDAVConflictCapture{
+		AddressBookID: book.ID, Href: mapping.Href,
+		ExpectedMappingRevision: mapping.MappingRevision,
+		BaseLocalHash:           mapping.LocalHash, LocalHash: mapping.LocalHash,
+		BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+		RemoteETag: `"remote-race"`, RemoteBody: remoteBody,
+		LocalTombstone: true,
+	}
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(t, err)
+	return service, st, book, mapping, conflict
+}
+
+func seedUnpublishConflict(
+	t *testing.T, fixture *conflictMutationServer,
+) (*Service, *store.Store, int64, store.CardDAVAddressBook, *store.CardDAVResource, *store.CardDAVConflict) {
+	t.Helper()
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	require.NoError(t, service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(t, err)
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote")
+	fixture.etag = `"remote-unpublish"`
+	fixture.delete412 = true
+	fixture.mu.Unlock()
+
+	var conflictErr *ConflictError
+	require.ErrorAs(t, service.UnpublishPerson(t.Context(), personID), &conflictErr)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(t, err)
+	require.NotNil(t, mapping.PersonID)
+	conflict, err := st.GetCardDAVConflictContext(t.Context(), conflictErr.ID)
+	require.NoError(t, err)
+	require.True(t, conflict.LocalTombstone)
+	return service, st, personID, book, mapping, conflict
+}
+
+func TestKeepLocalTombstoneTimeoutPersistsIntentAndRecoversWithoutReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{timeoutDelete: true}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	service.client.requestTimeout = 250 * time.Millisecond
+
+	require.Error(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	pending, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+	assert.Equal(conflict.MappingRevision+1, pending.MappingRevision)
+	assert.Equal(conflict.MappingRevision, pending.PreviousMappingRevision)
+	assert.NotNil(pending.PendingStartedAt)
+	fixture.mu.Lock()
+	deletesAfterTimeout := fixture.deletes
+	fixture.mu.Unlock()
+
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	assert.Equal(deletesAfterTimeout, fixture.deletes, "ambiguous tombstone recovery must not replay DELETE")
+	fixture.mu.Unlock()
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+}
+
+func TestPullTombstoneCompletesTimedOutKeepLocalWithoutDeleteReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{timeoutDelete: true, syncToken: "token-after-tombstone"}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	service.client.requestTimeout = 250 * time.Millisecond
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET supports_sync_collection = TRUE WHERE id = ?`), book.ID)
+	require.NoError(err)
+
+	require.Error(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	deletesAfterTimeout := fixture.deletes
+	fixture.mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	fixture.mu.Lock()
+	assert.Equal(deletesAfterTimeout, fixture.deletes, "pull proof must not replay DELETE")
+	fixture.mu.Unlock()
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepLocal, resolved.Resolution)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal("token-after-tombstone", books[0].SyncToken)
+}
+
+func TestKeepLocalTombstoneDefinitiveRejectionRestoresFence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{deleteStatus: http.StatusForbidden}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+
+	err = service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusForbidden, status.StatusCode)
+	refreshed, getErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(getErr)
+	assert.Empty(refreshed.PendingOperation)
+	assert.Zero(refreshed.PreviousMappingRevision)
+	after, getErr := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(getErr)
+	assert.Equal(before.MappingRevision, after.MappingRevision)
+
+	fixture.deleteStatus = 0
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+}
+
+func TestKeepLocalTombstoneThrottleClearsIntentAndPersistsGate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{deleteStatus: http.StatusTooManyRequests}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	started := time.Now()
+
+	err = service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	refreshed, getErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(getErr)
+	assert.Empty(refreshed.PendingOperation)
+	after, getErr := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(getErr)
+	assert.Equal(before.MappingRevision, after.MappingRevision)
+	gate, getErr := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(getErr)
+	require.NotNil(gate)
+	assert.WithinDuration(started.Add(time.Hour), *gate, 5*time.Second)
+}
+
+func TestKeepLocalUnpublishConflictRetainsPersonAndClearsPublication(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	service, st, personID, book, mapping, conflict := seedUnpublishConflict(t, fixture)
+
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	_, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepLocal, resolved.Resolution)
+}
+
+func TestPullTombstoneCompletesTimedOutUnpublishAndRetainsPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{timeoutDelete: true, syncToken: "token-after-unpublish"}
+	service, st, personID, book, mapping, conflict := seedUnpublishConflict(t, fixture)
+	service.client.requestTimeout = 250 * time.Millisecond
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET supports_sync_collection = TRUE WHERE id = ?`), book.ID)
+	require.NoError(err)
+
+	require.Error(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	pending, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	require.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+	fixture.mu.Lock()
+	deletesAfterTimeout := fixture.deletes
+	fixture.mu.Unlock()
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	fixture.mu.Lock()
+	assert.Equal(deletesAfterTimeout, fixture.deletes, "pull proof must not replay DELETE")
+	fixture.mu.Unlock()
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepLocal, resolved.Resolution)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal("token-after-unpublish", books[0].SyncToken)
+}
+
+func TestPullRefreshSupersedesTimedOutTombstoneIntentBeforeFreshDelete(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{timeoutDelete: true}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	service.client.requestTimeout = 250 * time.Millisecond
+	require.Error(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	pending, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	require.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+
+	latest := conflictCard("person", "Alice Updated After Timeout")
+	fixture.mu.Lock()
+	fixture.body = append([]byte(nil), latest...)
+	fixture.etag = `"remote-after-timeout"`
+	deletesBeforeSync := fixture.deletes
+	fixture.mu.Unlock()
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	fixture.mu.Lock()
+	assert.Equal(deletesBeforeSync, fixture.deletes, "pull must not replay the ambiguous DELETE")
+	fixture.mu.Unlock()
+
+	refreshed, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, refreshed.Status)
+	assert.Empty(refreshed.PendingOperation)
+	assert.Zero(refreshed.PreviousMappingRevision)
+	assert.Nil(refreshed.PendingStartedAt)
+	assert.Greater(refreshed.MappingRevision, pending.MappingRevision)
+	assert.Equal(`"remote-after-timeout"`, refreshed.RemoteETag)
+	assert.Equal(latest, refreshed.RemoteBody)
+	afterPull, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(refreshed.MappingRevision, afterPull.MappingRevision)
+
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	assert.Equal(deletesBeforeSync+1, fixture.deletes, "explicit retry must issue one freshly fenced DELETE")
+	assert.Equal(`"remote-after-timeout"`, fixture.lastIfMatch)
+	fixture.mu.Unlock()
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func TestDirectConflictRefreshDoesNotSupersedePendingTombstoneIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{timeoutDelete: true}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	service.client.requestTimeout = 250 * time.Millisecond
+	require.Error(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	pending, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	currentMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	latest := conflictCard("person", "Direct Refresh")
+
+	refreshed, err := st.RecordCardDAVConflictContext(t.Context(), store.CardDAVConflictCapture{
+		AddressBookID: book.ID, Href: mapping.Href,
+		ExpectedMappingRevision: currentMapping.MappingRevision,
+		BaseLocalHash:           currentMapping.LocalHash, LocalHash: pending.LocalHash,
+		BaseRemoteHash: currentMapping.RemoteSemanticHash, BaseRemoteETag: currentMapping.RemoteETag,
+		RemoteETag: `"direct-refresh"`, RemoteBody: latest, LocalTombstone: true,
+	})
+	require.NoError(err)
+	assert.Equal(store.CardDAVMutationDelete, refreshed.PendingOperation)
+	assert.Equal(pending.PreviousMappingRevision, refreshed.PreviousMappingRevision)
+	assert.NotNil(refreshed.PendingStartedAt)
+}
+
+func TestKeepLocalTombstone412RefreshesConflictBeforeExplicitRetry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	latest := conflictCard("person", "Alice Raced Again")
+	fixture := &conflictMutationServer{
+		delete412: true, deleteRaceBody: latest, deleteRaceETag: `"remote-latest"`,
+	}
+	service, st, _, _, conflict := seedLocalTombstoneConflict(t, fixture)
+
+	var conflictErr *ConflictError
+	require.ErrorAs(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal), &conflictErr)
+	assert.Equal(conflict.ID, conflictErr.ID)
+	refreshed, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, refreshed.Status)
+	assert.Empty(refreshed.PendingOperation)
+	assert.Equal(`"remote-latest"`, refreshed.RemoteETag)
+	assert.Equal(latest, refreshed.RemoteBody)
+
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal))
+	fixture.mu.Lock()
+	assert.Equal(2, fixture.deletes)
+	assert.Equal(`"remote-latest"`, fixture.lastIfMatch)
+	fixture.mu.Unlock()
+}
+
+func TestKeepLocalTombstoneCanonicalCommitHonorsBookFence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	service, st, book, mapping, conflict := seedLocalTombstoneConflict(t, fixture)
+	fixture.mu.Lock()
+	fencedGet := fixture.gets + 2
+	fixture.onGet = func(gets int) {
+		if gets != fencedGet {
+			return
+		}
+		_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+			SET sync_revision = sync_revision + 1 WHERE id = ?`), book.ID)
+		require.NoError(err)
+	}
+	fixture.mu.Unlock()
+
+	err := service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepLocal)
+	require.ErrorIs(err, store.ErrCardDAVStalePlan)
+	pending, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, pending.Status)
+	assert.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+}
+
+func TestOversized412RestoresMappingFenceAndClearsKnownUnappliedIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	_, err = st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "oversized-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	fixture.mu.Lock()
+	fixture.body = oversizedConflictCard("person")
+	fixture.etag = `"oversized"`
+	fixture.force412 = true
+	fixture.mu.Unlock()
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVConflictTooLarge)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(mapping.MappingRevision, after.MappingRevision)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	assert.Empty(conflicts)
+}
+
+func TestOversizedCreateCollisionCanBeCanceledWithoutDeletingRemote(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	remoteBody := oversizedConflictCard("remote-owner")
+	putCount := 0
+	deleteCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			putCount++
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			w.Header().Set("ETag", `"remote-owner"`)
+			_, err := w.Write(remoteBody)
+			assert.NoError(err)
+		case http.MethodDelete:
+			deleteCount++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+
+	err := service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVConflictTooLarge)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	assert.Equal(remoteBody, resource.RemoteBody)
+	assert.Nil(resource.PersonID)
+	assert.Equal(store.CardDAVMappingUnbound, resource.MappingStatus)
+	assert.Equal(store.CardDAVGovernanceNone, resource.Governance)
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationMismatch)
+	assert.Equal(1, putCount)
+	require.NoError(service.UnpublishPerson(t.Context(), personID))
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+	assert.Equal(1, putCount)
+	assert.Zero(deleteCount)
+}
+
+func TestOversizedAmbiguousRecoveryRebasesAndRetainsReadOnlyIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	service.client.requestTimeout = 250 * time.Millisecond
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "recovery-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	fixture.mu.Lock()
+	fixture.timeoutPut = true
+	fixture.mu.Unlock()
+	require.Error(service.PublishPerson(t.Context(), personID))
+	pending, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	require.Equal(store.CardDAVMutationUpdate, pending.PendingOperation)
+	fixture.mu.Lock()
+	fixture.body = oversizedConflictCard("person")
+	fixture.etag = `"oversized-recovery"`
+	putsBeforeRecovery := fixture.puts
+	fixture.mu.Unlock()
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVConflictTooLarge)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	assert.Equal(pending.PreviousMappingRevision, after.MappingRevision)
+	rebased, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(pending.PendingOperation, rebased.PendingOperation)
+	assert.Equal(pending.OutgoingBody, rebased.OutgoingBody)
+	assert.Equal(pending.RemoteETag, rebased.RemoteETag)
+	assert.Equal(pending.MutationRevision, rebased.MutationRevision)
+	assert.Equal(pending.PreviousMappingRevision, rebased.MappingRevision)
+	assert.Equal(pending.PreviousMappingRevision, rebased.PreviousMappingRevision)
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVConflictTooLarge)
+	fixture.mu.Lock()
+	assert.Equal(putsBeforeRecovery, fixture.puts, "oversized ambiguous recovery must remain read-only")
+	fixture.mu.Unlock()
+}
+
+func TestResolveConflictRejectsChoicesOutsideExactContract(t *testing.T) {
+	service := &Service{}
+	err := service.ResolveConflict(t.Context(), 1, ResolutionChoice("merge"))
+	require.ErrorIs(t, err, ErrInvalidResolutionChoice)
+}
+
+func TestConditionalDelete412KeepRemoteRevalidatesCanonicalCard(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote")
+	fixture.etag = `"remote-2"`
+	fixture.delete412 = true
+	fixture.mu.Unlock()
+
+	err := service.UnpublishPerson(t.Context(), personID)
+	var conflictErr *ConflictError
+	require.ErrorAs(err, &conflictErr)
+	conflict, err := st.GetCardDAVConflictContext(t.Context(), conflictErr.ID)
+	require.NoError(err)
+	assert.True(conflict.LocalTombstone)
+	assert.False(conflict.RemoteTombstone)
+	assert.Equal(conflictCard("person", "Alice Remote"), conflict.RemoteBody)
+	fixture.mu.Lock()
+	requestsBefore := fixture.puts + fixture.gets + fixture.deletes
+	fixture.body = conflictCard("person", "Alice Newer Remote")
+	fixture.etag = `"remote-3"`
+	fixture.mu.Unlock()
+
+	require.ErrorIs(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepRemote),
+		store.ErrCardDAVConflictStale)
+	unresolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, unresolved.Status)
+	fixture.mu.Lock()
+	fixture.body = conflict.RemoteBody
+	fixture.etag = conflict.RemoteETag
+	fixture.mu.Unlock()
+	require.NoError(service.ResolveConflict(t.Context(), conflict.ID, ResolutionKeepRemote))
+	fixture.mu.Lock()
+	assert.Equal(requestsBefore+2, fixture.puts+fixture.gets+fixture.deletes)
+	fixture.mu.Unlock()
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	assert.Equal(conflict.RemoteBody, mapping.RemoteBody)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	resolved, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVResolutionKeepRemote, resolved.Resolution)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+	fixture.mu.Lock()
+	deletesBeforeReconcile := fixture.deletes
+	fixture.mu.Unlock()
+	require.NoError(service.ReconcilePublications(t.Context()))
+	fixture.mu.Lock()
+	assert.Equal(deletesBeforeReconcile, fixture.deletes, "keep-remote must cancel the stale unpublish")
+	fixture.mu.Unlock()
+}
+
+func TestPullRefreshPreservesUnpublishTombstoneUntilKeepRemoteCancelsIt(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, _ := seededMutationServiceForServer(t, server)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote")
+	fixture.etag = `"remote-2"`
+	fixture.delete412 = true
+	fixture.mu.Unlock()
+
+	var conflictErr *ConflictError
+	require.ErrorAs(service.UnpublishPerson(t.Context(), personID), &conflictErr)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	_, err = st.UpdatePersonDisplayNameContext(t.Context(), personID, person.Revision, new("Alice Local After Unpublish"))
+	require.NoError(err)
+	latest := conflictCard("person", "Alice Remote Refreshed")
+	fixture.mu.Lock()
+	fixture.body = latest
+	fixture.etag = `"remote-3"`
+	fixture.mu.Unlock()
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+
+	refreshed, err := st.GetCardDAVConflictContext(t.Context(), conflictErr.ID)
+	require.NoError(err)
+	assert.True(refreshed.LocalTombstone)
+	assert.Equal(latest, refreshed.RemoteBody)
+	require.NoError(service.ResolveConflict(t.Context(), refreshed.ID, ResolutionKeepRemote))
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+	fixture.mu.Lock()
+	deletesBeforeReconcile := fixture.deletes
+	fixture.mu.Unlock()
+	require.NoError(service.ReconcilePublications(t.Context()))
+	fixture.mu.Lock()
+	assert.Equal(deletesBeforeReconcile, fixture.deletes)
+	fixture.mu.Unlock()
+}
+
+func TestConditionalDelete412WithCanonicalTombstoneCommitsCleanup(t *testing.T) {
+	require := require.New(t)
+
+	fixture := &conflictMutationServer{}
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	fixture.mu.Lock()
+	fixture.delete412 = true
+	fixture.deleteRaceTombstone = true
+	fixture.mu.Unlock()
+
+	require.NoError(service.UnpublishPerson(t.Context(), personID))
+	_, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+	conflicts, err := service.ListConflicts(t.Context())
+	require.NoError(err)
+	assert.Empty(t, conflicts)
+}
+
+func TestAmbiguousUpdateRecoveryCapturesConflictWithoutReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice-local@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	fixture.timeout = true
+	require.Error(service.PublishPerson(t.Context(), personID))
+	putsBeforeRecovery := fixture.puts
+	fixture.mu.Lock()
+	fixture.body = conflictCard("person", "Alice Remote After Timeout")
+	fixture.etag = `"remote-after-timeout"`
+	fixture.mu.Unlock()
+
+	err = service.PublishPerson(t.Context(), personID)
+	var conflictErr *ConflictError
+	require.ErrorAs(err, &conflictErr)
+	assert.Equal(putsBeforeRecovery, fixture.puts, "ambiguous mapped recovery must remain read-only")
+	conflict, err := st.GetCardDAVConflictContext(t.Context(), conflictErr.ID)
+	require.NoError(err)
+	assert.Contains(string(conflict.RemoteBody), "FN:Alice Remote After Timeout")
+	assert.Contains(string(conflict.RemoteBody), "PRODID:-//Server//EN")
+	assert.Contains(string(conflict.LocalBody), "EMAIL:alice-local@example.test")
+}

--- a/internal/carddav/credentials.go
+++ b/internal/carddav/credentials.go
@@ -1,0 +1,163 @@
+package carddav
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const cardDAVTokenFilename = "carddav.json" // #nosec G101 -- This is a credential filename, not a credential value.
+
+var ErrCredentialNotBound = errors.New("CardDAV credential is not bound to a connection")
+
+// Credential binds a password to the exact durable connection it may
+// authenticate. The generation closes the crash window between publishing the
+// filesystem pair and replacing the discovery snapshot: startup fails closed
+// until config, token, and database all describe the same connection.
+type Credential struct {
+	Password             string `json:"password"`
+	BaseURL              string `json:"base_url,omitempty"`
+	Username             string `json:"username,omitempty"`
+	ConnectionGeneration int64  `json:"connection_generation,omitempty"`
+}
+
+type credentialPermissionBackend interface {
+	secureDirectory(path string) error
+	secureFile(file *os.File) error
+	verifyFile(file *os.File) error
+}
+
+// SavePassword atomically replaces the CardDAV token file. The password is
+// deliberately kept out of config and durable database records.
+func SavePassword(tokenDir, password string) error {
+	return savePasswordWithPermissions(tokenDir, password, nativeCredentialPermissions{})
+}
+
+func savePasswordWithPermissions(tokenDir, password string, permissions credentialPermissionBackend) error {
+	return saveCredentialWithPermissions(tokenDir, Credential{Password: password}, permissions)
+}
+
+// SaveCredential atomically publishes an identity-bound CardDAV credential.
+func SaveCredential(tokenDir string, credential Credential) error {
+	if credential.Password == "" || credential.BaseURL == "" || credential.Username == "" || credential.ConnectionGeneration <= 0 {
+		return errors.New("CardDAV credential requires a connection identity")
+	}
+	return saveCredentialWithPermissions(tokenDir, credential, nativeCredentialPermissions{})
+}
+
+// RemoveCredential removes a published CardDAV credential. Missing files are
+// already the desired state and therefore succeed.
+func RemoveCredential(tokenDir string) error {
+	err := os.Remove(filepath.Join(tokenDir, cardDAVTokenFilename))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove CardDAV token file: %w", err)
+	}
+	return nil
+}
+
+func saveCredentialWithPermissions(tokenDir string, credential Credential, permissions credentialPermissionBackend) error {
+	if err := permissions.secureDirectory(tokenDir); err != nil {
+		return fmt.Errorf("secure CardDAV token directory: %w", err)
+	}
+
+	temporary, err := os.CreateTemp(tokenDir, ".carddav-*.json")
+	if err != nil {
+		return fmt.Errorf("create CardDAV token file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	keep := false
+	defer func() {
+		_ = temporary.Close()
+		if !keep {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := permissions.secureFile(temporary); err != nil {
+		return fmt.Errorf("secure CardDAV token file: %w", err)
+	}
+	// #nosec G117 -- The credential is intentionally marshaled only into the already-hardened private token file.
+	if err := json.NewEncoder(temporary).Encode(credential); err != nil {
+		return fmt.Errorf("encode CardDAV token file: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync CardDAV token file: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close CardDAV token file: %w", err)
+	}
+	target := filepath.Join(tokenDir, cardDAVTokenFilename)
+	if err := os.Rename(temporaryPath, target); err != nil {
+		return fmt.Errorf("replace CardDAV token file: %w", err)
+	}
+	// Rename publishes the already-hardened filesystem object; its mode/DACL
+	// travels with it. Keep publication as the final fallible operation so an
+	// error before replacement always leaves the prior credential intact.
+	keep = true
+	return nil
+}
+
+// LoadPassword reads the private CardDAV token file and rejects files exposed
+// to group or other users. Errors never include the token contents.
+func LoadPassword(tokenDir string) (string, error) {
+	return loadPasswordWithPermissions(tokenDir, nativeCredentialPermissions{})
+}
+
+func loadPasswordWithPermissions(tokenDir string, permissions credentialPermissionBackend) (string, error) {
+	credential, err := loadCredentialWithPermissions(tokenDir, permissions)
+	if err != nil {
+		return "", err
+	}
+	return credential.Password, nil
+}
+
+// LoadCredential reads an identity-bound private credential. Legacy
+// password-only files remain readable through LoadPassword, but are rejected
+// here so the daemon can never pair them with an arbitrary configured origin.
+func LoadCredential(tokenDir string) (Credential, error) {
+	credential, err := loadCredentialWithPermissions(tokenDir, nativeCredentialPermissions{})
+	if err != nil {
+		return Credential{}, err
+	}
+	if credential.BaseURL == "" || credential.Username == "" || credential.ConnectionGeneration <= 0 {
+		return Credential{}, ErrCredentialNotBound
+	}
+	return credential, nil
+}
+
+// LoadLegacyPassword reads only the historical password-only token shape.
+// Partially bound records fail closed instead of being silently rebound.
+func LoadLegacyPassword(tokenDir string) (string, error) {
+	credential, err := loadCredentialWithPermissions(tokenDir, nativeCredentialPermissions{})
+	if err != nil {
+		return "", err
+	}
+	if credential.BaseURL != "" || credential.Username != "" || credential.ConnectionGeneration != 0 {
+		return "", errors.New("CardDAV credential is not a legacy password-only record")
+	}
+	return credential.Password, nil
+}
+
+func loadCredentialWithPermissions(tokenDir string, permissions credentialPermissionBackend) (Credential, error) {
+	path := filepath.Join(tokenDir, cardDAVTokenFilename)
+	file, err := os.Open(path)
+	if err != nil {
+		return Credential{}, fmt.Errorf("open CardDAV token file: %w", err)
+	}
+	defer file.Close() //nolint:errcheck // read-only file
+	if err := permissions.verifyFile(file); err != nil {
+		return Credential{}, fmt.Errorf("verify CardDAV token file permissions: %w", err)
+	}
+	decoder := json.NewDecoder(io.LimitReader(file, 1<<20))
+	decoder.DisallowUnknownFields()
+	var saved Credential
+	if err := decoder.Decode(&saved); err != nil {
+		return Credential{}, fmt.Errorf("decode CardDAV token file: %w", err)
+	}
+	if saved.Password == "" {
+		return Credential{}, errors.New("CardDAV token file contains an empty password")
+	}
+	return saved, nil
+}

--- a/internal/carddav/credentials_permissions_unix.go
+++ b/internal/carddav/credentials_permissions_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package carddav
+
+import (
+	"errors"
+	"os"
+)
+
+type nativeCredentialPermissions struct{}
+
+func (nativeCredentialPermissions) secureDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o700) // #nosec G302 -- path is a directory and 0700 is the required private mode.
+}
+
+func (nativeCredentialPermissions) secureFile(file *os.File) error {
+	if err := file.Chmod(0o600); err != nil {
+		return err
+	}
+	return nativeCredentialPermissions{}.verifyFile(file)
+}
+
+func (nativeCredentialPermissions) verifyFile(file *os.File) error {
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Mode().Perm() != 0o600 {
+		return errors.New("CardDAV token file permissions must be 0600")
+	}
+	return nil
+}

--- a/internal/carddav/credentials_permissions_windows.go
+++ b/internal/carddav/credentials_permissions_windows.go
@@ -1,0 +1,165 @@
+//go:build windows
+
+package carddav
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type nativeCredentialPermissions struct{}
+
+const cardDAVFileAllAccess = windows.STANDARD_RIGHTS_REQUIRED | windows.SYNCHRONIZE | 0x1FF
+
+func (nativeCredentialPermissions) secureDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return err
+	}
+	handle, err := openCardDAVSecurityHandle(path, true, windows.READ_CONTROL|windows.WRITE_DAC)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck // security result is returned below
+	return secureCardDAVHandle(handle)
+}
+
+func (nativeCredentialPermissions) secureFile(file *os.File) error {
+	if err := file.Chmod(0o600); err != nil {
+		return err
+	}
+	handle, err := openCardDAVSecurityHandle(file.Name(), false, windows.READ_CONTROL|windows.WRITE_DAC)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck // security result is returned below
+	return secureCardDAVHandle(handle)
+}
+
+func (nativeCredentialPermissions) verifyFile(file *os.File) error {
+	handle, err := openCardDAVSecurityHandle(file.Name(), false, windows.READ_CONTROL)
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(handle) //nolint:errcheck // security result is returned below
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get current user SID: %w", err)
+	}
+	return verifyCardDAVHandleOwnerOnly(handle, user.User.Sid)
+}
+
+func openCardDAVSecurityHandle(path string, directory bool, access uint32) (windows.Handle, error) {
+	path16, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, err
+	}
+	flags := uint32(windows.FILE_ATTRIBUTE_NORMAL | windows.FILE_FLAG_OPEN_REPARSE_POINT)
+	if directory {
+		flags |= windows.FILE_FLAG_BACKUP_SEMANTICS
+	}
+	handle, err := windows.CreateFile(path16, access,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil, windows.OPEN_EXISTING, flags, 0)
+	if err != nil {
+		return 0, fmt.Errorf("open CardDAV token security handle: %w", err)
+	}
+	return handle, nil
+}
+
+func secureCardDAVHandle(handle windows.Handle) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get current user SID: %w", err)
+	}
+	entries := []windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.SET_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm: windows.TRUSTEE_IS_SID, TrusteeType: windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}
+	acl, err := windows.ACLFromEntries(entries, nil)
+	if err != nil {
+		return fmt.Errorf("build owner-only CardDAV DACL: %w", err)
+	}
+	securityInfo := windows.DACL_SECURITY_INFORMATION | windows.PROTECTED_DACL_SECURITY_INFORMATION
+	if err := windows.SetSecurityInfo(handle, windows.SE_FILE_OBJECT,
+		windows.SECURITY_INFORMATION(securityInfo), nil, nil, acl, nil); err != nil {
+		return fmt.Errorf("set owner-only CardDAV DACL: %w", err)
+	}
+	return verifyCardDAVHandleOwnerOnly(handle, user.User.Sid)
+}
+
+func verifyCardDAVHandleOwnerOnly(handle windows.Handle, user *windows.SID) error {
+	descriptor, err := windows.GetSecurityInfo(handle, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("read CardDAV DACL: %w", err)
+	}
+	owner, _, err := descriptor.Owner()
+	if err != nil || owner == nil {
+		return fmt.Errorf("read CardDAV owner: %w", err)
+	}
+	if err := verifyCardDAVOwner(owner, user); err != nil {
+		return err
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		return fmt.Errorf("read CardDAV DACL control: %w", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		return errors.New("CardDAV DACL permits inherited access")
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil || dacl == nil {
+		return fmt.Errorf("read CardDAV DACL entries: %w", err)
+	}
+	type aclHeader struct {
+		Revision byte
+		Sbz1     byte
+		Size     uint16
+		AceCount uint16
+		Sbz2     uint16
+	}
+	if (*aclHeader)(unsafe.Pointer(dacl)).AceCount != 1 {
+		return errors.New("CardDAV DACL must contain exactly one access entry")
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err := windows.GetAce(dacl, 0, &ace); err != nil {
+		return fmt.Errorf("read CardDAV owner ACE: %w", err)
+	}
+	if ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE ||
+		(ace.Mask != windows.GENERIC_ALL && ace.Mask != cardDAVFileAllAccess) {
+		return errors.New("CardDAV DACL does not grant exactly full control")
+	}
+	if ace.Header.AceFlags&windows.INHERITED_ACE != 0 {
+		return errors.New("CardDAV DACL contains inherited access")
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	if !aceSID.Equals(user) {
+		return errors.New("CardDAV DACL grants a principal other than the current user")
+	}
+	return nil
+}
+
+func verifyCardDAVOwner(owner, user *windows.SID) error {
+	if owner.Equals(user) {
+		return nil
+	}
+	if owner.IsWellKnown(windows.WinBuiltinAdministratorsSid) {
+		member, err := windows.Token(0).IsMember(owner)
+		if err != nil {
+			return fmt.Errorf("check Administrators membership: %w", err)
+		}
+		if member {
+			return nil
+		}
+	}
+	return errors.New("CardDAV token owner is not the current user")
+}

--- a/internal/carddav/credentials_test.go
+++ b/internal/carddav/credentials_test.go
@@ -1,0 +1,194 @@
+package carddav
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type injectedCredentialPermissionFailure struct {
+	delegate       credentialPermissionBackend
+	directoryError error
+	secureFileCall int
+	secureFileErr  error
+	verifyError    error
+}
+
+func (f *injectedCredentialPermissionFailure) secureDirectory(path string) error {
+	if f.directoryError != nil {
+		return f.directoryError
+	}
+	return f.delegate.secureDirectory(path)
+}
+
+func (f *injectedCredentialPermissionFailure) secureFile(file *os.File) error {
+	f.secureFileCall--
+	if f.secureFileCall == 0 {
+		return f.secureFileErr
+	}
+	return f.delegate.secureFile(file)
+}
+
+func (f *injectedCredentialPermissionFailure) verifyFile(file *os.File) error {
+	if f.verifyError != nil {
+		return f.verifyError
+	}
+	return f.delegate.verifyFile(file)
+}
+
+func TestCardDAVCredentialsRoundTripInPrivateTokenFile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	require.NoError(SavePassword(testCredentialTokenDir(home), "first-secret"))
+	require.NoError(SavePassword(testCredentialTokenDir(home), "replacement-secret"))
+
+	password, err := LoadPassword(testCredentialTokenDir(home))
+	require.NoError(err)
+	assert.Equal("replacement-secret", password)
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	path := filepath.Join(home, "tokens", "carddav.json")
+	info, err := os.Stat(path)
+	require.NoError(err)
+	assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+	tokensInfo, err := os.Stat(filepath.Dir(path))
+	require.NoError(err)
+	assert.Zero(tokensInfo.Mode().Perm() & 0o077)
+}
+
+func TestCardDAVCredentialBindsPasswordToConnectionIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	want := Credential{
+		Password:             "synthetic-secret",
+		BaseURL:              "https://contacts.example/dav",
+		Username:             "alice",
+		ConnectionGeneration: 3,
+	}
+	require.NoError(SaveCredential(testCredentialTokenDir(home), want))
+
+	got, err := LoadCredential(testCredentialTokenDir(home))
+	require.NoError(err)
+	assert.Equal(want, got)
+	assert.NotContains(string(mustReadCredentialFile(t, testCredentialTokenDir(home))), "connection_generation\":0")
+}
+
+func TestCardDAVCredentialRejectsLegacyUnboundPassword(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, SavePassword(testCredentialTokenDir(home), "synthetic-secret"))
+
+	_, err := LoadCredential(testCredentialTokenDir(home))
+	require.ErrorContains(t, err, "not bound to a connection")
+}
+
+func testCredentialTokenDir(home string) string {
+	return filepath.Join(home, "tokens")
+}
+
+func mustReadCredentialFile(t *testing.T, tokenDir string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(tokenDir, cardDAVTokenFilename))
+	require.NoError(t, err)
+	return content
+}
+
+func TestCardDAVCredentialsRejectExposedTokenFile(t *testing.T) {
+	require := require.New(t)
+
+	home := t.TempDir()
+	require.NoError(os.MkdirAll(filepath.Join(home, "tokens"), 0o700))
+	path := filepath.Join(home, "tokens", "carddav.json")
+	require.NoError(os.WriteFile(path, []byte(`{"password":"secret"}`), 0o644))
+	// The retained Linux verifier runs with a private umask, so WriteFile can
+	// narrow the requested mode. Chmod establishes the exposed fixture exactly.
+	require.NoError(os.Chmod(path, 0o644))
+
+	_, err := LoadPassword(testCredentialTokenDir(home))
+	require.ErrorContains(err, "permissions")
+	assert.NotContains(t, err.Error(), "secret")
+}
+
+func TestCardDAVCredentialsRequireUnixTokenMode0600(t *testing.T) {
+	if os.PathSeparator == '\\' {
+		t.Skip("Windows token privacy is verified from the DACL")
+	}
+	home := t.TempDir()
+	require.NoError(t, SavePassword(testCredentialTokenDir(home), "secret"))
+	path := filepath.Join(home, "tokens", cardDAVTokenFilename)
+	require.NoError(t, os.Chmod(path, 0o400))
+
+	_, err := LoadPassword(testCredentialTokenDir(home))
+	require.ErrorContains(t, err, "permissions")
+}
+
+func TestCardDAVCredentialsPropagatePermissionBackendFailures(t *testing.T) {
+	injected := errors.New("injected owner-only permission failure")
+	for _, tc := range []struct {
+		name        string
+		permissions *injectedCredentialPermissionFailure
+	}{
+		{name: "token directory", permissions: &injectedCredentialPermissionFailure{delegate: nativeCredentialPermissions{}, directoryError: injected}},
+		{name: "temporary token", permissions: &injectedCredentialPermissionFailure{delegate: nativeCredentialPermissions{}, secureFileCall: 1, secureFileErr: injected}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			home := t.TempDir()
+			require.NoError(SavePassword(testCredentialTokenDir(home), "prior-secret"))
+			err := savePasswordWithPermissions(testCredentialTokenDir(home), "replacement-secret", tc.permissions)
+			require.ErrorIs(err, injected)
+			assert.NotContains(err.Error(), "prior-secret")
+			assert.NotContains(err.Error(), "replacement-secret")
+			password, loadErr := LoadPassword(testCredentialTokenDir(home))
+			require.NoError(loadErr)
+			assert.Equal("prior-secret", password, "pre-publication failure must preserve the prior token")
+		})
+	}
+}
+
+func TestCardDAVCredentialsCompleteHardeningBeforeReplacingPriorToken(t *testing.T) {
+	require := require.New(t)
+
+	home := t.TempDir()
+	require.NoError(SavePassword(testCredentialTokenDir(home), "prior-secret"))
+	permissions := &injectedCredentialPermissionFailure{
+		delegate:       nativeCredentialPermissions{},
+		secureFileCall: 2,
+		secureFileErr:  errors.New("post-publication hardening must not run"),
+	}
+
+	err := savePasswordWithPermissions(testCredentialTokenDir(home), "replacement-secret", permissions)
+	require.NoError(err)
+	password, err := LoadPassword(testCredentialTokenDir(home))
+	require.NoError(err)
+	assert.Equal(t, "replacement-secret", password)
+}
+
+func TestCardDAVCredentialsLoadRequiresPermissionBackendVerification(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	require.NoError(SavePassword(testCredentialTokenDir(home), "secret"))
+	injected := errors.New("injected DACL verification failure")
+	permissions := &injectedCredentialPermissionFailure{
+		delegate: nativeCredentialPermissions{}, verifyError: injected,
+	}
+
+	password, err := loadPasswordWithPermissions(testCredentialTokenDir(home), permissions)
+	require.ErrorIs(err, injected)
+	assert.Empty(password)
+	assert.NotContains(err.Error(), "secret")
+}

--- a/internal/carddav/discovery.go
+++ b/internal/carddav/discovery.go
@@ -1,0 +1,490 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// Discovery is one complete CardDAV collection snapshot.
+type Discovery struct {
+	PrincipalURL *url.URL
+	HomeURL      *url.URL
+	HomeURLs     []*url.URL
+	Books        []DiscoveredBook
+}
+
+// DiscoveredBook describes one address-book collection in server order.
+type DiscoveredBook struct {
+	URL                    *url.URL
+	DiscoveryAliasURL      *url.URL
+	DisplayName            string
+	DiscoveryIndex         int
+	SupportsSyncCollection bool
+	SupportsMultiget       bool
+	SupportedVCardVersions []string
+	Capabilities           BookCapabilities
+}
+
+// BookCapabilities retains the distinction between a denied privilege and a
+// server which did not advertise current-user-privilege-set at all.
+type BookCapabilities struct {
+	Create      bool
+	CreateKnown bool
+	Update      bool
+	UpdateKnown bool
+	Delete      bool
+	DeleteKnown bool
+}
+
+// Discover follows RFC 6764/6352 discovery from the entered URL through the
+// principal and address-book home set, then enumerates every book at Depth 1.
+func Discover(ctx context.Context, client *Client, enteredURL string) (Discovery, error) {
+	if client == nil {
+		return Discovery{}, errors.New("CardDAV discovery requires a client")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, client.operationTimeout)
+	defer cancel()
+	entered, err := url.Parse(enteredURL)
+	if err != nil {
+		return Discovery{}, fmt.Errorf("parse CardDAV base URL: %w", ErrUnsafeTarget)
+	}
+	if _, err := client.validateTarget(operationCtx, entered); err != nil {
+		return Discovery{}, err
+	}
+	budget := &operationBudget{remaining: client.operationBytes}
+
+	principal, directErr := discoverHref(operationCtx, client, entered, CurrentUserPrincipalProperty, budget)
+	if directErr != nil || principal == nil {
+		if !discoveryFallbackAllowed(directErr) {
+			return Discovery{}, directErr
+		}
+		wellKnown := *client.origin
+		wellKnown.Path = "/.well-known/carddav"
+		principal, err = discoverHref(operationCtx, client, &wellKnown, CurrentUserPrincipalProperty, budget)
+		if err != nil {
+			return Discovery{}, fmt.Errorf("discover CardDAV principal: %w", err)
+		}
+	}
+	if principal == nil {
+		return Discovery{}, errors.New("CardDAV discovery did not return current-user-principal")
+	}
+
+	homes, err := discoverHrefs(operationCtx, client, principal, AddressbookHomeSetProperty, budget)
+	if err != nil {
+		return Discovery{}, fmt.Errorf("discover CardDAV address-book home: %w", err)
+	}
+	if len(homes) == 0 {
+		return Discovery{}, errors.New("CardDAV discovery did not return addressbook-home-set")
+	}
+	books := make([]DiscoveredBook, 0)
+	seenBooks := map[string]bool{}
+	for _, home := range homes {
+		discovered, err := discoverBooks(operationCtx, client, home, budget)
+		if err != nil {
+			return Discovery{}, err
+		}
+		for _, book := range discovered {
+			key := canonicalCollectionURL(book.URL)
+			if seenBooks[key] {
+				continue
+			}
+			seenBooks[key] = true
+			book.DiscoveryIndex = len(books)
+			books = append(books, book)
+			if len(books) > 1000 {
+				return Discovery{}, errors.New("CardDAV discovery exceeded 1000 address books")
+			}
+		}
+	}
+	return Discovery{PrincipalURL: principal, HomeURL: homes[0], HomeURLs: homes, Books: books}, nil
+}
+
+// DiscoverConnection validates the configured connection without persisting it.
+func (s *Service) DiscoverConnection(ctx context.Context, baseURL string) (Discovery, error) {
+	if s == nil || s.client == nil {
+		return Discovery{}, errors.New("CardDAV service is not configured")
+	}
+	return Discover(ctx, s.client, baseURL)
+}
+
+// DiscoverAndPersist validates the configured connection and atomically
+// replaces the durable discovery snapshot through the shared service.
+func (s *Service) DiscoverAndPersist(ctx context.Context, baseURL, username string) (Discovery, error) {
+	if s == nil || s.store == nil || s.client == nil {
+		return Discovery{}, errors.New("CardDAV service is not configured")
+	}
+	discovery, err := s.DiscoverConnection(ctx, baseURL)
+	if err != nil {
+		return Discovery{}, err
+	}
+	if err := s.PersistDiscovery(ctx, baseURL, username, discovery, false); err != nil {
+		return Discovery{}, err
+	}
+	return discovery, nil
+}
+
+// PersistDiscovery commits a previously completed network discovery. Keeping
+// this step separate lets callers publish crash-safe connection files before
+// the destructive replacement transaction begins.
+func (s *Service) PersistDiscovery(
+	ctx context.Context, baseURL, username string, discovery Discovery, credentialsChanged bool,
+) error {
+	if s == nil || s.store == nil {
+		return errors.New("CardDAV service is not configured")
+	}
+	if discovery.PrincipalURL == nil || discovery.HomeURL == nil {
+		return errors.New("CardDAV discovery is incomplete")
+	}
+	homeURLs := discoveryHomeURLStrings(discovery)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: baseURL, Username: username, CredentialsChanged: credentialsChanged,
+		PrincipalURL: discovery.PrincipalURL.String(), HomeURL: discovery.HomeURL.String(), HomeURLs: homeURLs,
+		Books: make([]store.CardDAVDiscoveredBook, 0, len(discovery.Books)),
+	}
+	for _, book := range discovery.Books {
+		input.Books = append(input.Books, store.CardDAVDiscoveredBook{
+			CanonicalURL: book.URL.String(), DiscoveryAliasURL: urlString(book.DiscoveryAliasURL),
+			DisplayName: book.DisplayName, DiscoveryIndex: book.DiscoveryIndex,
+			SupportsSyncCollection: book.SupportsSyncCollection, SupportsMultiget: book.SupportsMultiget,
+			SupportedVCardVersions: append([]string(nil), book.SupportedVCardVersions...),
+			CanCreate:              capabilityValue(book.Capabilities.CreateKnown, book.Capabilities.Create),
+			CanUpdate:              capabilityValue(book.Capabilities.UpdateKnown, book.Capabilities.Update),
+			CanDelete:              capabilityValue(book.Capabilities.DeleteKnown, book.Capabilities.Delete),
+		})
+	}
+	if _, _, err := s.store.ReplaceCardDAVDiscoveryContext(ctx, input); err != nil {
+		return err
+	}
+	return nil
+}
+
+func discoveryHomeURLStrings(discovery Discovery) []string {
+	homes := discovery.HomeURLs
+	if len(homes) == 0 && discovery.HomeURL != nil {
+		homes = []*url.URL{discovery.HomeURL}
+	}
+	result := make([]string, 0, len(homes))
+	for _, home := range homes {
+		if home != nil {
+			result = append(result, home.String())
+		}
+	}
+	return result
+}
+
+func capabilityValue(known, value bool) *bool {
+	if !known {
+		return nil
+	}
+	return &value
+}
+
+func urlString(value *url.URL) string {
+	if value == nil {
+		return ""
+	}
+	return value.String()
+}
+
+func discoverHref(
+	ctx context.Context, client *Client, target *url.URL, property PropertyName, budget *operationBudget,
+) (*url.URL, error) {
+	hrefs, err := discoverHrefs(ctx, client, target, property, budget)
+	if err != nil {
+		return nil, err
+	}
+	if len(hrefs) == 0 {
+		return nil, nil //nolint:nilnil // A missing optional DAV property is distinct from a request failure.
+	}
+	if len(hrefs) != 1 {
+		return nil, fmt.Errorf("CardDAV discovery returned conflicting %s values", property.Local)
+	}
+	return hrefs[0], nil
+}
+
+func discoverHrefs(
+	ctx context.Context, client *Client, target *url.URL, property PropertyName, budget *operationBudget,
+) ([]*url.URL, error) {
+	body, err := PropfindBody([]PropertyName{property})
+	if err != nil {
+		return nil, err
+	}
+	depth := 0
+	response, err := client.doWithBudget(
+		ctx, Request{Method: "PROPFIND", URL: target.String(), Depth: &depth, Body: body}, budget)
+	if err != nil {
+		return nil, err
+	}
+	effectiveTarget := response.EffectiveURL
+	if effectiveTarget == nil {
+		effectiveTarget = target
+	}
+	multiStatus, err := ParseMultiStatus(response.Body, DefaultXMLLimits())
+	if err != nil {
+		return nil, err
+	}
+	if len(multiStatus.Responses) != 1 {
+		return nil, fmt.Errorf("CardDAV discovery expected one response, got %d", len(multiStatus.Responses))
+	}
+	davResponse := multiStatus.Responses[0]
+	if _, err := resolveDiscoveryHref(ctx, client, effectiveTarget, davResponse.Href); err != nil {
+		return nil, err
+	}
+	if davResponse.StatusCode != 0 && (davResponse.StatusCode < 200 || davResponse.StatusCode >= 300) {
+		return nil, &StatusError{StatusCode: davResponse.StatusCode}
+	}
+	hrefs := []string{}
+	for _, propStat := range davResponse.PropStats {
+		if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+			continue
+		}
+		switch property {
+		case CurrentUserPrincipalProperty:
+			if propStat.Properties.CurrentUserPrincipal != "" {
+				hrefs = append(hrefs, propStat.Properties.CurrentUserPrincipal)
+			}
+		case AddressbookHomeSetProperty:
+			hrefs = append(hrefs, propStat.Properties.AddressbookHomeSet...)
+		}
+	}
+	resolved := make([]*url.URL, 0, len(hrefs))
+	seen := map[string]bool{}
+	for _, href := range hrefs {
+		value, err := resolveDiscoveryHref(ctx, client, effectiveTarget, href)
+		if err != nil {
+			return nil, err
+		}
+		key := canonicalCollectionURL(value)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		resolved = append(resolved, value)
+		if len(resolved) > 1000 {
+			return nil, errors.New("CardDAV discovery exceeded 1000 property hrefs")
+		}
+	}
+	return resolved, nil
+}
+
+func discoverBooks(
+	ctx context.Context, client *Client, home *url.URL, budget *operationBudget,
+) ([]DiscoveredBook, error) {
+	body, err := PropfindBody([]PropertyName{
+		ResourceTypeProperty,
+		DisplayNameProperty,
+		SupportedReportSetProperty,
+		CurrentUserPrivilegesProperty,
+		SupportedAddressDataProperty,
+	})
+	if err != nil {
+		return nil, err
+	}
+	depth := 1
+	response, err := client.doWithBudget(
+		ctx, Request{Method: "PROPFIND", URL: home.String(), Depth: &depth, Body: body}, budget)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate CardDAV address books: %w", err)
+	}
+	effectiveHome := response.EffectiveURL
+	if effectiveHome == nil {
+		effectiveHome = home
+	}
+	multiStatus, err := ParseMultiStatus(response.Body, DefaultXMLLimits())
+	if err != nil {
+		return nil, fmt.Errorf("parse CardDAV address books: %w", err)
+	}
+	if len(multiStatus.Responses) > 1000 {
+		return nil, errors.New("CardDAV discovery exceeded 1000 responses")
+	}
+
+	foundHome := false
+	books := make([]DiscoveredBook, 0, len(multiStatus.Responses))
+	seen := map[string]bool{}
+	for index, davResponse := range multiStatus.Responses {
+		resolved, err := resolveDiscoveryHref(ctx, client, effectiveHome, davResponse.Href)
+		if err != nil {
+			return nil, fmt.Errorf("resolve CardDAV discovery response %d: %w", index+1, err)
+		}
+		isHome := sameCollectionURL(resolved, effectiveHome)
+		if davResponse.StatusCode != 0 && (davResponse.StatusCode < 200 || davResponse.StatusCode >= 300) {
+			if isHome {
+				return nil, fmt.Errorf("CardDAV discovery response %d failed: %w", index+1, &StatusError{StatusCode: davResponse.StatusCode})
+			}
+			continue
+		}
+		properties := mergeSuccessfulProperties(davResponse.PropStats)
+		if isHome {
+			if !properties.ResourceTypePresent {
+				return nil, fmt.Errorf("CardDAV discovery response %d omitted successful resourcetype", index+1)
+			}
+			if foundHome || !properties.IsCollection {
+				return nil, errors.New("CardDAV discovery returned an invalid home collection response")
+			}
+			foundHome = true
+			continue
+		}
+		if !properties.ResourceTypePresent {
+			continue
+		}
+		if !properties.IsAddressBook {
+			continue
+		}
+		if !properties.IsCollection {
+			return nil, fmt.Errorf("CardDAV discovery response %d identified a non-collection address book", index+1)
+		}
+		if _, err := client.ValidateChildHref(ctx, effectiveHome, davResponse.Href); err != nil {
+			return nil, err
+		}
+		advertised, err := resolveDiscoveryHref(ctx, client, home, davResponse.Href)
+		if err != nil {
+			return nil, err
+		}
+		var alias *url.URL
+		if !sameCollectionURL(advertised, resolved) {
+			alias = advertised
+		}
+		key := canonicalCollectionURL(resolved)
+		if seen[key] {
+			return nil, fmt.Errorf("CardDAV discovery returned duplicate book %s", key)
+		}
+		seen[key] = true
+		displayName := strings.TrimSpace(properties.DisplayName)
+		if displayName == "" {
+			displayName = "Contacts"
+		}
+		books = append(books, DiscoveredBook{
+			URL: resolved, DiscoveryAliasURL: alias, DisplayName: displayName, DiscoveryIndex: len(books),
+			SupportsSyncCollection: properties.SupportsSync,
+			SupportsMultiget:       properties.SupportsMultiget,
+			SupportedVCardVersions: append([]string(nil), properties.SupportedVCard...),
+			Capabilities:           capabilitiesFrom(properties),
+		})
+	}
+	if !foundHome {
+		return nil, errors.New("CardDAV discovery did not include the home collection response")
+	}
+	return books, nil
+}
+
+func mergeSuccessfulProperties(propStats []PropStat) Properties {
+	var merged Properties
+	for _, propStat := range propStats {
+		if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+			continue
+		}
+		properties := propStat.Properties
+		if properties.DisplayName != "" {
+			merged.DisplayName = properties.DisplayName
+		}
+		if properties.ResourceTypePresent {
+			merged.ResourceTypePresent = true
+			merged.IsCollection = merged.IsCollection || properties.IsCollection
+			merged.IsAddressBook = merged.IsAddressBook || properties.IsAddressBook
+		}
+		if properties.PrivilegesPresent {
+			merged.PrivilegesPresent = true
+			for _, privilege := range properties.Privileges {
+				if !slices.Contains(merged.Privileges, privilege) {
+					merged.Privileges = append(merged.Privileges, privilege)
+				}
+			}
+		}
+		merged.SupportsSync = merged.SupportsSync || properties.SupportsSync
+		merged.SupportsMultiget = merged.SupportsMultiget || properties.SupportsMultiget
+		for _, version := range properties.SupportedVCard {
+			if !slices.Contains(merged.SupportedVCard, version) {
+				merged.SupportedVCard = append(merged.SupportedVCard, version)
+			}
+		}
+	}
+	return merged
+}
+
+func capabilitiesFrom(properties Properties) BookCapabilities {
+	if !properties.PrivilegesPresent {
+		return BookCapabilities{}
+	}
+	granted := map[string]bool{}
+	for _, privilege := range properties.Privileges {
+		granted[privilege] = true
+		// RFC 3744 section 3.8 explicitly excludes collection membership
+		// changes from DAV:write. Creating and deleting members require the
+		// separate DAV:bind and DAV:unbind privileges.
+		if privilege == "write" || privilege == "all" {
+			granted["write-content"] = true
+		}
+		if privilege == "all" {
+			granted["bind"] = true
+			granted["unbind"] = true
+		}
+	}
+	return BookCapabilities{
+		Create: granted["bind"], CreateKnown: true,
+		Update: granted["write-content"], UpdateKnown: true,
+		Delete: granted["unbind"], DeleteKnown: true,
+	}
+}
+
+func resolveDiscoveryHref(ctx context.Context, client *Client, base *url.URL, href string) (*url.URL, error) {
+	if href == "" || strings.TrimSpace(href) != href || strings.Contains(href, "\\") {
+		return nil, ErrUnsafeHref
+	}
+	resolved, err := base.Parse(href)
+	if err != nil || resolved.User != nil || resolved.Fragment != "" || !sameOrigin(client.origin, resolved) {
+		return nil, ErrUnsafeHref
+	}
+	if _, err := client.validateTarget(ctx, resolved); err != nil {
+		return nil, fmt.Errorf("discovery href: %w", ErrUnsafeHref)
+	}
+	return resolved, nil
+}
+
+func discoveryFallbackAllowed(err error) bool {
+	if err == nil {
+		return true
+	}
+	var status *StatusError
+	if !errors.As(err, &status) {
+		return false
+	}
+	switch status.StatusCode {
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusGone, http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+func sameCollectionURL(left, right *url.URL) bool {
+	return canonicalCollectionURL(left) == canonicalCollectionURL(right)
+}
+
+func canonicalDAVURLIdentity(value *url.URL) string {
+	clone := *value
+	clone.Scheme = strings.ToLower(clone.Scheme)
+	clone.Host = net.JoinHostPort(strings.ToLower(clone.Hostname()), originPort(&clone))
+	clone.Fragment = ""
+	return clone.String()
+}
+
+func canonicalCollectionURL(value *url.URL) string {
+	clone := *value
+	clone.Scheme = strings.ToLower(clone.Scheme)
+	clone.Host = net.JoinHostPort(strings.ToLower(clone.Hostname()), originPort(&clone))
+	clone.Fragment = ""
+	clone.Path = path.Clean(clone.Path)
+	if !strings.HasSuffix(clone.Path, "/") {
+		clone.Path += "/"
+	}
+	return clone.String()
+}

--- a/internal/carddav/discovery_test.go
+++ b/internal/carddav/discovery_test.go
@@ -1,0 +1,499 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoveryCollectionComparisonNormalizesOriginAndPath(t *testing.T) {
+	left, err := url.Parse("https://contacts.example/book/")
+	require.NoError(t, err)
+	right, err := url.Parse("HTTPS://CONTACTS.example:443/book")
+	require.NoError(t, err)
+
+	assert.True(t, sameCollectionURL(left, right))
+}
+
+func TestDAVWritePrivilegeDoesNotGrantCollectionMembershipChanges(t *testing.T) {
+	assert := assert.New(t)
+
+	capabilities := capabilitiesFrom(Properties{
+		PrivilegesPresent: true,
+		Privileges:        []string{"write"},
+	})
+
+	assert.False(capabilities.Create)
+	assert.True(capabilities.Update)
+	assert.False(capabilities.Delete)
+	assert.True(capabilities.CreateKnown)
+	assert.True(capabilities.UpdateKnown)
+	assert.True(capabilities.DeleteKnown)
+}
+
+func TestDiscoverUsesDirectPrincipalAndEnumeratesCapabilities(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path+" depth="+r.Header.Get("Depth"))
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/dav/principals/alice/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/dav/principals/alice/":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav/principals/alice/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/dav/books/alice/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/dav/books/alice/":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav/books/alice/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/dav/books/alice/personal/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype>
+				<D:displayname>Personal</D:displayname>
+				<D:supported-report-set>
+					<D:supported-report><D:report><D:sync-collection/></D:report></D:supported-report>
+					<D:supported-report><D:report><C:addressbook-multiget/></D:report></D:supported-report>
+				</D:supported-report-set>
+				<D:current-user-privilege-set>
+					<D:privilege><D:bind/></D:privilege>
+					<D:privilege><D:write-content/></D:privilege>
+				</D:current-user-privilege-set>
+				<C:supported-address-data>
+					<C:address-data-type content-type="text/vcard" version="4.0"/>
+					<C:address-data-type content-type="text/vcard" version="3.0"/>
+					<C:address-data-type content-type="application/json" version="9.9"/>
+				</C:supported-address-data>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	require.NoError(err)
+	require.Len(discovery.Books, 1)
+	assert.Equal("/dav/principals/alice/", discovery.PrincipalURL.Path)
+	assert.Equal("/dav/books/alice/", discovery.HomeURL.Path)
+	book := discovery.Books[0]
+	assert.Equal("/dav/books/alice/personal/", book.URL.Path)
+	assert.Equal("Personal", book.DisplayName)
+	assert.True(book.SupportsSyncCollection)
+	assert.True(book.SupportsMultiget)
+	assert.Equal([]string{"4.0", "3.0"}, book.SupportedVCardVersions)
+	assert.True(book.Capabilities.CreateKnown)
+	assert.True(book.Capabilities.Create)
+	assert.True(book.Capabilities.UpdateKnown)
+	assert.True(book.Capabilities.Update)
+	assert.True(book.Capabilities.DeleteKnown)
+	assert.False(book.Capabilities.Delete)
+	assert.Equal([]string{
+		"PROPFIND /dav depth=0",
+		"PROPFIND /dav/principals/alice/ depth=0",
+		"PROPFIND /dav/books/alice/ depth=1",
+	}, requests)
+}
+
+func TestDiscoverEnumeratesAllHomeCollectionsAndDeduplicatesBooks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set>
+					<D:href>/books/</D:href><D:href>/books/team/</D:href><D:href>/books/</D:href>
+				</C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/team/shared/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Shared</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/team/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/team/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/team/shared/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Shared</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/team/local/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Team</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	require.NoError(err)
+	require.Len(discovery.HomeURLs, 2)
+	assert.Equal([]string{"/books/", "/books/team/"}, []string{discovery.HomeURLs[0].Path, discovery.HomeURLs[1].Path})
+	assert.Equal(discovery.HomeURLs[0], discovery.HomeURL)
+	require.Len(discovery.Books, 2)
+	assert.Equal("/books/team/shared/", discovery.Books[0].URL.Path)
+	assert.Equal(0, discovery.Books[0].DiscoveryIndex)
+	assert.Equal("/books/team/local/", discovery.Books[1].URL.Path)
+	assert.Equal(1, discovery.Books[1].DiscoveryIndex)
+}
+
+func TestDiscoverSharesTransferBudgetAcrossRequests(t *testing.T) {
+	require := require.New(t)
+	direct := []byte(`<?xml version="1.0"?><D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/dav</D:href><D:propstat><D:prop><D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	principal := []byte(`<?xml version="1.0"?><D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/principal/</D:href><D:propstat><D:prop><C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusMultiStatus)
+		switch r.URL.Path {
+		case "/dav":
+			_, _ = w.Write(direct)
+		case "/principal/":
+			_, _ = w.Write(principal)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newFixtureClient(t, server.URL, "alice", "secret")
+	client.operationBytes = int64(len(direct) + len(principal) - 1)
+
+	_, err := Discover(t.Context(), client, server.URL+"/dav")
+	require.ErrorIs(err, ErrOperationLimit)
+	assert.Equal(t, 2, requests, "the second response must exhaust the shared budget")
+}
+
+func TestDiscoverSharesDeadlineAcrossRequests(t *testing.T) {
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newFixtureClient(t, server.URL, "alice", "secret")
+	client.operationTimeout = 300 * time.Millisecond
+
+	started := time.Now()
+	_, err := Discover(t.Context(), client, server.URL+"/dav")
+	require.ErrorIs(err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(started), 500*time.Millisecond, "requests must share one operation deadline")
+}
+
+func TestDiscoverFallsBackToWellKnownAndKeepsMissingPrivilegesUnknown(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/entered":
+			http.NotFound(w, r)
+		case "/.well-known/carddav":
+			writeMultiStatus(t, w, `<D:response><D:href>/.well-known/carddav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/personal/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Personal</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat>
+			<D:propstat><D:prop><D:current-user-privilege-set><D:privilege><D:bind/></D:privilege>
+			</D:current-user-privilege-set></D:prop><D:status>HTTP/1.1 403 Forbidden</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/directory/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype><D:displayname>Directory</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/entered")
+	require.NoError(err)
+	require.Len(discovery.Books, 2)
+	assert.Equal("/books/personal/", discovery.Books[0].URL.Path)
+	assert.False(discovery.Books[0].Capabilities.CreateKnown)
+	assert.False(discovery.Books[0].Capabilities.Create)
+	assert.Equal("/books/directory/", discovery.Books[1].URL.Path)
+}
+
+func TestDiscoverDoesNotMaskDirectTransientOrParsingFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		direct     func(http.ResponseWriter)
+		wantStatus int
+	}{
+		{
+			name: "rate limit with retry after",
+			direct: func(w http.ResponseWriter) {
+				w.Header().Set("Retry-After", "90")
+				w.WriteHeader(http.StatusTooManyRequests)
+			},
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name: "server failure",
+			direct: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name: "malformed multistatus",
+			direct: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusMultiStatus)
+				_, _ = w.Write([]byte(`<D:multistatus xmlns:D="DAV:"><D:response>`))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+				if r.URL.Path == "/entered" {
+					tc.direct(w)
+					return
+				}
+				http.Error(w, "fallback must not run", http.StatusTeapot)
+			}))
+			t.Cleanup(server.Close)
+
+			_, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/entered")
+			require.Error(t, err)
+			assert.Equal([]string{"/entered"}, paths)
+			if tc.wantStatus != 0 {
+				var status *StatusError
+				require.ErrorAs(t, err, &status)
+				assert.Equal(tc.wantStatus, status.StatusCode)
+				if tc.wantStatus == http.StatusTooManyRequests {
+					assert.Equal(90*time.Second, status.RetryAfter)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverDoesNotRetryNetworkFailureThroughWellKnown(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	origin, err := url.Parse("https://contacts.example")
+	require.NoError(err)
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("203.0.113.9"))
+	var dialCalls atomic.Int32
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin,
+		Username:         "alice",
+		Password:         "secret",
+		Resolver:         resolver,
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialCalls.Add(1)
+			return nil, errors.New("synthetic network failure")
+		},
+	})
+	require.NoError(err)
+
+	_, err = Discover(t.Context(), client, origin.String()+"/entered")
+	require.ErrorContains(err, "synthetic network failure")
+	assert.Equal(int32(1), dialCalls.Load(), "network failure must not trigger well-known discovery")
+}
+
+func TestDiscoverSkipsNonHomeResponseWithoutSuccessfulResourceType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/inaccessible/</D:href><D:propstat><D:prop>
+				<D:resourcetype/>
+			</D:prop><D:status>HTTP/1.1 403 Forbidden</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/personal/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype>
+				<D:displayname>Personal</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	require.NoError(t, err)
+	require.Len(t, discovery.Books, 1)
+	assert.Equal(t, "/books/personal/", discovery.Books[0].URL.Path)
+}
+
+func TestDiscoverSkipsUnavailableNonHomeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>/books/inaccessible/</D:href><D:status>HTTP/1.1 403 Forbidden</D:status></D:response>
+			<D:response><D:href>/books/personal/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype>
+				<D:displayname>Personal</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	require.NoError(t, err)
+	require.Len(t, discovery.Books, 1)
+	assert.Equal(t, "/books/personal/", discovery.Books[0].URL.Path)
+}
+
+func TestDiscoverRejectsUnavailableHomeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>/books/</D:href><D:status>HTTP/1.1 403 Forbidden</D:status></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	var status *StatusError
+	require.ErrorAs(t, err, &status)
+	assert.Equal(t, http.StatusForbidden, status.StatusCode)
+}
+
+func TestDiscoverPreservesRedirectedBookAlias(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch r.URL.Path {
+		case "/dav":
+			writeMultiStatus(t, w, `<D:response><D:href>/dav</D:href><D:propstat><D:prop>
+				<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/principal/":
+			writeMultiStatus(t, w, `<D:response><D:href>/principal/</D:href><D:propstat><D:prop>
+				<C:addressbook-home-set><D:href>/books/</D:href></C:addressbook-home-set>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		case "/books/":
+			http.Redirect(w, r, "/canonical/books/", http.StatusTemporaryRedirect)
+		case "/canonical/books/":
+			writeMultiStatus(t, w, `<D:response><D:href>./</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/></D:resourcetype>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>
+			<D:response><D:href>personal/</D:href><D:propstat><D:prop>
+				<D:resourcetype><D:collection/><C:addressbook/></D:resourcetype>
+				<D:displayname>Personal</D:displayname>
+			</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	discovery, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/dav")
+	require.NoError(err)
+	require.Len(discovery.Books, 1)
+	assert.Equal("/canonical/books/personal/", discovery.Books[0].URL.Path)
+	require.NotNil(discovery.Books[0].DiscoveryAliasURL)
+	assert.Equal("/books/personal/", discovery.Books[0].DiscoveryAliasURL.Path)
+}
+
+func TestDiscoverRejectsCrossOriginDiscoveryResponseHrefWithoutFallback(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		writeMultiStatus(t, w, `<D:response><D:href>https://elsewhere.example/dav</D:href><D:propstat><D:prop>
+			<D:current-user-principal><D:href>/principal/</D:href></D:current-user-principal>
+		</D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := Discover(t.Context(), newFixtureClient(t, server.URL, "alice", "secret"), server.URL+"/entered")
+	require.ErrorIs(t, err, ErrUnsafeHref)
+	assert.Equal(t, 1, requests, "an unsafe direct response must not be retried through well-known discovery")
+}
+
+func writeMultiStatus(t *testing.T, w http.ResponseWriter, responses string) {
+	t.Helper()
+	w.WriteHeader(http.StatusMultiStatus)
+	_, err := fmt.Fprintf(w, `<?xml version="1.0"?><D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">%s</D:multistatus>`, strings.TrimSpace(responses))
+	require.NoError(t, err)
+}

--- a/internal/carddav/fixture_test.go
+++ b/internal/carddav/fixture_test.go
@@ -1,0 +1,17 @@
+package carddav
+
+const cardDAVMultiStatusFixture = `<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:CR="urn:ietf:params:xml:ns:carddav">
+  <D:response>
+    <D:href>/dav/books/personal/alice.vcf</D:href>
+    <D:propstat>
+      <D:prop>
+        <D:getetag>"abc"</D:getetag>
+        <CR:address-data>BEGIN:VCARD
+VERSION:4.0
+END:VCARD</CR:address-data>
+      </D:prop>
+      <D:status>HTTP/1.1 200 OK</D:status>
+    </D:propstat>
+  </D:response>
+</D:multistatus>`

--- a/internal/carddav/hash.go
+++ b/internal/carddav/hash.go
@@ -1,0 +1,191 @@
+package carddav
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/vcard"
+)
+
+var serverOwnedProperties = map[string]bool{
+	"PRODID": true, "REV": true, "SOURCE": true,
+	"CREATED": true, "LAST-MODIFIED": true,
+}
+
+type semanticProperty struct {
+	Group      string              `json:"group,omitempty"`
+	Name       string              `json:"name"`
+	Parameters []semanticParameter `json:"parameters,omitempty"`
+	ValueType  string              `json:"value_type,omitempty"`
+	RawValue   string              `json:"raw_value"`
+}
+
+type semanticParameter struct {
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
+}
+
+// SemanticHash hashes the parsed vCard rather than its wire formatting. The
+// five properties CardDAV servers conventionally own are deliberately absent,
+// so their churn cannot masquerade as a user edit.
+func SemanticHash(body []byte) (string, error) {
+	envelope, err := vcard.ParseResourceEnvelope(body)
+	if err != nil {
+		return "", fmt.Errorf("parse vCard for semantic hash: %w", err)
+	}
+	properties := make([]semanticProperty, 0, len(envelope.PropertyTree))
+	for _, occurrence := range envelope.PropertyTree {
+		property := occurrence.Property
+		name := strings.ToUpper(property.Name)
+		if serverOwnedProperties[name] {
+			continue
+		}
+		parameters := make([]semanticParameter, 0, len(property.Parameters))
+		for _, parameter := range property.Parameters {
+			if strings.EqualFold(parameter.Name, "VALUE") {
+				continue
+			}
+			values := make([]string, 0, len(parameter.Values))
+			for _, value := range parameter.Values {
+				decoded := value.Decoded
+				if parameter.Name == "TYPE" || parameter.Name == "ENCODING" ||
+					parameter.Name == "VALUE" || parameter.Name == "MEDIATYPE" {
+					decoded = strings.ToLower(decoded)
+				}
+				values = append(values, decoded)
+			}
+			if strings.EqualFold(parameter.Name, "TYPE") {
+				slices.Sort(values)
+				values = slices.Compact(values)
+			}
+			parameters = append(parameters, semanticParameter{
+				Name: strings.ToUpper(parameter.Name), Values: values,
+			})
+		}
+		slices.SortFunc(parameters, func(left, right semanticParameter) int {
+			return strings.Compare(left.Name, right.Name)
+		})
+		properties = append(properties, semanticProperty{
+			Group: strings.ToLower(property.Group), Name: name,
+			Parameters: parameters,
+			ValueType:  semanticValueType(envelope.RenderMetadata.StoredVersion, property),
+			RawValue:   canonicalSemanticValue(envelope.RenderMetadata.StoredVersion, property),
+		})
+	}
+	slices.SortFunc(properties, compareSemanticProperties)
+	encoded, err := json.Marshal(properties)
+	if err != nil {
+		return "", fmt.Errorf("encode semantic vCard: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func semanticValueType(version vcard.Version, property vcard.Property) string {
+	for _, parameter := range property.Parameters {
+		if strings.EqualFold(parameter.Name, "VALUE") && len(parameter.Values) > 0 {
+			return strings.ToLower(strings.TrimSpace(parameter.Values[0].Decoded))
+		}
+	}
+	name := strings.ToUpper(property.Name)
+	if version == vcard.Version40 && v4URIProperties[name] {
+		return "uri"
+	}
+	if legacyURIProperties[name] {
+		return "uri"
+	}
+	if textProperties[name] {
+		return "text"
+	}
+	return ""
+}
+
+func canonicalSemanticValue(version vcard.Version, property vcard.Property) string {
+	value := strings.ReplaceAll(strings.ReplaceAll(property.RawValue, "\r\n", "\n"), "\r", "\n")
+	switch semanticValueType(version, property) {
+	case "text":
+		return canonicalTextEscapes(value)
+	case "uri":
+		return canonicalURI(value)
+	case "boolean", "language-tag":
+		return strings.ToLower(value)
+	default:
+		return value
+	}
+}
+
+// canonicalTextEscapes preserves structured and list delimiters while making
+// the two RFC 6350 spellings of an escaped newline identical.
+func canonicalTextEscapes(value string) string {
+	var canonical strings.Builder
+	canonical.Grow(len(value))
+	for index := 0; index < len(value); index++ {
+		if value[index] == '\\' && index+1 < len(value) && value[index+1] == 'N' {
+			canonical.WriteString(`\n`)
+			index++
+			continue
+		}
+		canonical.WriteByte(value[index])
+	}
+	return canonical.String()
+}
+
+func canonicalURI(value string) string {
+	if !vcard.IsURIValue(value) {
+		return value
+	}
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return value
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	return parsed.String()
+}
+
+var textProperties = map[string]bool{
+	"VERSION": true, "KIND": true, "XML": true, "FN": true, "N": true,
+	"NICKNAME": true, "GENDER": true, "ADR": true, "EMAIL": true,
+	"TITLE": true, "ROLE": true, "ORG": true, "CATEGORIES": true,
+	"NOTE": true, "PRODID": true, "CLIENTPIDMAP": true,
+}
+
+var legacyURIProperties = map[string]bool{
+	"SOURCE": true, "URL": true, "IMPP": true,
+}
+
+var v4URIProperties = map[string]bool{
+	"SOURCE": true, "PHOTO": true, "TEL": true, "IMPP": true, "GEO": true,
+	"LOGO": true, "MEMBER": true, "RELATED": true, "SOUND": true,
+	"UID": true, "URL": true, "KEY": true, "FBURL": true,
+	"CALADRURI": true, "CALURI": true, "BIRTHPLACE": true,
+	"DEATHPLACE": true, "CONTACT-URI": true, "ORG-DIRECTORY": true,
+}
+
+func compareSemanticProperties(left, right semanticProperty) int {
+	if result := cmp.Compare(left.Group, right.Group); result != 0 {
+		return result
+	}
+	if result := cmp.Compare(left.Name, right.Name); result != 0 {
+		return result
+	}
+	if result := slices.CompareFunc(left.Parameters, right.Parameters, func(
+		left, right semanticParameter,
+	) int {
+		if result := cmp.Compare(left.Name, right.Name); result != 0 {
+			return result
+		}
+		return slices.Compare(left.Values, right.Values)
+	}); result != 0 {
+		return result
+	}
+	if result := cmp.Compare(left.ValueType, right.ValueType); result != 0 {
+		return result
+	}
+	return cmp.Compare(left.RawValue, right.RawValue)
+}

--- a/internal/carddav/hash_test.go
+++ b/internal/carddav/hash_test.go
@@ -1,0 +1,68 @@
+package carddav
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemanticHashIgnoresOnlyServerOwnedProperties(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	left := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Alice Example\r\nREV:20260101T000000Z\r\nPRODID:-//one//EN\r\nEND:VCARD\r\n")
+	right := []byte("BEGIN:VCARD\nVERSION:4.0\nUID:remote-1\nFN:Alice Example\nREV:20260819T120000Z\nPRODID:-//two//EN\nEND:VCARD\n")
+	changed := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Bob Example\r\nREV:20260819T120000Z\r\nEND:VCARD\r\n")
+
+	leftHash, err := SemanticHash(left)
+	require.NoError(err)
+	rightHash, err := SemanticHash(right)
+	require.NoError(err)
+	changedHash, err := SemanticHash(changed)
+	require.NoError(err)
+
+	assert.Equal(leftHash, rightHash)
+	assert.NotEqual(leftHash, changedHash)
+}
+
+func TestSemanticHashRejectsMalformedVCard(t *testing.T) {
+	_, err := SemanticHash([]byte("not a vCard"))
+	require.Error(t, err)
+}
+
+func TestSemanticHashIgnoresPropertyOrderButPreservesDuplicates(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	left := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Alice Example\r\nEMAIL;TYPE=work:alice@example.test\r\nEMAIL;TYPE=home:alice@home.test\r\nEND:VCARD\r\n")
+	right := []byte("BEGIN:VCARD\r\nEMAIL;TYPE=home:alice@home.test\r\nFN:Alice Example\r\nVERSION:4.0\r\nEMAIL;TYPE=work:alice@example.test\r\nUID:remote-1\r\nEND:VCARD\r\n")
+	missingDuplicate := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Alice Example\r\nEMAIL;TYPE=work:alice@example.test\r\nEND:VCARD\r\n")
+
+	leftHash, err := SemanticHash(left)
+	require.NoError(err)
+	rightHash, err := SemanticHash(right)
+	require.NoError(err)
+	missingHash, err := SemanticHash(missingDuplicate)
+	require.NoError(err)
+
+	assert.Equal(leftHash, rightHash)
+	assert.NotEqual(leftHash, missingHash)
+}
+
+func TestSemanticHashCanonicalizesKnownTextAndURIValues(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	left := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Alice Example\r\nNOTE:Line one\\nLine two\r\nURL;VALUE=URI:HTTPS://example.test/alice\r\nEND:VCARD\r\n")
+	right := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN;VALUE=text:Alice Example\r\nNOTE:Line one\\NLine two\r\nURL:https://example.test/alice\r\nEND:VCARD\r\n")
+	changed := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-1\r\nFN:Alice Example\r\nNOTE:Line one\\nDifferent\r\nURL:https://example.test/alice\r\nEND:VCARD\r\n")
+
+	leftHash, err := SemanticHash(left)
+	require.NoError(err)
+	rightHash, err := SemanticHash(right)
+	require.NoError(err)
+	changedHash, err := SemanticHash(changed)
+	require.NoError(err)
+
+	assert.Equal(leftHash, rightHash)
+	assert.NotEqual(leftHash, changedHash)
+}

--- a/internal/carddav/mutation.go
+++ b/internal/carddav/mutation.go
@@ -1,0 +1,580 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vcard"
+	"go.kenn.io/msgvault/internal/vcardmap"
+)
+
+type Mutation struct {
+	PersonID int64
+	Desired  bool
+}
+
+func (s *Service) PublishPerson(ctx context.Context, personID int64) error {
+	return s.mutate(ctx, Mutation{PersonID: personID, Desired: true})
+}
+
+func (s *Service) UnpublishPerson(ctx context.Context, personID int64) error {
+	return s.mutate(ctx, Mutation{PersonID: personID, Desired: false})
+}
+
+// ReconcilePublications runs in person-ID order. A person's failure does not
+// prevent later people from being considered; an account-wide 429 gate stops
+// the sweep immediately.
+func (s *Service) ReconcilePublications(ctx context.Context) error {
+	return s.reconcilePublications(ctx, nil)
+}
+
+// recoverPendingPublications resolves only ambiguous in-flight mutations.
+// Sync calls it before pull so a successful remote write whose response was
+// lost is not mistaken for a new remote edit. Settled desired publications
+// remain in the normal post-pull reconciliation phase.
+func (s *Service) recoverPendingPublications(ctx context.Context) (map[int64]bool, error) {
+	ids, err := s.store.ListCardDAVPublicationPersonIDsContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	recovered := make(map[int64]bool)
+	var failures []error
+	for _, personID := range ids {
+		publication, err := s.store.GetCardDAVPublicationContext(ctx, personID)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		if publication.PendingOperation == "" {
+			continue
+		}
+		recovered[personID] = true
+		err = s.mutate(ctx, Mutation{PersonID: personID, Desired: publication.Desired})
+		if errors.Is(err, store.ErrCardDAVRetryAfter) || isStatus(err, http.StatusTooManyRequests) {
+			return recovered, err
+		}
+		if errors.Is(err, ErrCardDAVConflictPending) {
+			continue
+		}
+		if err != nil {
+			failures = append(failures, fmt.Errorf("reconcile CardDAV publication for person %d: %w", personID, err))
+		}
+	}
+	return recovered, errors.Join(failures...)
+}
+
+func (s *Service) reconcilePublications(ctx context.Context, skip map[int64]bool) error {
+	ids, err := s.store.ListCardDAVPublicationPersonIDsContext(ctx)
+	if err != nil {
+		return err
+	}
+	var failures []error
+	for _, personID := range ids {
+		if skip[personID] {
+			continue
+		}
+		publication, err := s.store.GetCardDAVPublicationContext(ctx, personID)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		err = s.mutate(ctx, Mutation{PersonID: personID, Desired: publication.Desired})
+		if errors.Is(err, store.ErrCardDAVRetryAfter) || isStatus(err, http.StatusTooManyRequests) {
+			return err
+		}
+		if errors.Is(err, ErrCardDAVConflictPending) {
+			continue
+		}
+		if err != nil {
+			failures = append(failures, fmt.Errorf("reconcile CardDAV publication for person %d: %w", personID, err))
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func (s *Service) mutate(ctx context.Context, mutation Mutation) error {
+	if s == nil || s.store == nil || s.client == nil || mutation.PersonID <= 0 {
+		return errors.New("CardDAV service is not configured")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, s.client.operationTimeout)
+	defer cancel()
+	if err := s.store.CheckCardDAVRetryAfterContext(operationCtx); err != nil {
+		return err
+	}
+
+	existing, publicationErr := s.store.GetCardDAVPublicationContext(operationCtx, mutation.PersonID)
+	if publicationErr == nil && existing.PendingOperation != "" {
+		if conflict, conflictErr := s.store.GetUnresolvedCardDAVConflictForMappingContext(
+			operationCtx, existing.AddressBookID, existing.Href,
+		); conflictErr == nil {
+			return &ConflictError{ID: conflict.ID}
+		} else if !errors.Is(conflictErr, store.ErrCardDAVConflictNotFound) {
+			return conflictErr
+		}
+		if existing.Desired != mutation.Desired {
+			return store.ErrCardDAVPublicationPending
+		}
+		existing.RecoveryOnly = true
+		return s.executeMutation(operationCtx, existing)
+	} else if publicationErr != nil && !errors.Is(publicationErr, store.ErrCardDAVPublicationNotFound) {
+		return publicationErr
+	}
+	if !mutation.Desired && errors.Is(publicationErr, store.ErrCardDAVPublicationNotFound) {
+		_, err := s.store.GetPersonContext(operationCtx, mutation.PersonID)
+		return err
+	}
+
+	account, err := s.store.GetCardDAVAccountContext(operationCtx)
+	if err != nil {
+		return err
+	}
+	if account == nil {
+		return store.ErrCardDAVNoWriteTarget
+	}
+	books, err := s.store.ListCardDAVAddressBooksContext(operationCtx)
+	if err != nil {
+		return err
+	}
+	book, ok := writeTarget(books)
+	if !ok {
+		return store.ErrCardDAVNoWriteTarget
+	}
+	person, err := s.store.GetPersonContext(operationCtx, mutation.PersonID)
+	if err != nil {
+		return err
+	}
+	resource, err := s.store.GetCardDAVResourceForPersonContext(operationCtx, book.ID, mutation.PersonID)
+	if err != nil && !errors.Is(err, store.ErrCardDAVResourceNotFound) {
+		return err
+	}
+	if errors.Is(err, store.ErrCardDAVResourceNotFound) {
+		resource = nil
+	}
+	if resource != nil {
+		if conflict, conflictErr := s.store.GetUnresolvedCardDAVConflictForMappingContext(
+			operationCtx, resource.AddressBookID, resource.Href,
+		); conflictErr == nil {
+			return &ConflictError{ID: conflict.ID}
+		} else if !errors.Is(conflictErr, store.ErrCardDAVConflictNotFound) {
+			return conflictErr
+		}
+	}
+	href, err := s.publicationHref(book.CanonicalURL, person.VCardUID)
+	if err != nil {
+		return err
+	}
+	if resource != nil {
+		href = resource.Href
+	}
+	plan := store.CardDAVPublicationPlan{
+		PersonID: mutation.PersonID, Desired: mutation.Desired,
+		AddressBookID: book.ID, Href: href,
+	}
+	if mutation.Desired {
+		body, localHash, err := s.renderPublicationCard(operationCtx, *person, book, resource)
+		if err != nil {
+			return err
+		}
+		semanticHash, err := SemanticHash(body)
+		if err != nil {
+			return err
+		}
+		plan.OutgoingBody, plan.OutgoingSemanticHash, plan.LocalHash = body, semanticHash, localHash
+	}
+	prepared, err := s.store.PrepareCardDAVPublicationContext(operationCtx, plan)
+	if err != nil {
+		return err
+	}
+	if prepared.Noop {
+		return nil
+	}
+	return s.executeMutation(operationCtx, prepared)
+}
+
+func writeTarget(books []store.CardDAVAddressBook) (store.CardDAVAddressBook, bool) {
+	for _, book := range books {
+		if book.IsWriteTarget && book.IsSubscribed {
+			return book, true
+		}
+	}
+	return store.CardDAVAddressBook{}, false
+}
+
+func (s *Service) renderPublicationCard(
+	ctx context.Context, person store.Person, book store.CardDAVAddressBook,
+	resource *store.CardDAVResource,
+) ([]byte, string, error) {
+	snapshot, err := s.store.LoadPersonVCardSnapshotContext(ctx, person.ID)
+	if err != nil {
+		return nil, "", err
+	}
+	var envelope vcard.ResourceEnvelope
+	version := publicationVersion(book.SupportedVCardVersions)
+	if resource != nil {
+		record, err := s.store.GetVCardResourceEnvelopeContext(ctx, fmt.Sprintf("carddav:%d", book.ID), resource.Href)
+		if err != nil {
+			return nil, "", err
+		}
+		envelope = record.ResourceEnvelope
+		if envelope.RenderMetadata.StoredVersion == vcard.Version30 || envelope.RenderMetadata.StoredVersion == vcard.Version40 {
+			version = envelope.RenderMetadata.StoredVersion
+		}
+	} else {
+		href, err := s.publicationHref(book.CanonicalURL, person.VCardUID)
+		if err != nil {
+			return nil, "", err
+		}
+		fullName := person.VCardUID
+		if person.DisplayName != nil && strings.TrimSpace(*person.DisplayName) != "" {
+			fullName = strings.TrimSpace(*person.DisplayName)
+		}
+		raw := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + vcard.EscapeText(person.VCardUID) +
+			"\r\nFN:" + vcard.EscapeText(fullName) + "\r\nEND:VCARD\r\n")
+		envelope, err = vcard.ParseResourceEnvelope(raw)
+		if err != nil {
+			return nil, "", err
+		}
+		envelope.SourceRef = fmt.Sprintf("carddav:%d", book.ID)
+		envelope.SourceResourceUID = href
+		envelope.Href = envelope.SourceResourceUID
+		envelope.CanonicalPersonUID = person.VCardUID
+	}
+	prepared, err := vcardmap.ProjectPersonEnvelope(*snapshot, envelope)
+	if err != nil {
+		return nil, "", fmt.Errorf("project person for CardDAV publication: %w", err)
+	}
+	body, err := prepared.RenderView(version)
+	if err != nil {
+		return nil, "", err
+	}
+	body, err = stripServerOwnedProperties(body, version)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, snapshot.Fingerprint, nil
+}
+
+func (s *Service) publicationHref(collectionURL, uid string) (string, error) {
+	if s == nil || s.client == nil || strings.TrimSpace(uid) == "" {
+		return "", ErrUnsafeTarget
+	}
+	collection, err := url.Parse(collectionURL)
+	if err != nil || !validHTTPURL(collection) || !sameOrigin(s.client.origin, collection) {
+		return "", fmt.Errorf("CardDAV publication collection: %w", ErrUnsafeTarget)
+	}
+	child := *collection
+	child.RawQuery = ""
+	child.ForceQuery = false
+	child.Fragment = ""
+	escapedBase := strings.TrimSuffix(collection.EscapedPath(), "/") + "/"
+	child.Path = strings.TrimSuffix(collection.Path, "/") + "/" + uid + ".vcf"
+	child.RawPath = escapedBase + url.PathEscape(uid) + ".vcf"
+	if !sameOrigin(collection, &child) || !sameOrigin(s.client.origin, &child) {
+		return "", fmt.Errorf("CardDAV publication href: %w", ErrUnsafeTarget)
+	}
+	return canonicalDAVURLIdentity(&child), nil
+}
+
+func publicationVersion(advertised []string) vcard.Version {
+	versions := slices.Clone(advertised)
+	slices.Sort(versions)
+	versions = slices.Compact(versions)
+	if len(versions) == 1 && versions[0] == string(vcard.Version40) {
+		return vcard.Version40
+	}
+	return vcard.Version30
+}
+
+func stripServerOwnedProperties(body []byte, version vcard.Version) ([]byte, error) {
+	envelope, err := vcard.ParseResourceEnvelope(body)
+	if err != nil {
+		return nil, err
+	}
+	edits := make([]vcard.PropertyEdit, 0)
+	for _, occurrence := range envelope.PropertyTree {
+		if serverOwnedProperties[strings.ToUpper(occurrence.Property.Name)] {
+			edits = append(edits, vcard.PropertyEdit{Identity: occurrence.Identity, Delete: true})
+		}
+	}
+	if len(edits) > 0 {
+		envelope, err = envelope.MergeProperties(edits)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return envelope.RenderView(version)
+}
+
+func (s *Service) executeMutation(ctx context.Context, pending *store.CardDAVPublication) error {
+	books, err := s.store.ListCardDAVAddressBooksContext(ctx)
+	if err != nil {
+		return err
+	}
+	book, ok := findCardDAVBook(books, pending.AddressBookID)
+	conflictScoped := pending.ResolutionConflictID != 0
+	if !ok || !book.IsSubscribed || (!book.IsWriteTarget && !conflictScoped) {
+		return store.ErrCardDAVNoWriteTarget
+	}
+	if pending.RecoveryOnly {
+		resolutionConflictID := pending.ResolutionConflictID
+		var refreshed *store.CardDAVPublication
+		var err error
+		if resolutionConflictID != 0 && pending.PersonID == 0 {
+			refreshed, err = s.store.RefreshCardDAVConflictMutationFenceContext(ctx, resolutionConflictID)
+		} else {
+			refreshed, err = s.store.RefreshCardDAVPublicationFenceContext(ctx, pending.PersonID)
+		}
+		if err != nil {
+			return err
+		}
+		refreshed.RecoveryOnly = true
+		refreshed.ResolutionConflictID = resolutionConflictID
+		pending = refreshed
+		if pending.PendingOperation == store.CardDAVMutationCreate {
+			return s.recoverCreate(ctx, pending)
+		}
+		remote, tombstone, err := s.fetchCanonical(ctx, pending.Href)
+		if err != nil {
+			return err
+		}
+		err = s.commitCardDAVCanonicalMutation(ctx, store.CardDAVCanonicalMutation{
+			Publication: *pending, Remote: remote, Tombstone: tombstone,
+		})
+		if errors.Is(err, store.ErrCardDAVPublicationMismatch) {
+			return s.captureCardDAVMutationConflict(ctx, pending, remote, tombstone, true)
+		}
+		return err
+	}
+
+	request := Request{URL: pending.Href, ETag: pending.RemoteETag}
+	switch pending.PendingOperation {
+	case store.CardDAVMutationCreate:
+		request.Method, request.Body, request.Create = http.MethodPut, pending.OutgoingBody, true
+	case store.CardDAVMutationUpdate:
+		request.Method, request.Body = http.MethodPut, pending.OutgoingBody
+	case store.CardDAVMutationDelete:
+		request.Method = http.MethodDelete
+	default:
+		return store.ErrCardDAVInvalidPlan
+	}
+	_, err = s.doRequest(ctx, request)
+	if err != nil {
+		var status *StatusError
+		if errors.As(err, &status) && status.StatusCode == http.StatusTooManyRequests {
+			if pending.PersonID == 0 && pending.ResolutionConflictID != 0 {
+				if rollbackErr := s.store.RollbackCardDAVConflictMutationContext(ctx, pending); rollbackErr != nil {
+					return errors.Join(err, rollbackErr)
+				}
+				return err
+			}
+			gate := time.Now().Add(status.RetryAfter).UTC()
+			if rollbackErr := s.store.RollbackCardDAVPublicationThrottleContext(ctx, pending, gate); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
+		}
+		canonicalTombstone := pending.PendingOperation == store.CardDAVMutationDelete &&
+			isAbsentStatus(err)
+		if canonicalTombstone {
+			// The required canonical read below proves the same tombstone.
+			return s.commitCanonical(ctx, pending)
+		}
+		if pending.PendingOperation == store.CardDAVMutationCreate && isStatus(err, http.StatusPreconditionFailed) {
+			return s.commitCanonical(ctx, pending)
+		}
+		if isStatus(err, http.StatusPreconditionFailed) {
+			remote, tombstone, fetchErr := s.fetchCanonical(ctx, pending.Href)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			if pending.PendingOperation == store.CardDAVMutationDelete && tombstone {
+				return s.commitCardDAVCanonicalMutation(ctx, store.CardDAVCanonicalMutation{
+					Publication: *pending, Remote: remote, Tombstone: true,
+				})
+			}
+			return s.captureCardDAVMutationConflict(ctx, pending, remote, tombstone, false)
+		}
+		if isDefinitiveMutationRejection(err) {
+			if rollbackErr := s.rollbackDefinitiveMutation(ctx, pending); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+			return err
+		}
+		// Transport ambiguity and conditional failures retain the exact
+		// intent. Mapped recovery never replays this request.
+		return err
+	}
+	return s.commitCanonical(ctx, pending)
+}
+
+func (s *Service) recoverCreate(ctx context.Context, pending *store.CardDAVPublication) error {
+	remote, tombstone, err := s.fetchCanonical(ctx, pending.Href)
+	if err != nil {
+		return err
+	}
+	if !tombstone {
+		err := s.store.CommitCardDAVPublicationContext(ctx, store.CardDAVCanonicalMutation{
+			Publication: *pending, Remote: remote,
+		})
+		if errors.Is(err, store.ErrCardDAVPublicationMismatch) {
+			return s.captureCardDAVCreateConflict(ctx, pending, remote)
+		}
+		return err
+	}
+	// A canonical 404 makes another conditional create safe. Do not gate this
+	// retry durably: a transient PUT failure or process exit would otherwise
+	// strand the pending publication forever. Concurrent attempts are still
+	// fenced by If-None-Match: * and the publication mutation revision.
+	_, err = s.doRequest(ctx, Request{
+		Method: http.MethodPut, URL: pending.Href,
+		Body: pending.OutgoingBody, Create: true,
+	})
+	if err != nil && !isStatus(err, http.StatusPreconditionFailed) {
+		if isStatus(err, http.StatusTooManyRequests) {
+			if status, ok := errors.AsType[*StatusError](err); ok {
+				gate := time.Now().Add(status.RetryAfter).UTC()
+				_ = s.store.RollbackCardDAVPublicationThrottleContext(ctx, pending, gate)
+			}
+		}
+		if isDefinitiveMutationRejection(err) {
+			if rollbackErr := s.rollbackDefinitiveMutation(ctx, pending); rollbackErr != nil {
+				return errors.Join(err, rollbackErr)
+			}
+		}
+		return err
+	}
+	return s.commitCanonical(ctx, pending)
+}
+
+func (s *Service) rollbackDefinitiveMutation(
+	ctx context.Context, pending *store.CardDAVPublication,
+) error {
+	if pending.PersonID == 0 && pending.ResolutionConflictID != 0 {
+		return s.store.RollbackCardDAVConflictMutationContext(ctx, pending)
+	}
+	return s.store.RollbackCardDAVPublicationContext(ctx, pending)
+}
+
+func isDefinitiveMutationRejection(err error) bool {
+	var status *StatusError
+	return errors.As(err, &status) && status.StatusCode >= http.StatusBadRequest &&
+		status.StatusCode < http.StatusInternalServerError &&
+		status.StatusCode != http.StatusRequestTimeout &&
+		status.StatusCode != http.StatusTooManyRequests &&
+		status.StatusCode != http.StatusPreconditionFailed
+}
+
+func (s *Service) commitCanonical(ctx context.Context, pending *store.CardDAVPublication) error {
+	remote, tombstone, err := s.fetchCanonical(ctx, pending.Href)
+	if err != nil {
+		return err
+	}
+	err = s.commitCardDAVCanonicalMutation(ctx, store.CardDAVCanonicalMutation{
+		Publication: *pending, Remote: remote, Tombstone: tombstone,
+	})
+	if errors.Is(err, store.ErrCardDAVPublicationMismatch) {
+		if pending.PendingOperation == store.CardDAVMutationCreate && !tombstone {
+			return s.captureCardDAVCreateConflict(ctx, pending, remote)
+		}
+		return s.captureCardDAVMutationConflict(ctx, pending, remote, tombstone, true)
+	}
+	return err
+}
+
+func (s *Service) captureCardDAVCreateConflict(
+	ctx context.Context, pending *store.CardDAVPublication, remote store.CardDAVRemoteResource,
+) error {
+	if pending.MappingRevision > 0 {
+		return s.recordPublicationConflict(ctx, pending, remote, false, true)
+	}
+	fenced, err := s.store.FenceCardDAVCreateCollisionContext(ctx, *pending, remote)
+	if err != nil {
+		return err
+	}
+	return s.recordPublicationConflict(ctx, fenced, remote, false, true)
+}
+
+func (s *Service) commitCardDAVCanonicalMutation(
+	ctx context.Context, input store.CardDAVCanonicalMutation,
+) error {
+	if input.Publication.ResolutionConflictID != 0 && input.Publication.PersonID == 0 {
+		return s.store.CommitCardDAVConflictLocalTombstoneContext(ctx, input)
+	}
+	return s.store.CommitCardDAVPublicationContext(ctx, input)
+}
+
+func (s *Service) captureCardDAVMutationConflict(
+	ctx context.Context, pending *store.CardDAVPublication,
+	remote store.CardDAVRemoteResource, tombstone, retainOversizeIntent bool,
+) error {
+	if pending.ResolutionConflictID == 0 || pending.PersonID != 0 {
+		return s.recordPublicationConflict(ctx, pending, remote, tombstone, retainOversizeIntent)
+	}
+	if tombstone {
+		return s.commitCardDAVCanonicalMutation(ctx, store.CardDAVCanonicalMutation{
+			Publication: *pending, Remote: remote, Tombstone: true,
+		})
+	}
+	conflict, err := s.store.ResetCardDAVConflictLocalTombstoneContext(
+		ctx, pending.ResolutionConflictID, remote)
+	if err != nil {
+		return err
+	}
+	return &ConflictError{ID: conflict.ID}
+}
+
+func (s *Service) fetchCanonical(ctx context.Context, href string) (store.CardDAVRemoteResource, bool, error) {
+	target, err := url.Parse(href)
+	if err != nil || !validHTTPURL(target) || !sameOrigin(s.client.origin, target) {
+		return store.CardDAVRemoteResource{}, false, ErrUnsafeTarget
+	}
+	href = canonicalDAVURLIdentity(target)
+	response, err := s.doRequest(ctx, Request{Method: http.MethodGet, URL: href})
+	if isAbsentStatus(err) {
+		return store.CardDAVRemoteResource{Href: href}, true, nil
+	}
+	if err != nil {
+		return store.CardDAVRemoteResource{}, false, err
+	}
+	etag := strings.TrimSpace(response.Header.Get("ETag"))
+	if etag == "" || len(response.Body) == 0 {
+		return store.CardDAVRemoteResource{}, false, ErrIncompleteMultiget
+	}
+	remote, err := parseRemoteResource(href, etag, response.Body)
+	return remote, false, err
+}
+
+func (s *Service) doRequest(ctx context.Context, request Request) (*Response, error) {
+	if err := s.store.CheckCardDAVRetryAfterContext(ctx); err != nil {
+		return nil, err
+	}
+	response, err := s.client.Do(ctx, request)
+	var status *StatusError
+	if errors.As(err, &status) && status.StatusCode == http.StatusTooManyRequests {
+		gate := time.Now().Add(status.RetryAfter).UTC()
+		if gateErr := s.store.SetCardDAVRetryAfterContext(ctx, gate); gateErr != nil {
+			return response, errors.Join(err, gateErr)
+		}
+	}
+	return response, err
+}
+
+func isStatus(err error, code int) bool {
+	var status *StatusError
+	return errors.As(err, &status) && status.StatusCode == code
+}
+
+func isAbsentStatus(err error) bool {
+	return isStatus(err, http.StatusNotFound) || isStatus(err, http.StatusGone)
+}
+
+func isAbsentStatusCode(code int) bool {
+	return code == http.StatusNotFound || code == http.StatusGone
+}

--- a/internal/carddav/mutation_integration_test.go
+++ b/internal/carddav/mutation_integration_test.go
@@ -1,0 +1,981 @@
+package carddav
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type mutationFixture struct {
+	mu                  sync.Mutex
+	body                []byte
+	etag                string
+	puts                int
+	deletes             int
+	gets                int
+	reports             int
+	timeout             bool
+	throttle            bool
+	throttleGets        int
+	throttleReport      bool
+	reportNoChanges     bool
+	reportCurrent       bool
+	missingStatus       int
+	deleteMissingStatus int
+	deleteTimeout       bool
+	throttleDeletes     int
+	putStatus           int
+	deleteStatus        int
+	putFailures         int
+	href                string
+}
+
+func (f *mutationFixture) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		switch r.Method {
+		case http.MethodPut:
+			f.puts++
+			f.href = r.URL.EscapedPath()
+			body, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, "text/vcard; charset=utf-8", r.Header.Get("Content-Type"))
+			assert.NotContains(t, string(body), "PRODID:")
+			assert.NotContains(t, string(body), "LAST-MODIFIED:")
+			if f.throttle {
+				w.Header().Set("Retry-After", "7200")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			if f.putFailures > 0 {
+				f.putFailures--
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			if len(f.body) == 0 {
+				assert.Equal(t, "*", r.Header.Get("If-None-Match"))
+				assert.Empty(t, r.Header.Get("If-Match"))
+			} else {
+				assert.Equal(t, f.etag, r.Header.Get("If-Match"))
+				assert.Empty(t, r.Header.Get("If-None-Match"))
+			}
+			if f.putStatus != 0 {
+				w.WriteHeader(f.putStatus)
+				return
+			}
+			f.body = append([]byte(nil), body...)
+			f.etag = `"remote-` + strings.Repeat("x", f.puts) + `"`
+			if f.timeout {
+				f.timeout = false
+				f.mu.Unlock()
+				<-r.Context().Done()
+				f.mu.Lock()
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+		case http.MethodGet:
+			f.gets++
+			if f.throttleGets > 0 {
+				f.throttleGets--
+				w.Header().Set("Retry-After", "7200")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			if len(f.body) == 0 {
+				status := f.missingStatus
+				if status == 0 {
+					status = http.StatusNotFound
+				}
+				w.WriteHeader(status)
+				return
+			}
+			w.Header().Set("ETag", f.etag)
+			_, err := w.Write(append(append([]byte(nil), f.body[:len(f.body)-len("END:VCARD\r\n")]...), []byte("PRODID:-//Server//EN\r\nEND:VCARD\r\n")...))
+			assert.NoError(t, err)
+		case http.MethodDelete:
+			f.deletes++
+			assert.Equal(t, f.etag, r.Header.Get("If-Match"))
+			if f.throttleDeletes > 0 {
+				f.throttleDeletes--
+				w.Header().Set("Retry-After", "7200")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			if f.deleteStatus != 0 {
+				w.WriteHeader(f.deleteStatus)
+				return
+			}
+			f.body = nil
+			f.etag = ""
+			if f.deleteTimeout {
+				f.deleteTimeout = false
+				f.mu.Unlock()
+				<-r.Context().Done()
+				f.mu.Lock()
+				return
+			}
+			if f.deleteMissingStatus != 0 {
+				w.WriteHeader(f.deleteMissingStatus)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		case "REPORT":
+			f.reports++
+			if f.throttleReport {
+				w.Header().Set("Retry-After", "7200")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			if f.reportNoChanges {
+				writeDAVXML(t, w, syncResponse("", "token-after-timeout"))
+				return
+			}
+			if f.reportCurrent {
+				card := strings.ReplaceAll(string(f.body), "&", "&amp;")
+				card = strings.ReplaceAll(card, "<", "&lt;")
+				href := f.href
+				if href == "" {
+					href = "/books/personal/person.vcf"
+				}
+				writeDAVXML(t, w, syncResponse(cardResponseRaw(
+					href, f.etag, card), "token-after-timeout"))
+				return
+			}
+			if len(f.body) == 0 {
+				writeDAVXML(t, w, syncResponse("", ""))
+				return
+			}
+			card := strings.ReplaceAll(string(f.body), "&", "&amp;")
+			card = strings.ReplaceAll(card, "<", "&lt;")
+			href := f.href
+			if href == "" {
+				href = "/books/personal/person.vcf"
+			}
+			writeDAVXML(t, w, syncResponse(cardResponseRaw(href, f.etag, card), ""))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+func cardResponseRaw(href, etag, card string) string {
+	return `<D:response><D:href>` + href + `</D:href><D:propstat><D:prop>` +
+		`<D:getetag>` + strings.ReplaceAll(etag, `"`, `&quot;`) + `</D:getetag>` +
+		`<C:address-data>` + card + `</C:address-data></D:prop>` +
+		`<D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`
+}
+
+func seededMutationService(t *testing.T, fixture *mutationFixture) (*Service, *store.Store, int64, store.CardDAVAddressBook) {
+	t.Helper()
+	server := httptest.NewServer(fixture.handler(t))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	service.client.requestTimeout = 250 * time.Millisecond
+	var personID int64
+	err := st.DB().QueryRow(st.Rebind(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES (?, ?) RETURNING id`), "person", "Alice Example").Scan(&personID)
+	require.NoError(t, err)
+	return service, st, personID, book
+}
+
+func TestPublishPersonCreatesConditionallyAndCommitsCanonicalCard(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal(1, fixture.puts)
+	assert.Equal(1, fixture.gets)
+	assert.Contains(string(fixture.body), "VERSION:3.0")
+
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(personID, *resource.PersonID)
+	assert.Contains(string(resource.RemoteBody), "PRODID:-//Server//EN")
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestPublishThenSyncAcceptsEscapedUIDChild(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE persons SET vcard_uid = ? WHERE id = ?`),
+		"a/b?c#d", personID)
+	require.NoError(err)
+
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal("/books/personal/a%2Fb%3Fc%23d.vcf", fixture.href)
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID,
+		book.CanonicalURL+"a%2Fb%3Fc%23d.vcf")
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(personID, *resource.PersonID)
+}
+
+func TestPublishPersonSkipsSemanticallyUnchangedMappedCard(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	puts, gets := fixture.puts, fixture.gets
+
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal(puts, fixture.puts)
+	assert.Equal(gets, fixture.gets)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, before.Href)
+	require.NoError(err)
+	assert.Equal(before.MappingRevision, after.MappingRevision)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestTimedOutUpdatePersistsIntentAndSyncRecoveryDoesNotReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	addProjectedEmail(t, st, personID)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET
+		supports_sync_collection = TRUE, sync_token = ? WHERE id = ?`), "token-before-timeout", book.ID)
+	require.NoError(err)
+	fixture.timeout = true
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.Error(err)
+	assert.Equal(2, fixture.puts)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVMutationUpdate, publication.PendingOperation)
+
+	fixture.reportCurrent = true
+	_, err = service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	assert.Equal(2, fixture.puts, "mapped recovery must be read-only")
+	publication, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestTimedOutCreateRecoveryProvesCanonicalResourceWithoutReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{timeout: true}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE persons SET display_name = ? WHERE id = ?`), "Alice\nExample", personID)
+	require.NoError(err)
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.Error(err)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVMutationCreate, publication.PendingOperation)
+	assert.Equal(1, fixture.puts)
+	fixture.mu.Lock()
+	fixture.body = bytes.ReplaceAll(fixture.body, []byte(`\n`), []byte(`\N`))
+	fixture.body = bytes.Replace(fixture.body, []byte("FN:"), []byte("FN;VALUE=text:"), 1)
+	fixture.mu.Unlock()
+
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal(1, fixture.puts, "a semantically equivalent canonical GET proved the timed-out create")
+	publication, getErr = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestTimedOutCreateRecoveryAdoptsResourceMaterializedByPull(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{timeout: true}
+	service, st, personID, _ := seededMutationService(t, fixture)
+
+	require.Error(service.PublishPerson(t.Context(), personID))
+	assert.Equal(1, fixture.puts)
+	service.client.requestTimeout = 2 * time.Second
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, fixture.puts, "create recovery after pull must not replay PUT")
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestCreateRecoveryAcceptsOneConditional412OnlyAfterCanonicalProof(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var body []byte
+	puts, gets := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.Method {
+		case http.MethodPut:
+			puts++
+			attempted, err := io.ReadAll(r.Body)
+			assert.NoError(err)
+			assert.Equal("*", r.Header.Get("If-None-Match"))
+			if puts == 1 {
+				mu.Unlock()
+				<-r.Context().Done()
+				mu.Lock()
+				return
+			}
+			body = attempted
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			gets++
+			if len(body) == 0 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("ETag", `"raced-create"`)
+			_, err := w.Write(body)
+			assert.NoError(err)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, personID, _ := seededMutationServiceForServer(t, server)
+	service.client.requestTimeout = 250 * time.Millisecond
+
+	require.Error(service.PublishPerson(t.Context(), personID))
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal(2, puts)
+	assert.Equal(2, gets)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestCreateRecoveryRetriesAfterRepeatedTransientFailures(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{putFailures: 2}
+	service, st, personID, _ := seededMutationService(t, fixture)
+
+	require.Error(service.PublishPerson(t.Context(), personID))
+	require.Error(service.PublishPerson(t.Context(), personID))
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	assert.Equal(3, fixture.puts)
+	assert.Equal(3, fixture.gets,
+		"each recovery attempt must prove absence and a successful retry must read the canonical card")
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestDefinitiveCreateRejectionClearsPendingIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{putStatus: http.StatusForbidden}
+	service, st, personID, _ := seededMutationService(t, fixture)
+
+	err := service.PublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusForbidden, status.StatusCode)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(getErr, store.ErrCardDAVPublicationNotFound)
+	assert.Nil(publication)
+
+	fixture.putStatus = 0
+	require.NoError(service.PublishPerson(t.Context(), personID))
+}
+
+func TestDefinitiveMappedMutationRejectionRestoresFence(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, *mutationFixture, *Service, *store.Store, int64) error
+	}{
+		{
+			name: "update",
+			mutate: func(t *testing.T, fixture *mutationFixture, service *Service, st *store.Store, personID int64) error {
+				t.Helper()
+				addProjectedEmail(t, st, personID)
+				fixture.putStatus = http.StatusMethodNotAllowed
+				return service.PublishPerson(t.Context(), personID)
+			},
+		},
+		{
+			name: "delete",
+			mutate: func(t *testing.T, fixture *mutationFixture, service *Service, _ *store.Store, personID int64) error {
+				t.Helper()
+				fixture.deleteStatus = http.StatusForbidden
+				return service.UnpublishPerson(t.Context(), personID)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			fixture := &mutationFixture{}
+			service, st, personID, book := seededMutationService(t, fixture)
+			require.NoError(service.PublishPerson(t.Context(), personID))
+			before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+			require.NoError(err)
+
+			err = test.mutate(t, fixture, service, st, personID)
+			var status *StatusError
+			require.ErrorAs(err, &status)
+			publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+			require.NoError(getErr)
+			assert.True(publication.Desired)
+			assert.Empty(publication.PendingOperation)
+			after, getErr := st.GetCardDAVResourceContext(t.Context(), book.ID, before.Href)
+			require.NoError(getErr)
+			assert.Equal(before.MappingRevision, after.MappingRevision)
+		})
+	}
+}
+
+func TestDefinitiveCreateRecoveryRejectionClearsPendingIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{putFailures: 1, putStatus: http.StatusForbidden}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.Error(service.PublishPerson(t.Context(), personID))
+
+	err := service.PublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusForbidden, status.StatusCode)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(getErr, store.ErrCardDAVPublicationNotFound)
+	assert.Nil(publication)
+}
+
+func TestMutationRejectsExplicitlyDeniedCapabilityBeforeNetwork(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		capability string
+		prepare    func(*testing.T, *Service, *store.Store, int64)
+		mutate     func(*testing.T, *Service, int64) error
+	}{
+		{
+			name: "create", capability: "can_create",
+			prepare: func(t *testing.T, _ *Service, _ *store.Store, _ int64) { t.Helper() },
+			mutate: func(t *testing.T, service *Service, personID int64) error {
+				t.Helper()
+				return service.PublishPerson(t.Context(), personID)
+			},
+		},
+		{
+			name: "update", capability: "can_update",
+			prepare: func(t *testing.T, service *Service, st *store.Store, personID int64) {
+				t.Helper()
+				require.NoError(t, service.PublishPerson(t.Context(), personID))
+				addProjectedEmail(t, st, personID)
+			},
+			mutate: func(t *testing.T, service *Service, personID int64) error {
+				t.Helper()
+				return service.PublishPerson(t.Context(), personID)
+			},
+		},
+		{
+			name: "delete", capability: "can_delete",
+			prepare: func(t *testing.T, service *Service, _ *store.Store, personID int64) {
+				t.Helper()
+				require.NoError(t, service.PublishPerson(t.Context(), personID))
+			},
+			mutate: func(t *testing.T, service *Service, personID int64) error {
+				t.Helper()
+				return service.UnpublishPerson(t.Context(), personID)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := &mutationFixture{}
+			service, st, personID, book := seededMutationService(t, fixture)
+			test.prepare(t, service, st, personID)
+			requestsBefore := fixture.puts + fixture.deletes
+			_, err := st.DB().Exec(st.Rebind(
+				"UPDATE carddav_address_books SET "+test.capability+" = FALSE WHERE id = ?"), book.ID)
+			require.NoError(t, err)
+
+			err = test.mutate(t, service, personID)
+			require.ErrorIs(t, err, store.ErrCardDAVReadOnlyAddressBook)
+			assert.Equal(t, requestsBefore, fixture.puts+fixture.deletes)
+		})
+	}
+}
+
+func TestConditionalCreateCollisionRecordsResolvableConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	remoteBody := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-owner\r\nFN:Remote Owner\r\nEND:VCARD\r\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			assert.Equal("*", r.Header.Get("If-None-Match"))
+			w.WriteHeader(http.StatusPreconditionFailed)
+		case http.MethodGet:
+			w.Header().Set("ETag", `"remote-owner"`)
+			_, err := w.Write(remoteBody)
+			assert.NoError(err)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, personID, book := seededMutationServiceForServer(t, server)
+
+	err := service.PublishPerson(t.Context(), personID)
+	var conflictErr *ConflictError
+	require.ErrorAs(err, &conflictErr)
+	assert.Positive(conflictErr.ID)
+	conflicts, listErr := service.ListConflicts(t.Context())
+	require.NoError(listErr)
+	require.Len(conflicts, 1)
+	assert.Contains(string(conflicts[0].RemoteBody), "UID:remote-owner")
+	assert.NotEmpty(conflicts[0].LocalBody)
+	mapping, getErr := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(getErr)
+	require.NotNil(mapping.PersonID)
+	assert.Equal(personID, *mapping.PersonID)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestTimedOutCreateRecoveryRoutesDivergentCanonicalCardToConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := &mutationFixture{timeout: true}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.Error(service.PublishPerson(t.Context(), personID))
+	remoteBody := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:person\r\nFN:Remote Owner\r\nEND:VCARD\r\n")
+	fixture.mu.Lock()
+	fixture.body = remoteBody
+	fixture.etag = `"remote-owner"`
+	fixture.mu.Unlock()
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	conflicts, listErr := service.ListConflicts(t.Context())
+	require.NoError(listErr)
+	require.Len(conflicts, 1)
+	assert.Contains(string(conflicts[0].RemoteBody), "FN:Remote Owner")
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestUnpublishPersonDeletesConditionallyButKeepsPerson(t *testing.T) {
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+
+	require.NoError(service.UnpublishPerson(t.Context(), personID))
+	assert.Equal(t, 1, fixture.deletes)
+	_, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func TestUnpublishRemoteImportWithoutPublicationPreservesSource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	remoteBody := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-import\r\nFN:Remote Import\r\nEND:VCARD\r\n")
+	fixture := &mutationFixture{body: remoteBody, etag: `"remote-import"`}
+	service, st, _, book := seededMutationService(t, fixture)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	href := book.CanonicalURL + "remote-import.vcf"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true,
+		Upserts: []store.CardDAVRemoteResource{{
+			Href: href, RemoteUID: "remote-import", RemoteETag: fixture.etag,
+			RemoteBody: remoteBody, SemanticHash: "semantic-remote-import",
+			DisplayName: "Remote Import",
+		}},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+
+	require.NoError(service.UnpublishPerson(t.Context(), personID))
+	assert.Zero(fixture.deletes)
+	preserved, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(preserved.PersonID)
+	assert.Equal(personID, *preserved.PersonID)
+	assert.Equal(remoteBody, preserved.RemoteBody)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+}
+
+func TestUnpublishPersonTreatsAbsentRemoteAsComplete(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusGone} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			fixture := &mutationFixture{}
+			service, _, personID, _ := seededMutationService(t, fixture)
+			require.NoError(t, service.PublishPerson(t.Context(), personID))
+			fixture.deleteMissingStatus = status
+
+			require.NoError(t, service.UnpublishPerson(t.Context(), personID))
+			assert.Equal(t, 1, fixture.deletes)
+		})
+	}
+}
+
+func TestTimedOutDeleteRecoveryAcceptsPullTombstoneWithoutReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	fixture.deleteTimeout = true
+
+	err := service.UnpublishPerson(t.Context(), personID)
+	require.Error(err)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVMutationDelete, publication.PendingOperation)
+	assert.Equal(1, fixture.deletes)
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, fixture.deletes, "delete recovery must be read-only")
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+}
+
+func TestTimedOutDeleteRecoveryAcceptsCanonicalGoneWithoutReplay(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{missingStatus: http.StatusGone}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	fixture.deleteTimeout = true
+
+	require.Error(service.UnpublishPerson(t.Context(), personID))
+	assert.Equal(1, fixture.deletes)
+	require.NoError(service.ReconcilePublications(t.Context()))
+	assert.Equal(1, fixture.deletes, "410 recovery must prove absence without replaying DELETE")
+	_, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+}
+
+func TestPublishPersonUsesV4ForV4OnlyWriteTarget(t *testing.T) {
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET supported_vcard_versions = ? WHERE id = ?`), `["4.0"]`, book.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, service.PublishPerson(t.Context(), personID))
+	assert.Contains(t, string(fixture.body), "VERSION:4.0")
+}
+
+func TestPublishPersonRejectsWildcardStoredETagBeforeNetwork(t *testing.T) {
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_resources
+		SET remote_etag = ? WHERE address_book_id = ? AND person_id = ?`), " * ", book.ID, personID)
+	require.NoError(err)
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVInvalidPlan)
+	assert.Equal(t, 1, fixture.puts)
+}
+
+func TestRetryAfterRollsBackIntentAndClampsGateToOneHour(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{throttle: true}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	before := time.Now()
+
+	err := service.PublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Empty(publication.PendingOperation)
+	gate, getErr := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(getErr)
+	require.NotNil(gate)
+	assert.WithinDuration(before.Add(time.Hour), *gate, 5*time.Second)
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVRetryAfter)
+	assert.Equal(1, fixture.puts)
+}
+
+func TestThrottledUnpublishRetriesAfterGateExpires(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{throttleDeletes: 1}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+
+	err := service.UnpublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.False(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+	assert.Equal(1, fixture.deletes)
+
+	err = service.ReconcilePublications(t.Context())
+	require.ErrorIs(err, store.ErrCardDAVRetryAfter)
+	assert.Equal(1, fixture.deletes)
+
+	setRetryGate(t, st, time.Now().Add(-time.Minute))
+	require.NoError(service.ReconcilePublications(t.Context()))
+	assert.Equal(2, fixture.deletes)
+	_, err = st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVPublicationNotFound)
+}
+
+func TestActiveRetryGateStopsSyncBeforeAnyRequest(t *testing.T) {
+	fixture := &mutationFixture{}
+	service, st, _, _ := seededMutationService(t, fixture)
+	setRetryGate(t, st, time.Now().Add(time.Hour))
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.ErrorIs(t, err, store.ErrCardDAVRetryAfter)
+	assert.Equal(t, 0, fixture.puts+fixture.gets+fixture.deletes+fixture.reports)
+}
+
+func TestActiveRetryGateStopsPendingRecoveryBeforeAnyRequest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{timeout: true}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.Error(service.PublishPerson(t.Context(), personID))
+	setRetryGate(t, st, time.Now().Add(time.Hour))
+	requestsBefore := fixture.puts + fixture.gets + fixture.deletes + fixture.reports
+
+	err := service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVRetryAfter)
+	assert.Equal(requestsBefore, fixture.puts+fixture.gets+fixture.deletes+fixture.reports)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVMutationCreate, publication.PendingOperation)
+}
+
+func TestCanonicalGet429PersistsGateAndPreservesAmbiguousUpdateIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, book := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	addProjectedEmail(t, st, personID)
+	beforeResource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(err)
+	fixture.throttleGets = 1
+	before := time.Now()
+
+	err = service.PublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	assert.Equal(2, fixture.puts)
+	assert.Equal(2, fixture.gets)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVMutationUpdate, publication.PendingOperation)
+	assert.NotEmpty(publication.OutgoingBody)
+	assert.Equal(beforeResource.MappingRevision, publication.PreviousMappingRevision)
+	resource, getErr := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"person.vcf")
+	require.NoError(getErr)
+	assert.Equal(beforeResource.MappingRevision+1, resource.MappingRevision)
+	gate, getErr := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(getErr)
+	require.NotNil(gate)
+	assert.WithinDuration(before.Add(time.Hour), *gate, 5*time.Second)
+	requestsBefore := fixture.puts + fixture.gets + fixture.deletes + fixture.reports
+
+	err = service.PublishPerson(t.Context(), personID)
+	require.ErrorIs(err, store.ErrCardDAVRetryAfter)
+	assert.Equal(requestsBefore, fixture.puts+fixture.gets+fixture.deletes+fixture.reports)
+}
+
+func TestRecoveryGet429PersistsGateAndPreservesPendingIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{}
+	service, st, personID, _ := seededMutationService(t, fixture)
+	require.NoError(service.PublishPerson(t.Context(), personID))
+	addProjectedEmail(t, st, personID)
+	fixture.timeout = true
+	require.Error(service.PublishPerson(t.Context(), personID))
+	fixture.throttleGets = 1
+	before := time.Now()
+	putsBefore := fixture.puts
+
+	err := service.PublishPerson(t.Context(), personID)
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	assert.Equal(putsBefore, fixture.puts, "mapped recovery must remain read-only")
+	assert.Equal(2, fixture.gets)
+	publication, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVMutationUpdate, publication.PendingOperation)
+	assert.NotEmpty(publication.OutgoingBody)
+	gate, getErr := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(getErr)
+	require.NotNil(gate)
+	assert.WithinDuration(before.Add(time.Hour), *gate, 5*time.Second)
+}
+
+func TestPull429PersistsAccountRetryGate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	fixture := &mutationFixture{throttleReport: true}
+	service, st, _, _ := seededMutationService(t, fixture)
+	before := time.Now()
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusTooManyRequests, status.StatusCode)
+	assert.Equal(1, fixture.reports)
+	gate, getErr := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(getErr)
+	require.NotNil(gate)
+	assert.WithinDuration(before.Add(time.Hour), *gate, 5*time.Second)
+}
+
+func TestConcurrent429sPreserveLongestAccountRetryGate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	shortStarted := make(chan struct{})
+	releaseShort := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseShort) }) })
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/short.vcf"):
+			close(shortStarted)
+			<-releaseShort
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+		case strings.HasSuffix(r.URL.Path, "/long.vcf"):
+			w.Header().Set("Retry-After", "3600")
+			w.WriteHeader(http.StatusTooManyRequests)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	shortResult := make(chan error, 1)
+	go func() {
+		_, err := service.doRequest(t.Context(), Request{
+			Method: http.MethodGet, URL: book.CanonicalURL + "short.vcf",
+		})
+		shortResult <- err
+	}()
+	<-shortStarted
+	before := time.Now()
+
+	_, longErr := service.doRequest(t.Context(), Request{
+		Method: http.MethodGet, URL: book.CanonicalURL + "long.vcf",
+	})
+	var longStatus *StatusError
+	require.ErrorAs(longErr, &longStatus)
+	assert.Equal(http.StatusTooManyRequests, longStatus.StatusCode)
+	releaseOnce.Do(func() { close(releaseShort) })
+	shortErr := <-shortResult
+	var shortStatus *StatusError
+	require.ErrorAs(shortErr, &shortStatus)
+	assert.Equal(http.StatusTooManyRequests, shortStatus.StatusCode)
+
+	gate, err := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(err)
+	require.NotNil(gate)
+	assert.WithinDuration(before.Add(time.Hour), *gate, 5*time.Second)
+}
+
+func setRetryGate(t *testing.T, st *store.Store, retryAfter time.Time) {
+	t.Helper()
+	_, err := st.DB().Exec(st.Rebind(`INSERT INTO carddav_retry_gate (account_id, retry_after_at, updated_at)
+		VALUES (1, ?, CURRENT_TIMESTAMP) ON CONFLICT(account_id) DO UPDATE SET
+		retry_after_at = excluded.retry_after_at, updated_at = CURRENT_TIMESTAMP`), retryAfter.UTC())
+	require.NoError(t, err)
+}
+
+func seededMutationServiceForServer(t *testing.T, server *httptest.Server) (*Service, *store.Store, int64, store.CardDAVAddressBook) {
+	t.Helper()
+	service, st, book := newPullService(t, server, false)
+	var personID int64
+	err := st.DB().QueryRow(st.Rebind(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES (?, ?) RETURNING id`), "person", "Alice Example").Scan(&personID)
+	require.NoError(t, err)
+	return service, st, personID, book
+}
+
+func addProjectedEmail(t *testing.T, st *store.Store, personID int64) {
+	t.Helper()
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice.updated@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(t, err)
+}

--- a/internal/carddav/mutation_test.go
+++ b/internal/carddav/mutation_test.go
@@ -1,0 +1,56 @@
+package carddav
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vcard"
+)
+
+func TestPublicationVersionUsesV4OnlyWhenItIsTheOnlyAdvertisedVersion(t *testing.T) {
+	assert.Equal(t, vcard.Version30, publicationVersion(nil))
+	assert.Equal(t, vcard.Version30, publicationVersion([]string{"3.0", "4.0"}))
+	assert.Equal(t, vcard.Version40, publicationVersion([]string{"4.0"}))
+}
+
+func TestPublicationHrefBuildsEscapedDirectCollectionChild(t *testing.T) {
+	assert := assert.New(t)
+
+	origin, err := url.Parse("https://contacts.example")
+	require.NoError(t, err)
+	service := &Service{client: &Client{origin: originURL(origin)}}
+
+	href, err := service.publicationHref(
+		"https://contacts.example/books/personal?ignored=yes#fragment", "a/b?c#d",
+	)
+	require.NoError(t, err)
+	assert.Equal("https://contacts.example:443/books/personal/a%2Fb%3Fc%23d.vcf", href)
+
+	_, err = service.publicationHref("https://elsewhere.example/books/personal/", "person")
+	assert.ErrorIs(err, ErrUnsafeTarget)
+}
+
+func TestPublicationHrefUsesCanonicalDefaultHTTPSPort(t *testing.T) {
+	origin, err := url.Parse("https://contacts.example")
+	require.NoError(t, err)
+	service := &Service{client: &Client{origin: originURL(origin)}}
+
+	href, err := service.publicationHref("https://CONTACTS.example/books/personal/", "alice")
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://contacts.example:443/books/personal/alice.vcf", href)
+}
+
+func TestStripServerOwnedPropertiesRemovesOnlyNamedProperties(t *testing.T) {
+	assert := assert.New(t)
+
+	body := []byte("BEGIN:VCARD\r\nVERSION:3.0\r\nUID:test\r\nFN:Test\r\nPRODID:server\r\nREV:one\r\nSOURCE:https://example.test\r\nCREATED:one\r\nLAST-MODIFIED:two\r\nX-KEEP:yes\r\nEND:VCARD\r\n")
+
+	got, err := stripServerOwnedProperties(body, vcard.Version30)
+	require.NoError(t, err)
+	assert.NotContains(string(got), "PRODID:")
+	assert.NotContains(string(got), "LAST-MODIFIED:")
+	assert.Contains(string(got), "X-KEEP:yes")
+}

--- a/internal/carddav/pull.go
+++ b/internal/carddav/pull.go
@@ -1,0 +1,756 @@
+package carddav
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vcard"
+)
+
+var (
+	ErrTruncatedSnapshot  = errors.New("CardDAV snapshot was truncated")
+	ErrSyncTokenCycle     = errors.New("CardDAV sync token continuation cycle")
+	ErrIncompleteMultiget = errors.New("CardDAV multiget response was incomplete")
+)
+
+const (
+	maxSyncPages   = 100
+	multigetBatch  = 100
+	maxSyncMembers = 50_000
+)
+
+type Service struct {
+	store  *store.Store
+	client *Client
+}
+
+func NewService(st *store.Store, client *Client) *Service {
+	return &Service{store: st, client: client}
+}
+
+type SyncOptions struct {
+	Full bool
+}
+
+type SyncResult struct {
+	Books   int `json:"books"`
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+	Removed int `json:"removed"`
+}
+
+// Sync fetches complete network plans before entering the store's fenced
+// apply transaction. A stale plan is re-fetched once; a second stale result is
+// returned rather than retried blindly.
+func (s *Service) Sync(ctx context.Context, options SyncOptions) (SyncResult, error) {
+	if s == nil || s.store == nil || s.client == nil {
+		return SyncResult{}, errors.New("CardDAV service is not configured")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, s.client.operationTimeout)
+	defer cancel()
+	if err := s.store.CheckCardDAVRetryAfterContext(operationCtx); err != nil {
+		return SyncResult{}, err
+	}
+	// Resolve ambiguous publication outcomes before interpreting remote changes.
+	// Otherwise a successful write whose response timed out can be misclassified
+	// as an edit/edit conflict by the pull that follows.
+	recovered, err := s.recoverPendingPublications(operationCtx)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	var failures []error
+	budget := &operationBudget{remaining: s.client.operationBytes}
+	var total SyncResult
+	books, err := s.store.ListCardDAVAddressBooksContext(operationCtx)
+	if err != nil {
+		return total, err
+	}
+	for _, initial := range books {
+		if !initial.IsSubscribed && !initial.IsLookupSource {
+			continue
+		}
+		applied, err := s.syncBook(operationCtx, initial.ID, options, budget)
+		if err != nil {
+			bookErr := fmt.Errorf("sync CardDAV address book %d: %w", initial.ID, err)
+			if isGlobalSyncFailure(operationCtx, err) {
+				return total, errors.Join(append(failures, bookErr)...)
+			}
+			failures = append(failures, bookErr)
+			continue
+		}
+		if applied == nil {
+			continue
+		}
+		total.Books++
+		total.Created += applied.Created
+		total.Updated += applied.Updated
+		total.Removed += applied.Removed
+	}
+	if err := s.reconcilePublications(operationCtx, recovered); err != nil {
+		failures = append(failures, err)
+		if isGlobalSyncFailure(operationCtx, err) {
+			return total, errors.Join(failures...)
+		}
+	}
+	if _, err := s.store.SweepResolvedCardDAVConflictsContext(operationCtx, time.Now()); err != nil {
+		failures = append(failures, err)
+	}
+	return total, errors.Join(failures...)
+}
+
+func isGlobalSyncFailure(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, ErrOperationLimit) || errors.Is(err, store.ErrCardDAVRetryAfter) {
+		return true
+	}
+	var status *StatusError
+	return errors.As(err, &status) &&
+		(status.StatusCode == http.StatusUnauthorized || status.StatusCode == http.StatusTooManyRequests)
+}
+
+func (s *Service) syncBook(
+	ctx context.Context, bookID int64, options SyncOptions, budget *operationBudget,
+) (*store.CardDAVApplyResult, error) {
+	state := &bookSyncState{}
+	for attempt := range 2 {
+		account, err := s.store.GetCardDAVAccountContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if account == nil {
+			return nil, store.ErrCardDAVStalePlan
+		}
+		books, err := s.store.ListCardDAVAddressBooksContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		book, ok := findCardDAVBook(books, bookID)
+		if !ok {
+			return nil, store.ErrCardDAVStalePlan
+		}
+		if !book.IsSubscribed && !book.IsLookupSource {
+			return nil, nil //nolint:nilnil // A deliberately ignored book produces no apply result and no error.
+		}
+		plan, err := s.fetchBookPlan(ctx, *account, book, options, budget, state)
+		if err != nil {
+			return nil, err
+		}
+		if err := s.prepareSyncConflicts(ctx, book, &plan); err != nil {
+			return nil, err
+		}
+		applied, err := s.store.ApplyCardDAVSyncPlanContext(ctx, plan)
+		if err == nil {
+			return applied, nil
+		}
+		if !errors.Is(err, store.ErrCardDAVStalePlan) || attempt == 1 {
+			return nil, err
+		}
+	}
+	return nil, store.ErrCardDAVStalePlan
+}
+
+type bookSyncState struct {
+	invalidTokenReconciled bool
+}
+
+func findCardDAVBook(books []store.CardDAVAddressBook, id int64) (store.CardDAVAddressBook, bool) {
+	for _, book := range books {
+		if book.ID == id {
+			return book, true
+		}
+	}
+	return store.CardDAVAddressBook{}, false
+}
+
+func (s *Service) fetchBookPlan(
+	ctx context.Context, account store.CardDAVAccount, book store.CardDAVAddressBook,
+	options SyncOptions, budget *operationBudget, state *bookSyncState,
+) (store.CardDAVSyncPlan, error) {
+	base := store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision,
+	}
+	token := book.SyncToken
+	if options.Full || book.NeedsFullReconcile {
+		token = ""
+	}
+	if book.SupportsSyncCollection {
+		plan, err := s.fetchSyncCollection(ctx, book, token, budget)
+		if err == nil {
+			plan.AddressBookID = base.AddressBookID
+			plan.ConnectionGeneration = base.ConnectionGeneration
+			plan.SyncRevision = base.SyncRevision
+			plan.CompletesFullReconcile = options.Full || book.NeedsFullReconcile
+			return plan, nil
+		}
+		var status *StatusError
+		switch {
+		case errors.As(err, &status) && status.Precondition == "valid-sync-token" &&
+			token != "" && !state.invalidTokenReconciled:
+			state.invalidTokenReconciled = true
+			plan, retryErr := s.fetchSyncCollection(ctx, book, "", budget)
+			if retryErr != nil {
+				return store.CardDAVSyncPlan{}, retryErr
+			}
+			plan.AddressBookID = base.AddressBookID
+			plan.ConnectionGeneration = base.ConnectionGeneration
+			plan.SyncRevision = base.SyncRevision
+			plan.CompletesFullReconcile = options.Full || book.NeedsFullReconcile
+			return plan, nil
+		case errors.As(err, &status) && (status.StatusCode == http.StatusMethodNotAllowed || status.StatusCode == http.StatusNotImplemented):
+			// Capability advertisements are hints. A standards-compliant snapshot
+			// is the bounded downgrade when sync-collection is unavailable.
+		default:
+			return store.CardDAVSyncPlan{}, err
+		}
+	}
+	plan, err := s.fetchSnapshot(ctx, book, budget)
+	if err != nil {
+		return store.CardDAVSyncPlan{}, err
+	}
+	plan.AddressBookID = base.AddressBookID
+	plan.ConnectionGeneration = base.ConnectionGeneration
+	plan.SyncRevision = base.SyncRevision
+	plan.CompletesFullReconcile = options.Full || book.NeedsFullReconcile
+	return plan, nil
+}
+
+func (s *Service) do(ctx context.Context, request Request, budget *operationBudget) (*Response, error) {
+	response, err := s.doRequest(ctx, request)
+	if response != nil {
+		if budgetErr := budget.consume(response); budgetErr != nil {
+			return nil, budgetErr
+		}
+	}
+	return response, err
+}
+
+func (s *Service) fetchSyncCollection(
+	ctx context.Context, book store.CardDAVAddressBook, token string, budget *operationBudget,
+) (store.CardDAVSyncPlan, error) {
+	collection, err := url.Parse(book.CanonicalURL)
+	if err != nil {
+		return store.CardDAVSyncPlan{}, ErrUnsafeTarget
+	}
+	events := map[string]bool{} // true = changed, false = removed
+	seenTokens := map[string]bool{}
+	pageToken := token
+	var nextToken string
+	for page := range maxSyncPages {
+		seenTokens[pageToken] = true
+		body, err := SyncCollectionBody(pageToken)
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		depth := 1
+		response, err := s.do(ctx, Request{Method: "REPORT", URL: book.CanonicalURL, Depth: &depth, Body: body}, budget)
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		multiStatus, err := ParseMultiStatus(response.Body, DefaultXMLLimits())
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		if response.EffectiveURL != nil {
+			collection = response.EffectiveURL
+		}
+		changed, removed, continuation, truncated, err := s.parseSyncPage(ctx, collection, multiStatus)
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		for _, href := range changed {
+			events[href] = true
+		}
+		for _, href := range removed {
+			events[href] = false
+		}
+		if len(events) > maxSyncMembers {
+			return store.CardDAVSyncPlan{}, fmt.Errorf("CardDAV sync exceeds %d members", maxSyncMembers)
+		}
+		nextToken = continuation
+		if !truncated {
+			break
+		}
+		if seenTokens[continuation] {
+			return store.CardDAVSyncPlan{}, ErrSyncTokenCycle
+		}
+		pageToken = continuation
+		if page == maxSyncPages-1 {
+			return store.CardDAVSyncPlan{}, fmt.Errorf("CardDAV sync exceeds %d pages", maxSyncPages)
+		}
+	}
+
+	changed := make([]string, 0, len(events))
+	removed := make([]string, 0, len(events))
+	for href, isChanged := range events {
+		if isChanged {
+			changed = append(changed, href)
+		} else {
+			removed = append(removed, href)
+		}
+	}
+	slices.Sort(changed)
+	slices.Sort(removed)
+	resources := make([]store.CardDAVRemoteResource, 0, len(changed))
+	if book.SupportsMultiget {
+		for offset := 0; offset < len(changed); offset += multigetBatch {
+			end := min(offset+multigetBatch, len(changed))
+			cards, missing, err := s.fetchMultiget(ctx, collection, changed[offset:end], budget)
+			if isStatus(err, http.StatusMethodNotAllowed) || isStatus(err, http.StatusNotImplemented) {
+				cards, missing, err = s.fetchMembersIndividually(ctx, collection, changed[offset:], budget)
+				if err != nil {
+					return store.CardDAVSyncPlan{}, err
+				}
+				resources = append(resources, cards...)
+				removed = append(removed, missing...)
+				break
+			}
+			if err != nil {
+				return store.CardDAVSyncPlan{}, err
+			}
+			resources = append(resources, cards...)
+			removed = append(removed, missing...)
+		}
+	} else {
+		cards, missing, err := s.fetchMembersIndividually(ctx, collection, changed, budget)
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		resources = append(resources, cards...)
+		removed = append(removed, missing...)
+	}
+	return store.CardDAVSyncPlan{
+		ReplaceAll: token == "", NextSyncToken: nextToken,
+		Upserts: resources, RemovedHrefs: removed,
+	}, nil
+}
+
+func (s *Service) fetchMembersIndividually(
+	ctx context.Context, collection *url.URL, hrefs []string, budget *operationBudget,
+) ([]store.CardDAVRemoteResource, []string, error) {
+	resources := make([]store.CardDAVRemoteResource, 0, len(hrefs))
+	missing := make([]string, 0)
+	for _, href := range hrefs {
+		response, err := s.do(ctx, Request{Method: http.MethodGet, URL: href}, budget)
+		if isAbsentStatus(err) {
+			missing = append(missing, href)
+			continue
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+		effective := response.EffectiveURL
+		if effective == nil {
+			effective, err = url.Parse(href)
+			if err != nil {
+				return nil, nil, ErrUnsafeHref
+			}
+		}
+		if _, err := s.resolveMemberHref(ctx, collection, effective.String(), false); err != nil {
+			return nil, nil, err
+		}
+		etag := strings.TrimSpace(response.Header.Get("ETag"))
+		if etag == "" || len(response.Body) == 0 {
+			return nil, nil, ErrIncompleteMultiget
+		}
+		resource, err := parseRemoteResource(href, etag, response.Body)
+		if err != nil {
+			return nil, nil, err
+		}
+		resources = append(resources, resource)
+	}
+	return resources, missing, nil
+}
+
+func (s *Service) parseSyncPage(
+	ctx context.Context, collection *url.URL, multiStatus MultiStatus,
+) ([]string, []string, string, bool, error) {
+	if multiStatus.SyncToken == "" {
+		return nil, nil, "", false, errors.New("CardDAV sync response lacks a usable sync token")
+	}
+	changed, removed := []string{}, []string{}
+	seen := map[string]bool{}
+	truncated := false
+	for _, davResponse := range multiStatus.Responses {
+		resolved, err := s.resolveMemberHref(ctx, collection, davResponse.Href, true)
+		if err != nil {
+			return nil, nil, "", false, err
+		}
+		isCollection := sameCollectionURL(resolved, collection)
+		if davResponse.StatusCode != 0 {
+			identity := canonicalDAVURLIdentity(resolved)
+			switch {
+			case davResponse.StatusCode == http.StatusInsufficientStorage && isCollection:
+				truncated = true
+				continue
+			case isAbsentStatusCode(davResponse.StatusCode) && !isCollection:
+				if seen[identity] {
+					return nil, nil, "", false, ErrIncompleteMultiget
+				}
+				seen[identity] = true
+				removed = append(removed, identity)
+				continue
+			default:
+				return nil, nil, "", false, &StatusError{StatusCode: davResponse.StatusCode}
+			}
+		}
+		if isCollection {
+			for _, propStat := range davResponse.PropStats {
+				if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+					return nil, nil, "", false, &StatusError{StatusCode: propStat.StatusCode}
+				}
+			}
+			continue
+		}
+		identity := canonicalDAVURLIdentity(resolved)
+		if seen[identity] {
+			return nil, nil, "", false, ErrIncompleteMultiget
+		}
+		seen[identity] = true
+		etag := ""
+		for _, propStat := range davResponse.PropStats {
+			if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+				return nil, nil, "", false, &StatusError{StatusCode: propStat.StatusCode}
+			}
+			if propStat.Properties.GetETag != "" {
+				etag = propStat.Properties.GetETag
+			}
+		}
+		if etag == "" {
+			return nil, nil, "", false, errors.New("CardDAV sync member lacks ETag")
+		}
+		changed = append(changed, identity)
+	}
+	return changed, removed, multiStatus.SyncToken, truncated, nil
+}
+
+func (s *Service) fetchMultiget(
+	ctx context.Context, collection *url.URL, hrefs []string, budget *operationBudget,
+) ([]store.CardDAVRemoteResource, []string, error) {
+	body, err := AddressbookMultigetBody([]PropertyName{GetETagProperty, AddressDataProperty}, hrefs)
+	if err != nil {
+		return nil, nil, err
+	}
+	depth := 0
+	response, err := s.do(ctx, Request{Method: "REPORT", URL: collection.String(), Depth: &depth, Body: body}, budget)
+	if err != nil {
+		return nil, nil, err
+	}
+	multiStatus, err := ParseMultiStatus(response.Body, DefaultXMLLimits())
+	if err != nil {
+		return nil, nil, err
+	}
+	if response.EffectiveURL != nil {
+		collection = response.EffectiveURL
+	}
+	wanted := make(map[string]bool, len(hrefs))
+	for _, href := range hrefs {
+		resolved, err := collection.Parse(href)
+		if err != nil {
+			return nil, nil, ErrIncompleteMultiget
+		}
+		identity := canonicalDAVURLIdentity(resolved)
+		if wanted[identity] {
+			return nil, nil, ErrIncompleteMultiget
+		}
+		wanted[identity] = true
+	}
+	seen := map[string]bool{}
+	resources := make([]store.CardDAVRemoteResource, 0, len(hrefs))
+	missing := []string{}
+	for _, davResponse := range multiStatus.Responses {
+		resolved, err := s.resolveMemberHref(ctx, collection, davResponse.Href, false)
+		if err != nil {
+			return nil, nil, err
+		}
+		identity := canonicalDAVURLIdentity(resolved)
+		href := identity
+		if !wanted[identity] || seen[identity] {
+			return nil, nil, ErrIncompleteMultiget
+		}
+		seen[identity] = true
+		if isAbsentStatusCode(davResponse.StatusCode) {
+			missing = append(missing, href)
+			continue
+		}
+		if davResponse.StatusCode != 0 {
+			return nil, nil, &StatusError{StatusCode: davResponse.StatusCode}
+		}
+		etag, data := "", ""
+		for _, propStat := range davResponse.PropStats {
+			if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+				return nil, nil, &StatusError{StatusCode: propStat.StatusCode}
+			}
+			if propStat.Properties.GetETag != "" {
+				etag = propStat.Properties.GetETag
+			}
+			if propStat.Properties.AddressData != "" {
+				data = propStat.Properties.AddressData
+			}
+		}
+		if etag == "" || strings.TrimSpace(data) == "" {
+			return nil, nil, ErrIncompleteMultiget
+		}
+		resource, err := parseRemoteResource(href, etag, []byte(data))
+		if err != nil {
+			return nil, nil, err
+		}
+		resources = append(resources, resource)
+	}
+	if len(seen) != len(wanted) {
+		return nil, nil, ErrIncompleteMultiget
+	}
+	return resources, missing, nil
+}
+
+func (s *Service) fetchSnapshot(
+	ctx context.Context, book store.CardDAVAddressBook, budget *operationBudget,
+) (store.CardDAVSyncPlan, error) {
+	collection, err := url.Parse(book.CanonicalURL)
+	if err != nil {
+		return store.CardDAVSyncPlan{}, ErrUnsafeTarget
+	}
+	body, err := AddressbookQueryBody([]PropertyName{GetETagProperty, AddressDataProperty})
+	if err != nil {
+		return store.CardDAVSyncPlan{}, err
+	}
+	depth := 1
+	response, err := s.do(ctx, Request{Method: "REPORT", URL: book.CanonicalURL, Depth: &depth, Body: body}, budget)
+	if err != nil {
+		var status *StatusError
+		if errors.As(err, &status) && status.StatusCode == http.StatusInsufficientStorage {
+			return store.CardDAVSyncPlan{}, ErrTruncatedSnapshot
+		}
+		return store.CardDAVSyncPlan{}, err
+	}
+	multiStatus, err := ParseMultiStatus(response.Body, DefaultXMLLimits())
+	if err != nil {
+		return store.CardDAVSyncPlan{}, err
+	}
+	if response.EffectiveURL != nil {
+		collection = response.EffectiveURL
+	}
+	resources := make([]store.CardDAVRemoteResource, 0, len(multiStatus.Responses))
+	seen := map[string]bool{}
+	for _, davResponse := range multiStatus.Responses {
+		resolved, err := s.resolveMemberHref(ctx, collection, davResponse.Href, true)
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		if davResponse.StatusCode == http.StatusInsufficientStorage {
+			return store.CardDAVSyncPlan{}, ErrTruncatedSnapshot
+		}
+		if isAbsentStatusCode(davResponse.StatusCode) && !sameCollectionURL(resolved, collection) {
+			continue
+		}
+		if davResponse.StatusCode != 0 && (davResponse.StatusCode < 200 || davResponse.StatusCode >= 300) {
+			return store.CardDAVSyncPlan{}, &StatusError{StatusCode: davResponse.StatusCode}
+		}
+		if sameCollectionURL(resolved, collection) {
+			for _, propStat := range davResponse.PropStats {
+				if propStat.StatusCode == http.StatusInsufficientStorage {
+					return store.CardDAVSyncPlan{}, ErrTruncatedSnapshot
+				}
+				if !isAbsentStatusCode(propStat.StatusCode) &&
+					(propStat.StatusCode < 200 || propStat.StatusCode >= 300) {
+					return store.CardDAVSyncPlan{}, &StatusError{StatusCode: propStat.StatusCode}
+				}
+			}
+			continue
+		}
+		href := canonicalDAVURLIdentity(resolved)
+		if seen[href] {
+			return store.CardDAVSyncPlan{}, ErrIncompleteMultiget
+		}
+		seen[href] = true
+		etag, data := "", ""
+		for _, propStat := range davResponse.PropStats {
+			if propStat.StatusCode < 200 || propStat.StatusCode >= 300 {
+				return store.CardDAVSyncPlan{}, &StatusError{StatusCode: propStat.StatusCode}
+			}
+			if propStat.Properties.GetETag != "" {
+				etag = propStat.Properties.GetETag
+			}
+			if propStat.Properties.AddressData != "" {
+				data = propStat.Properties.AddressData
+			}
+		}
+		if etag == "" || strings.TrimSpace(data) == "" {
+			return store.CardDAVSyncPlan{}, ErrIncompleteMultiget
+		}
+		resource, err := parseRemoteResource(href, etag, []byte(data))
+		if err != nil {
+			return store.CardDAVSyncPlan{}, err
+		}
+		resources = append(resources, resource)
+	}
+	return store.CardDAVSyncPlan{ReplaceAll: true, Upserts: resources}, nil
+}
+
+func (s *Service) resolveMemberHref(
+	ctx context.Context, collection *url.URL, href string, allowCollection bool,
+) (*url.URL, error) {
+	resolved, err := s.client.ValidateChildHref(ctx, collection, href)
+	if err != nil {
+		return nil, err
+	}
+	if sameCollectionURL(resolved, collection) {
+		if allowCollection {
+			return resolved, nil
+		}
+		return nil, ErrUnsafeHref
+	}
+	collectionPath := strings.TrimSuffix(path.Clean(collection.EscapedPath()), "/")
+	if path.Dir(path.Clean(resolved.EscapedPath())) != collectionPath {
+		return nil, ErrUnsafeHref
+	}
+	return resolved, nil
+}
+
+func parseRemoteResource(href, etag string, body []byte) (store.CardDAVRemoteResource, error) {
+	envelope, err := vcard.ParseResourceEnvelope(body)
+	if err != nil {
+		return store.CardDAVRemoteResource{}, fmt.Errorf("parse remote CardDAV vCard: %w", err)
+	}
+	semanticHash, err := SemanticHash(body)
+	if err != nil {
+		return store.CardDAVRemoteResource{}, err
+	}
+	resource := store.CardDAVRemoteResource{
+		Href: href, RemoteETag: etag, RemoteBody: append([]byte(nil), body...),
+		SemanticHash: semanticHash,
+	}
+	for _, occurrence := range envelope.PropertyTree {
+		property := occurrence.Property
+		identity := cardDAVVCardIdentity(occurrence)
+		switch strings.ToUpper(property.Name) {
+		case "UID":
+			if resource.RemoteUID == "" {
+				resource.RemoteUID = strings.TrimSpace(property.RawValue)
+			}
+		case "FN":
+			if resource.DisplayName == "" {
+				value, err := cardDAVPropertyValue(envelope.RenderMetadata.StoredVersion, property)
+				if err != nil {
+					return store.CardDAVRemoteResource{}, fmt.Errorf("decode CardDAV FN: %w", err)
+				}
+				resource.DisplayName = strings.TrimSpace(value)
+				resource.DisplayNameIdentity = identity
+			}
+		case "EMAIL":
+			value, err := cardDAVPropertyValue(envelope.RenderMetadata.StoredVersion, property)
+			if err != nil {
+				return store.CardDAVRemoteResource{}, fmt.Errorf("decode CardDAV EMAIL: %w", err)
+			}
+			value = strings.TrimSpace(trimPrefixFold(value, "mailto:"))
+			if value != "" {
+				resource.Emails = append(resource.Emails, value)
+				resource.EmailIdentities = append(resource.EmailIdentities, identity)
+			}
+		case "TEL":
+			value, err := cardDAVPropertyValue(envelope.RenderMetadata.StoredVersion, property)
+			if err != nil {
+				return store.CardDAVRemoteResource{}, fmt.Errorf("decode CardDAV TEL: %w", err)
+			}
+			value = strings.TrimSpace(trimPrefixFold(value, "tel:"))
+			if value != "" {
+				resource.Phones = append(resource.Phones, value)
+				resource.PhoneIdentities = append(resource.PhoneIdentities, identity)
+			}
+		}
+	}
+	return resource, nil
+}
+
+func cardDAVPropertyValue(version vcard.Version, property vcard.Property) (string, error) {
+	valueType := ""
+	for _, parameter := range property.ParametersNamed("VALUE") {
+		if len(parameter.Values) > 0 {
+			valueType = strings.ToLower(strings.TrimSpace(parameter.Values[0].Decoded))
+			break
+		}
+	}
+	name := strings.ToUpper(property.Name)
+	isText := valueType == "text" || valueType == "" &&
+		(name != "TEL" || version != vcard.Version40)
+	if !isText {
+		return property.RawValue, nil
+	}
+	return vcard.UnescapeText(property.RawValue)
+}
+
+func cardDAVVCardIdentity(occurrence vcard.PropertyOccurrence) store.VCardIdentity {
+	identity := store.VCardIdentity{
+		Property: strings.ToUpper(occurrence.Property.Name),
+		PropID:   occurrence.Identity.PropID,
+		PID:      append([]string(nil), occurrence.Identity.PID...),
+		AltID:    occurrence.Identity.AltID,
+	}
+	if occurrence.Identity.Group != "" {
+		group := occurrence.Identity.Group
+		identity.Group = &group
+	}
+	return identity
+}
+
+func trimPrefixFold(value, prefix string) string {
+	if len(value) >= len(prefix) && strings.EqualFold(value[:len(prefix)], prefix) {
+		return value[len(prefix):]
+	}
+	return value
+}
+
+// SyncCollectionBody builds the RFC 6578 level-1 incremental request.
+func SyncCollectionBody(token string) ([]byte, error) {
+	var body bytes.Buffer
+	encoder := xml.NewEncoder(&body)
+	root := xml.StartElement{Name: xml.Name{Space: davNamespace, Local: "sync-collection"}}
+	if err := encoder.EncodeToken(root); err != nil {
+		return nil, fmt.Errorf("encode CardDAV sync root: %w", err)
+	}
+	fields := []struct {
+		name, text string
+	}{{"sync-token", token}, {"sync-level", "1"}}
+	for _, value := range fields {
+		start := xml.StartElement{Name: xml.Name{Space: davNamespace, Local: value.name}}
+		if err := encoder.EncodeToken(start); err != nil {
+			return nil, fmt.Errorf("encode CardDAV sync field %s: %w", value.name, err)
+		}
+		if err := encoder.EncodeToken(xml.CharData(value.text)); err != nil {
+			return nil, fmt.Errorf("encode CardDAV sync value %s: %w", value.name, err)
+		}
+		if err := encoder.EncodeToken(start.End()); err != nil {
+			return nil, fmt.Errorf("close CardDAV sync field %s: %w", value.name, err)
+		}
+	}
+	prop := xml.StartElement{Name: xml.Name{Space: davNamespace, Local: "prop"}}
+	if err := encoder.EncodeToken(prop); err != nil {
+		return nil, fmt.Errorf("encode CardDAV sync properties: %w", err)
+	}
+	if err := encodeEmptyElement(encoder, xml.Name{Space: davNamespace, Local: "getetag"}); err != nil {
+		return nil, err
+	}
+	if err := encoder.EncodeToken(prop.End()); err != nil {
+		return nil, fmt.Errorf("close CardDAV sync properties: %w", err)
+	}
+	if err := encoder.EncodeToken(root.End()); err != nil {
+		return nil, fmt.Errorf("close CardDAV sync root: %w", err)
+	}
+	if err := encoder.Flush(); err != nil {
+		return nil, fmt.Errorf("flush CardDAV sync XML: %w", err)
+	}
+	return body.Bytes(), nil
+}

--- a/internal/carddav/pull_integration_test.go
+++ b/internal/carddav/pull_integration_test.go
@@ -1,0 +1,569 @@
+package carddav
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func integrationRemoteResource(href, uid, etag string) store.CardDAVRemoteResource {
+	body := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + uid + "\r\nFN:" + uid + "\r\nEMAIL:" + uid + "@example.test\r\nEND:VCARD\r\n")
+	return store.CardDAVRemoteResource{
+		Href: href, RemoteUID: uid, RemoteETag: etag, RemoteBody: body,
+		SemanticHash: "semantic-" + uid, DisplayName: uid, Emails: []string{uid + "@example.test"},
+	}
+}
+
+func TestSnapshot507NeverTombstonesOmittedResources(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := syncResponse(`<D:response><D:href>/books/personal/</D:href><D:status>HTTP/1.1 507 Insufficient Storage</D:status></D:response>`, "")
+		writeDAVXML(t, w, body)
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	seed := integrationRemoteResource(server.URL+"/books/personal/keep.vcf", "keep", `"seed"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{seed},
+	})
+	require.NoError(err)
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.ErrorIs(err, ErrTruncatedSnapshot)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, seed.Href)
+	require.NoError(err)
+}
+
+func TestSnapshotHTTP507NeverTombstonesOmittedResources(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInsufficientStorage)
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	seed := integrationRemoteResource(server.URL+"/books/personal/keep.vcf", "keep", `"seed"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{seed},
+	})
+	require.NoError(err)
+
+	_, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.ErrorIs(err, ErrTruncatedSnapshot)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, seed.Href)
+	require.NoError(err)
+}
+
+func TestSnapshotAcceptsEquivalentCollectionURLWithTrailingSlash(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		events := `<D:response><D:href>/books/personal/</D:href><D:propstat><D:prop/>` +
+			`<D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>` +
+			cardResponse("/books/personal/alice.vcf", `&quot;one&quot;`, "alice")
+		writeDAVXML(t, w, syncResponse(events, ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET canonical_url = ? WHERE id = ?`), server.URL+"/books/personal", book.ID)
+	require.NoError(err)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(t, 1, result.Created)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID,
+		server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+}
+
+func TestSnapshotMovesResourceByAddressBookScopedRemoteUID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	phase := 1
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		href, etag := "/books/personal/old.vcf", `&quot;one&quot;`
+		if phase == 2 {
+			href, etag = "/books/personal/new.vcf", `&quot;two&quot;`
+		}
+		writeDAVXML(t, w, syncResponse(cardResponse(href, etag, "stable-uid"), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	oldHref := server.URL + "/books/personal/old.vcf"
+	newHref := server.URL + "/books/personal/new.vcf"
+
+	first, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, first.Created)
+	oldMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.NoError(err)
+	require.NotNil(oldMapping.PersonID)
+	personID := *oldMapping.PersonID
+
+	phase = 2
+	second, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(0, second.Created)
+	assert.Equal(1, second.Updated)
+	assert.Equal(0, second.Removed)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	newMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, newHref)
+	require.NoError(err)
+	require.NotNil(newMapping.PersonID)
+	assert.Equal(personID, *newMapping.PersonID)
+	resources, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	assert.Len(resources, 1)
+	_, err = st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", oldHref)
+	require.ErrorIs(err, store.ErrVCardResourceNotFound)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", newHref)
+	require.NoError(err)
+	assert.Equal(personID, envelope.PersonID)
+}
+
+func TestSnapshotDuplicateRemoteUIDClaimsPreviousHrefOnlyOnce(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	phase := 1
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		events := cardResponse("/books/personal/old.vcf", `&quot;one&quot;`, "stable-uid")
+		if phase == 2 {
+			events = cardResponse("/books/personal/new-a.vcf", `&quot;two-a&quot;`, "stable-uid") +
+				cardResponse("/books/personal/new-b.vcf", `&quot;two-b&quot;`, "stable-uid")
+		}
+		writeDAVXML(t, w, syncResponse(events, ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+	oldHref := server.URL + "/books/personal/old.vcf"
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	oldMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.NoError(err)
+	require.NotNil(oldMapping.PersonID)
+	personID := *oldMapping.PersonID
+
+	phase = 2
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, result.Created)
+	assert.Equal(1, result.Updated)
+	assert.Zero(result.Removed)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	resources, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	require.Len(resources, 2)
+	for _, resource := range resources {
+		require.NotNil(resource.PersonID)
+		assert.Equal(personID, *resource.PersonID)
+	}
+}
+
+func TestSyncRefetchesOneStalePlanThenAborts(t *testing.T) {
+	requests := 0
+	var st *store.Store
+	var bookID int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		writeDAVXML(t, w, syncResponse("", ""))
+		if st != nil {
+			// This independent write completing inside the handler proves the
+			// service has not opened its apply transaction around network I/O.
+			_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET sync_revision = sync_revision + 1 WHERE id = ?`), bookID)
+			assert.NoError(t, err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, opened, book := newPullService(t, server, false)
+	st, bookID = opened, book.ID
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.ErrorIs(t, err, store.ErrCardDAVStalePlan)
+	assert.Equal(t, 2, requests)
+}
+
+func TestSyncUsesOneInvalidTokenReconcileAcrossStaleRefetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	requests := 0
+	var st *store.Store
+	var bookID int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		switch requests {
+		case 1, 3:
+			assert.Equal("stale-token", syncRequestToken(readRequestBody(t, r)))
+			w.WriteHeader(http.StatusForbidden)
+			_, err := w.Write([]byte(`<D:error xmlns:D="DAV:"><D:valid-sync-token/></D:error>`))
+			assert.NoError(err)
+		case 2:
+			assert.Empty(syncRequestToken(readRequestBody(t, r)))
+			writeDAVXML(t, w, syncResponse("", "fresh-token"))
+			_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+				SET sync_revision = sync_revision + 1 WHERE id = ?`), bookID)
+			assert.NoError(err)
+		default:
+			assert.Empty(syncRequestToken(readRequestBody(t, r)))
+			writeDAVXML(t, w, syncResponse("", "unexpected-second-reconcile"))
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, opened, book := newPullService(t, server, true)
+	st, bookID = opened, book.ID
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET sync_token = ? WHERE id = ?`), "stale-token", book.ID)
+	require.NoError(err)
+
+	_, err = service.Sync(t.Context(), SyncOptions{})
+	var status *StatusError
+	require.ErrorAs(err, &status)
+	assert.Equal(http.StatusForbidden, status.StatusCode)
+	assert.Equal(3, requests)
+}
+
+func TestETagOnlyChurnUpdatesLedgerWithoutDuplicatingPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	etag := `&quot;one&quot;`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			writeDAVXML(t, w, syncResponse(changedResponse("/books/personal/alice.vcf", etag), "next"))
+			return
+		}
+		writeDAVXML(t, w, syncResponse(cardResponse("/books/personal/alice.vcf", etag, "alice"), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	etag = `&quot;two&quot;`
+	_, err = service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, before.Href)
+	require.NoError(err)
+	assert.Equal(`"two"`, after.RemoteETag)
+	assert.Equal(before.PersonID, after.PersonID)
+	assert.Equal(before.MappingRevision+1, after.MappingRevision)
+}
+
+func TestSyncCanonicalizesEquivalentHrefSpellingsForUpdatesAndTombstones(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	phase := 1
+	canonicalBase := ""
+	equivalentBase := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			if phase == 1 {
+				writeDAVXML(t, w, syncResponse(
+					changedResponse(canonicalBase+"/books/personal/update.vcf", `&quot;one&quot;`)+
+						changedResponse(canonicalBase+"/books/personal/delete.vcf", `&quot;one&quot;`),
+					"token-one"))
+				return
+			}
+			removed := `<D:response><D:href>` + equivalentBase + `/books/personal/delete.vcf` +
+				`</D:href><D:status>HTTP/1.1 404 Not Found</D:status></D:response>`
+			writeDAVXML(t, w, syncResponse(
+				changedResponse(equivalentBase+"/books/personal/update.vcf", `&quot;two&quot;`)+removed,
+				"token-two"))
+			return
+		}
+		if phase == 1 {
+			writeDAVXML(t, w, syncResponse(
+				cardResponse(canonicalBase+"/books/personal/update.vcf", `&quot;one&quot;`, "update")+
+					cardResponse(canonicalBase+"/books/personal/delete.vcf", `&quot;one&quot;`, "delete"), ""))
+			return
+		}
+		writeDAVXML(t, w, syncResponse(
+			cardResponse(equivalentBase+"/books/personal/update.vcf", `&quot;two&quot;`, "update"), ""))
+	}))
+	t.Cleanup(server.Close)
+	serverURL := mustParseURL(t, server.URL)
+	canonicalBase = "http://contacts.example:" + serverURL.Port()
+	equivalentBase = "http://CONTACTS.example:" + serverURL.Port()
+	origin := mustParseURL(t, canonicalBase)
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("127.0.0.1"))
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin, Username: "alice", Password: "secret",
+		AllowInsecureCredentials: true, Resolver: resolver,
+	})
+	require.NoError(err)
+	client.allowPrivateOrigin = true
+	st := testutil.NewTestStore(t)
+	allowed := true
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: canonicalBase, Username: "alice", PrincipalURL: canonicalBase + "/principal/",
+		HomeURL: canonicalBase + "/books/", Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: canonicalBase + "/books/personal/", DisplayName: "Personal",
+			SupportsSyncCollection: true, SupportsMultiget: true, CanCreate: &allowed,
+		}},
+	})
+	require.NoError(err)
+	require.Len(books, 1)
+	service := NewService(st, client)
+	book := books[0]
+	updateHref := canonicalBase + "/books/personal/update.vcf"
+	deleteHref := canonicalBase + "/books/personal/delete.vcf"
+
+	first, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, first.Created)
+
+	phase = 2
+	second, err := service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	assert.Equal(1, second.Updated)
+	assert.Equal(1, second.Removed)
+	updated, err := st.GetCardDAVResourceContext(t.Context(), book.ID, updateHref)
+	require.NoError(err)
+	assert.Equal(`"two"`, updated.RemoteETag)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, deleteHref)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	resources, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	require.Len(resources, 1)
+	assert.Equal(updateHref, resources[0].Href)
+}
+
+func TestSnapshotKeepsCardWithNonE164PhoneWithoutAbortingOtherImports(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	localCard := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:local-number\r\nFN:Local Number\r\nTEL:12345\r\nEND:VCARD\r\n")
+	validCard := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:valid-contact\r\nFN:Valid Contact\r\nEMAIL:valid@example.test\r\nEND:VCARD\r\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeDAVXML(t, w, syncResponse(
+			cardResponseRaw("/books/personal/local.vcf", `"local"`, escapedCardData(localCard))+
+				cardResponseRaw("/books/personal/valid.vcf", `"valid"`, escapedCardData(validCard)), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, result.Created)
+	localHref := server.URL + "/books/personal/local.vcf"
+	local, err := st.GetCardDAVResourceContext(t.Context(), book.ID, localHref)
+	require.NoError(err)
+	require.NotNil(local.PersonID)
+	points, err := st.ListPersonContactPointsContext(t.Context(), *local.PersonID, true)
+	require.NoError(err)
+	assert.Empty(points)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", localHref)
+	require.NoError(err)
+	assert.Equal(localCard, envelope.StoredBody)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/valid.vcf")
+	require.NoError(err)
+}
+
+func TestSyncRebasesUntouchedRemoteProjectionAndPreservesUserOwnedPersonOnTombstone(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	phase := 0
+	cards := func() string {
+		switch phase {
+		case 0:
+			return cardResponseRaw("/books/personal/alice.vcf", `"alice-one"`, escapedCardData(
+				conflictCardWithEmail("alice", "Alice Initial", "alice-initial@example.test"))) +
+				cardResponseRaw("/books/personal/bob.vcf", `"bob-one"`, escapedCardData(
+					conflictCardWithEmail("bob", "Bob Initial", "bob-initial@example.test")))
+		case 1:
+			return cardResponseRaw("/books/personal/alice.vcf", `"alice-two"`, escapedCardData(
+				conflictCardWithEmail("alice", "Alice Remote", "alice-remote@example.test"))) +
+				cardResponseRaw("/books/personal/bob.vcf", `"bob-two"`, escapedCardData(
+					conflictCardWithEmail("bob", "Bob Remote", "bob-remote@example.test")))
+		default:
+			return ""
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeDAVXML(t, w, syncResponse(cards(), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, result.Created)
+	aliceHref := server.URL + "/books/personal/alice.vcf"
+	bobHref := server.URL + "/books/personal/bob.vcf"
+	aliceMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, aliceHref)
+	require.NoError(err)
+	require.NotNil(aliceMapping.PersonID)
+	bobMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, bobHref)
+	require.NoError(err)
+	require.NotNil(bobMapping.PersonID)
+
+	var noteID int64
+	err = st.DB().QueryRow(st.Rebind(`INSERT INTO daily_note_entries (local_date, ordinal, body)
+		VALUES (?, ?, ?) RETURNING id`), "2026-08-19", 1, "synthetic note").Scan(&noteID)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO daily_note_entry_persons (entry_id, person_id)
+		VALUES (?, ?)`), noteID, *bobMapping.PersonID)
+	require.NoError(err)
+
+	phase = 1
+	result, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, result.Updated)
+	alice, err := st.GetPersonContext(t.Context(), *aliceMapping.PersonID)
+	require.NoError(err)
+	require.NotNil(alice.DisplayName)
+	assert.Equal("Alice Remote", *alice.DisplayName)
+	alicePoints, err := st.ListPersonContactPointsContext(t.Context(), *aliceMapping.PersonID, true)
+	require.NoError(err)
+	require.Len(alicePoints, 1)
+	assert.Equal("alice-remote@example.test", alicePoints[0].OriginalValue)
+	bob, err := st.GetPersonContext(t.Context(), *bobMapping.PersonID)
+	require.NoError(err)
+	require.NotNil(bob.DisplayName)
+	assert.Equal("Bob Initial", *bob.DisplayName,
+		"user-owned state must keep the local projection while the remote ledger advances")
+	bobEnvelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", bobHref)
+	require.NoError(err)
+	assert.Contains(string(bobEnvelope.StoredBody), "FN:Bob Remote")
+
+	phase = 2
+	result, err = service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, result.Removed)
+	_, err = st.GetPersonContext(t.Context(), *aliceMapping.PersonID)
+	require.ErrorIs(err, store.ErrPersonNotFound,
+		"the untouched rebased import must remain eligible for later tombstone cleanup")
+	bob, err = st.GetPersonContext(t.Context(), *bobMapping.PersonID)
+	require.NoError(err)
+	require.NotNil(bob.DisplayName)
+	assert.Equal("Bob Initial", *bob.DisplayName)
+	var links int
+	err = st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM daily_note_entry_persons
+		WHERE entry_id = ? AND person_id = ?`), noteID, *bobMapping.PersonID).Scan(&links)
+	require.NoError(err)
+	assert.Equal(1, links)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, bobHref)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", bobHref)
+	require.ErrorIs(err, store.ErrVCardResourceNotFound)
+}
+
+func TestSnapshotPreservesLiteralCRLFAddressDataBytes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const href = "/books/personal/line-endings.vcf"
+	const card = "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:line-endings\r\nFN:Line Endings\r\nEND:VCARD\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := `<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">` +
+			`<D:response><D:href>` + href + `</D:href><D:propstat><D:prop>` +
+			`<D:getetag>&quot;literal-crlf&quot;</D:getetag><C:address-data>` + card +
+			`</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status>` +
+			`</D:propstat></D:response></D:multistatus>`
+		writeDAVXML(t, w, body)
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	resourceHref := server.URL + href
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, resourceHref)
+	require.NoError(err)
+	assert.Equal([]byte(card), resource.RemoteBody)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", resourceHref)
+	require.NoError(err)
+	assert.Equal([]byte(card), envelope.StoredBody)
+}
+
+func TestSyncCarriesRedirectedCollectionURLIntoRelativeHrefsAndMultiget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	redirects := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/books/personal" {
+			redirects++
+			http.Redirect(w, r, "/books/personal/", http.StatusMovedPermanently)
+			return
+		}
+		if !assert.Equal("/books/personal/", r.URL.Path) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			if r.Header.Get("Depth") != "1" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeDAVXML(t, w, syncResponse(changedResponse("alice.vcf", `&quot;one&quot;`), "next"))
+			return
+		}
+		writeDAVXML(t, w, syncResponse(cardResponse("alice.vcf", `&quot;one&quot;`, "alice"), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET canonical_url = ? WHERE id = ?`),
+		server.URL+"/books/personal", book.ID)
+	require.NoError(err)
+
+	result, err := service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	assert.Equal(1, result.Created)
+	assert.Equal(1, redirects, "multiget must use the effective collection URL")
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+}
+
+func TestSnapshotPreservesCDATAAddressDataBytes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const href = "/books/personal/cdata.vcf"
+	const card = "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:cdata\r\nFN:CDATA\r\nNOTE:literal &amp; text\r\nEND:VCARD\r\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := `<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">` +
+			`<D:response><D:href>` + href + `</D:href><D:propstat><D:prop>` +
+			`<D:getetag>&quot;cdata&quot;</D:getetag><C:address-data><![CDATA[` + card +
+			`]]></C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status>` +
+			`</D:propstat></D:response></D:multistatus>`
+		writeDAVXML(t, w, body)
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, false)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	resourceHref := server.URL + href
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, resourceHref)
+	require.NoError(err)
+	assert.Equal([]byte(card), resource.RemoteBody)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", resourceHref)
+	require.NoError(err)
+	assert.Equal([]byte(card), envelope.StoredBody)
+}

--- a/internal/carddav/pull_test.go
+++ b/internal/carddav/pull_test.go
@@ -1,0 +1,695 @@
+package carddav
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestParseSyncPageRecognizesEquivalentAbsoluteCollectionHref(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	collection := mustParseURL(t, "https://contacts.example/books/personal/")
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("203.0.113.9"))
+	client, err := NewClient(ClientOptions{CredentialOrigin: collection, Resolver: resolver})
+	require.NoError(err)
+	service := NewService(nil, client)
+
+	changed, removed, token, truncated, err := service.parseSyncPage(t.Context(), collection, MultiStatus{
+		SyncToken: "next-token",
+		Responses: []MultiStatusResponse{{
+			Href:      "https://CONTACTS.example:443/books/personal",
+			PropStats: []PropStat{{StatusCode: http.StatusOK}},
+		}},
+	})
+
+	require.NoError(err)
+	assert.Empty(changed)
+	assert.Empty(removed)
+	assert.Equal("next-token", token)
+	assert.False(truncated)
+}
+
+func TestPullBudgetChargesHTTPErrorBodies(t *testing.T) {
+	const errorBody = "remote error response body"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, err := w.Write([]byte(errorBody))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	service, _, _ := newPullService(t, server, false)
+	budget := &operationBudget{remaining: int64(len(errorBody) + 1)}
+
+	_, err := service.do(t.Context(), Request{Method: http.MethodGet, URL: server.URL + "/missing-one"}, budget)
+	require.Error(t, err)
+	_, err = service.do(t.Context(), Request{Method: http.MethodGet, URL: server.URL + "/missing-two"}, budget)
+	require.ErrorIs(t, err, ErrOperationLimit)
+}
+
+func TestPullBudgetChargesPartialBodiesOnResponseLimit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const responseBody = "abc"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, err := w.Write([]byte(responseBody))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	service, _, _ := newPullService(t, server, false)
+	service.client.responseBytes = 2
+	service.client.operationBytes = 10
+	budget := &operationBudget{remaining: 5}
+
+	response, err := service.do(t.Context(), Request{Method: http.MethodGet, URL: server.URL + "/oversized-one"}, budget)
+	require.ErrorIs(err, ErrResponseLimit)
+	require.NotNil(response)
+	assert.Equal([]byte(responseBody), response.Body)
+	assert.Equal(int64(2), budget.remaining)
+
+	response, err = service.do(t.Context(), Request{Method: http.MethodGet, URL: server.URL + "/oversized-two"}, budget)
+	require.ErrorIs(err, ErrOperationLimit)
+	assert.Nil(response)
+	assert.Equal(int64(-1), budget.remaining)
+	assert.Equal(2, requests)
+}
+
+func TestPullBudgetChargesRedirectResponseBodies(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path == "/start" {
+			w.Header().Set("Location", "/done")
+			w.WriteHeader(http.StatusFound)
+			_, err := w.Write([]byte("12"))
+			assert.NoError(err)
+			return
+		}
+		_, err := w.Write([]byte("345"))
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+	service, _, _ := newPullService(t, server, false)
+	budget := &operationBudget{remaining: 4}
+
+	response, err := service.do(t.Context(), Request{Method: http.MethodGet, URL: server.URL + "/start"}, budget)
+	require.ErrorIs(err, ErrOperationLimit)
+	assert.Nil(response)
+	assert.Equal(int64(-1), budget.remaining)
+	assert.Equal(2, requests)
+}
+
+func TestIndividualMemberFetchTreatsGoneAsMissing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusGone)
+	}))
+	t.Cleanup(server.Close)
+	service, _, book := newPullService(t, server, false)
+	collection, err := url.Parse(book.CanonicalURL)
+	require.NoError(err)
+	href := book.CanonicalURL + "gone.vcf"
+
+	resources, missing, err := service.fetchMembersIndividually(
+		t.Context(), collection, []string{href}, &operationBudget{remaining: defaultOperationBytes})
+	require.NoError(err)
+	assert.Empty(resources)
+	assert.Equal([]string{href}, missing)
+}
+
+func TestSyncPageTreatsGoneMemberAsRemoved(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	service, _, book := newPullService(t, server, false)
+	collection, err := url.Parse(book.CanonicalURL)
+	require.NoError(err)
+	href := book.CanonicalURL + "gone.vcf"
+
+	changed, removed, token, truncated, err := service.parseSyncPage(t.Context(), collection, MultiStatus{
+		SyncToken: "next-token",
+		Responses: []MultiStatusResponse{{Href: href, StatusCode: http.StatusGone}},
+	})
+	require.NoError(err)
+	assert.Empty(changed)
+	assert.Equal([]string{href}, removed)
+	assert.Equal("next-token", token)
+	assert.False(truncated)
+}
+
+func TestSyncContinuesAfterOneBookFailsAndReconcilesPublications(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		if strings.HasPrefix(r.URL.Path, "/books/broken/") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		writeDAVXML(t, w, syncResponse("", ""))
+	}))
+	t.Cleanup(server.Close)
+
+	st := testutil.NewTestStore(t)
+	allowed := true
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: server.URL, Username: "alice", PrincipalURL: server.URL + "/principal/",
+		HomeURL: server.URL + "/books/",
+		Books: []store.CardDAVDiscoveredBook{
+			{CanonicalURL: server.URL + "/books/broken/", DisplayName: "Broken", DiscoveryIndex: 0,
+				CanCreate: &allowed, CanUpdate: &allowed, CanDelete: &allowed},
+			{CanonicalURL: server.URL + "/books/healthy/", DisplayName: "Healthy", DiscoveryIndex: 1,
+				CanCreate: &allowed, CanUpdate: &allowed, CanDelete: &allowed},
+		},
+	})
+	require.NoError(err)
+	require.Len(books, 2)
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true,
+	}))
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid) VALUES ('local-only') RETURNING id`).Scan(&personID))
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO carddav_publications (person_id, desired) VALUES (?, FALSE)`), personID)
+	require.NoError(err)
+
+	origin := mustParseURL(t, server.URL)
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin, Username: "alice", Password: "secret", AllowInsecureCredentials: true,
+	})
+	require.NoError(err)
+	client.allowPrivateOrigin = true
+	service := NewService(st, client)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.Error(err)
+	assert.Equal(1, result.Books)
+	assert.Equal([]string{"/books/broken/", "/books/healthy/"}, requestedPaths)
+	_, publicationErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.ErrorIs(publicationErr, store.ErrCardDAVPublicationNotFound,
+		"publication reconciliation must still run after an independent book failure")
+}
+
+func newPullService(t *testing.T, server *httptest.Server, supportsSync bool) (*Service, *store.Store, store.CardDAVAddressBook) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	allowed := true
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: server.URL, Username: "alice", PrincipalURL: server.URL + "/principal/", HomeURL: server.URL + "/books/",
+		Books: []store.CardDAVDiscoveredBook{{CanonicalURL: server.URL + "/books/personal/", DisplayName: "Personal", SupportsSyncCollection: supportsSync, SupportsMultiget: true, CanCreate: &allowed}},
+	})
+	require.NoError(t, err)
+	origin := mustParseURL(t, server.URL)
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin, Username: "alice", Password: "secret",
+		AllowInsecureCredentials: true,
+	})
+	require.NoError(t, err)
+	client.allowPrivateOrigin = true
+	return NewService(st, client), st, books[0]
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	require.NoError(t, err)
+	return parsed
+}
+
+func readRequestBody(t *testing.T, r *http.Request) string {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	return string(body)
+}
+
+func requestedHrefs(body string) []string {
+	decoder := xml.NewDecoder(strings.NewReader(body))
+	var hrefs []string
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			break
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Space != davNamespace || start.Name.Local != "href" {
+			continue
+		}
+		var href string
+		if decoder.DecodeElement(&href, &start) == nil {
+			hrefs = append(hrefs, href)
+		}
+	}
+	return hrefs
+}
+
+func syncRequestToken(body string) string {
+	decoder := xml.NewDecoder(strings.NewReader(body))
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		start, ok := token.(xml.StartElement)
+		if !ok || start.Name.Space != davNamespace || start.Name.Local != "sync-token" {
+			continue
+		}
+		var value string
+		_ = decoder.DecodeElement(&value, &start)
+		return value
+	}
+}
+
+func syncResponse(events, token string) string {
+	return `<?xml version="1.0"?><D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">` + events + `<D:sync-token>` + token + `</D:sync-token></D:multistatus>`
+}
+
+func changedResponse(href, etag string) string {
+	return `<D:response><D:href>` + href + `</D:href><D:propstat><D:prop><D:getetag>` + etag + `</D:getetag></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`
+}
+
+func cardResponse(href, etag, uid string) string {
+	return `<D:response><D:href>` + href + `</D:href><D:propstat><D:prop><D:getetag>` + etag + `</D:getetag><C:address-data>BEGIN:VCARD&#13;
+VERSION:4.0&#13;
+UID:` + uid + `&#13;
+FN:` + uid + `&#13;
+EMAIL:` + uid + `@example.test&#13;
+END:VCARD&#13;
+</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response>`
+}
+
+func writeDAVXML(t *testing.T, w http.ResponseWriter, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusMultiStatus)
+	_, err := w.Write([]byte(body))
+	require.NoError(t, err)
+}
+
+func TestSyncEmptyTokenReturnsMembersAndAdvancesToken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		requests = append(requests, body)
+		if strings.Contains(body, "sync-collection") {
+			assert.Empty(syncRequestToken(body))
+			writeDAVXML(t, w, syncResponse(changedResponse("/books/personal/alice.vcf", `&quot;one&quot;`), "token-1"))
+			return
+		}
+		writeDAVXML(t, w, syncResponse(cardResponse("/books/personal/alice.vcf", `&quot;one&quot;`, "alice"), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, result.Created)
+	assert.Len(requests, 2)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, server.URL+"/books/personal/alice.vcf")
+	require.NoError(err)
+	assert.Equal(`"one"`, resource.RemoteETag)
+}
+
+func TestSyncMultigetUsesBatchesOfOneHundred(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var batchSizes []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			assert.Equal("token-before", syncRequestToken(body))
+			var events strings.Builder
+			for index := range 205 {
+				events.WriteString(changedResponse(fmt.Sprintf("/books/personal/%03d.vcf", index), `&quot;e&quot;`))
+			}
+			writeDAVXML(t, w, syncResponse(events.String(), "token-205"))
+			return
+		}
+		hrefs := requestedHrefs(body)
+		count := len(hrefs)
+		mu.Lock()
+		batchSizes = append(batchSizes, count)
+		mu.Unlock()
+		var cards strings.Builder
+		for _, href := range hrefs {
+			uid := strings.TrimSuffix(path.Base(href), ".vcf")
+			cards.WriteString(cardResponse(href, `&quot;e&quot;`, uid))
+		}
+		writeDAVXML(t, w, syncResponse(cards.String(), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET sync_token = ? WHERE id = ?`), "token-before", book.ID)
+	require.NoError(err)
+
+	result, err := service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	assert.Equal(205, result.Created)
+	assert.Equal([]int{100, 100, 5}, batchSizes)
+}
+
+func TestMultigetMatchesEquivalentAbsoluteHref(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var responseHref string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/books/personal/", r.URL.Path)
+		writeDAVXML(t, w, syncResponse(cardResponse(responseHref, `&quot;one&quot;`, "alice"), ""))
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(err)
+	origin := mustParseURL(t, "http://contacts.example:"+serverURL.Port())
+	responseHref = "http://CONTACTS.example:" + serverURL.Port() + "/books/personal/alice.vcf"
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("127.0.0.1"))
+	client, err := NewClient(ClientOptions{CredentialOrigin: origin, Resolver: resolver})
+	require.NoError(err)
+	client.allowPrivateOrigin = true
+	service := NewService(testutil.NewTestStore(t), client)
+	collection := mustParseURL(t, origin.String()+"/books/personal/")
+	requestedHref := origin.String() + "/books/personal/alice.vcf"
+
+	resources, missing, err := service.fetchMultiget(t.Context(), collection,
+		[]string{requestedHref}, &operationBudget{remaining: defaultOperationBytes})
+
+	require.NoError(err)
+	assert.Empty(missing)
+	require.Len(resources, 1)
+	assert.Equal(requestedHref, resources[0].Href)
+}
+
+func TestMultigetCanonicalizesEquivalentMissingHref(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var responseHref string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/books/personal/", r.URL.Path)
+		missing := `<D:response><D:href>` + responseHref +
+			`</D:href><D:status>HTTP/1.1 404 Not Found</D:status></D:response>`
+		writeDAVXML(t, w, syncResponse(missing, ""))
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(err)
+	origin := mustParseURL(t, "http://contacts.example:"+serverURL.Port())
+	responseHref = "http://CONTACTS.example:" + serverURL.Port() + "/books/personal/alice.vcf"
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("127.0.0.1"))
+	client, err := NewClient(ClientOptions{CredentialOrigin: origin, Resolver: resolver})
+	require.NoError(err)
+	client.allowPrivateOrigin = true
+	service := NewService(testutil.NewTestStore(t), client)
+	collection := mustParseURL(t, origin.String()+"/books/personal/")
+	requestedHref := origin.String() + "/books/personal/alice.vcf"
+
+	resources, missing, err := service.fetchMultiget(t.Context(), collection,
+		[]string{requestedHref}, &operationBudget{remaining: defaultOperationBytes})
+
+	require.NoError(err)
+	assert.Empty(resources)
+	assert.Equal([]string{requestedHref}, missing)
+}
+
+func TestSyncContinuesTruncated507PageWithNextToken(t *testing.T) {
+	syncRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			syncRequests++
+			if syncRequests == 1 {
+				events := changedResponse("/books/personal/alice.vcf", `&quot;one&quot;`) +
+					`<D:response><D:href>/books/personal/</D:href><D:status>HTTP/1.1 507 Insufficient Storage</D:status></D:response>`
+				writeDAVXML(t, w, syncResponse(events, "page-2"))
+				return
+			}
+			assert.Equal(t, "page-2", syncRequestToken(body))
+			writeDAVXML(t, w, syncResponse(changedResponse("/books/personal/bob.vcf", `&quot;two&quot;`), "final"))
+			return
+		}
+		var cards strings.Builder
+		for _, href := range requestedHrefs(body) {
+			cards.WriteString(cardResponse(href, `&quot;card&quot;`, strings.TrimSuffix(path.Base(href), ".vcf")))
+		}
+		writeDAVXML(t, w, syncResponse(cards.String(), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, _, _ := newPullService(t, server, true)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Created)
+	assert.Equal(t, 2, syncRequests)
+}
+
+func TestInitialSyncSendsEmptyTokenAndFallsBackToIndividualGET(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	reports, gets := 0, 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "REPORT":
+			reports++
+			body := readRequestBody(t, r)
+			if strings.Contains(body, "addressbook-multiget") {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			assert.Contains(body, "sync-token")
+			assert.Empty(syncRequestToken(body))
+			writeDAVXML(t, w, syncResponse(
+				changedResponse("/books/personal/alice.vcf", `&quot;one&quot;`), "next",
+			))
+		case http.MethodGet:
+			gets++
+			w.Header().Set("ETag", `"one"`)
+			_, err := w.Write(conflictCard("alice", "Alice"))
+			assert.NoError(err)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET supports_multiget = FALSE WHERE id = ?`),
+		book.ID)
+	require.NoError(err)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(1, result.Created)
+	assert.Equal(1, reports)
+	assert.Equal(1, gets)
+}
+
+func TestSyncFallsBackWhenAdvertisedMultigetIsUnsupported(t *testing.T) {
+	for _, status := range []int{http.StatusMethodNotAllowed, http.StatusNotImplemented} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			reports, gets := 0, 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case "REPORT":
+					reports++
+					body := readRequestBody(t, r)
+					if strings.Contains(body, "addressbook-multiget") {
+						w.WriteHeader(status)
+						return
+					}
+					writeDAVXML(t, w, syncResponse(
+						changedResponse("/books/personal/alice.vcf", `&quot;one&quot;`), "next",
+					))
+				case http.MethodGet:
+					gets++
+					w.Header().Set("ETag", `"one"`)
+					_, err := w.Write(conflictCard("alice", "Alice"))
+					assert.NoError(err)
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			t.Cleanup(server.Close)
+			service, _, _ := newPullService(t, server, true)
+
+			result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+			require.NoError(err)
+			assert.Equal(1, result.Created)
+			assert.Equal(2, reports)
+			assert.Equal(1, gets)
+		})
+	}
+}
+
+func TestSyncContinuesTruncated507PageAcrossEquivalentCollectionURLs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	syncRequests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		if strings.Contains(body, "sync-collection") {
+			syncRequests++
+			if syncRequests == 1 {
+				events := changedResponse("/books/personal/alice.vcf", `&quot;one&quot;`) +
+					`<D:response><D:href>/books/personal/</D:href><D:status>HTTP/1.1 507 Insufficient Storage</D:status></D:response>`
+				writeDAVXML(t, w, syncResponse(events, "page-2"))
+				return
+			}
+			assert.Equal("page-2", syncRequestToken(body))
+			writeDAVXML(t, w, syncResponse(changedResponse("/books/personal/bob.vcf", `&quot;two&quot;`), "final"))
+			return
+		}
+		var cards strings.Builder
+		for _, href := range requestedHrefs(body) {
+			cards.WriteString(cardResponse(href, `&quot;card&quot;`, strings.TrimSuffix(path.Base(href), ".vcf")))
+		}
+		writeDAVXML(t, w, syncResponse(cards.String(), ""))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET canonical_url = ? WHERE id = ?`), server.URL+"/books/personal", book.ID)
+	require.NoError(err)
+
+	result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.NoError(err)
+	assert.Equal(2, result.Created)
+	assert.Equal(2, syncRequests)
+}
+
+func TestSyncRejectsContinuationTokenCycle(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		events := `<D:response><D:href>/books/personal/</D:href><D:status>HTTP/1.1 507 Insufficient Storage</D:status></D:response>`
+		writeDAVXML(t, w, syncResponse(events, "cycle"))
+	}))
+	t.Cleanup(server.Close)
+	service, _, _ := newPullService(t, server, true)
+
+	_, err := service.Sync(t.Context(), SyncOptions{Full: true})
+	require.ErrorIs(t, err, ErrSyncTokenCycle)
+}
+
+func TestSyncReconcilesInvalidSyncTokenOnce(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		requests++
+		if requests == 1 {
+			w.WriteHeader(http.StatusForbidden)
+			_, err := w.Write([]byte(`<D:error xmlns:D="DAV:"><D:valid-sync-token/></D:error>`))
+			assert.NoError(t, err)
+			return
+		}
+		assert.Empty(t, syncRequestToken(body))
+		writeDAVXML(t, w, syncResponse("", "fresh-token"))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET sync_token = ? WHERE id = ?`), "stale-token", book.ID)
+	require.NoError(t, err)
+
+	_, err = service.Sync(t.Context(), SyncOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 2, requests)
+}
+
+func TestManualFullSyncMarksSnapshotAsCompleteReconciliation(t *testing.T) {
+	for _, supportsSync := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sync-collection=%t", supportsSync), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeDAVXML(t, w, syncResponse("", "fresh-token"))
+			}))
+			t.Cleanup(server.Close)
+			service, st, book := newPullService(t, server, supportsSync)
+			account, err := st.GetCardDAVAccountContext(t.Context())
+			require.NoError(err)
+			require.NotNil(account)
+
+			plan, err := service.fetchBookPlan(t.Context(), *account, book, SyncOptions{Full: true},
+				&operationBudget{remaining: defaultOperationBytes}, &bookSyncState{})
+			require.NoError(err)
+			assert.True(plan.CompletesFullReconcile)
+		})
+	}
+}
+
+func TestSyncDowngradesUnsupportedSyncCollectionToSnapshot(t *testing.T) {
+	for _, status := range []int{http.StatusMethodNotAllowed, http.StatusNotImplemented} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body := readRequestBody(t, r)
+				requests++
+				if strings.Contains(body, "sync-collection") {
+					w.WriteHeader(status)
+					return
+				}
+				writeDAVXML(t, w, syncResponse(cardResponse("/books/personal/alice.vcf", `&quot;one&quot;`, "alice"), ""))
+			}))
+			t.Cleanup(server.Close)
+			service, _, _ := newPullService(t, server, true)
+
+			result, err := service.Sync(t.Context(), SyncOptions{Full: true})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Created)
+			assert.Equal(t, 2, requests)
+		})
+	}
+}
+
+func TestParseRemoteResourceStripsContactSchemesCaseInsensitively(t *testing.T) {
+	body := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:schemes\r\nFN:Schemes\r\n" +
+		"EMAIL:MAILTO:Alice@Example.test\r\nTEL:TeL:+1-202-555-0100\r\nEND:VCARD\r\n")
+
+	resource, err := parseRemoteResource("https://contacts.example/schemes.vcf", `"one"`, body)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Alice@Example.test"}, resource.Emails)
+	assert.Equal(t, []string{"+1-202-555-0100"}, resource.Phones)
+}
+
+func TestParseRemoteResourceDecodesTextContactValues(t *testing.T) {
+	assert := assert.New(t)
+	body := []byte("BEGIN:VCARD\r\nVERSION:3.0\r\nUID:escaped\r\n" +
+		`FN:Doe\, Jane` + "\r\n" +
+		`EMAIL:local\,tag@example.test` + "\r\n" +
+		`TEL:+1\,202` + "\r\nEND:VCARD\r\n")
+
+	resource, err := parseRemoteResource("https://contacts.example/escaped.vcf", `"one"`, body)
+	require.NoError(t, err)
+	assert.Equal("Doe, Jane", resource.DisplayName)
+	assert.Equal([]string{"local,tag@example.test"}, resource.Emails)
+	assert.Equal([]string{"+1,202"}, resource.Phones)
+}

--- a/internal/carddav/roles.go
+++ b/internal/carddav/roles.go
@@ -1,0 +1,39 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type BookRoles struct {
+	WriteTarget  bool
+	Subscribed   bool
+	LookupSource bool
+}
+
+func (s *Service) ListBooks(ctx context.Context) ([]store.CardDAVAddressBook, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("CardDAV service is not configured")
+	}
+	return s.store.ListCardDAVAddressBooksContext(ctx)
+}
+
+func (s *Service) SetBookRoles(ctx context.Context, bookID int64, roles BookRoles) error {
+	if s == nil || s.store == nil {
+		return errors.New("CardDAV service is not configured")
+	}
+	return s.store.SetCardDAVBookRolesContext(ctx, bookID, store.CardDAVBookRoles{
+		IsWriteTarget:  roles.WriteTarget,
+		IsSubscribed:   roles.Subscribed,
+		IsLookupSource: roles.LookupSource,
+	})
+}
+
+func (s *Service) Publication(ctx context.Context, personID int64) (*store.CardDAVPublication, error) {
+	if s == nil || s.store == nil || personID <= 0 {
+		return nil, errors.New("CardDAV service is not configured")
+	}
+	return s.store.GetCardDAVPublicationContext(ctx, personID)
+}

--- a/internal/carddav/roles_test.go
+++ b/internal/carddav/roles_test.go
@@ -1,0 +1,304 @@
+package carddav
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestListBooksAndSetBookRolesUseServiceContract(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	service, _, book := newPullService(t, server, false)
+
+	books, err := service.ListBooks(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(t, book.ID, books[0].ID)
+
+	require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{
+		Subscribed: true, LookupSource: true, WriteTarget: true,
+	}))
+}
+
+func TestNonWriteTargetPendingMutationNeverReachesServer(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	service, _, book := newPullService(t, server, false)
+	require.NoError(t, service.SetBookRoles(t.Context(), book.ID, BookRoles{
+		Subscribed: true, LookupSource: true,
+	}))
+
+	err := service.executeMutation(t.Context(), &store.CardDAVPublication{
+		PersonID: 1, Desired: true, AddressBookID: book.ID,
+		Href: book.CanonicalURL + "person.vcf", PendingOperation: store.CardDAVMutationUpdate,
+		OutgoingBody: []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:person\r\nFN:Person\r\nEND:VCARD\r\n"),
+		RemoteETag:   `"one"`,
+	})
+	require.ErrorIs(t, err, store.ErrCardDAVNoWriteTarget)
+	assert.Zero(t, requests)
+}
+
+func TestRoleWideningForcesOneFullReconcile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var tokens []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readRequestBody(t, r)
+		tokens = append(tokens, syncRequestToken(body))
+		writeDAVXML(t, w, syncResponse("", "next-token"))
+	}))
+	t.Cleanup(server.Close)
+	service, st, book := newPullService(t, server, true)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_write_target = FALSE, is_subscribed = FALSE, is_lookup_source = FALSE,
+		    sync_token = ? WHERE id = ?`), "incremental-token", book.ID)
+	require.NoError(err)
+
+	require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{LookupSource: true}))
+	_, err = service.Sync(t.Context(), SyncOptions{})
+	require.NoError(err)
+	assert.Equal([]string{""}, tokens)
+	books, err := service.ListBooks(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.False(books[0].NeedsFullReconcile)
+	assert.Equal("next-token", books[0].SyncToken)
+}
+
+func TestRoleWideningReconcilesUnchangedUnboundResources(t *testing.T) {
+	tests := []struct {
+		name             string
+		prepare          func(t *testing.T, service *Service, st *store.Store, book store.CardDAVAddressBook) int64
+		wantSamePerson   bool
+		wantRequestCount int
+	}{
+		{
+			name: "lookup-only to subscribed materializes",
+			prepare: func(t *testing.T, service *Service, _ *store.Store, book store.CardDAVAddressBook) int64 {
+				t.Helper()
+				require.NoError(t, service.SetBookRoles(t.Context(), book.ID, BookRoles{
+					Subscribed: true, LookupSource: true,
+				}))
+				require.NoError(t, service.SetBookRoles(t.Context(), book.ID, BookRoles{LookupSource: true}))
+				return 0
+			},
+			wantRequestCount: 3,
+		},
+		{
+			name: "demoted subscription rebinds preserved person",
+			prepare: func(t *testing.T, service *Service, st *store.Store, book store.CardDAVAddressBook) int64 {
+				t.Helper()
+				_, err := service.Sync(t.Context(), SyncOptions{})
+				require.NoError(t, err)
+				mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"alice.vcf")
+				require.NoError(t, err)
+				require.NotNil(t, mapping.PersonID)
+				person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+				require.NoError(t, err)
+				_, err = st.UpdatePersonDisplayNameContext(t.Context(), person.ID, person.Revision, new("User preserved"))
+				require.NoError(t, err)
+				require.NoError(t, service.SetBookRoles(t.Context(), book.ID, BookRoles{
+					Subscribed: true, LookupSource: true,
+				}))
+				require.NoError(t, service.SetBookRoles(t.Context(), book.ID, BookRoles{LookupSource: true}))
+				return person.ID
+			},
+			wantSamePerson:   true,
+			wantRequestCount: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			requests := 0
+			failNext := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				if failNext {
+					failNext = false
+					http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+					return
+				}
+				writeDAVXML(t, w, syncResponse(
+					cardResponse("/books/personal/alice.vcf", `&quot;one&quot;`, "alice"), "",
+				))
+			}))
+			t.Cleanup(server.Close)
+			service, st, book := newPullService(t, server, false)
+			preparedPersonID := tt.prepare(t, service, st, book)
+
+			_, err := service.Sync(t.Context(), SyncOptions{})
+			require.NoError(err)
+			mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"alice.vcf")
+			require.NoError(err)
+			assert.Nil(mapping.PersonID)
+
+			require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{
+				Subscribed: true, LookupSource: true,
+			}))
+			failNext = true
+			_, err = service.Sync(t.Context(), SyncOptions{})
+			require.Error(err)
+			books, listErr := service.ListBooks(t.Context())
+			require.NoError(listErr)
+			require.Len(books, 1)
+			assert.True(books[0].NeedsFullReconcile)
+
+			_, err = service.Sync(t.Context(), SyncOptions{})
+			require.NoError(err)
+			mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, book.CanonicalURL+"alice.vcf")
+			require.NoError(err)
+			require.NotNil(mapping.PersonID)
+			if tt.wantSamePerson {
+				assert.Equal(preparedPersonID, *mapping.PersonID)
+			}
+			people, err := st.ListPersonsContext(t.Context())
+			require.NoError(err)
+			assert.Len(people, 1, "role widening must materialize or rebind exactly once")
+			books, err = service.ListBooks(t.Context())
+			require.NoError(err)
+			assert.False(books[0].NeedsFullReconcile)
+			assert.Equal(tt.wantRequestCount, requests)
+		})
+	}
+}
+
+func TestRoleWideningPreservesMappedLocalTombstones(t *testing.T) {
+	tests := []struct {
+		name          string
+		changeRemote  bool
+		wantConflicts int
+	}{
+		{name: "unchanged remote stays deleted"},
+		{name: "changed remote captures conflict", changeRemote: true, wantConflicts: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			remoteBody := conflictCard("alice", "Alice Base")
+			remoteETag := `"one"`
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeDAVXML(t, w, syncResponse(cardResponseRaw(
+					"/books/personal/alice.vcf", remoteETag, escapedCardData(remoteBody),
+				), ""))
+			}))
+			t.Cleanup(server.Close)
+			service, st, book := newPullService(t, server, false)
+			require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{
+				Subscribed: true, LookupSource: true,
+			}))
+
+			_, err := service.Sync(t.Context(), SyncOptions{})
+			require.NoError(err)
+			href := book.CanonicalURL + "alice.vcf"
+			mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+			require.NoError(err)
+			require.NotNil(mapping.PersonID)
+			person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+			require.NoError(err)
+			require.NoError(st.DeletePersonContext(t.Context(), person.ID, person.Revision))
+
+			deleted, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+			require.NoError(err)
+			assert.Nil(deleted.PersonID)
+			assert.Equal(store.CardDAVMappingMapped, deleted.MappingStatus)
+
+			require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{LookupSource: true}))
+			demoted, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+			require.NoError(err)
+			assert.Nil(demoted.PersonID)
+			assert.Equal(store.CardDAVMappingMapped, demoted.MappingStatus,
+				"role demotion must retain the local tombstone distinction")
+
+			require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{
+				Subscribed: true, LookupSource: true,
+			}))
+			if tt.changeRemote {
+				remoteBody = conflictCard("alice", "Alice Remote")
+				remoteETag = `"two"`
+			}
+			_, err = service.Sync(t.Context(), SyncOptions{})
+			require.NoError(err)
+
+			after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+			require.NoError(err)
+			assert.Nil(after.PersonID)
+			assert.Equal(store.CardDAVMappingMapped, after.MappingStatus)
+			if !tt.changeRemote {
+				assert.Equal(demoted.MappingRevision, after.MappingRevision,
+					"unchanged full reconciliation must not rewrite the tombstone")
+				assert.Equal(demoted.RemoteBody, after.RemoteBody)
+				assert.Equal(demoted.RemoteETag, after.RemoteETag)
+			}
+			people, err := st.ListPersonsContext(t.Context())
+			require.NoError(err)
+			assert.Empty(people)
+			conflicts, err := service.ListConflicts(t.Context())
+			require.NoError(err)
+			assert.Len(conflicts, tt.wantConflicts)
+			if tt.changeRemote {
+				require.Len(conflicts, 1)
+				assert.True(conflicts[0].LocalTombstone)
+				assert.Equal(remoteBody, conflicts[0].RemoteBody)
+			}
+			books, err := service.ListBooks(t.Context())
+			require.NoError(err)
+			require.Len(books, 1)
+			assert.False(books[0].NeedsFullReconcile)
+		})
+	}
+}
+
+func TestSyncStopsWhenBookBecomesIgnoredBetweenFetchAndApply(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	requests := 0
+	var service *Service
+	var book store.CardDAVAddressBook
+	var roleErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			roleErr = service.SetBookRoles(t.Context(), book.ID, BookRoles{})
+		}
+		writeDAVXML(t, w, syncResponse(
+			cardResponse("/books/personal/alice.vcf", `&quot;one&quot;`, "alice"), "",
+		))
+	}))
+	t.Cleanup(server.Close)
+	var st *store.Store
+	service, st, book = newPullService(t, server, false)
+	require.NoError(service.SetBookRoles(t.Context(), book.ID, BookRoles{
+		Subscribed: true, LookupSource: true,
+	}))
+
+	result, err := service.Sync(t.Context(), SyncOptions{})
+	require.NoError(roleErr)
+	require.NoError(err)
+	assert.Zero(result.Books)
+	assert.Equal(1, requests, "the stale retry must not refetch an ignored book")
+	ledger, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	assert.Empty(ledger)
+}

--- a/internal/carddav/transport.go
+++ b/internal/carddav/transport.go
@@ -1,0 +1,390 @@
+package carddav
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/netguard"
+)
+
+// Client sends authenticated DAV requests only to its credential origin.
+type Client struct {
+	origin             *url.URL
+	username           string
+	password           string
+	requestTimeout     time.Duration
+	operationTimeout   time.Duration
+	responseBytes      int64
+	operationBytes     int64
+	resolver           *net.Resolver
+	dialContext        func(context.Context, string, string) (net.Conn, error)
+	allowPrivateOrigin bool // test seam for local httptest servers
+}
+
+// NewClient creates a client with the task-wide default time and byte limits
+// when an option is zero.
+func NewClient(options ClientOptions) (*Client, error) {
+	if options.CredentialOrigin == nil {
+		return nil, fmt.Errorf("credential origin: %w", ErrUnsafeTarget)
+	}
+	origin := *options.CredentialOrigin
+	if !validHTTPURL(&origin) {
+		return nil, fmt.Errorf("credential origin: %w", ErrUnsafeTarget)
+	}
+	if origin.Scheme != "https" && (options.Username != "" || options.Password != "") &&
+		!options.AllowInsecureCredentials {
+		return nil, fmt.Errorf("credential origin requires HTTPS: %w", ErrUnsafeTarget)
+	}
+	origin.Path = ""
+	origin.RawPath = ""
+	origin.RawQuery = ""
+	origin.Fragment = ""
+
+	if options.RequestTimeout <= 0 {
+		options.RequestTimeout = defaultRequestTimeout
+	}
+	if options.OperationTimeout <= 0 {
+		options.OperationTimeout = defaultOperationTimeout
+	}
+	if options.ResponseBytes <= 0 {
+		options.ResponseBytes = defaultResponseBytes
+	}
+	if options.OperationBytes <= 0 {
+		options.OperationBytes = defaultOperationBytes
+	}
+	if options.Resolver == nil {
+		options.Resolver = net.DefaultResolver
+	}
+	if options.DialContext == nil {
+		dialer := &net.Dialer{Timeout: options.RequestTimeout}
+		options.DialContext = dialer.DialContext
+	}
+	return &Client{
+		origin: originURL(&origin), username: options.Username, password: options.Password,
+		requestTimeout: options.RequestTimeout, operationTimeout: options.OperationTimeout,
+		responseBytes: options.ResponseBytes, operationBytes: options.OperationBytes,
+		resolver: options.Resolver, dialContext: options.DialContext,
+	}, nil
+}
+
+// Do performs one DAV request, manually validating and following only
+// same-origin redirects. Each connection is pinned to one of the addresses
+// validated immediately before it is dialed.
+func (c *Client) Do(ctx context.Context, request Request) (*Response, error) {
+	operationCtx, cancelOperation := context.WithTimeout(ctx, c.operationTimeout)
+	defer cancelOperation()
+
+	target, err := url.Parse(request.URL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing DAV URL: %w", ErrUnsafeTarget)
+	}
+	var operationBytes int64
+	for redirects := 0; ; redirects++ {
+		pinned, err := c.validateTarget(operationCtx, target)
+		if err != nil {
+			return nil, err
+		}
+		response, status, err := c.doPinned(operationCtx, target, pinned, request, &operationBytes)
+		if response != nil {
+			response.transferredBytes = operationBytes
+		}
+		if err != nil {
+			return response, err
+		}
+		if isRedirect(status) {
+			if isDAVMutation(request.Method) && status != http.StatusTemporaryRedirect && status != http.StatusPermanentRedirect {
+				return response, fmt.Errorf("ambiguous mutation redirect: %w", ErrUnsafeRedirect)
+			}
+			if redirects >= 3 {
+				return response, fmt.Errorf("redirect limit: %w", ErrUnsafeRedirect)
+			}
+			location := response.Header.Get("Location")
+			next, parseErr := target.Parse(location)
+			if location == "" || parseErr != nil || !sameOrigin(c.origin, next) {
+				return response, fmt.Errorf("redirect target: %w", ErrUnsafeRedirect)
+			}
+			target = next
+			continue
+		}
+		if status >= http.StatusBadRequest {
+			return response, &StatusError{
+				StatusCode:   status,
+				RetryAfter:   retryAfter(response.Header.Get("Retry-After"), time.Now()),
+				Precondition: davErrorPrecondition(response.Body),
+			}
+		}
+		effectiveURL := *target
+		response.EffectiveURL = &effectiveURL
+		return response, nil
+	}
+}
+
+func (c *Client) doWithBudget(
+	ctx context.Context, request Request, budget *operationBudget,
+) (*Response, error) {
+	if budget == nil {
+		return c.Do(ctx, request)
+	}
+	if budget.remaining <= 0 {
+		return nil, ErrOperationLimit
+	}
+	limited := *c
+	limited.operationBytes = min(limited.operationBytes, budget.remaining)
+	response, err := limited.Do(ctx, request)
+	if response != nil {
+		if budgetErr := budget.consume(response); budgetErr != nil {
+			return nil, budgetErr
+		}
+	}
+	return response, err
+}
+
+func davErrorPrecondition(body []byte) string {
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return ""
+		}
+		start, ok := token.(xml.StartElement)
+		if ok && start.Name.Space == davNamespace && start.Name.Local == "valid-sync-token" {
+			return start.Name.Local
+		}
+	}
+}
+
+func (c *Client) validateTarget(ctx context.Context, target *url.URL) ([]netip.AddrPort, error) {
+	if !validHTTPURL(target) || !sameOrigin(c.origin, target) {
+		return nil, fmt.Errorf("DAV URL: %w", ErrUnsafeTarget)
+	}
+	port, err := targetPort(target)
+	if err != nil {
+		return nil, fmt.Errorf("DAV URL port: %w", ErrUnsafeTarget)
+	}
+	host := target.Hostname()
+	if literal, parseErr := netip.ParseAddr(host); parseErr == nil {
+		if netguard.ProhibitedIP(literal) && !c.allowPrivateOrigin {
+			return nil, fmt.Errorf("DAV literal destination: %w", ErrUnsafeTarget)
+		}
+		return []netip.AddrPort{netip.AddrPortFrom(literal.Unmap(), port)}, nil
+	}
+	if netguard.ProhibitedHostname(host) {
+		return nil, fmt.Errorf("DAV hostname: %w", ErrUnsafeTarget)
+	}
+	addrs, err := c.resolver.LookupNetIP(ctx, "ip", host)
+	if err != nil || len(addrs) == 0 {
+		return nil, fmt.Errorf("resolving DAV host %q: %w", host, err)
+	}
+	pinned := make([]netip.AddrPort, 0, len(addrs))
+	seen := make(map[netip.AddrPort]bool, len(addrs))
+	for _, addr := range addrs {
+		if netguard.ProhibitedIP(addr) && !c.allowPrivateOrigin {
+			return nil, fmt.Errorf("DAV resolved destination: %w", ErrUnsafeTarget)
+		}
+		candidate := netip.AddrPortFrom(addr.Unmap(), port)
+		if !seen[candidate] {
+			seen[candidate] = true
+			pinned = append(pinned, candidate)
+		}
+	}
+	return pinned, nil
+}
+
+func (c *Client) doPinned(ctx context.Context, target *url.URL, pinned []netip.AddrPort, davRequest Request, operationBytes *int64) (*Response, int, error) {
+	requestCtx, cancelRequest := context.WithTimeout(ctx, c.requestTimeout)
+	defer cancelRequest()
+	transport := &http.Transport{
+		DialContext: func(dialCtx context.Context, network, _ string) (net.Conn, error) {
+			var failures []error
+			for index, address := range pinned {
+				attemptCtx := dialCtx
+				cancelAttempt := func() {}
+				if deadline, ok := dialCtx.Deadline(); ok && index < len(pinned)-1 {
+					remaining := time.Until(deadline)
+					if remaining <= 0 {
+						return nil, dialCtx.Err()
+					}
+					attemptCtx, cancelAttempt = context.WithTimeout(
+						dialCtx, remaining/time.Duration(len(pinned)-index),
+					)
+				}
+				connection, err := c.dialContext(attemptCtx, network, address.String())
+				cancelAttempt()
+				if err == nil {
+					return connection, nil
+				}
+				failures = append(failures, err)
+			}
+			return nil, errors.Join(failures...)
+		},
+		TLSHandshakeTimeout: c.requestTimeout,
+		DisableKeepAlives:   true,
+	}
+	client := &http.Client{
+		Transport:     transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	req, err := http.NewRequestWithContext(requestCtx, davRequest.Method, target.String(), bytes.NewReader(davRequest.Body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("building DAV request: %w", err)
+	}
+	if len(davRequest.Body) > 0 {
+		contentType := "application/xml; charset=utf-8"
+		if davRequest.Method == http.MethodPut {
+			contentType = "text/vcard; charset=utf-8"
+		}
+		req.Header.Set("Content-Type", contentType)
+	}
+	if davRequest.Depth != nil {
+		req.Header.Set("Depth", strconv.Itoa(*davRequest.Depth))
+	}
+	if davRequest.Create {
+		req.Header.Set("If-None-Match", "*")
+	} else if davRequest.ETag != "" {
+		req.Header.Set("If-Match", davRequest.ETag)
+	}
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	httpResponse, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("DAV request: %w", err)
+	}
+	defer func() { _ = httpResponse.Body.Close() }()
+	body, err := c.readResponseBody(httpResponse.Body, operationBytes)
+	response := &Response{StatusCode: httpResponse.StatusCode, Header: httpResponse.Header.Clone(), Body: body}
+	if err != nil {
+		return response, httpResponse.StatusCode, err
+	}
+	return response, httpResponse.StatusCode, nil
+}
+
+func (c *Client) readResponseBody(reader io.Reader, operationBytes *int64) ([]byte, error) {
+	remaining := c.operationBytes - *operationBytes
+	if remaining < 0 {
+		return nil, ErrOperationLimit
+	}
+	limit := min(c.responseBytes, remaining)
+	limited := io.LimitReader(reader, limit+1)
+	var body bytes.Buffer
+	buffer := make([]byte, 32<<10)
+	for {
+		read, err := limited.Read(buffer)
+		if read > 0 {
+			*operationBytes += int64(read)
+			_, _ = body.Write(buffer[:read])
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return body.Bytes(), fmt.Errorf("reading DAV response: %w", err)
+		}
+	}
+	if int64(body.Len()) > limit {
+		if remaining <= c.responseBytes {
+			return body.Bytes(), ErrOperationLimit
+		}
+		return body.Bytes(), ErrResponseLimit
+	}
+	return body.Bytes(), nil
+}
+
+// ValidateChildHref resolves href from collection and rejects resources that
+// leave the credential origin or collection. It reuses the request target
+// validation path so literal and resolved destinations remain denylisted.
+func (c *Client) ValidateChildHref(ctx context.Context, collection *url.URL, href string) (*url.URL, error) {
+	if collection == nil || !validHTTPURL(collection) || href == "" || !sameOrigin(c.origin, collection) {
+		return nil, ErrUnsafeHref
+	}
+	resolved, err := collection.Parse(href)
+	if err != nil || resolved.User != nil || resolved.Fragment != "" || !sameOrigin(c.origin, resolved) {
+		return nil, ErrUnsafeHref
+	}
+	basePath := path.Clean(collection.Path)
+	if !strings.HasSuffix(collection.Path, "/") {
+		basePath = path.Dir(basePath)
+	}
+	childPath := path.Clean(resolved.Path)
+	if childPath != basePath && !strings.HasPrefix(childPath, strings.TrimSuffix(basePath, "/")+"/") {
+		return nil, ErrUnsafeHref
+	}
+	if _, err := c.validateTarget(ctx, resolved); err != nil {
+		return nil, fmt.Errorf("href target: %w: %w", ErrUnsafeHref, err)
+	}
+	return resolved, nil
+}
+
+func validHTTPURL(target *url.URL) bool {
+	return target != nil && (target.Scheme == "http" || target.Scheme == "https") && target.Hostname() != "" && target.User == nil
+}
+
+func originURL(target *url.URL) *url.URL {
+	clone := *target
+	clone.Path, clone.RawPath, clone.RawQuery, clone.Fragment = "", "", "", ""
+	return &clone
+}
+
+func sameOrigin(left, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Hostname(), right.Hostname()) &&
+		originPort(left) == originPort(right)
+}
+
+func originPort(target *url.URL) string {
+	if port := target.Port(); port != "" {
+		return port
+	}
+	if strings.EqualFold(target.Scheme, "https") {
+		return "443"
+	}
+	return "80"
+}
+
+func targetPort(target *url.URL) (uint16, error) {
+	if rawPort := target.Port(); rawPort != "" {
+		port, err := strconv.ParseUint(rawPort, 10, 16)
+		if err != nil || port == 0 {
+			return 0, errors.New("invalid port")
+		}
+		return uint16(port), nil
+	}
+	if target.Scheme == "https" {
+		return 443, nil
+	}
+	return 80, nil
+}
+
+func isRedirect(status int) bool {
+	return status == http.StatusMovedPermanently || status == http.StatusFound || status == http.StatusSeeOther || status == http.StatusTemporaryRedirect || status == http.StatusPermanentRedirect
+}
+
+func isDAVMutation(method string) bool {
+	return method == http.MethodPut || method == http.MethodDelete
+}
+
+func retryAfter(value string, now time.Time) time.Duration {
+	const maximum = time.Hour
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds >= 0 {
+		return min(time.Duration(seconds)*time.Second, maximum)
+	}
+	if deadline, err := http.ParseTime(value); err == nil && deadline.After(now) {
+		return min(time.Until(deadline), maximum)
+	}
+	return 0
+}

--- a/internal/carddav/transport_test.go
+++ b/internal/carddav/transport_test.go
@@ -1,0 +1,395 @@
+package carddav
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFixtureClient(t *testing.T, rawOrigin, username, password string) *Client {
+	t.Helper()
+	origin, err := url.Parse(rawOrigin)
+	require.NoError(t, err)
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin:         origin,
+		Username:                 username,
+		Password:                 password,
+		AllowInsecureCredentials: true,
+	})
+	require.NoError(t, err)
+	client.allowPrivateOrigin = true
+	return client
+}
+
+func TestClientRejectsCredentialsOverHTTPByDefault(t *testing.T) {
+	origin, err := url.Parse("http://contacts.example/dav")
+	require.NoError(t, err)
+
+	_, err = NewClient(ClientOptions{
+		CredentialOrigin: origin, Username: "alice", Password: "app-password",
+	})
+	require.ErrorIs(t, err, ErrUnsafeTarget)
+}
+
+func TestClientNeverSendsBasicAuthAcrossOrigin(t *testing.T) {
+	var redirectedAuth string
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusMultiStatus)
+	}))
+	t.Cleanup(destination.Close)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusFound)
+	}))
+	t.Cleanup(source.Close)
+
+	client := newFixtureClient(t, source.URL, "alice", "app-password")
+	_, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: source.URL})
+	require.ErrorIs(t, err, ErrUnsafeRedirect)
+	assert.Empty(t, redirectedAuth)
+}
+
+func TestClientSetsDAVPreconditionsAndTypedStatusErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Basic YWxpY2U6YXBwLXBhc3N3b3Jk", r.Header.Get("Authorization"))
+		assert.Equal(t, "1", r.Header.Get("Depth"))
+		assert.Equal(t, "\"prior\"", r.Header.Get("If-Match"))
+		w.Header().Set("Retry-After", "90")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	depth := 1
+	client := newFixtureClient(t, server.URL, "alice", "app-password")
+	_, err := client.Do(t.Context(), Request{
+		Method: "PROPFIND", URL: server.URL, Depth: &depth, ETag: "\"prior\"",
+	})
+	var statusErr *StatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusTooManyRequests, statusErr.StatusCode)
+	assert.Equal(t, 90, int(statusErr.RetryAfter.Seconds()))
+}
+
+func TestClientValidateChildHrefRejectsOriginAndCollectionEscapes(t *testing.T) {
+	require := require.New(t)
+
+	base, err := url.Parse("https://contacts.example/dav/books/personal/")
+	require.NoError(err)
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("203.0.113.9"))
+	client, err := NewClient(ClientOptions{CredentialOrigin: base, Resolver: resolver})
+	require.NoError(err)
+
+	valid, err := client.ValidateChildHref(t.Context(), base, "alice.vcf")
+	require.NoError(err)
+	assert.Equal(t, "https://contacts.example/dav/books/personal/alice.vcf", valid.String())
+
+	for _, href := range []string{
+		"https://elsewhere.example/card.vcf",
+		"/dav/books/other/card.vcf",
+		"../card.vcf",
+		"alice.vcf#one",
+	} {
+		_, err = client.ValidateChildHref(t.Context(), base, href)
+		require.ErrorIsf(err, ErrUnsafeHref, "%q", href)
+	}
+}
+
+func TestClientValidateChildHrefTreatsExplicitDefaultPortAsSameOrigin(t *testing.T) {
+	require := require.New(t)
+
+	base, err := url.Parse("https://contacts.example/dav/books/personal/")
+	require.NoError(err)
+	resolver, _ := newFixtureResolver(t, netip.MustParseAddr("203.0.113.9"))
+	client, err := NewClient(ClientOptions{CredentialOrigin: base, Resolver: resolver})
+	require.NoError(err)
+
+	resolved, err := client.ValidateChildHref(t.Context(), base, "https://contacts.example:443/dav/books/personal/alice.vcf")
+	require.NoError(err)
+	assert.Equal(t, "https://contacts.example:443/dav/books/personal/alice.vcf", resolved.String())
+}
+
+func TestClientValidateChildHrefRejectsPrivateLiteralAndDNSDestination(t *testing.T) {
+	t.Run("literal", func(t *testing.T) {
+		origin, err := url.Parse("http://127.0.0.1/dav/books/personal/")
+		require.NoError(t, err)
+		client, err := NewClient(ClientOptions{CredentialOrigin: origin})
+		require.NoError(t, err)
+
+		_, err = client.ValidateChildHref(t.Context(), origin, "alice.vcf")
+		require.ErrorIs(t, err, ErrUnsafeHref)
+	})
+
+	t.Run("DNS", func(t *testing.T) {
+		origin, err := url.Parse("http://contacts.example/dav/books/personal/")
+		require.NoError(t, err)
+		resolver, _ := newFixtureResolver(t, netip.MustParseAddr("10.0.0.8"))
+		client, err := NewClient(ClientOptions{CredentialOrigin: origin, Resolver: resolver})
+		require.NoError(t, err)
+
+		_, err = client.ValidateChildHref(t.Context(), origin, "alice.vcf")
+		require.ErrorIs(t, err, ErrUnsafeHref)
+	})
+}
+
+func TestClientPinsValidatedAddressAndRevalidatesSameOriginRedirect(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "/after", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusMultiStatus)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(err)
+	resolver, queries := newFixtureResolver(t, netip.MustParseAddr("203.0.113.9"))
+	var dialed []string
+	dialer := net.Dialer{}
+	origin, err := url.Parse("http://contacts.example:" + serverURL.Port())
+	require.NoError(err)
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin,
+		Resolver:         resolver,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			return dialer.DialContext(ctx, network, serverURL.Host)
+		},
+	})
+	require.NoError(err)
+
+	response, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: origin.String() + "/redirect"})
+	require.NoError(err)
+	assert.Equal(http.StatusMultiStatus, response.StatusCode)
+	assert.Equal([]string{"/redirect", "/after"}, paths)
+	require.Len(dialed, 2)
+	assert.Equal(net.JoinHostPort("203.0.113.9", serverURL.Port()), dialed[0])
+	assert.Equal(net.JoinHostPort("203.0.113.9", serverURL.Port()), dialed[1])
+	assert.GreaterOrEqual(queries.Load(), int32(2))
+}
+
+func TestClientTriesEveryValidatedAddressWithoutResolvingAgain(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusMultiStatus)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(err)
+	resolver, queries := newFixtureResolver(t,
+		netip.MustParseAddr("203.0.113.8"),
+		netip.MustParseAddr("203.0.113.9"),
+	)
+	origin, err := url.Parse("http://contacts.example:" + serverURL.Port())
+	require.NoError(err)
+	var dialed []string
+	dialer := net.Dialer{}
+	client, err := NewClient(ClientOptions{
+		CredentialOrigin: origin,
+		Resolver:         resolver,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			dialed = append(dialed, address)
+			if len(dialed) == 1 {
+				return nil, errors.New("fixture address is unreachable")
+			}
+			return dialer.DialContext(ctx, network, serverURL.Host)
+		},
+	})
+	require.NoError(err)
+
+	response, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: origin.String() + "/dav"})
+	require.NoError(err)
+	assert.Equal(http.StatusMultiStatus, response.StatusCode)
+	assert.ElementsMatch([]string{
+		net.JoinHostPort("203.0.113.8", serverURL.Port()),
+		net.JoinHostPort("203.0.113.9", serverURL.Port()),
+	}, dialed)
+	assert.Positive(queries.Load())
+	assert.LessOrEqual(queries.Load(), int32(2), "one LookupNetIP may issue one A and one AAAA query")
+}
+
+func TestClientNeverReplaysDAVMutationAcrossAmbiguousRedirect(t *testing.T) {
+	for _, status := range []int{http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther} {
+		for _, method := range []string{http.MethodPut, http.MethodDelete} {
+			t.Run(http.StatusText(status)+"/"+method, func(t *testing.T) {
+				var startRequests, redirectedRequests atomic.Int32
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/start":
+						startRequests.Add(1)
+						w.Header().Set("Location", "/redirected")
+						w.WriteHeader(status)
+					case "/redirected":
+						redirectedRequests.Add(1)
+						w.WriteHeader(http.StatusNoContent)
+					}
+				}))
+				t.Cleanup(server.Close)
+
+				client := newFixtureClient(t, server.URL, "", "")
+				_, err := client.Do(t.Context(), Request{Method: method, URL: server.URL + "/start", Body: []byte("synthetic-body")})
+				require.ErrorIs(t, err, ErrUnsafeRedirect)
+				assert.Equal(t, int32(1), startRequests.Load())
+				assert.Equal(t, int32(0), redirectedRequests.Load())
+			})
+		}
+	}
+}
+
+func TestClientPreservesDAVMutationOnlyAcrossSameOrigin307And308(t *testing.T) {
+	for _, status := range []int{http.StatusTemporaryRedirect, http.StatusPermanentRedirect} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var requests []struct {
+				path, method, body string
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				requests = append(requests, struct{ path, method, body string }{r.URL.Path, r.Method, string(body)})
+				if r.URL.Path == "/start" {
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(status)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(server.Close)
+
+			client := newFixtureClient(t, server.URL, "", "")
+			response, err := client.Do(t.Context(), Request{Method: http.MethodPut, URL: server.URL + "/start", Body: []byte("synthetic-body")})
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, response.StatusCode)
+			assert.Equal(t, []struct{ path, method, body string }{
+				{path: "/start", method: http.MethodPut, body: "synthetic-body"},
+				{path: "/redirected", method: http.MethodPut, body: "synthetic-body"},
+			}, requests)
+		})
+	}
+}
+
+func TestClientEnforcesResponseAndOperationByteBudgets(t *testing.T) {
+	t.Run("response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("abc"))
+		}))
+		t.Cleanup(server.Close)
+		client := newFixtureClient(t, server.URL, "", "")
+		client.responseBytes = 2
+		client.operationBytes = 10
+
+		response, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: server.URL})
+		require.ErrorIs(t, err, ErrResponseLimit)
+		require.NotNil(t, response)
+		assert.Equal(t, []byte("abc"), response.Body)
+	})
+
+	t.Run("operation across redirect", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/start" {
+				w.Header().Set("Location", "/done")
+				w.WriteHeader(http.StatusFound)
+				_, _ = w.Write([]byte("12"))
+				return
+			}
+			_, _ = w.Write([]byte("345"))
+		}))
+		t.Cleanup(server.Close)
+		client := newFixtureClient(t, server.URL, "", "")
+		client.responseBytes = 10
+		client.operationBytes = 4
+
+		_, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: server.URL + "/start"})
+		require.ErrorIs(t, err, ErrOperationLimit)
+	})
+}
+
+func TestClientHonorsRequestAndOperationTimeouts(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusMultiStatus)
+	}))
+	t.Cleanup(server.Close)
+
+	for name, configure := range map[string]func(*Client){
+		"request":   func(client *Client) { client.requestTimeout = 5 * time.Millisecond },
+		"operation": func(client *Client) { client.operationTimeout = 5 * time.Millisecond },
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := newFixtureClient(t, server.URL, "", "")
+			configure(client)
+			_, err := client.Do(t.Context(), Request{Method: "PROPFIND", URL: server.URL})
+			require.Error(t, err)
+		})
+	}
+}
+
+func newFixtureResolver(t *testing.T, addresses ...netip.Addr) (*net.Resolver, *atomic.Int32) {
+	t.Helper()
+	listener, err := net.ListenPacket("udp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	queries := new(atomic.Int32)
+	go func() {
+		buffer := make([]byte, 512)
+		for {
+			n, remote, readErr := listener.ReadFrom(buffer)
+			if readErr != nil {
+				return
+			}
+			_, _ = listener.WriteTo(fixtureDNSResponse(buffer[:n], addresses...), remote)
+		}
+	}()
+	dialer := net.Dialer{}
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			queries.Add(1)
+			return dialer.DialContext(ctx, network, listener.LocalAddr().String())
+		},
+	}, queries
+}
+
+func fixtureDNSResponse(request []byte, addresses ...netip.Addr) []byte {
+	questionEnd := 12
+	for questionEnd < len(request) && request[questionEnd] != 0 {
+		questionEnd += int(request[questionEnd]) + 1
+	}
+	questionEnd += 5
+	queryType := uint16(0)
+	if questionEnd >= 4 {
+		queryType = uint16(request[questionEnd-4])<<8 | uint16(request[questionEnd-3])
+	}
+	answers := make([]netip.Addr, 0, len(addresses))
+	for _, address := range addresses {
+		address = address.Unmap()
+		if (queryType == 1 && address.Is4()) || (queryType == 28 && address.Is6()) {
+			answers = append(answers, address)
+		}
+	}
+	response := append([]byte{}, request[:2]...)
+	response = append(response, 0x81, 0x80, 0x00, 0x01, byte(len(answers)>>8), byte(len(answers)), 0x00, 0x00, 0x00, 0x00)
+	response = append(response, request[12:questionEnd]...)
+	for _, address := range answers {
+		response = append(response, 0xc0, 0x0c, byte(queryType>>8), byte(queryType), 0x00, 0x01, 0x00, 0x00, 0x00, 0x3c,
+			0x00, byte(len(address.AsSlice())))
+		response = append(response, address.AsSlice()...)
+	}
+	return response
+}

--- a/internal/carddav/types.go
+++ b/internal/carddav/types.go
@@ -1,0 +1,173 @@
+// Package carddav provides the standards-only CardDAV client used by msgvault.
+package carddav
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var (
+	ErrUnsafeRedirect  = errors.New("carddav redirect leaves credential origin")
+	ErrUnsafeHref      = errors.New("carddav href leaves collection")
+	ErrUnsafeTarget    = errors.New("carddav target is unsafe")
+	ErrUnsafeXML       = errors.New("unsafe XML")
+	ErrXMLLimit        = errors.New("XML limit exceeded")
+	ErrResponseLimit   = errors.New("CardDAV response exceeds byte limit")
+	ErrOperationLimit  = errors.New("CardDAV operation exceeds byte limit")
+	ErrInvalidProperty = errors.New("unsupported DAV property")
+)
+
+const (
+	davNamespace     = "DAV:"
+	cardDAVNamespace = "urn:ietf:params:xml:ns:carddav"
+)
+
+const (
+	defaultRequestTimeout   = 30 * time.Second
+	defaultOperationTimeout = 5 * time.Minute
+	defaultResponseBytes    = 32 << 20
+	defaultOperationBytes   = 256 << 20
+)
+
+// ClientOptions controls bounded, authenticated DAV requests.
+type ClientOptions struct {
+	CredentialOrigin *url.URL
+	Username         string
+	Password         string
+	RequestTimeout   time.Duration
+	OperationTimeout time.Duration
+	ResponseBytes    int64
+	OperationBytes   int64
+	Resolver         *net.Resolver
+	DialContext      func(context.Context, string, string) (net.Conn, error)
+	// AllowInsecureCredentials permits Basic authentication over HTTP. It is
+	// intended only for controlled test fixtures; production callers must use
+	// the zero value so credentials require HTTPS.
+	AllowInsecureCredentials bool
+}
+
+// Request is one DAV request. ETag selects If-Match unless Create selects
+// If-None-Match: * instead.
+type Request struct {
+	Method string
+	URL    string
+	Depth  *int
+	Body   []byte
+	ETag   string
+	Create bool
+}
+
+// Response contains an already-bounded response body.
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+	// transferredBytes includes bounded bodies consumed from redirect hops as
+	// well as Body so callers can enforce budgets spanning multiple requests.
+	transferredBytes int64
+	// EffectiveURL is the final validated same-origin URL after redirects.
+	EffectiveURL *url.URL
+}
+
+type operationBudget struct {
+	remaining int64
+}
+
+func (b *operationBudget) consume(response *Response) error {
+	consumed := response.transferredBytes
+	if consumed == 0 {
+		consumed = int64(len(response.Body))
+	}
+	b.remaining -= consumed
+	if b.remaining < 0 {
+		return ErrOperationLimit
+	}
+	return nil
+}
+
+// StatusError represents an HTTP error response that callers can branch on
+// without parsing strings. RetryAfter is populated for 429 responses when the
+// server supplied a valid value, clamped to one hour.
+type StatusError struct {
+	StatusCode   int
+	RetryAfter   time.Duration
+	Precondition string
+}
+
+func (e *StatusError) Error() string { return http.StatusText(e.StatusCode) }
+
+// XMLLimits bounds untrusted DAV XML before it is unmarshaled.
+type XMLLimits struct {
+	MaxBytes     int64
+	MaxDepth     int
+	MaxElements  int
+	MaxResponses int
+	MaxPropStats int
+}
+
+// DefaultXMLLimits returns the CardDAV operation's per-response XML budget.
+func DefaultXMLLimits() XMLLimits {
+	return XMLLimits{
+		MaxBytes: defaultResponseBytes, MaxDepth: 64,
+		MaxElements: 500_000, MaxResponses: 50_001, MaxPropStats: 100_000,
+	}
+}
+
+// MultiStatus is a parsed DAV multistatus response.
+type MultiStatus struct {
+	Responses []MultiStatusResponse
+	SyncToken string
+}
+
+type MultiStatusResponse struct {
+	Href       string
+	StatusCode int
+	PropStats  []PropStat
+}
+
+type PropStat struct {
+	StatusCode int
+	Properties Properties
+}
+
+// Properties preserves the DAV/CardDAV properties needed by discovery and
+// synchronization without retaining unbounded arbitrary XML.
+type Properties struct {
+	GetETag              string
+	AddressData          string
+	SyncToken            string
+	DisplayName          string
+	CurrentUserPrincipal string
+	AddressbookHomeSet   []string
+	ResourceTypePresent  bool
+	IsCollection         bool
+	IsAddressBook        bool
+	PrivilegesPresent    bool
+	Privileges           []string
+	SupportsSync         bool
+	SupportsMultiget     bool
+	SupportedVCard       []string
+}
+
+// PropertyName identifies a DAV XML property.
+type PropertyName struct {
+	Namespace string
+	Local     string
+}
+
+var (
+	CurrentUserPrincipalProperty  = PropertyName{Namespace: davNamespace, Local: "current-user-principal"}
+	AddressbookHomeSetProperty    = PropertyName{Namespace: cardDAVNamespace, Local: "addressbook-home-set"}
+	GetETagProperty               = PropertyName{Namespace: davNamespace, Local: "getetag"}
+	AddressDataProperty           = PropertyName{Namespace: cardDAVNamespace, Local: "address-data"}
+	DisplayNameProperty           = PropertyName{Namespace: davNamespace, Local: "displayname"}
+	SyncTokenProperty             = PropertyName{Namespace: davNamespace, Local: "sync-token"}
+	ResourceTypeProperty          = PropertyName{Namespace: davNamespace, Local: "resourcetype"}
+	SupportedReportSetProperty    = PropertyName{Namespace: davNamespace, Local: "supported-report-set"}
+	CurrentUserPrivilegesProperty = PropertyName{Namespace: davNamespace, Local: "current-user-privilege-set"}
+	SupportedAddressDataProperty  = PropertyName{Namespace: cardDAVNamespace, Local: "supported-address-data"}
+)

--- a/internal/carddav/xml.go
+++ b/internal/carddav/xml.go
@@ -1,0 +1,479 @@
+package carddav
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// ParseMultiStatus parses a bounded DAV multistatus document. Directives are
+// forbidden so entities and external subsets cannot alter parser behavior.
+func ParseMultiStatus(body []byte, limits XMLLimits) (MultiStatus, error) {
+	defaults := DefaultXMLLimits()
+	if limits.MaxBytes <= 0 {
+		limits.MaxBytes = defaults.MaxBytes
+	}
+	if limits.MaxDepth <= 0 {
+		limits.MaxDepth = defaults.MaxDepth
+	}
+	if limits.MaxElements <= 0 {
+		limits.MaxElements = defaults.MaxElements
+	}
+	if limits.MaxResponses <= 0 {
+		limits.MaxResponses = defaults.MaxResponses
+	}
+	if limits.MaxPropStats <= 0 {
+		limits.MaxPropStats = defaults.MaxPropStats
+	}
+	if int64(len(body)) > limits.MaxBytes {
+		return MultiStatus{}, ErrXMLLimit
+	}
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	depth := 0
+	elements := 0
+	responses := 0
+	propStats := 0
+	rootSeen := false
+	unsafeNamespace := false
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return MultiStatus{}, fmt.Errorf("parsing CardDAV XML: %w", err)
+		}
+		switch typed := token.(type) {
+		case xml.Directive:
+			return MultiStatus{}, ErrUnsafeXML
+		case xml.StartElement:
+			depth++
+			elements++
+			if typed.Name == (xml.Name{Space: davNamespace, Local: "response"}) {
+				responses++
+			}
+			if typed.Name == (xml.Name{Space: davNamespace, Local: "propstat"}) {
+				propStats++
+			}
+			if depth > limits.MaxDepth || elements > limits.MaxElements ||
+				responses > limits.MaxResponses || propStats > limits.MaxPropStats {
+				return MultiStatus{}, ErrXMLLimit
+			}
+			if err := validateDAVElement(typed.Name, !rootSeen); err != nil {
+				unsafeNamespace = true
+			}
+			rootSeen = true
+		case xml.EndElement:
+			depth--
+		}
+	}
+	if unsafeNamespace {
+		return MultiStatus{}, ErrUnsafeXML
+	}
+	var raw rawMultiStatus
+	if err := xml.Unmarshal(body, &raw); err != nil {
+		return MultiStatus{}, fmt.Errorf("unmarshaling CardDAV XML: %w", err)
+	}
+	if raw.XMLName.Space != davNamespace || raw.XMLName.Local != "multistatus" {
+		return MultiStatus{}, fmt.Errorf("multistatus root: %w", ErrUnsafeXML)
+	}
+	result := MultiStatus{SyncToken: strings.TrimSpace(raw.SyncToken)}
+	for _, response := range raw.Responses {
+		responseStatus, _, err := parseHTTPStatus(response.Status)
+		if err != nil {
+			return MultiStatus{}, fmt.Errorf("response status: %w", err)
+		}
+		parsed := MultiStatusResponse{Href: strings.TrimSpace(response.Href), StatusCode: responseStatus}
+		for _, propStat := range response.PropStats {
+			propStatus, present, err := parseHTTPStatus(propStat.Status)
+			if err != nil {
+				return MultiStatus{}, fmt.Errorf("propstat status: %w", err)
+			}
+			if !present {
+				return MultiStatus{}, errors.New("propstat status is missing")
+			}
+			addressData, err := decodeXMLText(propStat.Prop.AddressData.InnerXML)
+			if err != nil {
+				return MultiStatus{}, fmt.Errorf("decode CardDAV address-data: %w", err)
+			}
+			properties := Properties{
+				GetETag: strings.TrimSpace(propStat.Prop.GetETag), AddressData: addressData,
+				SyncToken: strings.TrimSpace(propStat.Prop.SyncToken), DisplayName: strings.TrimSpace(propStat.Prop.DisplayName),
+				CurrentUserPrincipal: strings.TrimSpace(propStat.Prop.CurrentUserPrincipal.Href),
+				AddressbookHomeSet:   trimmedNonempty(propStat.Prop.AddressbookHomeSet.Hrefs),
+			}
+			if propStat.Prop.ResourceType != nil {
+				properties.ResourceTypePresent = true
+				properties.IsCollection = propStat.Prop.ResourceType.Collection != nil
+				properties.IsAddressBook = propStat.Prop.ResourceType.AddressBook != nil
+			}
+			if propStat.Prop.Privileges != nil {
+				properties.PrivilegesPresent = true
+				for _, privilege := range propStat.Prop.Privileges.Privileges {
+					if privilege.Name.Space == davNamespace {
+						properties.Privileges = append(properties.Privileges, privilege.Name.Local)
+					}
+				}
+			}
+			if propStat.Prop.SupportedReports != nil {
+				for _, supported := range propStat.Prop.SupportedReports.Reports {
+					switch supported.Report.Name {
+					case (xml.Name{Space: davNamespace, Local: "sync-collection"}):
+						properties.SupportsSync = true
+					case (xml.Name{Space: cardDAVNamespace, Local: "addressbook-multiget"}):
+						properties.SupportsMultiget = true
+					}
+				}
+			}
+			if propStat.Prop.SupportedAddressData != nil {
+				for _, dataType := range propStat.Prop.SupportedAddressData.Types {
+					contentType := strings.ToLower(strings.TrimSpace(dataType.ContentType))
+					if contentType == "" {
+						contentType = "text/vcard"
+					}
+					if contentType != "text/vcard" && contentType != "text/x-vcard" {
+						continue
+					}
+					version := strings.TrimSpace(dataType.Version)
+					if version == "" {
+						version = "3.0"
+					}
+					if !slices.Contains(properties.SupportedVCard, version) {
+						properties.SupportedVCard = append(properties.SupportedVCard, version)
+					}
+				}
+			}
+			parsed.PropStats = append(parsed.PropStats, PropStat{
+				StatusCode: propStatus,
+				Properties: properties,
+			})
+		}
+		result.Responses = append(result.Responses, parsed)
+	}
+	return result, nil
+}
+
+func validateDAVElement(name xml.Name, root bool) error {
+	if root && (name.Space != davNamespace || name.Local != "multistatus") {
+		return ErrUnsafeXML
+	}
+	expectedNamespaces := map[string]string{
+		"multistatus":                davNamespace,
+		"response":                   davNamespace,
+		"href":                       davNamespace,
+		"status":                     davNamespace,
+		"propstat":                   davNamespace,
+		"prop":                       davNamespace,
+		"getetag":                    davNamespace,
+		"sync-token":                 davNamespace,
+		"displayname":                davNamespace,
+		"current-user-principal":     davNamespace,
+		"address-data":               cardDAVNamespace,
+		"addressbook-home-set":       cardDAVNamespace,
+		"resourcetype":               davNamespace,
+		"collection":                 davNamespace,
+		"addressbook":                cardDAVNamespace,
+		"supported-report-set":       davNamespace,
+		"supported-report":           davNamespace,
+		"report":                     davNamespace,
+		"sync-collection":            davNamespace,
+		"addressbook-multiget":       cardDAVNamespace,
+		"current-user-privilege-set": davNamespace,
+		"privilege":                  davNamespace,
+		"all":                        davNamespace,
+		"write":                      davNamespace,
+		"bind":                       davNamespace,
+		"write-content":              davNamespace,
+		"unbind":                     davNamespace,
+		"supported-address-data":     cardDAVNamespace,
+		"address-data-type":          cardDAVNamespace,
+	}
+	if expected, known := expectedNamespaces[name.Local]; known && name.Space != expected {
+		return ErrUnsafeXML
+	}
+	return nil
+}
+
+type rawMultiStatus struct {
+	XMLName   xml.Name      `xml:"multistatus"`
+	Responses []rawResponse `xml:"response"`
+	SyncToken string        `xml:"sync-token"`
+}
+
+type rawResponse struct {
+	Href      string        `xml:"href"`
+	Status    string        `xml:"status"`
+	PropStats []rawPropStat `xml:"propstat"`
+}
+
+type rawPropStat struct {
+	Prop   rawProperties `xml:"prop"`
+	Status string        `xml:"status"`
+}
+
+type rawProperties struct {
+	GetETag              string                   `xml:"getetag"`
+	AddressData          rawAddressData           `xml:"address-data"`
+	SyncToken            string                   `xml:"sync-token"`
+	DisplayName          string                   `xml:"displayname"`
+	CurrentUserPrincipal rawHref                  `xml:"current-user-principal"`
+	AddressbookHomeSet   rawHrefs                 `xml:"addressbook-home-set"`
+	ResourceType         *rawResourceType         `xml:"resourcetype"`
+	SupportedReports     *rawSupportedReports     `xml:"supported-report-set"`
+	Privileges           *rawPrivileges           `xml:"current-user-privilege-set"`
+	SupportedAddressData *rawSupportedAddressData `xml:"supported-address-data"`
+}
+
+type rawAddressData struct {
+	InnerXML []byte `xml:",innerxml"`
+}
+
+type rawHrefs struct {
+	Hrefs []string `xml:"href"`
+}
+
+func trimmedNonempty(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func decodeXMLText(raw []byte) (string, error) {
+	decoded := make([]byte, 0, len(raw))
+	for offset := 0; offset < len(raw); {
+		switch raw[offset] {
+		case '<':
+			const opener = "<![CDATA["
+			if !bytes.HasPrefix(raw[offset:], []byte(opener)) {
+				return "", ErrUnsafeXML
+			}
+			contentStart := offset + len(opener)
+			contentEnd := bytes.Index(raw[contentStart:], []byte("]]>"))
+			if contentEnd < 0 {
+				return "", ErrUnsafeXML
+			}
+			contentEnd += contentStart
+			decoded = append(decoded, raw[contentStart:contentEnd]...)
+			offset = contentEnd + len("]]>")
+		case '&':
+			end := bytes.IndexByte(raw[offset+1:], ';')
+			if end < 0 {
+				return "", ErrUnsafeXML
+			}
+			end += offset + 1
+			entity, err := decodeXMLEntity(raw[offset+1 : end])
+			if err != nil {
+				return "", err
+			}
+			decoded = append(decoded, entity...)
+			offset = end + 1
+		default:
+			decoded = append(decoded, raw[offset])
+			offset++
+		}
+	}
+	return string(decoded), nil
+}
+
+func decodeXMLEntity(entity []byte) ([]byte, error) {
+	switch string(entity) {
+	case "amp":
+		return []byte{'&'}, nil
+	case "lt":
+		return []byte{'<'}, nil
+	case "gt":
+		return []byte{'>'}, nil
+	case "apos":
+		return []byte{'\''}, nil
+	case "quot":
+		return []byte{'"'}, nil
+	}
+	base := 10
+	if len(entity) <= 1 || entity[0] != '#' {
+		return nil, ErrUnsafeXML
+	}
+	digits := entity[1:]
+	if len(digits) > 1 && (digits[0] == 'x' || digits[0] == 'X') {
+		base, digits = 16, digits[1:]
+	}
+	if len(digits) == 0 {
+		return nil, ErrUnsafeXML
+	}
+	value, err := strconv.ParseUint(string(digits), base, 32)
+	if err != nil || value > utf8.MaxRune {
+		return nil, ErrUnsafeXML
+	}
+	decoded := rune(value) // #nosec G115 -- value is explicitly bounded to utf8.MaxRune above.
+	if !validXMLRune(decoded) {
+		return nil, ErrUnsafeXML
+	}
+	return []byte(string(decoded)), nil
+}
+
+func validXMLRune(value rune) bool {
+	return value == '\t' || value == '\n' || value == '\r' ||
+		value >= 0x20 && value <= 0xd7ff ||
+		value >= 0xe000 && value <= 0xfffd ||
+		value >= 0x10000 && value <= 0x10ffff
+}
+
+type rawResourceType struct {
+	Collection  *struct{} `xml:"collection"`
+	AddressBook *struct{} `xml:"addressbook"`
+}
+
+type rawPrivileges struct {
+	Privileges []rawPrivilege `xml:"privilege"`
+}
+
+type rawPrivilege struct {
+	Name xml.Name `xml:",any"`
+}
+
+type rawSupportedReports struct {
+	Reports []rawSupportedReport `xml:"supported-report"`
+}
+
+type rawSupportedReport struct {
+	Report rawReport `xml:"report"`
+}
+
+type rawReport struct {
+	Name xml.Name `xml:",any"`
+}
+
+type rawSupportedAddressData struct {
+	Types []rawAddressDataType `xml:"address-data-type"`
+}
+
+type rawAddressDataType struct {
+	ContentType string `xml:"content-type,attr"`
+	Version     string `xml:"version,attr"`
+}
+
+type rawHref struct {
+	Href string `xml:"href"`
+}
+
+var davHTTPStatusPattern = regexp.MustCompile(`^HTTP/[0-9]\.[0-9] ([1-5][0-9]{2})(?: .*)?$`)
+
+func parseHTTPStatus(value string) (int, bool, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false, nil
+	}
+	match := davHTTPStatusPattern.FindStringSubmatch(value)
+	if match == nil {
+		return 0, true, fmt.Errorf("invalid HTTP/DAV status line %q", value)
+	}
+	status, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0, true, fmt.Errorf("invalid HTTP/DAV status code: %w", err)
+	}
+	return status, true, nil
+}
+
+// PropfindBody builds a namespace-correct DAV PROPFIND body.
+func PropfindBody(properties []PropertyName) ([]byte, error) {
+	return propertyBody(xml.Name{Space: davNamespace, Local: "propfind"}, properties, nil)
+}
+
+// AddressbookQueryBody builds an addressbook-query REPORT body.
+func AddressbookQueryBody(properties []PropertyName) ([]byte, error) {
+	return propertyBody(xml.Name{Space: cardDAVNamespace, Local: "addressbook-query"}, properties, func(encoder *xml.Encoder) error {
+		return encodeEmptyElement(encoder, xml.Name{Space: cardDAVNamespace, Local: "filter"})
+	})
+}
+
+// AddressbookMultigetBody builds an addressbook-multiget REPORT body.
+func AddressbookMultigetBody(properties []PropertyName, hrefs []string) ([]byte, error) {
+	return propertyBody(xml.Name{Space: cardDAVNamespace, Local: "addressbook-multiget"}, properties, func(encoder *xml.Encoder) error {
+		for _, href := range hrefs {
+			start := xml.StartElement{Name: xml.Name{Space: davNamespace, Local: "href"}}
+			if err := encoder.EncodeToken(start); err != nil {
+				return fmt.Errorf("encode CardDAV multiget href: %w", err)
+			}
+			if err := encoder.EncodeToken(xml.CharData(href)); err != nil {
+				return fmt.Errorf("encode CardDAV multiget href value: %w", err)
+			}
+			if err := encoder.EncodeToken(start.End()); err != nil {
+				return fmt.Errorf("close CardDAV multiget href: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+func propertyBody(root xml.Name, properties []PropertyName, extra func(*xml.Encoder) error) ([]byte, error) {
+	var body bytes.Buffer
+	encoder := xml.NewEncoder(&body)
+	if err := encoder.EncodeToken(xml.StartElement{Name: root}); err != nil {
+		return nil, fmt.Errorf("encode CardDAV XML root: %w", err)
+	}
+	prop := xml.StartElement{Name: xml.Name{Space: davNamespace, Local: "prop"}}
+	if err := encoder.EncodeToken(prop); err != nil {
+		return nil, fmt.Errorf("encode CardDAV XML properties: %w", err)
+	}
+	for _, property := range properties {
+		if err := validatePropertyName(property); err != nil {
+			return nil, err
+		}
+		if err := encodeEmptyElement(encoder, xml.Name{Space: property.Namespace, Local: property.Local}); err != nil {
+			return nil, err
+		}
+	}
+	if err := encoder.EncodeToken(prop.End()); err != nil {
+		return nil, fmt.Errorf("close CardDAV XML properties: %w", err)
+	}
+	if extra != nil {
+		if err := extra(encoder); err != nil {
+			return nil, err
+		}
+	}
+	if err := encoder.EncodeToken(xml.EndElement{Name: root}); err != nil {
+		return nil, fmt.Errorf("close CardDAV XML root: %w", err)
+	}
+	if err := encoder.Flush(); err != nil {
+		return nil, fmt.Errorf("flush CardDAV XML: %w", err)
+	}
+	return body.Bytes(), nil
+}
+
+func encodeEmptyElement(encoder *xml.Encoder, name xml.Name) error {
+	start := xml.StartElement{Name: name}
+	if err := encoder.EncodeToken(start); err != nil {
+		return fmt.Errorf("encode empty CardDAV XML element: %w", err)
+	}
+	if err := encoder.EncodeToken(start.End()); err != nil {
+		return fmt.Errorf("close empty CardDAV XML element: %w", err)
+	}
+	return nil
+}
+
+func validatePropertyName(property PropertyName) error {
+	if property.Namespace != davNamespace && property.Namespace != cardDAVNamespace {
+		return ErrInvalidProperty
+	}
+	if property.Local == "" {
+		return ErrInvalidProperty
+	}
+	for index, character := range property.Local {
+		if (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || character == '_' ||
+			(index > 0 && ((character >= '0' && character <= '9') || character == '.' || character == '-')) {
+			continue
+		}
+		return ErrInvalidProperty
+	}
+	return nil
+}

--- a/internal/carddav/xml_test.go
+++ b/internal/carddav/xml_test.go
@@ -1,0 +1,202 @@
+package carddav
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMultiStatusRejectsDoctypeAndDepthOverflow(t *testing.T) {
+	_, err := ParseMultiStatus([]byte(`<!DOCTYPE x><multistatus/>`), DefaultXMLLimits())
+	require.ErrorIs(t, err, ErrUnsafeXML)
+	deep := strings.Repeat("<x>", 65) + strings.Repeat("</x>", 65)
+	_, err = ParseMultiStatus([]byte(deep), DefaultXMLLimits())
+	require.ErrorIs(t, err, ErrXMLLimit)
+}
+
+func TestParseMultiStatusKeepsResponseAndPropstatStatus(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	multi, err := ParseMultiStatus([]byte(cardDAVMultiStatusFixture), DefaultXMLLimits())
+	require.NoError(err)
+	require.Len(multi.Responses, 1)
+	assert.Equal("/dav/books/personal/alice.vcf", multi.Responses[0].Href)
+	require.Len(multi.Responses[0].PropStats, 1)
+	assert.Equal(200, multi.Responses[0].PropStats[0].StatusCode)
+	assert.Equal("\"abc\"", multi.Responses[0].PropStats[0].Properties.GetETag)
+	assert.Equal("BEGIN:VCARD\nVERSION:4.0\nEND:VCARD", multi.Responses[0].PropStats[0].Properties.AddressData)
+}
+
+func TestParseMultiStatusPreservesAddressDataAndRejectsWrongNamespaces(t *testing.T) {
+	const exactAddressData = "  BEGIN:VCARD\nVERSION:4.0\nEND:VCARD  "
+	body := []byte(`<D:multistatus xmlns:D="DAV:" xmlns:CR="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><CR:address-data>` + exactAddressData + `</CR:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	multi, err := ParseMultiStatus(body, DefaultXMLLimits())
+	require.NoError(t, err)
+	assert.Equal(t, exactAddressData, multi.Responses[0].PropStats[0].Properties.AddressData)
+
+	for _, wrongNamespace := range [][]byte{
+		[]byte(`<X:multistatus xmlns:X="https://example.invalid"/>`),
+		[]byte(`<D:multistatus xmlns:D="DAV:" xmlns:X="https://example.invalid"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><X:getetag>spoof</X:getetag></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`),
+		[]byte(`<D:multistatus xmlns:D="DAV:" xmlns:X="https://example.invalid"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><X:address-data>spoof</X:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`),
+	} {
+		_, err := ParseMultiStatus(wrongNamespace, DefaultXMLLimits())
+		require.ErrorIs(t, err, ErrUnsafeXML)
+	}
+}
+
+func TestParseMultiStatusAddressDataPreservesLinesAndDecodesXMLEntities(t *testing.T) {
+	const encoded = "BEGIN:VCARD\r\nNOTE:&amp;&lt;&gt;&apos;&quot;&#35;&#x40;\rEND:VCARD\r\n"
+	const expected = "BEGIN:VCARD\r\nNOTE:&<>'\"#@\rEND:VCARD\r\n"
+	body := []byte(`<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><C:address-data>` + encoded + `</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	multi, err := ParseMultiStatus(body, DefaultXMLLimits())
+	require.NoError(t, err)
+	assert.Equal(t, expected, multi.Responses[0].PropStats[0].Properties.AddressData)
+}
+
+func TestParseMultiStatusAddressDataPreservesCDATABytes(t *testing.T) {
+	const encoded = "BEGIN:VCARD\r\nNOTE:ordinary&amp;<![CDATA[<literal>&amp;\r\n]]><![CDATA[more\r]]>END:VCARD\r\n"
+	const expected = "BEGIN:VCARD\r\nNOTE:ordinary&<literal>&amp;\r\nmore\rEND:VCARD\r\n"
+	body := []byte(`<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><C:address-data>` + encoded + `</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	multi, err := ParseMultiStatus(body, DefaultXMLLimits())
+	require.NoError(t, err)
+	assert.Equal(t, expected, multi.Responses[0].PropStats[0].Properties.AddressData)
+}
+
+func TestParseMultiStatusRejectsMarkupInsideAddressData(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		content string
+	}{
+		{name: "child element", content: `BEGIN:VCARD<D:href>nested</D:href>END:VCARD`},
+		{name: "comment", content: `BEGIN:VCARD<!--hidden-->END:VCARD`},
+		{name: "processing instruction", content: `BEGIN:VCARD<?hidden value?>END:VCARD`},
+		{name: "declaration", content: `BEGIN:VCARD<!DOCTYPE hidden>END:VCARD`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := []byte(`<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><C:address-data>` + test.content + `</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+			_, err := ParseMultiStatus(body, DefaultXMLLimits())
+			require.ErrorIs(t, err, ErrUnsafeXML)
+		})
+	}
+
+	unterminated := []byte(`<D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav"><D:response><D:href>/alice.vcf</D:href><D:propstat><D:prop><C:address-data><![CDATA[BEGIN:VCARD</C:address-data></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`)
+	_, err := ParseMultiStatus(unterminated, DefaultXMLLimits())
+	require.Error(t, err)
+}
+
+func TestParseMultiStatusRejectsByteLimit(t *testing.T) {
+	_, err := ParseMultiStatus([]byte(`<D:multistatus xmlns:D="DAV:"/>`), XMLLimits{MaxBytes: 8, MaxDepth: 64})
+	require.ErrorIs(t, err, ErrXMLLimit)
+}
+
+func TestParseMultiStatusRejectsStructuralAmplificationBeforeUnmarshal(t *testing.T) {
+	response := `<D:response><D:href>/a.vcf</D:href></D:response>`
+	body := []byte(`<D:multistatus xmlns:D="DAV:">` + strings.Repeat(response, 3) + `</D:multistatus>`)
+	limits := DefaultXMLLimits()
+	limits.MaxResponses = 2
+	_, err := ParseMultiStatus(body, limits)
+	require.ErrorIs(t, err, ErrXMLLimit)
+
+	propStat := `<D:propstat><D:prop/><D:status>HTTP/1.1 200 OK</D:status></D:propstat>`
+	body = []byte(`<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href>` +
+		strings.Repeat(propStat, 3) + `</D:response></D:multistatus>`)
+	limits = DefaultXMLLimits()
+	limits.MaxPropStats = 2
+	_, err = ParseMultiStatus(body, limits)
+	require.ErrorIs(t, err, ErrXMLLimit)
+
+	body = []byte(`<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href>` +
+		propStat + `</D:response></D:multistatus>`)
+	limits = DefaultXMLLimits()
+	limits.MaxElements = 4
+	_, err = ParseMultiStatus(body, limits)
+	require.ErrorIs(t, err, ErrXMLLimit)
+}
+
+func TestParseMultiStatusRejectsMalformedHTTPStatusLines(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		xml  string
+	}{
+		{
+			name: "response status with 2xx-looking suffix",
+			xml:  `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:status>garbage 200</D:status></D:response></D:multistatus>`,
+		},
+		{
+			name: "propstat status with 2xx-looking suffix",
+			xml:  `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:propstat><D:prop/><D:status>garbage 200</D:status></D:propstat></D:response></D:multistatus>`,
+		},
+		{
+			name: "out of range status",
+			xml:  `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:status>HTTP/1.1 999 Impossible</D:status></D:response></D:multistatus>`,
+		},
+		{
+			name: "missing propstat status",
+			xml:  `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:propstat><D:prop/></D:propstat></D:response></D:multistatus>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseMultiStatus([]byte(tc.xml), DefaultXMLLimits())
+			require.ErrorContains(t, err, "status")
+		})
+	}
+}
+
+func TestParseMultiStatusAllowsAbsentResponseStatusWhenPropstatIsValid(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const body = `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:propstat><D:prop/><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>`
+	multi, err := ParseMultiStatus([]byte(body), DefaultXMLLimits())
+	require.NoError(err)
+	require.Len(multi.Responses, 1)
+	assert.Zero(multi.Responses[0].StatusCode)
+	assert.Equal(200, multi.Responses[0].PropStats[0].StatusCode)
+}
+
+func TestParseMultiStatusAcceptsHTTPStatusWithoutReasonPhrase(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const body = `<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:status>HTTP/1.1 200</D:status><D:propstat><D:prop/><D:status>HTTP/1.1 204</D:status></D:propstat></D:response></D:multistatus>`
+	multi, err := ParseMultiStatus([]byte(body), DefaultXMLLimits())
+	require.NoError(err)
+	require.Len(multi.Responses, 1)
+	assert.Equal(200, multi.Responses[0].StatusCode)
+	require.Len(multi.Responses[0].PropStats, 1)
+	assert.Equal(204, multi.Responses[0].PropStats[0].StatusCode)
+}
+
+func TestParseMultiStatusRequiresSingleDigitHTTPVersionComponents(t *testing.T) {
+	require := require.New(t)
+
+	valid := []byte(`<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:status>HTTP/1.1 200</D:status></D:response></D:multistatus>`)
+	multi, err := ParseMultiStatus(valid, DefaultXMLLimits())
+	require.NoError(err)
+	require.Len(multi.Responses, 1)
+	assert.Equal(t, 200, multi.Responses[0].StatusCode)
+
+	malformed := []byte(`<D:multistatus xmlns:D="DAV:"><D:response><D:href>/a.vcf</D:href><D:status>HTTP/12.34 200</D:status></D:response></D:multistatus>`)
+	_, err = ParseMultiStatus(malformed, DefaultXMLLimits())
+	require.ErrorContains(err, "status")
+}
+
+func TestRequestBodiesUseDAVNamespaces(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	propfind, err := PropfindBody([]PropertyName{CurrentUserPrincipalProperty})
+	require.NoError(err)
+	assert.Contains(string(propfind), "DAV:")
+	query, err := AddressbookQueryBody([]PropertyName{GetETagProperty})
+	require.NoError(err)
+	assert.Contains(string(query), "urn:ietf:params:xml:ns:carddav")
+
+	_, err = PropfindBody([]PropertyName{{Namespace: "https://example.invalid", Local: "injected"}})
+	require.ErrorIs(err, ErrInvalidProperty)
+	_, err = PropfindBody([]PropertyName{{Namespace: "DAV:", Local: `getetag/><X:evil`}})
+	require.ErrorIs(err, ErrInvalidProperty)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -254,6 +254,15 @@ type AccountSchedule struct {
 	Enabled  bool   `toml:"enabled"`  // Whether scheduled sync is active
 }
 
+// CardDAVConfig contains non-secret connection settings for the external
+// address book. The password is stored separately in tokens/carddav.json.
+type CardDAVConfig struct {
+	BaseURL  string `toml:"base_url"`
+	Username string `toml:"username"`
+	Schedule string `toml:"schedule"`
+	Enabled  bool   `toml:"enabled"`
+}
+
 type SynctechSMSConfig struct {
 	Sources []SynctechSMSSource `toml:"sources"`
 }
@@ -400,6 +409,7 @@ type Config struct {
 	Vector       vector.Config                   `toml:"vector"`
 	Identity     IdentityConfig                  `toml:"identity"`
 	Fastmail     []FastmailSource                `toml:"fastmail"`
+	CardDAV      CardDAVConfig                   `toml:"carddav"`
 	Accounts     []AccountSchedule               `toml:"accounts"`
 	SynctechSMS  SynctechSMSConfig               `toml:"synctech_sms"`
 	GCal         []GCalSource                    `toml:"gcal"`
@@ -767,6 +777,11 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		// Anonymous loopback mode instead defaults to no credential, while an
 		// explicitly configured key remains visible to validation and is rejected.
 		cfg.People.Sweep.Provider.APIKeyEnv = ""
+	}
+	for _, key := range metadata.Undecoded() {
+		if key.String() == "carddav.password" {
+			return nil, errors.New("[carddav] password is not allowed in config; store it in tokens/carddav.json")
+		}
 	}
 	if err := cfg.validateFastmailSources(fastmailSourceIDConfigured(content)); err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -8,9 +9,46 @@ import (
 	"testing"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCardDAVConfigLoadsWithoutSerializingAPassword(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(path, []byte(`[carddav]
+base_url = "https://contacts.example/dav"
+username = "alice"
+schedule = "15 */6 * * *"
+enabled = true
+`), 0o600))
+	cfg, err := Load(path, "")
+	require.NoError(err)
+	assert.Equal(CardDAVConfig{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		Schedule: "15 */6 * * *", Enabled: true,
+	}, cfg.CardDAV)
+
+	var encoded bytes.Buffer
+	require.NoError(toml.NewEncoder(&encoded).Encode(cfg))
+	assert.NotContains(encoded.String(), "password")
+}
+
+func TestCardDAVConfigRejectsPasswordField(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`[carddav]
+base_url = "https://contacts.example/dav"
+username = "alice"
+password = "must-not-live-here"
+`), 0o600))
+
+	_, err := Load(path, "")
+	require.ErrorContains(t, err, "tokens/carddav.json")
+	assert.NotContains(t, err.Error(), "must-not-live-here")
+}
 
 func TestServerConfigDefaults(t *testing.T) {
 	// Create a temp dir without a config file

--- a/internal/netguard/policy.go
+++ b/internal/netguard/policy.go
@@ -1,0 +1,121 @@
+// Package netguard identifies destinations that network clients must not
+// contact. It centralizes the SSRF policy shared by user-controlled remote
+// fetchers and protocol clients.
+package netguard
+
+import (
+	"net/netip"
+	"strings"
+)
+
+var prohibitedV4 = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+}
+
+var prohibitedV6 = []netip.Prefix{
+	netip.MustParsePrefix("fc00::/7"),
+	netip.MustParsePrefix("fe80::/10"),
+	netip.MustParsePrefix("ff00::/8"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+}
+
+var (
+	v4CompatPrefix = netip.MustParsePrefix("::/96")
+	nat64Prefix    = netip.MustParsePrefix("64:ff9b::/96")
+	sixToFour      = netip.MustParsePrefix("2002::/16")
+	teredoPrefix   = netip.MustParsePrefix("2001::/32")
+)
+
+// ProhibitedIP reports whether addr is invalid, scoped, private, reserved, or
+// an IPv6 transition address that ultimately reaches a prohibited IPv4
+// destination.
+func ProhibitedIP(addr netip.Addr) bool {
+	if !addr.IsValid() || addr.Zone() != "" {
+		return true
+	}
+	addr = addr.Unmap()
+	if addr.Is6() {
+		if embedded, ok := embeddedIPv4(addr); ok {
+			addr = embedded
+		}
+	}
+	prefixes := prohibitedV4
+	if addr.Is6() {
+		prefixes = prohibitedV6
+	}
+	for _, prefix := range prefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func embeddedIPv4(addr netip.Addr) (netip.Addr, bool) {
+	raw := addr.As16()
+	switch {
+	case v4CompatPrefix.Contains(addr) || nat64Prefix.Contains(addr):
+		return netip.AddrFrom4([4]byte{raw[12], raw[13], raw[14], raw[15]}), true
+	case sixToFour.Contains(addr):
+		return netip.AddrFrom4([4]byte{raw[2], raw[3], raw[4], raw[5]}), true
+	case teredoPrefix.Contains(addr):
+		return netip.AddrFrom4([4]byte{raw[12] ^ 0xff, raw[13] ^ 0xff, raw[14] ^ 0xff, raw[15] ^ 0xff}), true
+	default:
+		return netip.Addr{}, false
+	}
+}
+
+// ProhibitedHostname reports whether hostname is a reserved/private name,
+// unqualified name, or an obfuscated numeric destination.
+func ProhibitedHostname(hostname string) bool {
+	host := strings.ToLower(strings.TrimSpace(hostname))
+	host = strings.TrimSuffix(host, ".")
+	if host == "" {
+		return true
+	}
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 || decimalLabel(labels[len(labels)-1]) || hexLabel(labels[len(labels)-1]) {
+		return true
+	}
+	for _, suffix := range []string{"localhost", "local", "internal", "home.arpa"} {
+		if host == suffix || strings.HasSuffix(host, "."+suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func decimalLabel(label string) bool {
+	if label == "" {
+		return false
+	}
+	for _, r := range label {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func hexLabel(label string) bool {
+	rest, ok := strings.CutPrefix(label, "0x")
+	if !ok {
+		return false
+	}
+	for _, r := range rest {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/netguard/policy_test.go
+++ b/internal/netguard/policy_test.go
@@ -1,0 +1,28 @@
+package netguard
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProhibitedHostnameRejectsPrivateAndObfuscatedNames(t *testing.T) {
+	for _, hostname := range []string{
+		"localhost", "api.localhost", "printer.local.", "nas.home.arpa",
+		"api.internal", "nas", "images.7", "0x7f000001",
+	} {
+		assert.Truef(t, ProhibitedHostname(hostname), "%q", hostname)
+	}
+	assert.False(t, ProhibitedHostname("images.example.com"))
+}
+
+func TestProhibitedIPRejectsPrivateAndTranslatedDestinations(t *testing.T) {
+	for _, raw := range []string{
+		"127.0.0.1", "10.0.0.1", "169.254.169.254", "::1", "fd00::1",
+		"64:ff9b::a00:1", "2002:a00:1::", "2001:0:1234:5678::f5ff:fffe",
+	} {
+		assert.Truef(t, ProhibitedIP(netip.MustParseAddr(raw)), "%q", raw)
+	}
+	assert.False(t, ProhibitedIP(netip.MustParseAddr("203.0.113.7")))
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -226,6 +226,23 @@ func (s *Scheduler) AddJob(job Job) error {
 	return nil
 }
 
+// RemoveJob removes a generic job's cron entry and callable registration.
+// An invocation already running is allowed to finish under the normal work
+// gate; no future cron or manual invocation can start after removal returns.
+func (s *Scheduler) RemoveJob(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if entryID, exists := s.genericJobs[name]; exists {
+		s.cron.Remove(entryID)
+	}
+	delete(s.genericJobs, name)
+	delete(s.genericSchedules, name)
+	delete(s.genericFuncs, name)
+	delete(s.genericLastRun, name)
+	delete(s.genericLastErr, name)
+	s.logger.Info("removed scheduled job", "job", name)
+}
+
 // RemoveAccount removes the schedule for an account.
 func (s *Scheduler) RemoveAccount(email string) {
 	s.mu.Lock()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2187,6 +2187,21 @@ func TestGenericJobShutdownContextFinishesCleanly(t *testing.T) {
 	}
 }
 
+func TestRemoveJobClearsStableGenericScheduleAndRunner(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s := New(nil)
+	require.NoError(s.AddJob(Job{Name: "carddav", Schedule: "0 1 * * *", Run: func(context.Context) error { return nil }}))
+	require.True(s.IsJobScheduled("carddav"))
+
+	s.RemoveJob("carddav")
+
+	assert.False(s.IsJobScheduled("carddav"))
+	assert.Empty(s.JobStatus())
+	require.ErrorContains(s.TriggerJob("carddav"), "not scheduled")
+}
+
 func TestScheduledSyncYieldsToWaiter(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/store/carddav_accounts.go
+++ b/internal/store/carddav_accounts.go
@@ -1,0 +1,784 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// CardDAVDiscoveryInput is one complete, successfully enumerated discovery
+// snapshot. Its Books list is authoritative for active books; deliberately
+// ignored books and books with unresolved remote-first work retain their stored
+// identity while temporarily absent.
+type CardDAVDiscoveryInput struct {
+	BaseURL  string
+	Username string
+	// CredentialsChanged advances the connection fence even when the URL and
+	// username are unchanged, invalidating work authenticated with an old secret.
+	CredentialsChanged bool
+	PrincipalURL       string
+	HomeURL            string
+	HomeURLs           []string
+	Books              []CardDAVDiscoveredBook
+}
+
+// CardDAVDiscoveredBook is the store-neutral form of one discovered book.
+// Nil capabilities mean the server did not advertise the privilege.
+type CardDAVDiscoveredBook struct {
+	CanonicalURL           string
+	DiscoveryAliasURL      string
+	DisplayName            string
+	DiscoveryIndex         int
+	SupportsSyncCollection bool
+	SupportsMultiget       bool
+	SupportedVCardVersions []string
+	CanCreate              *bool
+	CanUpdate              *bool
+	CanDelete              *bool
+}
+
+type CardDAVAccount struct {
+	ID                   int64
+	BaseURL              string
+	Username             string
+	PrincipalURL         string
+	HomeURL              string
+	HomeURLs             []string
+	ConnectionGeneration int64
+	DiscoveryRevision    int64
+}
+
+type CardDAVAddressBook struct {
+	ID                     int64
+	AccountID              int64
+	CanonicalURL           string
+	DiscoveryAliasURL      string
+	DisplayName            string
+	DiscoveryIndex         int
+	SupportsSyncCollection bool
+	SupportsMultiget       bool
+	SupportedVCardVersions []string
+	CanCreate              *bool
+	CanUpdate              *bool
+	CanDelete              *bool
+	IsWriteTarget          bool
+	IsSubscribed           bool
+	IsLookupSource         bool
+	SyncToken              string
+	SyncRevision           int64
+	NeedsFullReconcile     bool
+	LastSeenRevision       int64
+}
+
+type CardDAVBookRoles struct {
+	IsWriteTarget  bool
+	IsSubscribed   bool
+	IsLookupSource bool
+}
+
+var (
+	ErrCardDAVAddressBookNotFound     = errors.New("CardDAV address book not found")
+	ErrCardDAVWriteTargetSubscribed   = errors.New("CardDAV write target must remain subscribed")
+	ErrCardDAVReadOnlyAddressBook     = errors.New("CardDAV address book is read-only")
+	ErrCardDAVRoleChangePending       = errors.New("CardDAV role change would strand remote ownership or intent")
+	ErrCardDAVCredentialChangePending = errors.New("CardDAV credential change blocked by pending remote-first state")
+	ErrCardDAVIdentityChangeOwned     = errors.New("CardDAV identity change blocked by owned remote state")
+)
+
+// ReplaceCardDAVDiscoveryContext atomically replaces the complete discovery
+// snapshot. Existing role choices survive rediscovery; deliberately ignored
+// books and books with unresolved remote-first work also survive a temporary
+// absence. Only the first complete discovery may choose a write target.
+func (s *Store) ReplaceCardDAVDiscoveryContext(
+	ctx context.Context, input CardDAVDiscoveryInput,
+) (_ *CardDAVAccount, _ []CardDAVAddressBook, retErr error) {
+	if err := validateCardDAVDiscoveryInput(input); err != nil {
+		return nil, nil, err
+	}
+	homeURLs := cardDAVDiscoveryHomeURLs(input)
+	tx, err := s.db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin CardDAV discovery replacement: %w", err)
+	}
+	defer func() {
+		if retErr != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	logged := &loggedTx{Tx: tx, rebind: s.Rebind}
+	if err := lockCardDAVDiscoveryReplacement(ctx, tx, s.Rebind, s.IsPostgreSQL()); err != nil {
+		return nil, nil, err
+	}
+
+	account, err := getCardDAVAccountForUpdateFrom(ctx, tx, s.Rebind, s.dialect.SelectForUpdate())
+	if err != nil {
+		return nil, nil, err
+	}
+	identityChanged := account != nil &&
+		(account.BaseURL != input.BaseURL || account.Username != input.Username)
+	if identityChanged || input.CredentialsChanged {
+		if err := cardDAVConnectionChangeBlocker(ctx, logged, identityChanged); err != nil {
+			return nil, nil, err
+		}
+	}
+	existing, err := listCardDAVBooksFrom(ctx, tx, s.Rebind)
+	if err != nil {
+		return nil, nil, err
+	}
+	if identityChanged {
+		if err := s.lockIdentityMutationTxContext(ctx, logged); err != nil {
+			return nil, nil, err
+		}
+		for _, oldBook := range existing {
+			if err := s.dropCardDAVBookResourcesForIdentityChangeTx(ctx, logged, oldBook.ID); err != nil {
+				return nil, nil, fmt.Errorf("clean prior CardDAV connection book: %w", err)
+			}
+		}
+		if _, err := logged.ExecContext(ctx,
+			`DELETE FROM carddav_address_books WHERE account_id = 1`); err != nil {
+			return nil, nil, fmt.Errorf("delete prior CardDAV connection books: %w", err)
+		}
+		if _, err := logged.ExecContext(ctx,
+			`DELETE FROM carddav_retry_gate WHERE account_id = 1`); err != nil {
+			return nil, nil, fmt.Errorf("clear prior CardDAV connection retry gate: %w", err)
+		}
+		existing = nil
+	}
+	firstDiscovery := account == nil || account.DiscoveryRevision == 0 || identityChanged
+	if account == nil {
+		account = &CardDAVAccount{ID: 1, ConnectionGeneration: 1}
+	} else if identityChanged || input.CredentialsChanged {
+		account.ConnectionGeneration++
+	}
+	account.BaseURL = input.BaseURL
+	account.Username = input.Username
+	account.PrincipalURL = input.PrincipalURL
+	account.HomeURL = input.HomeURL
+	account.HomeURLs = append([]string(nil), homeURLs...)
+	account.DiscoveryRevision++
+	if _, err := tx.ExecContext(ctx, s.Rebind(`
+		INSERT INTO carddav_accounts (
+			id, base_url, username, principal_url, home_url,
+			connection_generation, discovery_revision, discovered_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			base_url = excluded.base_url,
+			username = excluded.username,
+			principal_url = excluded.principal_url,
+			home_url = excluded.home_url,
+			connection_generation = excluded.connection_generation,
+			discovery_revision = excluded.discovery_revision,
+			discovered_at = CURRENT_TIMESTAMP,
+			updated_at = CURRENT_TIMESTAMP`),
+		account.ID, account.BaseURL, account.Username, account.PrincipalURL,
+		account.HomeURL, account.ConnectionGeneration, account.DiscoveryRevision,
+	); err != nil {
+		return nil, nil, fmt.Errorf("save CardDAV account discovery: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, s.Rebind(
+		`DELETE FROM carddav_account_home_urls WHERE account_id = ?`), account.ID); err != nil {
+		return nil, nil, fmt.Errorf("clear CardDAV account home URLs: %w", err)
+	}
+	for index, homeURL := range homeURLs {
+		if _, err := tx.ExecContext(ctx, s.Rebind(`
+			INSERT INTO carddav_account_home_urls (account_id, home_url, discovery_index)
+			VALUES (?, ?, ?)`), account.ID, homeURL, index); err != nil {
+			return nil, nil, fmt.Errorf("save CardDAV account home URL: %w", err)
+		}
+	}
+
+	matches := make([]*CardDAVAddressBook, len(input.Books))
+	claimedBookIDs := make(map[int64]bool, len(input.Books))
+	for index, discovered := range input.Books {
+		matches[index], err = matchDiscoveredCardDAVBook(existing, discovered)
+		if err != nil {
+			return nil, nil, err
+		}
+		if matches[index] == nil {
+			continue
+		}
+		if claimedBookIDs[matches[index].ID] {
+			return nil, nil, errors.New("multiple discovered CardDAV books match the same stored book")
+		}
+		claimedBookIDs[matches[index].ID] = true
+	}
+	for _, matched := range matches {
+		if matched == nil {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, s.Rebind(
+			`DELETE FROM carddav_address_book_urls WHERE address_book_id = ?`), matched.ID); err != nil {
+			return nil, nil, fmt.Errorf("clear discovered CardDAV address book URL identities: %w", err)
+		}
+	}
+	writeTargetChosen := false
+	seenBookIDs := make(map[int64]bool, len(input.Books))
+	for index, discovered := range input.Books {
+		matched := matches[index]
+		versions, err := json.Marshal(discovered.SupportedVCardVersions)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode CardDAV supported vCard versions: %w", err)
+		}
+		if matched != nil {
+			canonicalURL := discovered.CanonicalURL
+			aliasURL := discovered.DiscoveryAliasURL
+			if aliasURL == "" && matched.DiscoveryAliasURL != "" {
+				if cardDAVURLIdentityEqual(matched.DiscoveryAliasURL, canonicalURL) {
+					canonicalURL = matched.CanonicalURL
+				}
+				aliasURL = matched.DiscoveryAliasURL
+			}
+			canonicalURLChanged := canonicalURL != matched.CanonicalURL
+			if _, err := tx.ExecContext(ctx, s.Rebind(`
+				UPDATE carddav_address_books SET
+					canonical_url = ?, discovery_alias_url = NULLIF(?, ''),
+					display_name = ?, discovery_index = ?,
+					supports_sync_collection = ?, supports_multiget = ?,
+					supported_vcard_versions = `+s.dialect.JSONBindExpr()+`, can_create = ?, can_update = ?, can_delete = ?,
+					sync_token = CASE WHEN ? THEN '' ELSE sync_token END,
+					needs_full_reconcile = CASE WHEN ? THEN TRUE ELSE needs_full_reconcile END,
+					sync_revision = sync_revision + CASE WHEN ? THEN 1 ELSE 0 END,
+					last_seen_revision = ?, updated_at = CURRENT_TIMESTAMP
+				WHERE id = ?`), canonicalURL, aliasURL,
+				discovered.DisplayName, discovered.DiscoveryIndex,
+				discovered.SupportsSyncCollection, discovered.SupportsMultiget,
+				string(versions), discovered.CanCreate, discovered.CanUpdate, discovered.CanDelete,
+				canonicalURLChanged, canonicalURLChanged, canonicalURLChanged,
+				account.DiscoveryRevision, matched.ID,
+			); err != nil {
+				return nil, nil, fmt.Errorf("update discovered CardDAV address book: %w", err)
+			}
+			if err := insertCardDAVBookURLIdentities(ctx, tx, s.Rebind,
+				account.ID, matched.ID, canonicalURL, aliasURL); err != nil {
+				return nil, nil, err
+			}
+			seenBookIDs[matched.ID] = true
+			continue
+		}
+
+		isWriteTarget := firstDiscovery && !writeTargetChosen &&
+			cardDAVDiscoveredBookSupportsWriteLifecycle(discovered)
+		if isWriteTarget {
+			writeTargetChosen = true
+		}
+		var bookID int64
+		if err := tx.QueryRowContext(ctx, s.Rebind(`
+			INSERT INTO carddav_address_books (
+				account_id, canonical_url, discovery_alias_url, display_name, discovery_index,
+				supports_sync_collection, supports_multiget, supported_vcard_versions,
+				can_create, can_update, can_delete,
+				is_write_target, is_subscribed, is_lookup_source, last_seen_revision
+			) VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, `+s.dialect.JSONBindExpr()+`, ?, ?, ?, ?, ?, TRUE, ?)
+			RETURNING id`),
+			account.ID, discovered.CanonicalURL, discovered.DiscoveryAliasURL,
+			discovered.DisplayName, discovered.DiscoveryIndex,
+			discovered.SupportsSyncCollection, discovered.SupportsMultiget, string(versions),
+			discovered.CanCreate, discovered.CanUpdate, discovered.CanDelete,
+			isWriteTarget, isWriteTarget, account.DiscoveryRevision,
+		).Scan(&bookID); err != nil {
+			return nil, nil, fmt.Errorf("insert discovered CardDAV address book: %w", err)
+		}
+		if err := insertCardDAVBookURLIdentities(ctx, tx, s.Rebind,
+			account.ID, bookID, discovered.CanonicalURL, discovered.DiscoveryAliasURL); err != nil {
+			return nil, nil, err
+		}
+		seenBookIDs[bookID] = true
+	}
+	for _, stale := range existing {
+		if seenBookIDs[stale.ID] {
+			continue
+		}
+		ignored := !stale.IsWriteTarget && !stale.IsSubscribed && !stale.IsLookupSource
+		if ignored {
+			continue
+		}
+		protected, err := cardDAVBookHasProtectedStateTx(ctx, logged, stale.ID,
+			cardDAVProtectedStateScope{IncludeAllConflicts: true})
+		if err != nil {
+			return nil, nil, err
+		}
+		if protected {
+			continue
+		}
+		if err := s.dropCardDAVBookResourcesTx(ctx, logged, stale.ID); err != nil {
+			return nil, nil, fmt.Errorf("clean unseen CardDAV address book: %w", err)
+		}
+		if _, err := logged.ExecContext(ctx, `DELETE FROM carddav_address_books WHERE id = ?`, stale.ID); err != nil {
+			return nil, nil, fmt.Errorf("prune unseen CardDAV address book: %w", err)
+		}
+	}
+	books, err := listCardDAVBooksFrom(ctx, tx, s.Rebind)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("commit CardDAV discovery replacement: %w", err)
+	}
+	return account, books, nil
+}
+
+// ValidateCardDAVConnectionChangeContext is the no-network admission check
+// used by account setup. ReplaceCardDAVDiscoveryContext repeats the check
+// under the discovery transaction so a racing writer still fails closed.
+func (s *Store) ValidateCardDAVConnectionChangeContext(
+	ctx context.Context, baseURL, username string, credentialsChanged bool,
+) error {
+	account, err := s.GetCardDAVAccountContext(ctx)
+	if err != nil || account == nil {
+		return err
+	}
+	identityChanged := account.BaseURL != baseURL || account.Username != username
+	if !identityChanged && !credentialsChanged {
+		return nil
+	}
+	return cardDAVConnectionChangeBlocker(ctx, s.db, identityChanged)
+}
+
+func cardDAVConnectionChangeBlocker(
+	ctx context.Context, queryer contextRowQuerier, identityChanged bool,
+) error {
+	query := `SELECT
+		EXISTS (SELECT 1 FROM carddav_publications WHERE pending_operation IS NOT NULL)
+		OR EXISTS (SELECT 1 FROM carddav_conflicts WHERE pending_operation IS NOT NULL)`
+	want := ErrCardDAVCredentialChangePending
+	if identityChanged {
+		query = `SELECT
+			EXISTS (SELECT 1 FROM carddav_publications)
+			OR EXISTS (SELECT 1 FROM carddav_conflicts)`
+		want = ErrCardDAVIdentityChangeOwned
+	}
+	var blocked bool
+	if err := queryer.QueryRowContext(ctx, query).Scan(&blocked); err != nil {
+		return fmt.Errorf("check CardDAV connection change ownership: %w", err)
+	}
+	if blocked {
+		return want
+	}
+	return nil
+}
+
+type cardDAVProtectedStateScope struct {
+	IncludeCurrentWriteTarget  bool
+	IncludeUnresolvedConflicts bool
+	IncludeAllConflicts        bool
+}
+
+func cardDAVBookHasProtectedStateTx(
+	ctx context.Context, tx *loggedTx, bookID int64, scope cardDAVProtectedStateScope,
+) (bool, error) {
+	var protected bool
+	if err := tx.QueryRowContext(ctx, `WITH affected_books AS (
+		SELECT id FROM carddav_address_books
+		WHERE account_id = 1
+		  AND (id = ? OR (? AND is_write_target = TRUE))
+	)
+	SELECT
+		EXISTS (SELECT 1 FROM carddav_publications
+			WHERE address_book_id IN (SELECT id FROM affected_books))
+		OR EXISTS (SELECT 1 FROM carddav_conflicts
+			WHERE address_book_id IN (SELECT id FROM affected_books)
+			  AND (pending_operation IS NOT NULL
+			       OR (? AND status = 'unresolved') OR ?))`,
+		bookID, scope.IncludeCurrentWriteTarget, scope.IncludeUnresolvedConflicts,
+		scope.IncludeAllConflicts,
+	).Scan(&protected); err != nil {
+		return false, fmt.Errorf("check CardDAV address book protected state: %w", err)
+	}
+	return protected, nil
+}
+
+func lockCardDAVDiscoveryReplacement(
+	ctx context.Context, tx *sql.Tx, rebind func(string) string, postgres bool,
+) error {
+	if postgres {
+		var singleton int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT singleton FROM carddav_discovery_lock WHERE singleton = 1 FOR UPDATE`,
+		).Scan(&singleton); err != nil {
+			return fmt.Errorf("lock CardDAV discovery replacement: %w", err)
+		}
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, rebind(
+		`UPDATE carddav_discovery_lock SET singleton = singleton WHERE singleton = ?`), 1); err != nil {
+		return fmt.Errorf("lock CardDAV discovery replacement: %w", err)
+	}
+	return nil
+}
+
+func insertCardDAVBookURLIdentities(
+	ctx context.Context, tx *sql.Tx, rebind func(string) string,
+	accountID, bookID int64, canonicalURL, aliasURL string,
+) error {
+	for _, identity := range []struct {
+		role, rawURL string
+	}{{"canonical", canonicalURL}, {"alias", aliasURL}} {
+		if identity.rawURL == "" {
+			continue
+		}
+		normalized, err := normalizeCardDAVURLIdentity(identity.rawURL)
+		if err != nil {
+			return fmt.Errorf("normalize CardDAV %s URL identity: %w", identity.role, err)
+		}
+		if _, err := tx.ExecContext(ctx, rebind(`
+			INSERT INTO carddav_address_book_urls (
+				account_id, address_book_id, url_role, normalized_url
+			) VALUES (?, ?, ?, ?)`), accountID, bookID, identity.role, normalized); err != nil {
+			return fmt.Errorf("save CardDAV %s URL identity: %w", identity.role, err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) GetCardDAVAccountContext(ctx context.Context) (*CardDAVAccount, error) {
+	return getCardDAVAccountFrom(ctx, s.db.DB, s.Rebind)
+}
+
+func (s *Store) ListCardDAVAddressBooksContext(ctx context.Context) ([]CardDAVAddressBook, error) {
+	return listCardDAVBooksFrom(ctx, s.db.DB, s.Rebind)
+}
+
+// SetCardDAVBookRolesContext applies one complete role state. The account row
+// serializes write-target swaps, while sync revisions fence pulls and pending
+// writes prepared against the previous state.
+func (s *Store) SetCardDAVBookRolesContext(
+	ctx context.Context, bookID int64, roles CardDAVBookRoles,
+) error {
+	if bookID <= 0 {
+		return ErrCardDAVAddressBookNotFound
+	}
+	if roles.IsWriteTarget && !roles.IsSubscribed {
+		return ErrCardDAVWriteTargetSubscribed
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVAddressBookNotFound
+			}
+			return fmt.Errorf("lock CardDAV account roles: %w", err)
+		}
+
+		var current CardDAVBookRoles
+		var canCreate, canUpdate, canDelete sql.NullBool
+		if err := tx.QueryRowContext(ctx, `SELECT can_create, can_update, can_delete, is_write_target,
+			is_subscribed, is_lookup_source FROM carddav_address_books
+			WHERE id = ?`+s.dialect.SelectForUpdate(), bookID).Scan(
+			&canCreate, &canUpdate, &canDelete,
+			&current.IsWriteTarget, &current.IsSubscribed, &current.IsLookupSource,
+		); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVAddressBookNotFound
+			}
+			return fmt.Errorf("lock CardDAV address book roles: %w", err)
+		}
+		if roles.IsWriteTarget && (cardDAVCapabilityDenied(canCreate) ||
+			cardDAVCapabilityDenied(canUpdate) || cardDAVCapabilityDenied(canDelete)) {
+			return ErrCardDAVReadOnlyAddressBook
+		}
+		if current == roles {
+			return nil
+		}
+		protectedScope := cardDAVProtectedStateScope{}
+		checkProtectedState := false
+		if current.IsWriteTarget != roles.IsWriteTarget {
+			checkProtectedState = true
+			protectedScope.IncludeCurrentWriteTarget = true
+			protectedScope.IncludeUnresolvedConflicts = true
+		}
+		removesMaterializedMappings := (current.IsSubscribed && !roles.IsSubscribed) ||
+			(current.IsLookupSource && !roles.IsSubscribed && !roles.IsLookupSource)
+		if removesMaterializedMappings {
+			checkProtectedState = true
+			protectedScope.IncludeUnresolvedConflicts = true
+		}
+		if checkProtectedState {
+			protected, err := cardDAVBookHasProtectedStateTx(ctx, tx, bookID,
+				protectedScope)
+			if err != nil {
+				return err
+			}
+			if protected {
+				return ErrCardDAVRoleChangePending
+			}
+		}
+
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		if roles.IsWriteTarget && !current.IsWriteTarget {
+			if _, err := tx.ExecContext(ctx, `UPDATE carddav_address_books SET
+				is_write_target = FALSE, sync_revision = sync_revision + 1,
+				updated_at = `+s.dialect.Now()+`
+				WHERE account_id = 1 AND is_write_target = TRUE AND id <> ?`, bookID); err != nil {
+				return fmt.Errorf("release previous CardDAV write target: %w", err)
+			}
+		}
+
+		widened := (!current.IsSubscribed && roles.IsSubscribed) ||
+			(!current.IsLookupSource && roles.IsLookupSource)
+		if current.IsSubscribed && !roles.IsSubscribed {
+			if err := s.demoteCardDAVBookResourcesTx(ctx, tx, bookID); err != nil {
+				return err
+			}
+		}
+		if !roles.IsSubscribed && !roles.IsLookupSource {
+			if err := s.dropCardDAVBookResourcesTx(ctx, tx, bookID); err != nil {
+				return err
+			}
+			widened = false
+		}
+
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_address_books SET
+			is_write_target = ?, is_subscribed = ?, is_lookup_source = ?,
+			needs_full_reconcile = CASE
+				WHEN ? THEN FALSE
+				WHEN ? THEN TRUE
+				ELSE needs_full_reconcile
+			END, sync_revision = sync_revision + 1,
+			updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+			roles.IsWriteTarget, roles.IsSubscribed, roles.IsLookupSource,
+			!roles.IsSubscribed && !roles.IsLookupSource, widened, bookID)
+		if err != nil {
+			return fmt.Errorf("set CardDAV address book roles: %w", err)
+		}
+		if affected, err := result.RowsAffected(); err != nil {
+			return fmt.Errorf("count CardDAV address book role update: %w", err)
+		} else if affected != 1 {
+			return ErrCardDAVAddressBookNotFound
+		}
+		return nil
+	})
+}
+
+func cardDAVDiscoveredBookSupportsWriteLifecycle(book CardDAVDiscoveredBook) bool {
+	return book.CanCreate != nil && *book.CanCreate &&
+		(book.CanUpdate == nil || *book.CanUpdate) &&
+		(book.CanDelete == nil || *book.CanDelete)
+}
+
+func cardDAVCapabilityDenied(capability sql.NullBool) bool {
+	return capability.Valid && !capability.Bool
+}
+
+type cardDAVQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func getCardDAVAccountFrom(
+	ctx context.Context, queryer cardDAVQueryer, rebind func(string) string,
+) (*CardDAVAccount, error) {
+	return getCardDAVAccountForUpdateFrom(ctx, queryer, rebind, "")
+}
+
+func getCardDAVAccountForUpdateFrom(
+	ctx context.Context, queryer cardDAVQueryer, rebind func(string) string, suffix string,
+) (*CardDAVAccount, error) {
+	var account CardDAVAccount
+	err := queryer.QueryRowContext(ctx, rebind(`
+		SELECT id, base_url, username, principal_url, home_url,
+		       connection_generation, discovery_revision
+		FROM carddav_accounts WHERE id = 1`)+suffix).Scan(
+		&account.ID, &account.BaseURL, &account.Username, &account.PrincipalURL,
+		&account.HomeURL, &account.ConnectionGeneration, &account.DiscoveryRevision,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil //nolint:nilnil // An unconfigured singleton account is a valid absence state.
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get CardDAV account: %w", err)
+	}
+	rows, err := queryer.QueryContext(ctx, rebind(`
+		SELECT home_url FROM carddav_account_home_urls
+		WHERE account_id = ? ORDER BY discovery_index`), account.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list CardDAV account home URLs: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only cursor
+	for rows.Next() {
+		var homeURL string
+		if err := rows.Scan(&homeURL); err != nil {
+			return nil, fmt.Errorf("scan CardDAV account home URL: %w", err)
+		}
+		account.HomeURLs = append(account.HomeURLs, homeURL)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate CardDAV account home URLs: %w", err)
+	}
+	if len(account.HomeURLs) == 0 {
+		account.HomeURLs = []string{account.HomeURL}
+	}
+	return &account, nil
+}
+
+func listCardDAVBooksFrom(
+	ctx context.Context, queryer cardDAVQueryer, rebind func(string) string,
+) ([]CardDAVAddressBook, error) {
+	rows, err := queryer.QueryContext(ctx, rebind(`
+		SELECT id, account_id, canonical_url, discovery_alias_url, display_name,
+		       discovery_index, supports_sync_collection, supports_multiget,
+		       supported_vcard_versions, can_create, can_update, can_delete,
+		       is_write_target, is_subscribed, is_lookup_source,
+		       sync_token, sync_revision, needs_full_reconcile, last_seen_revision
+		FROM carddav_address_books
+		ORDER BY discovery_index, id`))
+	if err != nil {
+		return nil, fmt.Errorf("list CardDAV address books: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only cursor
+	books := []CardDAVAddressBook{}
+	for rows.Next() {
+		var book CardDAVAddressBook
+		var alias sql.NullString
+		var versions []byte
+		if err := rows.Scan(
+			&book.ID, &book.AccountID, &book.CanonicalURL, &alias, &book.DisplayName,
+			&book.DiscoveryIndex, &book.SupportsSyncCollection, &book.SupportsMultiget,
+			&versions, &book.CanCreate, &book.CanUpdate, &book.CanDelete,
+			&book.IsWriteTarget, &book.IsSubscribed, &book.IsLookupSource,
+			&book.SyncToken, &book.SyncRevision, &book.NeedsFullReconcile, &book.LastSeenRevision,
+		); err != nil {
+			return nil, fmt.Errorf("scan CardDAV address book: %w", err)
+		}
+		if alias.Valid {
+			book.DiscoveryAliasURL = alias.String
+		}
+		if err := json.Unmarshal(versions, &book.SupportedVCardVersions); err != nil {
+			return nil, fmt.Errorf("decode CardDAV supported vCard versions: %w", err)
+		}
+		books = append(books, book)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate CardDAV address books: %w", err)
+	}
+	return books, nil
+}
+
+func validateCardDAVDiscoveryInput(input CardDAVDiscoveryInput) error {
+	for label, value := range map[string]string{
+		"base URL": input.BaseURL, "principal URL": input.PrincipalURL, "home URL": input.HomeURL,
+	} {
+		if _, err := normalizeCardDAVURLIdentity(value); err != nil {
+			return fmt.Errorf("invalid CardDAV %s", label)
+		}
+	}
+	homeURLs := cardDAVDiscoveryHomeURLs(input)
+	seenHomes := map[string]bool{}
+	for _, homeURL := range homeURLs {
+		key, err := normalizeCardDAVURLIdentity(homeURL)
+		if err != nil {
+			return errors.New("invalid CardDAV home URL")
+		}
+		if seenHomes[key] {
+			return fmt.Errorf("duplicate CardDAV home URL %q", homeURL)
+		}
+		seenHomes[key] = true
+	}
+	primary, _ := normalizeCardDAVURLIdentity(input.HomeURL)
+	first, _ := normalizeCardDAVURLIdentity(homeURLs[0])
+	if primary != first {
+		return errors.New("CardDAV primary home URL must be first")
+	}
+	seen := map[string]bool{}
+	for _, book := range input.Books {
+		if book.DiscoveryIndex < 0 {
+			return errors.New("CardDAV discovery index must not be negative")
+		}
+		for label, value := range map[string]string{"canonical URL": book.CanonicalURL, "discovery alias URL": book.DiscoveryAliasURL} {
+			if value == "" && label == "discovery alias URL" {
+				continue
+			}
+			key, err := normalizeCardDAVURLIdentity(value)
+			if err != nil {
+				return fmt.Errorf("invalid CardDAV book %s", label)
+			}
+			if seen[key] {
+				return fmt.Errorf("duplicate CardDAV book URL %q", value)
+			}
+			seen[key] = true
+		}
+	}
+	return nil
+}
+
+func cardDAVDiscoveryHomeURLs(input CardDAVDiscoveryInput) []string {
+	if len(input.HomeURLs) > 0 {
+		return input.HomeURLs
+	}
+	return []string{input.HomeURL}
+}
+
+func matchDiscoveredCardDAVBook(
+	existing []CardDAVAddressBook, discovered CardDAVDiscoveredBook,
+) (*CardDAVAddressBook, error) {
+	var match *CardDAVAddressBook
+	for index := range existing {
+		book := &existing[index]
+		if !cardDAVURLsOverlap(book.CanonicalURL, book.DiscoveryAliasURL, discovered.CanonicalURL, discovered.DiscoveryAliasURL) {
+			continue
+		}
+		if match != nil && match.ID != book.ID {
+			return nil, errors.New("CardDAV discovery aliases match multiple stored books")
+		}
+		clone := *book
+		match = &clone
+	}
+	return match, nil
+}
+
+func cardDAVURLsOverlap(leftCanonical, leftAlias, rightCanonical, rightAlias string) bool {
+	for _, left := range []string{leftCanonical, leftAlias} {
+		for _, right := range []string{rightCanonical, rightAlias} {
+			if left != "" && right != "" && cardDAVURLIdentityEqual(left, right) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cardDAVURLIdentityEqual(left, right string) bool {
+	leftIdentity, leftErr := normalizeCardDAVURLIdentity(left)
+	rightIdentity, rightErr := normalizeCardDAVURLIdentity(right)
+	return leftErr == nil && rightErr == nil && leftIdentity == rightIdentity
+}
+
+// normalizeCardDAVURLIdentity folds only URL components that are
+// case-insensitive. Collection paths, queries, and their escaping remain
+// byte-sensitive because CardDAV servers may assign them distinct resources.
+func normalizeCardDAVURLIdentity(raw string) (string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Opaque != "" || parsed.Host == "" || parsed.User != nil || parsed.Fragment != "" {
+		return "", errors.New("invalid CardDAV URL")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", errors.New("invalid CardDAV URL scheme")
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return "", errors.New("invalid CardDAV URL host")
+	}
+	port := parsed.Port()
+	if (scheme == "http" && port == "80") || (scheme == "https" && port == "443") {
+		port = ""
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	identity := scheme + "://" + host + parsed.EscapedPath()
+	if parsed.ForceQuery || parsed.RawQuery != "" {
+		identity += "?" + parsed.RawQuery
+	}
+	return identity, nil
+}

--- a/internal/store/carddav_accounts_pg_test.go
+++ b/internal/store/carddav_accounts_pg_test.go
@@ -1,0 +1,90 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestPostgreSQLCardDAVDiscoveryReplacementsSerializeCompleteSnapshots(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	if !st.IsPostgreSQL() {
+		t.Skip("PostgreSQL row locks are required for the CardDAV snapshot serialization regression")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+
+	blocker, err := st.DB().BeginTx(ctx, &sql.TxOptions{})
+	require.NoError(err)
+	t.Cleanup(func() { _ = blocker.Rollback() })
+	var singleton int
+	require.NoError(blocker.QueryRowContext(ctx,
+		`SELECT singleton FROM carddav_discovery_lock WHERE singleton = 1 FOR UPDATE`).Scan(&singleton))
+
+	inputs := []store.CardDAVDiscoveryInput{
+		cardDAVConcurrentInput("bob", "snapshot-a"),
+		cardDAVConcurrentInput("carol", "snapshot-b"),
+	}
+	errs := make(chan error, 2)
+	for _, input := range inputs {
+		go func() {
+			_, _, replaceErr := st.ReplaceCardDAVDiscoveryContext(ctx, input)
+			errs <- replaceErr
+		}()
+	}
+	var blockedWriters int
+	require.Eventually(func() bool {
+		err := st.DB().QueryRowContext(ctx, `SELECT COUNT(*)
+			FROM pg_stat_activity
+			WHERE cardinality(pg_blocking_pids(pid)) > 0
+			  AND POSITION('carddav_discovery_lock' IN query) > 0`).Scan(&blockedWriters)
+		return err == nil && blockedWriters == 2
+	}, 5*time.Second, 10*time.Millisecond,
+		"both replacement connections must wait on the singleton discovery lock")
+	require.NoError(blocker.Commit())
+	require.NoError(<-errs)
+	require.NoError(<-errs)
+
+	account, err := st.GetCardDAVAccountContext(ctx)
+	require.NoError(err)
+	require.NotNil(account)
+	assert.Equal(int64(2), account.ConnectionGeneration)
+	assert.Equal(int64(2), account.DiscoveryRevision)
+	books, err := st.ListCardDAVAddressBooksContext(ctx)
+	require.NoError(err)
+	got := make([]string, 0, len(books))
+	for _, book := range books {
+		got = append(got, book.CanonicalURL)
+		assert.Equal([]string{"3.0", "4.0"}, book.SupportedVCardVersions)
+	}
+	sort.Strings(got)
+	wantA := []string{"https://contacts.example/snapshot-a/one/", "https://contacts.example/snapshot-a/two/"}
+	wantB := []string{"https://contacts.example/snapshot-b/one/", "https://contacts.example/snapshot-b/two/"}
+	assert.True(slices.Equal(wantA, got) || slices.Equal(wantB, got),
+		"final books must be exactly one authoritative snapshot: %v", got)
+}
+
+func cardDAVConcurrentInput(username, prefix string) store.CardDAVDiscoveryInput {
+	return store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: username,
+		PrincipalURL: "https://contacts.example/principal/" + username + "/",
+		HomeURL:      "https://contacts.example/books/" + username + "/",
+		Books: []store.CardDAVDiscoveredBook{
+			{CanonicalURL: "https://contacts.example/" + prefix + "/one/", DiscoveryIndex: 0,
+				SupportedVCardVersions: []string{"3.0", "4.0"}},
+			{CanonicalURL: "https://contacts.example/" + prefix + "/two/", DiscoveryIndex: 1,
+				SupportedVCardVersions: []string{"3.0", "4.0"}},
+		},
+	}
+}

--- a/internal/store/carddav_accounts_test.go
+++ b/internal/store/carddav_accounts_test.go
@@ -1,0 +1,1901 @@
+package store_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func cardDAVRoleDiscovery() store.CardDAVDiscoveryInput {
+	allowed := true
+	return store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{
+			{
+				CanonicalURL: "https://contacts.example/books/alice/personal/",
+				DisplayName:  "Personal", DiscoveryIndex: 0, CanCreate: &allowed,
+			},
+			{
+				CanonicalURL:      "https://contacts.example/books/alice/directory/",
+				DiscoveryAliasURL: "https://contacts.example/books/alice/directory-alias/",
+				DisplayName:       "Directory", DiscoveryIndex: 1, CanCreate: &allowed,
+			},
+		},
+	}
+}
+
+func TestCardDAVDiscoveryPersistsEveryHomeURL(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := cardDAVRoleDiscovery()
+	input.HomeURLs = []string{
+		"https://contacts.example/books/alice/",
+		"https://contacts.example/books/team/",
+	}
+	account, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	assert.Equal(input.HomeURLs, account.HomeURLs)
+
+	stored, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	assert.Equal(input.HomeURLs, stored.HomeURLs)
+}
+
+func importCardDAVRoleTestPeople(
+	t *testing.T, slugs ...string,
+) (*store.Store, store.CardDAVAddressBook, map[string]store.CardDAVResource) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(t, err)
+	require.Len(t, books, 2)
+	book := books[1]
+	require.NoError(t, st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(t, err)
+	book = books[1]
+	resources := make([]store.CardDAVRemoteResource, 0, len(slugs))
+	for _, slug := range slugs {
+		resources = append(resources, remoteResource(
+			book.CanonicalURL+slug+".vcf", slug, slug, slug+"@example.test", `"one"`,
+		))
+	}
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: resources,
+	})
+	require.NoError(t, err)
+	mappings, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(t, err)
+	require.Len(t, mappings, len(slugs))
+	bySlug := make(map[string]store.CardDAVResource, len(mappings))
+	for _, mapping := range mappings {
+		require.NotNil(t, mapping.PersonID)
+		for _, slug := range slugs {
+			if mapping.Href == book.CanonicalURL+slug+".vcf" {
+				bySlug[slug] = mapping
+				break
+			}
+		}
+	}
+	require.Len(t, bySlug, len(slugs))
+	return st, book, bySlug
+}
+
+func TestCardDAVSetBookRolesAtomicallySwapsWriteTargetAndSchedulesWidening(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	oldRevision := books[1].SyncRevision
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+	})
+	require.NoError(err)
+
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.False(books[0].IsWriteTarget)
+	assert.True(books[0].IsSubscribed, "the old target remains materialized")
+	assert.True(books[1].IsWriteTarget)
+	assert.True(books[1].IsSubscribed)
+	assert.True(books[1].NeedsFullReconcile)
+	assert.Greater(books[1].SyncRevision, oldRevision)
+
+	var targets int
+	err = st.DB().QueryRow(`SELECT COUNT(*) FROM carddav_address_books WHERE is_write_target = TRUE`).Scan(&targets)
+	require.NoError(err)
+	assert.Equal(1, targets)
+}
+
+func TestCardDAVSetBookRolesRefusesUnsubscribingWriteTarget(t *testing.T) {
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[0].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: false, IsLookupSource: true,
+	})
+	require.ErrorIs(err, store.ErrCardDAVWriteTargetSubscribed)
+
+	after, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.Equal(t, books, after)
+}
+
+func TestCardDAVSetBookRolesClearsWriteTargetAndSubscriptionTogether(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.True(books[0].IsWriteTarget)
+	require.True(books[0].IsSubscribed)
+
+	require.NoError(st.SetCardDAVBookRolesContext(
+		t.Context(), books[0].ID, store.CardDAVBookRoles{},
+	))
+	after, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.False(after[0].IsWriteTarget)
+	assert.False(after[0].IsSubscribed)
+	assert.False(after[0].IsLookupSource)
+
+	var targets int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM carddav_address_books WHERE is_write_target = TRUE`,
+	).Scan(&targets))
+	assert.Zero(targets)
+}
+
+func TestCardDAVSetBookRolesPreservesScheduledReconcileAcrossNarrowing(t *testing.T) {
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: false,
+	}))
+	after, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.True(t, after[1].NeedsFullReconcile,
+		"a later narrow role edit must not cancel the pending materializing pull")
+}
+
+func TestCardDAVSetBookRolesRejectsLifecycleDeniedWriteTarget(t *testing.T) {
+	for _, capability := range []string{"create", "update", "delete"} {
+		t.Run(capability, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st := testutil.NewTestStore(t)
+			input := cardDAVRoleDiscovery()
+			denied := false
+			switch capability {
+			case "create":
+				input.Books[1].CanCreate = &denied
+			case "update":
+				input.Books[1].CanUpdate = &denied
+			case "delete":
+				input.Books[1].CanDelete = &denied
+			}
+			_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+			require.NoError(err)
+
+			err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+				IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+			})
+			require.ErrorIs(err, store.ErrCardDAVReadOnlyAddressBook)
+			after, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(listErr)
+			assert.True(after[0].IsWriteTarget)
+			assert.False(after[1].IsWriteTarget)
+		})
+	}
+}
+
+func TestCardDAVDiscoverySkipsLifecycleDeniedAutomaticWriteTarget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	input := cardDAVRoleDiscovery()
+	denied, allowed := false, true
+	input.Books[0].CanUpdate = &denied
+	input.Books[1].CanUpdate = &allowed
+	input.Books[1].CanDelete = &allowed
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(books, 2)
+	assert.False(books[0].IsWriteTarget)
+	assert.True(books[1].IsWriteTarget)
+}
+
+func TestCardDAVSetBookRolesUnsubscribeDeletesOnlyUntouchedImportedPeople(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	book := books[1]
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	book = books[1]
+
+	resources := []store.CardDAVRemoteResource{
+		remoteResource(book.CanonicalURL+"untouched.vcf", "untouched", "Untouched", "untouched@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"edited.vcf", "edited", "Edited", "edited@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"linked.vcf", "linked", "Linked", "linked@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"relationship-source.vcf", "relationship-source", "Relationship Source", "relationship-source@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"relationship-target.vcf", "relationship-target", "Relationship Target", "relationship-target@example.test", `"one"`),
+	}
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: resources,
+	})
+	require.NoError(err)
+	mappings, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	require.Len(mappings, 5)
+	personByHref := make(map[string]int64, len(mappings))
+	for _, mapping := range mappings {
+		require.NotNil(mapping.PersonID)
+		personByHref[mapping.Href] = *mapping.PersonID
+	}
+
+	edited, err := st.GetPersonContext(t.Context(), personByHref[resources[1].Href])
+	require.NoError(err)
+	_, err = st.UpdatePersonDisplayNameContext(t.Context(), edited.ID, edited.Revision, new("User edited"))
+	require.NoError(err)
+	participantID, err := st.EnsureParticipantByIdentifier("email", "linked@example.test", "Linked")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO person_participants (person_id, participant_id) VALUES (?, ?)`),
+		personByHref[resources[2].Href], participantID)
+	require.NoError(err)
+	_, err = st.AddPersonRelationshipContext(t.Context(), store.PersonRelationshipInput{
+		SourcePersonID: personByHref[resources[3].Href],
+		TargetPersonID: personByHref[resources[4].Href],
+		TypeSlug:       "agent",
+		Source:         store.ProvenanceUser,
+		Actor:          "user",
+	})
+	require.NoError(err)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: false, IsLookupSource: true,
+	})
+	require.NoError(err)
+
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[0].Href])
+	require.ErrorIs(err, store.ErrPersonNotFound)
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[1].Href])
+	require.NoError(err, "user-edited imported person must survive")
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[2].Href])
+	require.NoError(err, "participant-linked imported person must survive")
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[3].Href])
+	require.NoError(err, "relationship source imported person must survive")
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[4].Href])
+	require.NoError(err, "relationship target imported person must survive")
+
+	mappings, err = st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	require.Len(mappings, 5)
+	for _, mapping := range mappings {
+		assert.Nil(mapping.PersonID)
+		assert.Nil(mapping.PersonRevisionAtBind)
+		assert.Equal(store.CardDAVMappingUnbound, mapping.MappingStatus)
+		assert.Equal(store.CardDAVGovernanceNone, mapping.Governance)
+	}
+}
+
+func TestCardDAVSetBookRolesUnsubscribePreservesUserLinkedImports(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	book := books[1]
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	book = books[1]
+
+	resources := []store.CardDAVRemoteResource{
+		remoteResource(book.CanonicalURL+"untouched.vcf", "untouched", "Untouched", "untouched@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"user-employment.vcf", "user-employment", "User Employment", "user-employment@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"remote-employment.vcf", "remote-employment", "Remote Employment", "remote-employment@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"daily-note.vcf", "daily-note", "Daily Note", "daily-note@example.test", `"one"`),
+		remoteResource(book.CanonicalURL+"user-attribute.vcf", "user-attribute", "User Attribute", "user-attribute@example.test", `"one"`),
+	}
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: resources,
+	})
+	require.NoError(err)
+	mappings, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	require.Len(mappings, 5)
+	personByHref := make(map[string]int64, len(mappings))
+	revisionAtBind := make(map[int64]int64, len(mappings))
+	for _, mapping := range mappings {
+		require.NotNil(mapping.PersonID)
+		require.NotNil(mapping.PersonRevisionAtBind)
+		personByHref[mapping.Href] = *mapping.PersonID
+		revisionAtBind[*mapping.PersonID] = *mapping.PersonRevisionAtBind
+	}
+
+	organization, err := st.CreateOrganizationContext(t.Context(), store.OrganizationInput{
+		Name: "Example Org", Kind: store.OrganizationKindCompany,
+	})
+	require.NoError(err)
+	userEmploymentPersonID := personByHref[resources[1].Href]
+	_, err = st.AddEmploymentContext(t.Context(), store.EmploymentInput{
+		PersonID: userEmploymentPersonID, OrganizationID: organization.ID,
+		Title: new("Engineer"), Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	remoteEmploymentPersonID := personByHref[resources[2].Href]
+	_, err = st.AddEmploymentContext(t.Context(), store.EmploymentInput{
+		PersonID: remoteEmploymentPersonID, OrganizationID: organization.ID,
+		Title: new("Imported Role"), Source: store.ProvenanceCardDAVImport,
+	})
+	require.NoError(err)
+	dailyNotePersonID := personByHref[resources[3].Href]
+	note, err := st.CreateDailyNoteEntryContext(t.Context(), store.DailyNoteEntryInput{
+		LocalDate: "2026-08-19", Body: "Follow up", Author: "user",
+		PersonIDs: []int64{dailyNotePersonID},
+	})
+	require.NoError(err)
+	definition := personTextDefinition("carddav_preserved_note")
+	definition.UniversalID = "test-carddav-preserved-note"
+	_, err = st.CreateAttributeDefinitionContext(t.Context(), definition)
+	require.NoError(err)
+	userAttributePersonID := personByHref[resources[4].Href]
+	attributeWrite, err := st.SetPersonAttributeValueContext(t.Context(), store.PersonAttributeValueInput{
+		PersonID: userAttributePersonID, DefinitionSlug: definition.Slug,
+		Value: store.AttributeValue{
+			Type: store.AttributeValueText, Text: new("Remember this"),
+		},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	for _, personID := range []int64{
+		userEmploymentPersonID, remoteEmploymentPersonID, dailyNotePersonID, userAttributePersonID,
+	} {
+		person, getErr := st.GetPersonContext(t.Context(), personID)
+		require.NoError(getErr)
+		assert.Equal(revisionAtBind[personID], person.Revision,
+			"linkage must exercise the non-person-revision deletion guards")
+	}
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: false, IsLookupSource: true,
+	})
+	require.NoError(err)
+
+	_, err = st.GetPersonContext(t.Context(), personByHref[resources[0].Href])
+	require.ErrorIs(err, store.ErrPersonNotFound, "untouched import remains the deletion control")
+	_, err = st.GetPersonContext(t.Context(), userEmploymentPersonID)
+	require.NoError(err, "user employment must preserve its imported person")
+	_, err = st.GetPersonContext(t.Context(), remoteEmploymentPersonID)
+	require.ErrorIs(err, store.ErrPersonNotFound,
+		"non-user employment must not turn a remote-only person into user-owned state")
+	_, err = st.GetPersonContext(t.Context(), dailyNotePersonID)
+	require.NoError(err, "daily-note target must preserve its imported person")
+	_, err = st.GetPersonContext(t.Context(), userAttributePersonID)
+	require.NoError(err, "user attribute must preserve its imported person")
+
+	userEmployments, err := st.ListEmploymentsContext(t.Context(), store.EmploymentFilter{
+		PersonID: userEmploymentPersonID,
+	})
+	require.NoError(err)
+	assert.Len(userEmployments, 1)
+	remoteEmployments, err := st.ListEmploymentsContext(t.Context(), store.EmploymentFilter{
+		PersonID: remoteEmploymentPersonID,
+	})
+	require.NoError(err)
+	assert.Empty(remoteEmployments)
+	notes, err := st.ListDailyNoteEntriesForPersonContext(
+		t.Context(), dailyNotePersonID, "2026-08-19", 10, 0,
+	)
+	require.NoError(err)
+	require.Len(notes, 1)
+	assert.Equal(note.ID, notes[0].ID)
+	assert.Equal([]int64{dailyNotePersonID}, notes[0].PersonIDs)
+	attributes, err := st.ListPersonAttributeValuesContext(
+		t.Context(), userAttributePersonID,
+		store.PersonAttributeQuery{DefinitionSlug: definition.Slug, IncludeHistory: true},
+	)
+	require.NoError(err)
+	require.Len(attributes, 1)
+	assert.Equal(attributeWrite.Value.ID, attributes[0].ID)
+}
+
+func TestCardDAVSetBookRolesUnsubscribePreservesReviewedRelationships(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, book, mappings := importCardDAVRoleTestPeople(t, "accepted", "rejected", "pending")
+	participantID, err := st.EnsureParticipantByIdentifier(
+		"email", "relationship-counterpart@example.test", "Relationship Counterpart",
+	)
+	require.NoError(err)
+	counterpart, _, err := st.CreatePersonFromParticipantContext(t.Context(), participantID)
+	require.NoError(err)
+
+	stage := func(slug string) *store.RelationshipReview {
+		t.Helper()
+		mapping := mappings[slug]
+		resolved, resolveErr := st.ResolveRelatedValueContext(t.Context(), store.RelatedImport{
+			PersonID: *mapping.PersonID, RawValue: "Review " + slug,
+			RawType: "unknown", ValueKind: store.RelatedValueKindText,
+			Source: store.ProvenanceCardDAVImport, Actor: "system",
+			VCardIdentity: store.VCardIdentity{Property: "RELATED"},
+		})
+		require.NoError(resolveErr)
+		require.NotNil(resolved.Review)
+		return resolved.Review
+	}
+	acceptedReview := stage("accepted")
+	acceptedEdge, err := st.AcceptRelationshipReviewContext(
+		t.Context(), acceptedReview.ID, "friend", counterpart.ID, "user",
+	)
+	require.NoError(err)
+	assert.Equal(store.ProvenanceCardDAVImport, acceptedEdge.Source)
+	rejectedReview := stage("rejected")
+	rejectedReview, err = st.RejectRelationshipReviewContext(t.Context(), rejectedReview.ID, "user")
+	require.NoError(err)
+	require.NotNil(rejectedReview.ReviewedBy)
+	require.NotNil(rejectedReview.ReviewedAt)
+	pendingReview := stage("pending")
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: false, IsLookupSource: true,
+	}))
+
+	_, err = st.GetPersonContext(t.Context(), *mappings["accepted"].PersonID)
+	require.NoError(err, "accepted imported relationship review must preserve its person")
+	_, err = st.GetPersonContext(t.Context(), *mappings["rejected"].PersonID)
+	require.NoError(err, "rejected imported relationship review must preserve its person")
+	_, err = st.GetPersonContext(t.Context(), *mappings["pending"].PersonID)
+	require.ErrorIs(err, store.ErrPersonNotFound,
+		"an untouched pending imported review remains remote-only state")
+	_, err = st.GetPersonRelationshipContext(t.Context(), acceptedEdge.ID)
+	require.NoError(err, "the accepted imported edge must survive with its person")
+	reviews, err := st.ListRelationshipReviewsContext(
+		t.Context(), store.RelationshipReviewListOptions{},
+	)
+	require.NoError(err)
+	statusByID := make(map[int64]store.RelationshipReviewStatus, len(reviews))
+	for _, review := range reviews {
+		statusByID[review.ID] = review.Status
+	}
+	assert.Equal(store.RelationshipReviewAccepted, statusByID[acceptedReview.ID])
+	assert.Equal(store.RelationshipReviewRejected, statusByID[rejectedReview.ID])
+	_, pendingExists := statusByID[pendingReview.ID]
+	assert.False(pendingExists)
+}
+
+func TestCardDAVSetBookRolesUnsubscribePreservesReviewedIdentityMatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, book, mappings := importCardDAVRoleTestPeople(
+		t, "accepted", "rejected", "user-source", "user-evidence", "system-control",
+	)
+	participantID, err := st.EnsureParticipantByIdentifier(
+		"email", "identity-counterpart@example.test", "Identity Counterpart",
+	)
+	require.NoError(err)
+	counterpart, _, err := st.CreatePersonFromParticipantContext(t.Context(), participantID)
+	require.NoError(err)
+
+	personCandidate := func(
+		slug string, source store.Provenance, importedOnRight bool,
+	) *store.IdentityMatchCandidate {
+		t.Helper()
+		leftID, rightID := *mappings[slug].PersonID, counterpart.ID
+		if importedOnRight {
+			leftID, rightID = rightID, leftID
+		}
+		candidate, created, candidateErr := st.UpsertIdentityMatchCandidateContext(
+			t.Context(), store.IdentityMatchCandidateInput{
+				LeftKind: store.IdentityMatchPerson, LeftID: leftID,
+				RightKind: store.IdentityMatchPerson, RightID: rightID,
+				Basis: store.IdentityMatchDisplayName, NormalizedValue: new(slug),
+				State: store.IdentityMatchStateCandidate, Source: source,
+			})
+		require.NoError(candidateErr)
+		assert.True(created)
+		return candidate
+	}
+	accepted := personCandidate("accepted", store.ProvenanceArchiveObservation, false)
+	accepted, err = st.DecideIdentityMatchCandidateContext(
+		t.Context(), accepted.ID, store.IdentityMatchStateAccepted, "user", new("confirmed"),
+	)
+	require.NoError(err)
+	rejected := personCandidate("rejected", store.ProvenanceArchiveObservation, true)
+	rejected, err = st.DecideIdentityMatchCandidateContext(
+		t.Context(), rejected.ID, store.IdentityMatchStateRejected, "user", new("not the same"),
+	)
+	require.NoError(err)
+	userSource := personCandidate("user-source", store.ProvenanceUser, false)
+
+	points, err := st.ListPersonContactPointsContext(
+		t.Context(), *mappings["user-evidence"].PersonID, true,
+	)
+	require.NoError(err)
+	require.NotEmpty(points)
+	userEvidence, created, err := st.UpsertIdentityMatchCandidateContext(
+		t.Context(), store.IdentityMatchCandidateInput{
+			LeftKind: store.IdentityMatchPerson, LeftID: counterpart.ID,
+			RightKind: store.IdentityMatchContactPoint, RightID: points[0].Envelope.ID,
+			Basis: store.IdentityMatchEmail, NormalizedValue: new("user-evidence@example.test"),
+			State: store.IdentityMatchStateCandidate, Source: store.ProvenanceArchiveObservation,
+		})
+	require.NoError(err)
+	assert.True(created)
+	_, err = st.AddIdentityMatchEvidenceContext(
+		t.Context(), userEvidence.ID, store.IdentityMatchEvidenceInput{
+			EvidenceKind: "manual confirmation", Source: store.ProvenanceUser,
+		},
+	)
+	require.NoError(err)
+	systemControl := personCandidate("system-control", store.ProvenanceArchiveObservation, false)
+	_, err = st.AddIdentityMatchEvidenceContext(
+		t.Context(), systemControl.ID, store.IdentityMatchEvidenceInput{
+			EvidenceKind: "generated similarity", Source: store.ProvenanceArchiveObservation,
+		},
+	)
+	require.NoError(err)
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: false, IsLookupSource: true,
+	}))
+
+	for _, slug := range []string{"accepted", "rejected", "user-source", "user-evidence"} {
+		_, getErr := st.GetPersonContext(t.Context(), *mappings[slug].PersonID)
+		require.NoError(getErr, "%s identity review must preserve its person", slug)
+	}
+	_, err = st.GetPersonContext(t.Context(), *mappings["system-control"].PersonID)
+	require.ErrorIs(err, store.ErrPersonNotFound,
+		"pure generated candidate and evidence remain deletable")
+	for _, candidate := range []*store.IdentityMatchCandidate{accepted, rejected, userSource, userEvidence} {
+		_, getErr := st.GetIdentityMatchCandidateContext(t.Context(), candidate.ID)
+		require.NoError(getErr, "reviewed identity candidate %d must survive", candidate.ID)
+	}
+	_, err = st.GetIdentityMatchCandidateContext(t.Context(), systemControl.ID)
+	require.ErrorIs(err, store.ErrIdentityMatchNotFound)
+}
+
+func TestCardDAVIgnoredBookDropsLedgerOnceAndSurvivesAliasRediscovery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	book := books[1]
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	book = books[1]
+	input := remoteResource(book.CanonicalURL+"ignored.vcf", "ignored", "Ignored", "ignored@example.test", `"one"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{}))
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	ignoredBooks, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	ignoredBook := ignoredBooks[1]
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: ignoredBook.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: ignoredBook.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.ErrorIs(err, store.ErrCardDAVStalePlan,
+		"an ignored book must reject even a revision-current apply plan")
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{}),
+		"reapplying ignored roles must be idempotent")
+
+	rediscovered := cardDAVRoleDiscovery()
+	rediscovered.Books[1].CanonicalURL = rediscovered.Books[1].DiscoveryAliasURL
+	rediscovered.Books[1].DiscoveryAliasURL = ""
+	_, after, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), rediscovered)
+	require.NoError(err)
+	require.Len(after, 2)
+	assert.Equal(book.ID, after[1].ID)
+	assert.False(after[1].IsWriteTarget)
+	assert.False(after[1].IsSubscribed)
+	assert.False(after[1].IsLookupSource)
+	assert.False(after[1].NeedsFullReconcile)
+	ledger, err := st.ListCardDAVResourcesContext(t.Context(), book.ID)
+	require.NoError(err)
+	assert.Empty(ledger)
+}
+
+func TestCardDAVIgnoredBookIdentitySurvivesTemporaryDiscoveryAbsence(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	initial := cardDAVRoleDiscovery()
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), initial)
+	require.NoError(err)
+	require.Len(books, 2)
+	ignored := books[1]
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), ignored.ID, store.CardDAVBookRoles{}))
+
+	absent := initial
+	absent.Books = initial.Books[:1]
+	_, afterAbsence, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), absent)
+	require.NoError(err)
+	require.Len(afterAbsence, 2)
+	assert.Equal(ignored.ID, afterAbsence[1].ID)
+	assert.False(afterAbsence[1].IsWriteTarget)
+	assert.False(afterAbsence[1].IsSubscribed)
+	assert.False(afterAbsence[1].IsLookupSource)
+
+	rediscovered := initial
+	rediscovered.Books[1].CanonicalURL = initial.Books[1].DiscoveryAliasURL
+	rediscovered.Books[1].DiscoveryAliasURL = ""
+	_, afterRediscovery, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), rediscovered)
+	require.NoError(err)
+	require.Len(afterRediscovery, 2)
+	assert.Equal(ignored.ID, afterRediscovery[1].ID)
+	assert.False(afterRediscovery[1].IsWriteTarget)
+	assert.False(afterRediscovery[1].IsSubscribed)
+	assert.False(afterRediscovery[1].IsLookupSource)
+}
+
+func TestCardDAVDiscoveryPruneUsesGovernanceAwareImportedCleanup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"removed.vcf", "removed", "Removed", "removed@example.test", `"one"`)
+	preserved := remoteResource(book.CanonicalURL+"preserved.vcf", "preserved", "Preserved", "preserved@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input, preserved},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+	preservedMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, preserved.Href)
+	require.NoError(err)
+	require.NotNil(preservedMapping.PersonID)
+	preservedPersonID := *preservedMapping.PersonID
+	_, err = st.AddPersonContactPointContext(t.Context(), preservedPersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "user-owned@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	})
+	require.NoError(err)
+	assert.Empty(books)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+	_, err = st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", input.Href)
+	require.ErrorIs(err, store.ErrVCardResourceNotFound)
+	preservedPerson, err := st.GetPersonContext(t.Context(), preservedPersonID)
+	require.NoError(err, "user-owned state must keep the person while pruning its remote book")
+	require.NotNil(preservedPerson.DisplayName)
+	assert.Equal(preserved.DisplayName, *preservedPerson.DisplayName)
+	points, err := st.ListPersonContactPointsContext(t.Context(), preservedPersonID, true)
+	require.NoError(err)
+	assert.Contains(contactOriginalValues(points), "user-owned@example.test")
+	assert.Contains(contactOriginalValues(points), preserved.Emails[0])
+	names, err := st.ListPersonNamesContext(t.Context(), preservedPersonID, true)
+	require.NoError(err)
+	require.Len(names, 1)
+	assert.Equal(preserved.DisplayName, names[0].OriginalValue)
+	_, err = st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", preserved.Href)
+	require.ErrorIs(err, store.ErrVCardResourceNotFound)
+}
+
+func contactOriginalValues(points []store.PersonContactPoint) []string {
+	values := make([]string, 0, len(points))
+	for _, point := range points {
+		values = append(values, point.OriginalValue)
+	}
+	return values
+}
+
+func TestCardDAVDiscoveryRetainsBookWithPendingPublicationIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('pending-person', 'Pending Person') RETURNING id`).Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID,
+		Href:                 book.CanonicalURL + "pending-person.vcf",
+		OutgoingBody:         []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:pending-person\r\nFN:Pending Person\r\nEND:VCARD\r\n"),
+		OutgoingSemanticHash: "semantic-pending", LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	require.NotEmpty(pending.PendingOperation)
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(account)
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	})
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(book.ID, books[0].ID)
+	after, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(pending.PendingOperation, after.PendingOperation)
+}
+
+func TestCardDAVDiscoveryRetainsBookWithSettledPublicationOwnership(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, book := newCardDAVResourceStore(t)
+	personID, settledRemote := settleCardDAVTestPublication(t, st, book, "settled-owner")
+
+	before, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(before.Desired)
+	assert.Empty(before.PendingOperation)
+	resourceBefore, err := st.GetCardDAVResourceContext(t.Context(), book.ID, settledRemote.Href)
+	require.NoError(err)
+
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(account)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	})
+	require.NoError(err)
+	require.Len(books, 1,
+		"settled remote ownership must retain a temporarily absent address book")
+	assert.Equal(book.ID, books[0].ID)
+	after, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(after.Desired)
+	assert.Empty(after.PendingOperation)
+	resourceAfter, err := st.GetCardDAVResourceContext(t.Context(), book.ID, settledRemote.Href)
+	require.NoError(err)
+	assert.Equal(resourceBefore.ID, resourceAfter.ID,
+		"discovery absence must not cascade-delete settled remote state")
+}
+
+func TestCardDAVDiscoveryRetainsBookWithClearedPublicationRetryState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('retry-owner', 'Retry Owner') RETURNING id`).Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	remote := remoteResource(book.CanonicalURL+"retry-owner.vcf", "retry-owner", "Retry Owner", "retry@example.test", `"retry"`)
+	pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID, Href: remote.Href,
+		OutgoingBody: remote.RemoteBody, OutgoingSemanticHash: remote.SemanticHash,
+		LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	retryAfter := time.Now().UTC().Add(time.Hour)
+	require.NoError(st.RollbackCardDAVPublicationThrottleContext(t.Context(), pending, retryAfter))
+	cleared, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(cleared.Desired)
+	assert.Empty(cleared.PendingOperation)
+	gateBefore, err := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(err)
+	require.NotNil(gateBefore)
+
+	account, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(account)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	})
+	require.NoError(err)
+	require.Len(books, 1,
+		"clearing a throttled mutation must not make its remote ownership disposable")
+	assert.Equal(book.ID, books[0].ID)
+	after, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Empty(after.PendingOperation)
+	gateAfter, err := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(err)
+	require.NotNil(gateAfter)
+	assert.Equal(gateBefore.UTC(), gateAfter.UTC())
+}
+
+func TestCardDAVDiscoveryRetainsBookWithUnresolvedConflictIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	initial := remoteResource(book.CanonicalURL+"conflicted.vcf", "conflicted", "Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, initial.Href)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	_, err = st.AddPersonContactPointContext(t.Context(), *mapping.PersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "user-edit@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	local, err := st.LoadPersonVCardSnapshotContext(t.Context(), *mapping.PersonID)
+	require.NoError(err)
+	remote := remoteResource(initial.Href, "conflicted", "Remote", "remote@example.test", `"two"`)
+	remote.SemanticHash = "semantic-conflicted-remote"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{remote},
+		Conflicts: []store.CardDAVConflictCapture{{
+			AddressBookID: book.ID, Href: initial.Href,
+			ExpectedMappingRevision: mapping.MappingRevision,
+			BaseLocalHash:           mapping.LocalHash, LocalHash: local.Fingerprint,
+			BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+			RemoteETag: remote.RemoteETag, LocalBody: initial.RemoteBody, RemoteBody: remote.RemoteBody,
+		}},
+	})
+	require.NoError(err)
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	})
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(book.ID, books[0].ID)
+	conflicts, err := st.ListCardDAVConflictsContext(t.Context(), true)
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.Equal(initial.Href, conflicts[0].Href)
+}
+
+func TestCardDAVSetBookRolesRejectsWriteTargetSwapWithPendingMutation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('pending-role-person', 'Pending Role Person') RETURNING id`).Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	_, err = st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: books[0].ID,
+		Href:                 books[0].CanonicalURL + "pending-role-person.vcf",
+		OutgoingBody:         []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:pending-role-person\r\nFN:Pending Role Person\r\nEND:VCARD\r\n"),
+		OutgoingSemanticHash: "semantic-pending-role", LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+	})
+	require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+	after, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.True(after[0].IsWriteTarget)
+	assert.False(after[1].IsWriteTarget)
+	pending, pendingErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(pendingErr)
+	assert.NotEmpty(pending.PendingOperation)
+}
+
+func TestCardDAVSetBookRolesRejectsWriteTargetSwapWithSettledPublication(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	personID, _ := settleCardDAVTestPublication(t, st, books[0], "settled-role-owner")
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+	})
+	require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+	after, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.True(after[0].IsWriteTarget)
+	assert.False(after[1].IsWriteTarget)
+	settled, publicationErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(publicationErr)
+	assert.True(settled.Desired)
+	assert.Empty(settled.PendingOperation)
+}
+
+func TestCardDAVSetBookRolesRejectsWriteTargetSwapWhenProposedTargetHasPublication(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), cardDAVRoleDiscovery())
+	require.NoError(err)
+	require.Len(books, 2)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('proposed-owner', 'Proposed Owner') RETURNING id`).Scan(&personID))
+	_, err = st.DB().Exec(st.Rebind(`INSERT INTO carddav_publications
+		(person_id, desired, address_book_id, href)
+		VALUES (?, TRUE, ?, ?)`), personID, books[1].ID, books[1].CanonicalURL+"proposed-owner.vcf")
+	require.NoError(err)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+	})
+	require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+	after, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.True(after[0].IsWriteTarget)
+	assert.False(after[1].IsWriteTarget)
+	_, publicationErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(publicationErr)
+}
+
+func TestCardDAVSetBookRolesRejectsWriteTargetSwapWithPendingConflictIntent(t *testing.T) {
+	for _, test := range []struct {
+		name                     string
+		demoteCurrentTarget      bool
+		conflictOnProposedTarget bool
+	}{
+		{name: "swap away from current target"},
+		{name: "demote current target", demoteCurrentTarget: true},
+		{name: "swap to proposed target", conflictOnProposedTarget: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, _, conflictBook, _, conflict, remote := seededCardDAVTombstoneConflict(t, false)
+			pending, err := st.PrepareCardDAVConflictLocalTombstoneContext(
+				t.Context(), conflict.ID, conflict.MappingRevision, remote)
+			require.NoError(err)
+			require.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+			allowed := true
+			_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+				BaseURL: "https://contacts.example/dav", Username: "alice",
+				PrincipalURL: "https://contacts.example/principal/alice/",
+				HomeURL:      "https://contacts.example/books/alice/",
+				Books: []store.CardDAVDiscoveredBook{
+					{CanonicalURL: conflictBook.CanonicalURL, DisplayName: "Personal", CanCreate: &allowed},
+					{CanonicalURL: "https://contacts.example/books/alice/next/", DisplayName: "Next", CanCreate: &allowed},
+				},
+			})
+			require.NoError(err)
+			require.Len(books, 2)
+			nextBook := books[1]
+			targetBook := nextBook
+			expectedTargetID := conflictBook.ID
+			roles := store.CardDAVBookRoles{
+				IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+			}
+			if test.demoteCurrentTarget {
+				targetBook = conflictBook
+				roles.IsWriteTarget = false
+			}
+			if test.conflictOnProposedTarget {
+				_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+					SET is_write_target = FALSE WHERE id = ?`), conflictBook.ID)
+				require.NoError(err)
+				_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+					SET is_write_target = TRUE, is_subscribed = TRUE WHERE id = ?`), nextBook.ID)
+				require.NoError(err)
+				targetBook = conflictBook
+				expectedTargetID = nextBook.ID
+			}
+
+			err = st.SetCardDAVBookRolesContext(t.Context(), targetBook.ID, roles)
+			require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+			afterBooks, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(listErr)
+			var actualTargetID int64
+			for _, book := range afterBooks {
+				if book.IsWriteTarget {
+					actualTargetID = book.ID
+				}
+			}
+			assert.Equal(expectedTargetID, actualTargetID)
+			afterConflict, conflictErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+			require.NoError(conflictErr)
+			assert.Equal(store.CardDAVMutationDelete, afterConflict.PendingOperation)
+			assert.Equal(pending.MappingRevision, afterConflict.MappingRevision)
+		})
+	}
+}
+
+func TestCardDAVSetBookRolesRejectsTransitionWithUnresolvedConflict(t *testing.T) {
+	for _, test := range []struct {
+		name                     string
+		demoteCurrentTarget      bool
+		conflictOnProposedTarget bool
+	}{
+		{name: "swap away from current target"},
+		{name: "demote current target", demoteCurrentTarget: true},
+		{name: "swap to proposed target", conflictOnProposedTarget: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, account, conflictBook, mapping := seededCardDAVConflictMapping(t)
+			conflict, err := st.RecordCardDAVConflictContext(t.Context(), conflictCapture(mapping))
+			require.NoError(err)
+			require.Equal(store.CardDAVConflictUnresolved, conflict.Status)
+			require.Empty(conflict.PendingOperation)
+			books := addCardDAVRoleTransitionBook(t, st, account, conflictBook)
+			nextBook := books[1]
+			targetBook := nextBook
+			expectedTargetID := conflictBook.ID
+			roles := store.CardDAVBookRoles{
+				IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+			}
+			if test.demoteCurrentTarget {
+				targetBook = conflictBook
+				roles.IsWriteTarget = false
+			}
+			if test.conflictOnProposedTarget {
+				setCardDAVRoleTestWriteTarget(t, st, conflictBook.ID, nextBook.ID)
+				targetBook = conflictBook
+				expectedTargetID = nextBook.ID
+			}
+
+			err = st.SetCardDAVBookRolesContext(t.Context(), targetBook.ID, roles)
+			require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+			afterBooks, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(listErr)
+			assert.Equal(expectedTargetID, cardDAVRoleTestWriteTargetID(afterBooks))
+			afterConflict, conflictErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+			require.NoError(conflictErr)
+			assert.Equal(store.CardDAVConflictUnresolved, afterConflict.Status)
+			assert.Empty(afterConflict.PendingOperation)
+		})
+	}
+}
+
+func TestCardDAVSetBookRolesAllowsTransitionWithResolvedConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, conflictBook, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	retained := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision, Remote: retained,
+	})
+	require.NoError(err)
+	require.Equal(store.CardDAVConflictResolved, resolved.Status)
+	require.Empty(resolved.PendingOperation)
+	books := addCardDAVRoleTransitionBook(t, st, account, conflictBook)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), books[1].ID, store.CardDAVBookRoles{
+		IsWriteTarget: true, IsSubscribed: true, IsLookupSource: true,
+	})
+	require.NoError(err)
+	afterBooks, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Equal(books[1].ID, cardDAVRoleTestWriteTargetID(afterBooks))
+	afterConflict, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, afterConflict.Status)
+}
+
+func TestCardDAVSetBookRolesRejectsNonTargetNarrowingWithUnresolvedConflict(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		roles store.CardDAVBookRoles
+	}{
+		{name: "lookup only", roles: store.CardDAVBookRoles{IsLookupSource: true}},
+		{name: "ignored", roles: store.CardDAVBookRoles{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, account, conflictBook, mapping := seededCardDAVConflictMapping(t)
+			capture := conflictCapture(mapping)
+			conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+			require.NoError(err)
+			books := addCardDAVRoleTransitionBook(t, st, account, conflictBook)
+			setCardDAVRoleTestWriteTarget(t, st, conflictBook.ID, books[1].ID)
+
+			err = st.SetCardDAVBookRolesContext(t.Context(), conflictBook.ID, test.roles)
+
+			require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+			afterBooks, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+			require.NoError(listErr)
+			require.Len(afterBooks, 2)
+			assert.True(afterBooks[0].IsSubscribed)
+			assert.True(afterBooks[0].IsLookupSource)
+			afterMapping, mappingErr := st.GetCardDAVResourceContext(
+				t.Context(), conflictBook.ID, mapping.Href)
+			require.NoError(mappingErr)
+			assert.Equal(conflict.MappingRevision, afterMapping.MappingRevision)
+			afterConflict, conflictErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+			require.NoError(conflictErr)
+			assert.Equal(store.CardDAVConflictUnresolved, afterConflict.Status)
+			assert.Equal(capture.LocalBody, afterConflict.LocalBody)
+			assert.Equal(capture.RemoteBody, afterConflict.RemoteBody)
+		})
+	}
+}
+
+func TestCardDAVSetBookRolesRejectsNonTargetNarrowingWithPendingPublication(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('pending-narrowing', 'Pending Narrowing') RETURNING id`).Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID,
+		Href:                 book.CanonicalURL + "pending-narrowing.vcf",
+		OutgoingBody:         []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:pending-narrowing\r\nFN:Pending Narrowing\r\nEND:VCARD\r\n"),
+		OutgoingSemanticHash: "semantic-pending-narrowing", LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	books := addCardDAVRoleTransitionBook(t, st, account, book)
+	setCardDAVRoleTestWriteTarget(t, st, book.ID, books[1].ID)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsLookupSource: true,
+	})
+
+	require.ErrorIs(err, store.ErrCardDAVRoleChangePending)
+	after, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(getErr)
+	assert.Equal(pending.PendingOperation, after.PendingOperation)
+	afterBooks, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.True(afterBooks[0].IsSubscribed)
+}
+
+func TestCardDAVSetBookRolesAllowsResolvedConflictNarrowingAndKeepsAudit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, conflictBook, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	remote := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision, Remote: remote,
+	})
+	require.NoError(err)
+	books := addCardDAVRoleTransitionBook(t, st, account, conflictBook)
+	setCardDAVRoleTestWriteTarget(t, st, conflictBook.ID, books[1].ID)
+
+	err = st.SetCardDAVBookRolesContext(t.Context(), conflictBook.ID, store.CardDAVBookRoles{})
+
+	require.NoError(err)
+	afterBooks, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	require.Len(afterBooks, 2)
+	assert.False(afterBooks[0].IsSubscribed)
+	assert.False(afterBooks[0].IsLookupSource)
+	afterConflict, conflictErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(conflictErr)
+	assert.Equal(store.CardDAVConflictResolved, afterConflict.Status)
+	assert.Equal(resolved.ResolvedAt, afterConflict.ResolvedAt)
+}
+
+func TestCardDAVSetBookRolesAllowsOrdinaryNonTargetNarrowing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, book, mappings := importCardDAVRoleTestPeople(t, "ordinary-narrowing")
+	mapping := mappings["ordinary-narrowing"]
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsLookupSource: true,
+	}))
+	afterDemotion, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Nil(afterDemotion.PersonID)
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{}))
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func addCardDAVRoleTransitionBook(
+	t *testing.T, st *store.Store, account store.CardDAVAccount, current store.CardDAVAddressBook,
+) []store.CardDAVAddressBook {
+	t.Helper()
+	require := require.New(t)
+	input := cardDAVRediscoveryForBook(account, current)
+	input.Books = append(input.Books, store.CardDAVDiscoveredBook{
+		CanonicalURL: "https://contacts.example/books/alice/next/",
+		DisplayName:  "Next", CanCreate: new(true),
+	})
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(books, 2)
+	return books
+}
+
+func setCardDAVRoleTestWriteTarget(t *testing.T, st *store.Store, oldID, newID int64) {
+	t.Helper()
+	require := require.New(t)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_write_target = FALSE WHERE id = ?`), oldID)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_write_target = TRUE, is_subscribed = TRUE WHERE id = ?`), newID)
+	require.NoError(err)
+}
+
+func cardDAVRoleTestWriteTargetID(books []store.CardDAVAddressBook) int64 {
+	for _, book := range books {
+		if book.IsWriteTarget {
+			return book.ID
+		}
+	}
+	return 0
+}
+
+func settleCardDAVTestPublication(
+	t *testing.T, st *store.Store, book store.CardDAVAddressBook, slug string,
+) (int64, store.CardDAVRemoteResource) {
+	t.Helper()
+	var personID int64
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES (?, ?) RETURNING id`), slug, "Settled Owner").Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(t, err)
+	remote := remoteResource(book.CanonicalURL+slug+".vcf", slug, "Settled Owner", slug+"@example.test", `"settled"`)
+	pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID, Href: remote.Href,
+		OutgoingBody: remote.RemoteBody, OutgoingSemanticHash: remote.SemanticHash,
+		LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.CommitCardDAVPublicationContext(t.Context(), store.CardDAVCanonicalMutation{
+		Publication: *pending, Remote: remote,
+	}))
+	return personID, remote
+}
+
+func TestCardDAVDiscoveryPersistsRolesAndPrunesOnlyAfterCompleteReplacement(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	initial := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{
+			{CanonicalURL: "https://contacts.example/books/alice/personal/", DisplayName: "Personal", DiscoveryIndex: 0, CanCreate: new(true), CanUpdate: new(true), SupportedVCardVersions: []string{"4.0", "3.0"}},
+			{CanonicalURL: "https://contacts.example/books/alice/directory/", DisplayName: "Directory", DiscoveryIndex: 1},
+		},
+	}
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), initial)
+	require.NoError(err)
+	assert.Equal(int64(1), account.ConnectionGeneration)
+	require.Len(books, 2)
+	assert.True(books[0].IsWriteTarget)
+	assert.True(books[0].IsSubscribed)
+	assert.True(books[0].IsLookupSource)
+	assert.False(books[1].IsWriteTarget)
+	assert.False(books[1].IsSubscribed)
+	assert.True(books[1].IsLookupSource)
+	assert.Equal([]string{"4.0", "3.0"}, books[0].SupportedVCardVersions)
+
+	// A deliberately ignored book remains ignored when it is seen again.
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_subscribed = FALSE, is_lookup_source = FALSE
+		WHERE canonical_url = ?`), initial.Books[1].CanonicalURL)
+	require.NoError(err)
+	second := initial
+	second.Books = []store.CardDAVDiscoveredBook{
+		initial.Books[1],
+		{CanonicalURL: "https://contacts.example/books/alice/new/", DisplayName: "New", DiscoveryIndex: 1, CanCreate: new(true)},
+	}
+	account, books, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), second)
+	require.NoError(err)
+	assert.Equal(int64(1), account.ConnectionGeneration)
+	require.Len(books, 2)
+	assert.Equal("Directory", books[0].DisplayName)
+	assert.False(books[0].IsSubscribed)
+	assert.False(books[0].IsLookupSource)
+	assert.False(books[1].IsWriteTarget, "later create-capable books must not silently become the write target")
+	assert.False(books[1].IsSubscribed)
+	assert.True(books[1].IsLookupSource)
+}
+
+func TestCardDAVDiscoveryBumpsConnectionGenerationForConnectionOrCredentialChanges(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/", HomeURL: "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{CanonicalURL: "https://contacts.example/books/alice/personal/", DisplayName: "Personal"}},
+	}
+	first, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	input.PrincipalURL = "https://contacts.example/principal/renamed/"
+	metadataOnly, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	assert.Equal(first.ConnectionGeneration, metadataOnly.ConnectionGeneration)
+
+	input.Username = "alice-renamed"
+	changed, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	assert.Equal(first.ConnectionGeneration+1, changed.ConnectionGeneration)
+	input.CredentialsChanged = true
+	credentialChanged, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	assert.Equal(changed.ConnectionGeneration+1, credentialChanged.ConnectionGeneration)
+
+	loaded, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(loaded)
+	assert.Equal(credentialChanged, loaded)
+	listed, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Len(listed, 1)
+}
+
+func TestCardDAVDiscoveryRejectsIncompleteSnapshotWithoutChangingStoredBooks(t *testing.T) {
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/", HomeURL: "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{CanonicalURL: "https://contacts.example/books/alice/personal/", DisplayName: "Personal"}},
+	}
+	_, before, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	input.Books = []store.CardDAVDiscoveredBook{
+		{CanonicalURL: "https://contacts.example/books/alice/new/", DisplayName: "New"},
+		{CanonicalURL: "https://contacts.example/books/alice/new/", DisplayName: "Duplicate"},
+	}
+	_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.ErrorContains(err, "duplicate")
+	after, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Equal(t, before, after)
+}
+
+func TestCardDAVDiscoveryKeepsCanonicalURLWhenServerReadvertisesItsAlias(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/", HomeURL: "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL:      "https://contacts.example/books/alice/canonical/",
+			DiscoveryAliasURL: "https://contacts.example/books/alice/advertised/",
+			DisplayName:       "Personal",
+		}},
+	}
+	_, first, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(first, 1)
+	firstID := first[0].ID
+
+	// A canonical-only snapshot must not erase the durable discovery alias.
+	input.Books[0].DiscoveryAliasURL = ""
+	_, second, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(second, 1)
+	assert.Equal(firstID, second[0].ID)
+	assert.Equal("https://contacts.example/books/alice/canonical/", second[0].CanonicalURL)
+	assert.Equal("https://contacts.example/books/alice/advertised/", second[0].DiscoveryAliasURL)
+
+	input.Books[0].CanonicalURL = input.Books[0].DiscoveryAliasURL
+	if input.Books[0].CanonicalURL == "" {
+		input.Books[0].CanonicalURL = "https://contacts.example/books/alice/advertised/"
+	}
+	input.Books[0].DiscoveryAliasURL = ""
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(firstID, books[0].ID)
+	assert.Equal("https://contacts.example/books/alice/canonical/", books[0].CanonicalURL)
+	assert.Equal("https://contacts.example/books/alice/advertised/", books[0].DiscoveryAliasURL)
+	assert.Equal(first[0].IsWriteTarget, books[0].IsWriteTarget)
+	assert.Equal(first[0].IsSubscribed, books[0].IsSubscribed)
+	assert.Equal(first[0].IsLookupSource, books[0].IsLookupSource)
+}
+
+func TestCardDAVDiscoveryCanonicalURLChangeInvalidatesIncrementalSync(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, NextSyncToken: "incremental-token",
+	})
+	require.NoError(err)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	book = books[0]
+	stalePlan := store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, NextSyncToken: "stale-next-token",
+	}
+
+	rediscovered := cardDAVRediscoveryForBook(account, book)
+	rediscovered.Books[0].CanonicalURL = "https://contacts.example/books/alice/renamed/"
+	rediscovered.Books[0].DiscoveryAliasURL = book.CanonicalURL
+	_, books, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), rediscovered)
+
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(book.ID, books[0].ID)
+	assert.Equal(rediscovered.Books[0].CanonicalURL, books[0].CanonicalURL)
+	assert.Equal(book.CanonicalURL, books[0].DiscoveryAliasURL)
+	assert.Empty(books[0].SyncToken)
+	assert.True(books[0].NeedsFullReconcile)
+	assert.Equal(book.SyncRevision+1, books[0].SyncRevision)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), stalePlan)
+	require.ErrorIs(err, store.ErrCardDAVStalePlan)
+}
+
+func TestCardDAVDiscoveryRejectsTwoBooksClaimingOneStoredURLIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL:      "https://contacts.example/books/alice/canonical/",
+			DiscoveryAliasURL: "https://contacts.example/books/alice/alias/",
+			DisplayName:       "Personal",
+		}},
+	}
+	beforeAccount, beforeBooks, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+
+	input.Books = []store.CardDAVDiscoveredBook{
+		{
+			CanonicalURL:      "https://contacts.example/books/alice/canonical/",
+			DiscoveryAliasURL: "https://contacts.example/books/alice/first-new-alias/",
+			DisplayName:       "First",
+		},
+		{
+			CanonicalURL:      "https://contacts.example/books/alice/alias/",
+			DiscoveryAliasURL: "https://contacts.example/books/alice/second-new-alias/",
+			DisplayName:       "Second",
+		},
+	}
+	_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.ErrorContains(err, "match the same stored book")
+
+	afterAccount, err := st.GetCardDAVAccountContext(t.Context())
+	require.NoError(err)
+	require.NotNil(afterAccount)
+	assert.Equal(*beforeAccount, *afterAccount)
+	afterBooks, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Equal(beforeBooks, afterBooks)
+}
+
+func TestCardDAVURLIdentityPreservesPathCase(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	input := store.CardDAVDiscoveryInput{
+		BaseURL: "https://CONTACTS.example:443/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/", HomeURL: "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{
+			{CanonicalURL: "https://contacts.example/Books/", DisplayName: "Upper", DiscoveryIndex: 0},
+			{CanonicalURL: "https://contacts.example/books/", DisplayName: "Lower", DiscoveryIndex: 1},
+		},
+	}
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+	require.NoError(err)
+	require.Len(books, 2)
+	assert.Equal("https://contacts.example/Books/", books[0].CanonicalURL)
+	assert.Equal("https://contacts.example/books/", books[1].CanonicalURL)
+}
+
+func TestCardDAVURLIdentityUsesOneCanonicalAndAliasNamespace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+	base := store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/", HomeURL: "https://contacts.example/books/alice/",
+	}
+
+	selfAlias := base
+	selfAlias.Books = []store.CardDAVDiscoveredBook{{
+		CanonicalURL:      "https://CONTACTS.example:443/Books/",
+		DiscoveryAliasURL: "https://contacts.example/Books/",
+	}}
+	_, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), selfAlias)
+	require.ErrorContains(err, "duplicate")
+
+	crossColumn := base
+	crossColumn.Books = []store.CardDAVDiscoveredBook{
+		{CanonicalURL: "https://contacts.example/a/", DiscoveryAliasURL: "https://contacts.example/b/", DiscoveryIndex: 0},
+		{CanonicalURL: "https://contacts.example/b/", DiscoveryIndex: 1},
+	}
+	_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), crossColumn)
+	require.ErrorContains(err, "duplicate")
+
+	nullAlias := base
+	nullAlias.Books = []store.CardDAVDiscoveredBook{{CanonicalURL: "https://contacts.example/only/"}}
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), nullAlias)
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Empty(books[0].DiscoveryAliasURL)
+	var identityCount int
+	err = st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM carddav_address_book_urls WHERE address_book_id = ?`), books[0].ID).Scan(&identityCount)
+	require.NoError(err)
+	assert.Equal(1, identityCount, "NULL alias must create only the canonical identity")
+}
+
+func cardDAVRediscoveryForBook(
+	account store.CardDAVAccount, book store.CardDAVAddressBook,
+) store.CardDAVDiscoveryInput {
+	allowed := true
+	return store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: book.CanonicalURL, DisplayName: book.DisplayName,
+			SupportsSyncCollection: true, SupportsMultiget: true, CanCreate: &allowed,
+		}},
+	}
+}
+
+func TestCardDAVDiscoveryRejectsCredentialRotationWithPendingRemoteFirstIntent(t *testing.T) {
+	t.Run("publication", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		st, account, book := newCardDAVResourceStore(t)
+		var personID int64
+		require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+			VALUES ('rotation-publication', 'Rotation Publication') RETURNING id`).Scan(&personID))
+		snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+		require.NoError(err)
+		pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+			PersonID: personID, Desired: true, AddressBookID: book.ID,
+			Href:                 book.CanonicalURL + "rotation-publication.vcf",
+			OutgoingBody:         []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:rotation-publication\r\nFN:Rotation Publication\r\nEND:VCARD\r\n"),
+			OutgoingSemanticHash: "semantic-rotation-publication", LocalHash: snapshot.Fingerprint,
+		})
+		require.NoError(err)
+
+		input := cardDAVRediscoveryForBook(account, book)
+		input.CredentialsChanged = true
+		_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+
+		require.ErrorContains(err, "pending remote-first")
+		afterAccount, getErr := st.GetCardDAVAccountContext(t.Context())
+		require.NoError(getErr)
+		require.NotNil(afterAccount)
+		assert.Equal(account.ConnectionGeneration, afterAccount.ConnectionGeneration)
+		after, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+		require.NoError(getErr)
+		assert.Equal(pending.PendingOperation, after.PendingOperation)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		st, account, book, _, conflict, remote := seededCardDAVTombstoneConflict(t, false)
+		pending, err := st.PrepareCardDAVConflictLocalTombstoneContext(
+			t.Context(), conflict.ID, conflict.MappingRevision, remote)
+		require.NoError(err)
+		require.Equal(store.CardDAVMutationDelete, pending.PendingOperation)
+
+		input := cardDAVRediscoveryForBook(account, book)
+		input.CredentialsChanged = true
+		_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+
+		require.ErrorContains(err, "pending remote-first")
+		afterAccount, getErr := st.GetCardDAVAccountContext(t.Context())
+		require.NoError(getErr)
+		require.NotNil(afterAccount)
+		assert.Equal(account.ConnectionGeneration, afterAccount.ConnectionGeneration)
+		after, getErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+		require.NoError(getErr)
+		assert.Equal(store.CardDAVMutationDelete, after.PendingOperation)
+	})
+}
+
+func TestCardDAVConnectionIdentityChangeCreatesFreshBooksAndCleansOldImportState(t *testing.T) {
+	for _, tc := range []struct {
+		name, baseURL, username, localDisplay string
+	}{
+		{name: "username with same URLs", baseURL: "https://contacts.example/dav", username: "bob"},
+		{name: "base URL", baseURL: "https://other.example/dav", username: "alice", localDisplay: "Locally Renamed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, account, book := newCardDAVResourceStore(t)
+			removed := remoteResource(book.CanonicalURL+"removed.vcf", "removed-identity", "Removed", "removed@example.test", `"one"`)
+			preserved := remoteResource(book.CanonicalURL+"preserved.vcf", "preserved-identity", "Preserved", "preserved@example.test", `"one"`)
+			_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+				AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+				SyncRevision: book.SyncRevision, NextSyncToken: "old-account-token",
+				Upserts: []store.CardDAVRemoteResource{removed, preserved},
+			})
+			require.NoError(err)
+			removedMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, removed.Href)
+			require.NoError(err)
+			require.NotNil(removedMapping.PersonID)
+			preservedMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, preserved.Href)
+			require.NoError(err)
+			require.NotNil(preservedMapping.PersonID)
+			_, err = st.AddPersonContactPointContext(t.Context(), *preservedMapping.PersonID, store.PersonContactPointInput{
+				AddressKind: store.ContactAddressEmail, OriginalValue: "user-owned@example.test",
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			})
+			require.NoError(err)
+			if tc.localDisplay != "" {
+				person, getErr := st.GetPersonContext(t.Context(), *preservedMapping.PersonID)
+				require.NoError(getErr)
+				_, err = st.UpdatePersonDisplayNameContext(
+					t.Context(), person.ID, person.Revision, &tc.localDisplay)
+				require.NoError(err)
+			}
+			beforeNames, err := st.ListPersonNamesContext(t.Context(), *preservedMapping.PersonID, true)
+			require.NoError(err)
+			require.Len(beforeNames, 1)
+
+			input := cardDAVRediscoveryForBook(account, book)
+			input.BaseURL = tc.baseURL
+			input.Username = tc.username
+			input.PrincipalURL = tc.baseURL + "/principal/"
+			input.HomeURL = tc.baseURL + "/books/"
+			afterAccount, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+
+			require.NoError(err)
+			require.Len(books, 1)
+			assert.Equal(account.ConnectionGeneration+1, afterAccount.ConnectionGeneration)
+			assert.NotEqual(book.ID, books[0].ID, "a new connection must not reuse URL-matched book identity")
+			assert.Empty(books[0].SyncToken)
+			assert.True(books[0].IsWriteTarget)
+			assert.True(books[0].IsSubscribed)
+			_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, removed.Href)
+			require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+			newResources, err := st.ListCardDAVResourcesContext(t.Context(), books[0].ID)
+			require.NoError(err)
+			assert.Empty(newResources)
+			_, err = st.GetPersonContext(t.Context(), *removedMapping.PersonID)
+			require.ErrorIs(err, store.ErrPersonNotFound)
+			preservedPerson, err := st.GetPersonContext(t.Context(), *preservedMapping.PersonID)
+			require.NoError(err, "user-owned state must survive old connection cleanup")
+			if tc.localDisplay == "" {
+				assert.Nil(preservedPerson.DisplayName, "a retired remote name must not remain as the scalar display label")
+			} else {
+				require.NotNil(preservedPerson.DisplayName)
+				assert.Equal(tc.localDisplay, *preservedPerson.DisplayName,
+					"a locally changed scalar display label must survive")
+			}
+			points, err := st.ListPersonContactPointsContext(t.Context(), *preservedMapping.PersonID, true)
+			require.NoError(err)
+			assert.Equal([]string{"user-owned@example.test"}, contactOriginalValues(points))
+			names, err := st.ListPersonNamesContext(t.Context(), *preservedMapping.PersonID, true)
+			require.NoError(err)
+			assert.Empty(names)
+			allNames, err := st.ListPersonNamesContext(t.Context(), *preservedMapping.PersonID, false)
+			require.NoError(err)
+			require.Len(allNames, 1)
+			assert.NotNil(allNames[0].Envelope.SupersededAt)
+			allPoints, err := st.ListPersonContactPointsContext(t.Context(), *preservedMapping.PersonID, false)
+			require.NoError(err)
+			require.Len(allPoints, 2)
+			for _, point := range allPoints {
+				if point.OriginalValue == preserved.Emails[0] {
+					assert.NotNil(point.Envelope.SupersededAt)
+				}
+			}
+			_, err = st.GetVCardResourceEnvelopeContext(
+				t.Context(), fmt.Sprintf("carddav:%d", book.ID), preserved.Href)
+			require.ErrorIs(err, store.ErrVCardResourceNotFound)
+
+			rematch := remoteResource(books[0].CanonicalURL+"rematch.vcf", "rematch-identity", "Rematch", preserved.Emails[0], `"one"`)
+			_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+				AddressBookID: books[0].ID, ConnectionGeneration: afterAccount.ConnectionGeneration,
+				SyncRevision: books[0].SyncRevision, Upserts: []store.CardDAVRemoteResource{rematch},
+			})
+			require.NoError(err)
+			rematched, err := st.GetCardDAVResourceContext(t.Context(), books[0].ID, rematch.Href)
+			require.NoError(err)
+			require.NotNil(rematched.PersonID)
+			assert.NotEqual(*preservedMapping.PersonID, *rematched.PersonID,
+				"retired imported email must not participate in identity matching")
+		})
+	}
+}
+
+func TestCardDAVConnectionIdentityChangeRejectsOwnedPublicationOrConflict(t *testing.T) {
+	t.Run("publication", func(t *testing.T) {
+		st, account, book := newCardDAVResourceStore(t)
+		personID, _ := settleCardDAVTestPublication(t, st, book, "identity-owner")
+		input := cardDAVRediscoveryForBook(account, book)
+		input.Username = "bob"
+
+		_, _, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+
+		require.ErrorContains(t, err, "owned remote state")
+		_, getErr := st.GetCardDAVPublicationContext(t.Context(), personID)
+		require.NoError(t, getErr)
+	})
+
+	t.Run("unresolved conflict", func(t *testing.T) {
+		require := require.New(t)
+
+		st, account, book, mapping := seededCardDAVConflictMapping(t)
+		conflict, err := st.RecordCardDAVConflictContext(t.Context(), conflictCapture(mapping))
+		require.NoError(err)
+		input := cardDAVRediscoveryForBook(account, book)
+		input.BaseURL = "https://other.example/dav"
+
+		_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), input)
+
+		require.ErrorContains(err, "owned remote state")
+		after, getErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+		require.NoError(getErr)
+		assert.Equal(t, store.CardDAVConflictUnresolved, after.Status)
+	})
+}
+
+func TestCardDAVDiscoveryRetainsResolvedConflictUntilAuditSweep(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	remote := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision, Remote: remote,
+	})
+	require.NoError(err)
+	require.NotNil(resolved.ResolvedAt)
+	absent := store.CardDAVDiscoveryInput{
+		BaseURL: account.BaseURL, Username: account.Username,
+		PrincipalURL: account.PrincipalURL, HomeURL: account.HomeURL,
+	}
+
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), absent)
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(book.ID, books[0].ID)
+	retained, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, retained.Status)
+
+	removed, err := st.SweepResolvedCardDAVConflictsContext(
+		t.Context(), resolved.ResolvedAt.Add(30*24*time.Hour+time.Second))
+	require.NoError(err)
+	assert.Equal(int64(1), removed)
+	_, books, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), absent)
+	require.NoError(err)
+	assert.Empty(books)
+	_, err = st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.ErrorIs(err, store.ErrCardDAVConflictNotFound)
+}
+
+func TestCardDAVIdentityChangeWaitsForResolvedConflictAuditSweep(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	remote := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision, Remote: remote,
+	})
+	require.NoError(err)
+	changed := cardDAVRediscoveryForBook(account, book)
+	changed.Username = "bob"
+
+	require.ErrorIs(st.ValidateCardDAVConnectionChangeContext(
+		t.Context(), changed.BaseURL, changed.Username, false), store.ErrCardDAVIdentityChangeOwned)
+	_, _, err = st.ReplaceCardDAVDiscoveryContext(t.Context(), changed)
+	require.ErrorIs(err, store.ErrCardDAVIdentityChangeOwned)
+	after, getErr := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(getErr)
+	assert.Equal(store.CardDAVConflictResolved, after.Status)
+
+	removed, err := st.SweepResolvedCardDAVConflictsContext(
+		t.Context(), resolved.ResolvedAt.Add(30*24*time.Hour+time.Second))
+	require.NoError(err)
+	assert.Equal(int64(1), removed)
+	require.NoError(st.ValidateCardDAVConnectionChangeContext(
+		t.Context(), changed.BaseURL, changed.Username, false))
+	afterAccount, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), changed)
+	require.NoError(err)
+	require.Len(books, 1)
+	assert.Equal(account.ConnectionGeneration+1, afterAccount.ConnectionGeneration)
+	assert.NotEqual(book.ID, books[0].ID)
+}

--- a/internal/store/carddav_conflicts.go
+++ b/internal/store/carddav_conflicts.go
@@ -1,0 +1,1302 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const MaxCardDAVConflictSnapshotBytes = 32 << 20
+
+type CardDAVConflictStatus string
+
+const (
+	CardDAVConflictUnresolved CardDAVConflictStatus = "unresolved"
+	CardDAVConflictResolved   CardDAVConflictStatus = "resolved"
+)
+
+type CardDAVConflictResolution string
+
+const (
+	CardDAVResolutionKeepLocal  CardDAVConflictResolution = "keep_local"
+	CardDAVResolutionKeepRemote CardDAVConflictResolution = "keep_remote"
+)
+
+var (
+	ErrCardDAVConflictNotFound   = errors.New("CardDAV conflict not found")
+	ErrCardDAVConflictStale      = errors.New("CardDAV conflict is stale or already resolved")
+	ErrCardDAVConflictTooLarge   = errors.New("CardDAV conflict snapshots exceed 32 MiB")
+	ErrCardDAVConflictResolution = errors.New("invalid CardDAV conflict resolution")
+)
+
+type CardDAVConflict struct {
+	ID                      int64
+	AddressBookID           int64
+	Href                    string
+	BaseLocalHash           string
+	LocalHash               string
+	BaseRemoteHash          string
+	BaseRemoteETag          string
+	RemoteETag              string
+	MappingRevision         int64
+	LocalBody               []byte
+	RemoteBody              []byte
+	LocalTombstone          bool
+	RemoteTombstone         bool
+	PendingOperation        CardDAVMutationOperation
+	ConnectionGeneration    int64
+	BookSyncRevision        int64
+	PreviousMappingRevision int64
+	PendingStartedAt        *time.Time
+	Status                  CardDAVConflictStatus
+	Resolution              CardDAVConflictResolution
+	ResolvedAt              *time.Time
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+}
+
+type CardDAVConflictCapture struct {
+	AddressBookID           int64
+	Href                    string
+	ExpectedMappingRevision int64
+	BaseLocalHash           string
+	LocalHash               string
+	BaseRemoteHash          string
+	BaseRemoteETag          string
+	RemoteETag              string
+	LocalBody               []byte
+	RemoteBody              []byte
+	LocalTombstone          bool
+	RemoteTombstone         bool
+}
+
+type CardDAVConflictRemoteResolution struct {
+	ConflictID              int64
+	ExpectedMappingRevision int64
+	Remote                  CardDAVRemoteResource
+	RemoteTombstone         bool
+}
+
+type CardDAVConflictLocalPlan struct {
+	ConflictID              int64
+	ExpectedMappingRevision int64
+	RemoteETag              string
+	RemoteTombstone         bool
+	OutgoingSemanticHash    string
+}
+
+type cardDAVConflictIdentity struct {
+	AddressBookID int64
+	Href          string
+}
+
+func (s *Store) getCardDAVConflictIdentityContext(
+	ctx context.Context, conflictID int64,
+) (cardDAVConflictIdentity, error) {
+	var identity cardDAVConflictIdentity
+	err := s.db.QueryRowContext(ctx, `SELECT address_book_id, href
+		FROM carddav_conflicts WHERE id = ?`, conflictID).Scan(
+		&identity.AddressBookID, &identity.Href)
+	if errors.Is(err, sql.ErrNoRows) {
+		return cardDAVConflictIdentity{}, ErrCardDAVConflictNotFound
+	}
+	if err != nil {
+		return cardDAVConflictIdentity{}, fmt.Errorf("get CardDAV conflict identity: %w", err)
+	}
+	return identity, nil
+}
+
+func (s *Store) lockCardDAVConflictResolutionBookTx(
+	ctx context.Context, tx *loggedTx, addressBookID int64,
+) (CardDAVAddressBook, error) {
+	var book CardDAVAddressBook
+	err := tx.QueryRowContext(ctx, `SELECT id, account_id, canonical_url,
+		is_write_target, is_subscribed, is_lookup_source, sync_revision,
+		can_create, can_update, can_delete
+		FROM carddav_address_books WHERE id = ?`+
+		s.dialect.SelectForUpdate(), addressBookID).Scan(
+		&book.ID, &book.AccountID, &book.CanonicalURL,
+		&book.IsWriteTarget, &book.IsSubscribed, &book.IsLookupSource, &book.SyncRevision,
+		&book.CanCreate, &book.CanUpdate, &book.CanDelete)
+	if errors.Is(err, sql.ErrNoRows) {
+		return CardDAVAddressBook{}, ErrCardDAVConflictStale
+	}
+	if err != nil {
+		return CardDAVAddressBook{}, fmt.Errorf("lock CardDAV conflict book: %w", err)
+	}
+	return book, nil
+}
+
+func cardDAVConflictBookAllowsMutation(book CardDAVAddressBook, operation CardDAVMutationOperation) bool {
+	if !book.IsSubscribed {
+		return false
+	}
+	var capability *bool
+	switch operation {
+	case CardDAVMutationCreate:
+		capability = book.CanCreate
+	case CardDAVMutationUpdate:
+		capability = book.CanUpdate
+	case CardDAVMutationDelete:
+		capability = book.CanDelete
+	default:
+		return false
+	}
+	// A missing privilege advertisement is not a denial. The remote mutation
+	// still enforces capability through its HTTP result.
+	return capability == nil || *capability
+}
+
+func (s *Store) PrepareCardDAVConflictLocalContext(
+	ctx context.Context, plan CardDAVConflictLocalPlan,
+) (*CardDAVPublication, error) {
+	if plan.ConflictID <= 0 || plan.ExpectedMappingRevision <= 0 ||
+		(!plan.RemoteTombstone && (strings.TrimSpace(plan.RemoteETag) == "" || plan.RemoteETag == "*")) ||
+		strings.TrimSpace(plan.OutgoingSemanticHash) == "" {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	var prepared *CardDAVPublication
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		conflict, err := getCardDAVConflictFrom(ctx, tx, plan.ConflictID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if conflict.Status != CardDAVConflictUnresolved || conflict.MappingRevision != plan.ExpectedMappingRevision ||
+			conflict.LocalTombstone || len(conflict.LocalBody) == 0 {
+			return ErrCardDAVConflictStale
+		}
+		mapping, err := s.findCardDAVResourceTx(ctx, tx, conflict.AddressBookID, conflict.Href)
+		if err != nil || mapping.PersonID == nil {
+			return ErrCardDAVConflictStale
+		}
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, *mapping.PersonID)
+		if err != nil {
+			return err
+		}
+		if snapshot.Fingerprint != conflict.LocalHash {
+			return ErrCardDAVConflictStale
+		}
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			return err
+		}
+		book, err := s.lockCardDAVConflictResolutionBookTx(ctx, tx, conflict.AddressBookID)
+		if err != nil {
+			return err
+		}
+		operation := CardDAVMutationUpdate
+		remoteETag := plan.RemoteETag
+		if plan.RemoteTombstone {
+			operation = CardDAVMutationCreate
+			remoteETag = ""
+		}
+		if !cardDAVConflictBookAllowsMutation(book, operation) {
+			return ErrCardDAVNoWriteTarget
+		}
+		publication, publicationErr := getCardDAVPublicationFrom(ctx, tx, *mapping.PersonID,
+			s.dialect.SelectForUpdate())
+		if publicationErr != nil && !errors.Is(publicationErr, ErrCardDAVPublicationNotFound) {
+			return publicationErr
+		}
+		if publicationErr == nil && publication.PendingOperation != "" {
+			if publication.AddressBookID != conflict.AddressBookID || publication.Href != conflict.Href ||
+				publication.PreviousMappingRevision != conflict.MappingRevision ||
+				publication.MappingRevision != mapping.MappingRevision {
+				return ErrCardDAVConflictStale
+			}
+			publication.RecoveryOnly = true
+			publication.ResolutionConflictID = conflict.ID
+			prepared = publication
+			return nil
+		}
+		if mapping.MappingRevision != plan.ExpectedMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		nextMappingRevision := mapping.MappingRevision + 1
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND mapping_revision = ?`, nextMappingRevision, mapping.ID, mapping.MappingRevision)
+		if err != nil {
+			return err
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		mutationRevision := int64(1)
+		if publication != nil {
+			mutationRevision = publication.MutationRevision + 1
+		}
+		now := time.Now().UTC()
+		_, err = tx.ExecContext(ctx, `INSERT INTO carddav_publications (
+			person_id, desired, address_book_id, href, pending_operation,
+			outgoing_body, outgoing_semantic_hash, local_hash, remote_etag,
+			connection_generation, book_sync_revision, mapping_revision,
+			previous_mapping_revision, create_recovery_used, mutation_revision,
+			pending_started_at, updated_at
+		) VALUES (?, TRUE, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, FALSE, ?, ?, `+s.dialect.Now()+`)
+		ON CONFLICT(person_id) DO UPDATE SET
+			desired = TRUE, address_book_id = excluded.address_book_id, href = excluded.href,
+			pending_operation = excluded.pending_operation, outgoing_body = excluded.outgoing_body,
+			outgoing_semantic_hash = excluded.outgoing_semantic_hash,
+			local_hash = excluded.local_hash, remote_etag = excluded.remote_etag,
+			connection_generation = excluded.connection_generation,
+			book_sync_revision = excluded.book_sync_revision,
+			mapping_revision = excluded.mapping_revision,
+			previous_mapping_revision = excluded.previous_mapping_revision,
+			create_recovery_used = FALSE, mutation_revision = excluded.mutation_revision,
+			pending_started_at = excluded.pending_started_at, updated_at = `+s.dialect.Now(),
+			*mapping.PersonID, conflict.AddressBookID, conflict.Href, operation,
+			conflict.LocalBody, plan.OutgoingSemanticHash, conflict.LocalHash, remoteETag,
+			generation, book.SyncRevision, nextMappingRevision, mapping.MappingRevision,
+			mutationRevision, timeValue(&now))
+		if err != nil {
+			return fmt.Errorf("prepare keep-local CardDAV conflict mutation: %w", err)
+		}
+		prepared, err = getCardDAVPublicationFrom(ctx, tx, *mapping.PersonID, "")
+		if err == nil {
+			prepared.ResolutionConflictID = conflict.ID
+		}
+		return err
+	})
+	return prepared, err
+}
+
+func (s *Store) PrepareCardDAVConflictLocalTombstoneContext(
+	ctx context.Context, conflictID, expectedMappingRevision int64,
+	remote CardDAVRemoteResource,
+) (*CardDAVPublication, error) {
+	if conflictID <= 0 || expectedMappingRevision <= 0 || strings.TrimSpace(remote.Href) == "" ||
+		strings.TrimSpace(remote.RemoteETag) == "" || remote.RemoteETag == "*" ||
+		len(remote.RemoteBody) == 0 || strings.TrimSpace(remote.SemanticHash) == "" {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	if len(remote.RemoteBody) > MaxCardDAVConflictSnapshotBytes {
+		return nil, ErrCardDAVConflictTooLarge
+	}
+	identity, err := s.getCardDAVConflictIdentityContext(ctx, conflictID)
+	if err != nil {
+		return nil, err
+	}
+	if s.cardDAVTombstonePrepareSnapshotHook != nil {
+		s.cardDAVTombstonePrepareSnapshotHook()
+	}
+	var prepared *CardDAVPublication
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVNoWriteTarget
+			}
+			return err
+		}
+		book, err := s.lockCardDAVConflictResolutionBookTx(ctx, tx, identity.AddressBookID)
+		if err != nil {
+			return err
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		mapping, err := s.findCardDAVResourceTx(ctx, tx, identity.AddressBookID, identity.Href)
+		if errors.Is(err, ErrCardDAVResourceNotFound) {
+			return ErrCardDAVConflictStale
+		}
+		if err != nil {
+			return err
+		}
+		conflict, err := getCardDAVConflictFrom(ctx, tx, conflictID, s.dialect.SelectForUpdate())
+		if errors.Is(err, ErrCardDAVConflictNotFound) {
+			return ErrCardDAVConflictStale
+		}
+		if err != nil {
+			return err
+		}
+		if conflict.Status != CardDAVConflictUnresolved || !conflict.LocalTombstone ||
+			conflict.RemoteTombstone || conflict.AddressBookID != identity.AddressBookID ||
+			conflict.Href != identity.Href || remote.Href != identity.Href ||
+			conflict.MappingRevision != expectedMappingRevision ||
+			mapping.AddressBookID != conflict.AddressBookID || mapping.Href != conflict.Href ||
+			mapping.MappingRevision != expectedMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		if err := s.validateCardDAVConflictLocalTombstoneMappingTx(ctx, tx, conflict, mapping); err != nil {
+			return err
+		}
+		if conflict.PendingOperation != "" {
+			if _, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict); err != nil {
+				return err
+			}
+			prepared = cardDAVPublicationFromConflict(conflict)
+			prepared.RecoveryOnly = true
+			return nil
+		}
+		if !cardDAVConflictBookAllowsMutation(book, CardDAVMutationDelete) {
+			return ErrCardDAVNoWriteTarget
+		}
+		nextRevision := mapping.MappingRevision + 1
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND mapping_revision = ?`, nextRevision, mapping.ID, mapping.MappingRevision)
+		if err != nil {
+			return fmt.Errorf("advance keep-local tombstone mapping fence: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		now := time.Now().UTC()
+		row := tx.QueryRowContext(ctx, `UPDATE carddav_conflicts SET
+			remote_etag = ?, remote_body = ?, remote_tombstone = FALSE,
+			mapping_revision = ?, pending_operation = ?, connection_generation = ?,
+			book_sync_revision = ?, previous_mapping_revision = ?, pending_started_at = ?,
+			updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND status = 'unresolved' AND mapping_revision = ?
+			RETURNING `+cardDAVConflictColumns,
+			remote.RemoteETag, remote.RemoteBody, nextRevision, CardDAVMutationDelete,
+			generation, book.SyncRevision, mapping.MappingRevision, timeValue(&now),
+			conflict.ID, conflict.MappingRevision)
+		conflict, err = scanCardDAVConflict(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrCardDAVConflictStale
+		}
+		if err != nil {
+			return fmt.Errorf("persist keep-local tombstone intent: %w", err)
+		}
+		prepared = cardDAVPublicationFromConflict(conflict)
+		return nil
+	})
+	return prepared, err
+}
+
+func (s *Store) RefreshCardDAVConflictMutationFenceContext(
+	ctx context.Context, conflictID int64,
+) (*CardDAVPublication, error) {
+	var refreshed *CardDAVPublication
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		conflict, err := getCardDAVConflictFrom(ctx, tx, conflictID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		mapping, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict)
+		if err != nil {
+			return err
+		}
+		var generation, bookRevision int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`).Scan(&generation); err != nil {
+			return err
+		}
+		if generation != conflict.ConnectionGeneration {
+			return ErrCardDAVStalePlan
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT sync_revision FROM carddav_address_books
+			WHERE id = ?`, conflict.AddressBookID).Scan(&bookRevision); err != nil {
+			return err
+		}
+		row := tx.QueryRowContext(ctx, `UPDATE carddav_conflicts SET
+			book_sync_revision = ?, mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND status = 'unresolved' AND pending_operation = ?
+			RETURNING `+cardDAVConflictColumns,
+			bookRevision, mapping.MappingRevision, conflict.ID, CardDAVMutationDelete)
+		conflict, err = scanCardDAVConflict(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrCardDAVConflictStale
+		}
+		if err != nil {
+			return err
+		}
+		refreshed = cardDAVPublicationFromConflict(conflict)
+		refreshed.RecoveryOnly = true
+		return nil
+	})
+	return refreshed, err
+}
+
+func (s *Store) CommitCardDAVConflictLocalTombstoneContext(
+	ctx context.Context, input CardDAVCanonicalMutation,
+) error {
+	pending := input.Publication
+	identity, err := s.getCardDAVConflictIdentityContext(ctx, pending.ResolutionConflictID)
+	if err != nil {
+		return err
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			return err
+		}
+		book, err := s.lockCardDAVConflictResolutionBookTx(ctx, tx, identity.AddressBookID)
+		if err != nil {
+			return err
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		mapping, err := s.findCardDAVResourceTx(ctx, tx, identity.AddressBookID, identity.Href)
+		if err != nil {
+			return ErrCardDAVConflictStale
+		}
+		conflict, err := getCardDAVConflictFrom(ctx, tx, pending.ResolutionConflictID,
+			s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if conflict.AddressBookID != identity.AddressBookID || conflict.Href != identity.Href ||
+			mapping.AddressBookID != conflict.AddressBookID || mapping.Href != conflict.Href {
+			return ErrCardDAVConflictStale
+		}
+		validatedMapping, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict)
+		if err != nil {
+			return err
+		}
+		if pending.MappingRevision != conflict.MappingRevision ||
+			pending.ConnectionGeneration != conflict.ConnectionGeneration ||
+			pending.BookSyncRevision != conflict.BookSyncRevision || !input.Tombstone {
+			return ErrCardDAVPublicationMismatch
+		}
+		if generation != conflict.ConnectionGeneration || book.SyncRevision != conflict.BookSyncRevision {
+			return ErrCardDAVStalePlan
+		}
+		_, err = s.completeCardDAVConflictLocalTombstoneTx(ctx, tx, conflict, validatedMapping)
+		return err
+	})
+}
+
+func (s *Store) ResetCardDAVConflictLocalTombstoneContext(
+	ctx context.Context, conflictID int64, remote CardDAVRemoteResource,
+) (*CardDAVConflict, error) {
+	if conflictID <= 0 || remote.Href == "" || remote.RemoteETag == "" ||
+		len(remote.RemoteBody) == 0 || remote.SemanticHash == "" {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	if len(remote.RemoteBody) > MaxCardDAVConflictSnapshotBytes {
+		return nil, ErrCardDAVConflictTooLarge
+	}
+	var reset *CardDAVConflict
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		conflict, err := getCardDAVConflictFrom(ctx, tx, conflictID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		mapping, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict)
+		if err != nil || remote.Href != conflict.Href {
+			return ErrCardDAVConflictStale
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND mapping_revision = ?`,
+			conflict.PreviousMappingRevision, mapping.ID, conflict.MappingRevision)
+		if err != nil {
+			return fmt.Errorf("restore keep-local tombstone mapping fence: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		row := tx.QueryRowContext(ctx, `UPDATE carddav_conflicts SET
+			remote_etag = ?, remote_body = ?, remote_tombstone = FALSE,
+			mapping_revision = previous_mapping_revision, pending_operation = NULL,
+			connection_generation = NULL, book_sync_revision = NULL,
+			previous_mapping_revision = NULL, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+` WHERE id = ? AND status = 'unresolved'
+			RETURNING `+cardDAVConflictColumns,
+			remote.RemoteETag, remote.RemoteBody, conflict.ID)
+		reset, err = scanCardDAVConflict(row)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrCardDAVConflictStale
+		}
+		return err
+	})
+	return reset, err
+}
+
+// RollbackCardDAVConflictMutationContext clears a definitively rejected
+// keep-local tombstone and restores its mapping fence without changing the
+// canonical remote snapshot retained by the unresolved conflict.
+func (s *Store) RollbackCardDAVConflictMutationContext(
+	ctx context.Context, pending *CardDAVPublication,
+) error {
+	if pending == nil || pending.ResolutionConflictID <= 0 ||
+		pending.PendingOperation != CardDAVMutationDelete {
+		return ErrCardDAVInvalidPlan
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		conflict, err := getCardDAVConflictFrom(ctx, tx, pending.ResolutionConflictID,
+			s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		mapping, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict)
+		if err != nil || conflict.MappingRevision != pending.MappingRevision ||
+			conflict.PreviousMappingRevision != pending.PreviousMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND mapping_revision = ?`,
+			conflict.PreviousMappingRevision, mapping.ID, conflict.MappingRevision)
+		if err != nil {
+			return fmt.Errorf("restore rejected keep-local tombstone mapping fence: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		result, err = tx.ExecContext(ctx, `UPDATE carddav_conflicts SET
+			mapping_revision = previous_mapping_revision, pending_operation = NULL,
+			connection_generation = NULL, book_sync_revision = NULL,
+			previous_mapping_revision = NULL, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND status = 'unresolved' AND pending_operation = ?`,
+			conflict.ID, CardDAVMutationDelete)
+		if err != nil {
+			return err
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		return nil
+	})
+}
+
+func (s *Store) validatePendingCardDAVConflictTombstoneTx(
+	ctx context.Context, tx *loggedTx, conflict *CardDAVConflict,
+) (*CardDAVResource, error) {
+	if conflict == nil || conflict.Status != CardDAVConflictUnresolved ||
+		!conflict.LocalTombstone || conflict.PendingOperation != CardDAVMutationDelete ||
+		conflict.ConnectionGeneration <= 0 || conflict.BookSyncRevision < 0 ||
+		conflict.PreviousMappingRevision <= 0 || conflict.MappingRevision <= conflict.PreviousMappingRevision {
+		return nil, ErrCardDAVConflictStale
+	}
+	mapping, err := s.findCardDAVResourceTx(ctx, tx, conflict.AddressBookID, conflict.Href)
+	if err != nil || mapping.MappingRevision != conflict.MappingRevision {
+		return nil, ErrCardDAVConflictStale
+	}
+	if err := s.validateCardDAVConflictLocalTombstoneMappingTx(ctx, tx, conflict, mapping); err != nil {
+		return nil, err
+	}
+	return mapping, nil
+}
+
+func (s *Store) validateCardDAVConflictLocalTombstoneMappingTx(
+	ctx context.Context, tx *loggedTx, conflict *CardDAVConflict, mapping *CardDAVResource,
+) error {
+	if conflict == nil || mapping == nil || mapping.AddressBookID != conflict.AddressBookID ||
+		mapping.Href != conflict.Href {
+		return ErrCardDAVConflictStale
+	}
+	if mapping.PersonID == nil {
+		return nil
+	}
+	publication, err := getCardDAVPublicationFrom(ctx, tx, *mapping.PersonID,
+		s.dialect.SelectForUpdate())
+	if errors.Is(err, ErrCardDAVPublicationNotFound) {
+		return ErrCardDAVConflictStale
+	}
+	if err != nil {
+		return err
+	}
+	if publication.Desired || publication.PendingOperation != "" ||
+		publication.AddressBookID != conflict.AddressBookID || publication.Href != conflict.Href {
+		return ErrCardDAVConflictStale
+	}
+	return nil
+}
+
+func (s *Store) completeCardDAVConflictLocalTombstoneTx(
+	ctx context.Context, tx *loggedTx, conflict *CardDAVConflict, mapping *CardDAVResource,
+) (*CardDAVConflict, error) {
+	retainPerson := mapping.PersonID != nil
+	removed, err := s.removeCardDAVResourceWithPersonRetentionTx(
+		ctx, tx, conflict.AddressBookID, conflict.Href, retainPerson)
+	if err != nil {
+		return nil, err
+	}
+	if !removed {
+		return nil, ErrCardDAVConflictStale
+	}
+	if retainPerson {
+		result, err := tx.ExecContext(ctx, `DELETE FROM carddav_publications
+			WHERE person_id = ? AND desired = FALSE AND address_book_id = ? AND href = ?`,
+			*mapping.PersonID, conflict.AddressBookID, conflict.Href)
+		if err != nil {
+			return nil, fmt.Errorf("clear resolved CardDAV unpublish intent: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return nil, ErrCardDAVConflictStale
+		}
+	}
+	return resolveCardDAVConflictAuditTx(ctx, tx, s.dialect,
+		conflict.ID, CardDAVResolutionKeepLocal)
+}
+
+func (s *Store) completePendingCardDAVConflictTombstoneFromPullTx(
+	ctx context.Context, tx *loggedTx, book CardDAVAddressBook, connectionGeneration int64,
+	capture CardDAVConflictCapture,
+) (bool, error) {
+	conflict, err := scanCardDAVConflict(tx.QueryRowContext(ctx,
+		`SELECT `+cardDAVConflictColumns+` FROM carddav_conflicts
+		 WHERE address_book_id = ? AND href = ? AND status = 'unresolved'`+
+			s.dialect.SelectForUpdate(), book.ID, capture.Href))
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock pulled CardDAV tombstone conflict: %w", err)
+	}
+	if conflict.PendingOperation == "" {
+		return false, nil
+	}
+	mapping, err := s.validatePendingCardDAVConflictTombstoneTx(ctx, tx, conflict)
+	if err != nil {
+		return false, err
+	}
+	if !capture.LocalTombstone || !capture.RemoteTombstone ||
+		capture.AddressBookID != conflict.AddressBookID || capture.Href != conflict.Href ||
+		capture.ExpectedMappingRevision != mapping.MappingRevision ||
+		capture.BaseLocalHash != mapping.LocalHash || capture.LocalHash != mapping.LocalHash ||
+		capture.BaseRemoteHash != mapping.RemoteSemanticHash ||
+		capture.BaseRemoteETag != mapping.RemoteETag ||
+		conflict.ConnectionGeneration != connectionGeneration ||
+		conflict.BookSyncRevision != book.SyncRevision {
+		return false, ErrCardDAVConflictStale
+	}
+	if _, err := s.completeCardDAVConflictLocalTombstoneTx(ctx, tx, conflict, mapping); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func cardDAVPublicationFromConflict(conflict *CardDAVConflict) *CardDAVPublication {
+	return &CardDAVPublication{
+		Desired: false, AddressBookID: conflict.AddressBookID, Href: conflict.Href,
+		PendingOperation: conflict.PendingOperation, RemoteETag: conflict.RemoteETag,
+		ConnectionGeneration: conflict.ConnectionGeneration, BookSyncRevision: conflict.BookSyncRevision,
+		MappingRevision: conflict.MappingRevision, PreviousMappingRevision: conflict.PreviousMappingRevision,
+		PendingStartedAt: conflict.PendingStartedAt, ResolutionConflictID: conflict.ID,
+	}
+}
+
+func (s *Store) RecordCardDAVPublicationConflictContext(
+	ctx context.Context, pending CardDAVPublication, capture CardDAVConflictCapture,
+) (*CardDAVConflict, error) {
+	return s.recordCardDAVPublicationConflictContext(ctx, pending, capture, false)
+}
+
+func (s *Store) RecordCardDAVPublicationConflictRetainingIntentContext(
+	ctx context.Context, pending CardDAVPublication, capture CardDAVConflictCapture,
+) (*CardDAVConflict, error) {
+	return s.recordCardDAVPublicationConflictContext(ctx, pending, capture, true)
+}
+
+func (s *Store) recordCardDAVPublicationConflictContext(
+	ctx context.Context, pending CardDAVPublication, capture CardDAVConflictCapture,
+	retainOversizeIntent bool,
+) (*CardDAVConflict, error) {
+	if err := validateCardDAVConflictCapture(capture); err != nil {
+		if errors.Is(err, ErrCardDAVConflictTooLarge) {
+			rollbackErr := s.rollbackOversizedCardDAVPublicationConflictContext(
+				ctx, pending, retainOversizeIntent)
+			if rollbackErr != nil {
+				return nil, errors.Join(err, rollbackErr)
+			}
+		}
+		return nil, err
+	}
+	var conflict *CardDAVConflict
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, pending.PersonID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.MutationRevision != pending.MutationRevision ||
+			current.PendingOperation != pending.PendingOperation ||
+			current.AddressBookID != capture.AddressBookID || current.Href != capture.Href ||
+			current.MappingRevision != capture.ExpectedMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		conflict, err = s.recordCardDAVConflictTx(ctx, tx, capture, cardDAVConflictRecordOptions{
+			allowIntentTombstone: true,
+		})
+		if err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET
+			pending_operation = NULL, outgoing_body = NULL,
+			outgoing_semantic_hash = NULL, local_hash = NULL, remote_etag = NULL,
+			connection_generation = NULL, book_sync_revision = NULL,
+			mapping_revision = NULL, previous_mapping_revision = NULL,
+			create_recovery_used = FALSE, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND mutation_revision = ?`, current.PersonID, current.MutationRevision)
+		if err != nil {
+			return fmt.Errorf("clear conflicted CardDAV publication intent: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		return nil
+	})
+	return conflict, err
+}
+
+func (s *Store) rollbackOversizedCardDAVPublicationConflictContext(
+	ctx context.Context, pending CardDAVPublication, retainIntent bool,
+) error {
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, pending.PersonID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.MutationRevision != pending.MutationRevision ||
+			current.PendingOperation != pending.PendingOperation ||
+			current.AddressBookID != pending.AddressBookID || current.Href != pending.Href ||
+			current.MappingRevision != pending.MappingRevision ||
+			current.PreviousMappingRevision != pending.PreviousMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		resource, err := findCardDAVResourceForPersonTx(ctx, tx, current.AddressBookID,
+			current.PersonID, s.dialect.SelectForUpdate())
+		if err != nil || resource.Href != current.Href || resource.MappingRevision != current.MappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		if current.PendingOperation == CardDAVMutationCreate {
+			if current.MappingRevision <= 0 || current.PreviousMappingRevision != current.MappingRevision ||
+				resource.RemoteSemanticHash == current.OutgoingSemanticHash {
+				return ErrCardDAVConflictStale
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+				WHERE (left_kind = ? AND left_id = ?) OR (right_kind = ? AND right_id = ?)`,
+				IdentityMatchCardDAVResource, resource.ID, IdentityMatchCardDAVResource, resource.ID); err != nil {
+				return fmt.Errorf("delete oversized CardDAV create collision candidates: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM vcard_resource_envelopes
+				WHERE source_ref = ? AND source_resource_uid = ?`,
+				fmt.Sprintf("carddav:%d", current.AddressBookID), current.Href); err != nil {
+				return fmt.Errorf("delete oversized CardDAV create collision envelope: %w", err)
+			}
+			result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+				local_hash = remote_semantic_hash, mapping_status = ?,
+				mapping_revision = mapping_revision + 1, governance = ?,
+				person_id = NULL, person_revision_at_bind = NULL,
+				updated_at = `+s.dialect.Now()+`
+				WHERE id = ? AND person_id = ? AND mapping_revision = ?`,
+				CardDAVMappingUnbound, CardDAVGovernanceNone, resource.ID,
+				current.PersonID, current.MappingRevision)
+			if err != nil {
+				return fmt.Errorf("demote oversized CardDAV create collision: %w", err)
+			}
+			if affected, _ := result.RowsAffected(); affected != 1 {
+				return ErrCardDAVConflictStale
+			}
+			result, err = tx.ExecContext(ctx, `DELETE FROM carddav_publications
+				WHERE person_id = ? AND mutation_revision = ? AND pending_operation = ?`,
+				current.PersonID, current.MutationRevision, CardDAVMutationCreate)
+			if err != nil {
+				return fmt.Errorf("cancel oversized CardDAV create publication: %w", err)
+			}
+			if affected, _ := result.RowsAffected(); affected != 1 {
+				return ErrCardDAVConflictStale
+			}
+			return nil
+		}
+		if current.PreviousMappingRevision <= 0 {
+			return ErrCardDAVConflictStale
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND mapping_revision = ?`,
+			current.PreviousMappingRevision, resource.ID, current.MappingRevision)
+		if err != nil {
+			return fmt.Errorf("restore oversized CardDAV conflict mapping fence: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		if retainIntent {
+			result, err = tx.ExecContext(ctx, `UPDATE carddav_publications SET
+				mapping_revision = ?, previous_mapping_revision = ?,
+				updated_at = `+s.dialect.Now()+`
+				WHERE person_id = ? AND mutation_revision = ? AND pending_operation = ?`,
+				current.PreviousMappingRevision, current.PreviousMappingRevision,
+				current.PersonID, current.MutationRevision, current.PendingOperation)
+		} else {
+			result, err = tx.ExecContext(ctx, `UPDATE carddav_publications SET
+				pending_operation = NULL, outgoing_body = NULL,
+				outgoing_semantic_hash = NULL, local_hash = NULL, remote_etag = NULL,
+				connection_generation = NULL, book_sync_revision = NULL,
+				mapping_revision = NULL, previous_mapping_revision = NULL,
+				create_recovery_used = FALSE, pending_started_at = NULL,
+				updated_at = `+s.dialect.Now()+`
+				WHERE person_id = ? AND mutation_revision = ? AND pending_operation = ?`,
+				current.PersonID, current.MutationRevision, current.PendingOperation)
+		}
+		if err != nil {
+			return fmt.Errorf("restore oversized CardDAV publication intent: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVConflictStale
+		}
+		return nil
+	})
+}
+
+func validateCardDAVConflictCapture(capture CardDAVConflictCapture) error {
+	if capture.AddressBookID <= 0 || strings.TrimSpace(capture.Href) == "" ||
+		capture.ExpectedMappingRevision <= 0 || strings.TrimSpace(capture.BaseLocalHash) == "" ||
+		strings.TrimSpace(capture.LocalHash) == "" ||
+		strings.TrimSpace(capture.BaseRemoteHash) == "" || strings.TrimSpace(capture.BaseRemoteETag) == "" {
+		return ErrCardDAVInvalidPlan
+	}
+	if (!capture.LocalTombstone && len(capture.LocalBody) == 0) ||
+		(!capture.RemoteTombstone && len(capture.RemoteBody) == 0) {
+		return ErrCardDAVInvalidPlan
+	}
+	size := 0
+	if !capture.LocalTombstone {
+		size += len(capture.LocalBody)
+	}
+	if !capture.RemoteTombstone {
+		size += len(capture.RemoteBody)
+	}
+	if size > MaxCardDAVConflictSnapshotBytes {
+		return ErrCardDAVConflictTooLarge
+	}
+	return nil
+}
+
+func (s *Store) RecordCardDAVConflictContext(
+	ctx context.Context, capture CardDAVConflictCapture,
+) (*CardDAVConflict, error) {
+	if err := validateCardDAVConflictCapture(capture); err != nil {
+		return nil, err
+	}
+	var conflict *CardDAVConflict
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		var err error
+		conflict, err = s.recordCardDAVConflictTx(ctx, tx, capture, cardDAVConflictRecordOptions{})
+		return err
+	})
+	return conflict, err
+}
+
+type cardDAVConflictRecordOptions struct {
+	allowIntentTombstone           bool
+	supersedePendingIntent         bool
+	preserveExistingLocalTombstone bool
+}
+
+func (s *Store) recordCardDAVConflictTx(
+	ctx context.Context, tx *loggedTx, capture CardDAVConflictCapture,
+	options cardDAVConflictRecordOptions,
+) (*CardDAVConflict, error) {
+	var mappingID, revision int64
+	var baseLocalHash, baseRemoteHash, baseRemoteETag string
+	var personID sql.NullInt64
+	var mappingStatus CardDAVMappingStatus
+	if err := tx.QueryRowContext(ctx, `SELECT id, mapping_revision, local_hash,
+		remote_semantic_hash, remote_etag, person_id, mapping_status FROM carddav_resources
+		WHERE address_book_id = ? AND href = ?`+s.dialect.SelectForUpdate(),
+		capture.AddressBookID, capture.Href).Scan(&mappingID, &revision, &baseLocalHash,
+		&baseRemoteHash, &baseRemoteETag, &personID, &mappingStatus); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrCardDAVConflictStale
+		}
+		return nil, fmt.Errorf("lock CardDAV conflict mapping: %w", err)
+	}
+	if revision != capture.ExpectedMappingRevision || baseLocalHash != capture.BaseLocalHash ||
+		baseRemoteHash != capture.BaseRemoteHash || baseRemoteETag != capture.BaseRemoteETag ||
+		mappingStatus != CardDAVMappingMapped {
+		return nil, ErrCardDAVConflictStale
+	}
+	currentLocalHash := baseLocalHash
+	localTombstone := !personID.Valid
+	if personID.Valid {
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, personID.Int64)
+		if err != nil {
+			return nil, err
+		}
+		currentLocalHash = snapshot.Fingerprint
+	}
+	preservedLocalTombstone := false
+	if options.preserveExistingLocalTombstone && capture.LocalTombstone && !localTombstone {
+		var existing bool
+		err := tx.QueryRowContext(ctx, `SELECT local_tombstone FROM carddav_conflicts
+			WHERE address_book_id = ? AND href = ? AND status = 'unresolved'`,
+			capture.AddressBookID, capture.Href).Scan(&existing)
+		preservedLocalTombstone = err == nil && existing
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("load existing CardDAV tombstone intent: %w", err)
+		}
+	}
+	if preservedLocalTombstone {
+		currentLocalHash = baseLocalHash
+	}
+	if (!options.allowIntentTombstone && !preservedLocalTombstone && localTombstone != capture.LocalTombstone) ||
+		currentLocalHash != capture.LocalHash {
+		return nil, ErrCardDAVConflictStale
+	}
+	nextRevision := revision + 1
+	result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+		mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+		WHERE id = ? AND mapping_revision = ?`, nextRevision, mappingID, revision)
+	if err != nil {
+		return nil, fmt.Errorf("advance CardDAV conflict mapping fence: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected != 1 {
+		return nil, ErrCardDAVConflictStale
+	}
+	row := tx.QueryRowContext(ctx, `INSERT INTO carddav_conflicts (
+		address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+		base_remote_etag, remote_etag, mapping_revision, local_body,
+		remote_body, local_tombstone, remote_tombstone
+	) VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?)
+	ON CONFLICT(address_book_id, href) WHERE status = 'unresolved' DO UPDATE SET
+		base_local_hash = excluded.base_local_hash,
+		local_hash = excluded.local_hash,
+		base_remote_hash = excluded.base_remote_hash,
+		base_remote_etag = excluded.base_remote_etag,
+		remote_etag = excluded.remote_etag,
+		mapping_revision = excluded.mapping_revision,
+		local_body = excluded.local_body,
+		remote_body = excluded.remote_body,
+		local_tombstone = excluded.local_tombstone,
+		remote_tombstone = excluded.remote_tombstone,
+		updated_at = `+s.dialect.Now()+`
+	RETURNING `+cardDAVConflictColumns,
+		capture.AddressBookID, capture.Href, capture.BaseLocalHash, capture.LocalHash,
+		capture.BaseRemoteHash, capture.BaseRemoteETag, capture.RemoteETag,
+		nextRevision, nullableConflictBody(capture.LocalBody, capture.LocalTombstone),
+		nullableConflictBody(capture.RemoteBody, capture.RemoteTombstone),
+		capture.LocalTombstone, capture.RemoteTombstone)
+	conflict, err := scanCardDAVConflict(row)
+	if err != nil {
+		return nil, fmt.Errorf("record CardDAV conflict: %w", err)
+	}
+	if options.supersedePendingIntent && conflict.PendingOperation != "" {
+		conflict, err = scanCardDAVConflict(tx.QueryRowContext(ctx, `UPDATE carddav_conflicts SET
+			pending_operation = NULL, connection_generation = NULL, book_sync_revision = NULL,
+			previous_mapping_revision = NULL, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+` WHERE id = ? AND status = 'unresolved'
+			RETURNING `+cardDAVConflictColumns, conflict.ID))
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrCardDAVConflictStale
+		}
+		if err != nil {
+			return nil, fmt.Errorf("supersede refreshed CardDAV conflict intent: %w", err)
+		}
+	}
+	return conflict, nil
+}
+
+func nullableConflictBody(body []byte, tombstone bool) any {
+	if tombstone {
+		return nil
+	}
+	return body
+}
+
+func (s *Store) GetCardDAVConflictContext(ctx context.Context, id int64) (*CardDAVConflict, error) {
+	conflict, err := scanCardDAVConflict(s.db.QueryRowContext(ctx,
+		`SELECT `+cardDAVConflictColumns+` FROM carddav_conflicts WHERE id = ?`, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVConflictNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get CardDAV conflict: %w", err)
+	}
+	return conflict, nil
+}
+
+func (s *Store) GetUnresolvedCardDAVConflictForMappingContext(
+	ctx context.Context, addressBookID int64, href string,
+) (*CardDAVConflict, error) {
+	conflict, err := scanCardDAVConflict(s.db.QueryRowContext(ctx,
+		`SELECT `+cardDAVConflictColumns+` FROM carddav_conflicts
+		 WHERE address_book_id = ? AND href = ? AND status = 'unresolved'`,
+		addressBookID, href))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVConflictNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get unresolved CardDAV conflict: %w", err)
+	}
+	return conflict, nil
+}
+
+func (s *Store) ListCardDAVConflictsContext(
+	ctx context.Context, unresolvedOnly bool,
+) ([]CardDAVConflict, error) {
+	query := `SELECT ` + cardDAVConflictColumns + ` FROM carddav_conflicts`
+	if unresolvedOnly {
+		query += ` WHERE status = 'unresolved'`
+	}
+	query += ` ORDER BY updated_at DESC, id`
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list CardDAV conflicts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	conflicts := []CardDAVConflict{}
+	for rows.Next() {
+		conflict, err := scanCardDAVConflict(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan CardDAV conflict list: %w", err)
+		}
+		conflicts = append(conflicts, *conflict)
+	}
+	return conflicts, rows.Err()
+}
+
+func (s *Store) ResolveCardDAVConflictRemoteContext(
+	ctx context.Context, input CardDAVConflictRemoteResolution,
+) (*CardDAVConflict, error) {
+	if input.ConflictID <= 0 || input.ExpectedMappingRevision <= 0 {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	identity, err := s.getCardDAVConflictIdentityContext(ctx, input.ConflictID)
+	if err != nil {
+		return nil, err
+	}
+	if s.cardDAVConflictResolveSnapshotHook != nil {
+		s.cardDAVConflictResolveSnapshotHook()
+	}
+	var resolved *CardDAVConflict
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		book, err := s.lockCardDAVConflictResolutionBookTx(ctx, tx, identity.AddressBookID)
+		if err != nil {
+			return err
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		mapping, err := s.findCardDAVResourceTx(ctx, tx, identity.AddressBookID, identity.Href)
+		if err != nil || mapping.MappingRevision != input.ExpectedMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		conflict, err := getCardDAVConflictFrom(ctx, tx, input.ConflictID, s.dialect.SelectForUpdate())
+		if err != nil {
+			if errors.Is(err, ErrCardDAVConflictNotFound) {
+				return ErrCardDAVConflictStale
+			}
+			return err
+		}
+		if conflict.Status != CardDAVConflictUnresolved ||
+			conflict.AddressBookID != identity.AddressBookID || conflict.Href != identity.Href ||
+			conflict.MappingRevision != input.ExpectedMappingRevision ||
+			mapping.AddressBookID != conflict.AddressBookID || mapping.Href != conflict.Href {
+			return ErrCardDAVConflictStale
+		}
+		publicationPersonID := mapping.PersonID
+		if input.RemoteTombstone != conflict.RemoteTombstone {
+			return ErrCardDAVConflictStale
+		}
+		if input.RemoteTombstone {
+			removed, err := s.removeCardDAVResourceTx(ctx, tx, conflict.AddressBookID, conflict.Href)
+			if err != nil {
+				return err
+			}
+			if !removed {
+				return ErrCardDAVConflictStale
+			}
+			if publicationPersonID != nil {
+				if _, err := tx.ExecContext(ctx, `DELETE FROM carddav_publications WHERE person_id = ?`,
+					*publicationPersonID); err != nil {
+					return fmt.Errorf("cancel retained CardDAV remote tombstone publication: %w", err)
+				}
+			}
+		} else {
+			if input.Remote.Href != conflict.Href || input.Remote.RemoteETag != conflict.RemoteETag ||
+				!bytes.Equal(input.Remote.RemoteBody, conflict.RemoteBody) || input.Remote.SemanticHash == "" {
+				return ErrCardDAVConflictStale
+			}
+			remoteOwnsDisplay := false
+			if mapping.PersonID != nil {
+				remoteOwnsDisplay, err = s.rebaseCardDAVImportedProjectionTx(
+					ctx, tx, book.ID, *mapping.PersonID, input.Remote,
+				)
+				if err != nil {
+					return err
+				}
+			}
+			_, changed, err := s.applyCardDAVResourceTx(ctx, tx, book, input.Remote, false)
+			if err != nil {
+				return err
+			}
+			if !changed {
+				return ErrCardDAVConflictStale
+			}
+			if mapping.PersonID != nil && mapping.Governance == CardDAVGovernanceRemote {
+				if err := s.refreshCardDAVImportedPersonBindBaselineTx(
+					ctx, tx, mapping.ID, *mapping.PersonID, remoteOwnsDisplay,
+				); err != nil {
+					return err
+				}
+			}
+			if publicationPersonID != nil {
+				if _, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET
+					desired = TRUE, pending_operation = NULL, outgoing_body = NULL,
+					outgoing_semantic_hash = NULL, local_hash = NULL, remote_etag = NULL,
+					connection_generation = NULL, book_sync_revision = NULL,
+					mapping_revision = NULL, previous_mapping_revision = NULL,
+					create_recovery_used = FALSE, pending_started_at = NULL,
+					updated_at = `+s.dialect.Now()+` WHERE person_id = ?`,
+					*publicationPersonID); err != nil {
+					return fmt.Errorf("retain CardDAV remote publication choice: %w", err)
+				}
+			}
+		}
+		resolved, err = resolveCardDAVConflictAuditTx(ctx, tx, s.dialect, conflict.ID,
+			CardDAVResolutionKeepRemote)
+		return err
+	})
+	return resolved, err
+}
+
+func (s *Store) ResolveCardDAVConflictLocalTombstoneContext(
+	ctx context.Context, conflictID, expectedMappingRevision int64,
+) (*CardDAVConflict, error) {
+	if conflictID <= 0 || expectedMappingRevision <= 0 {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	identity, err := s.getCardDAVConflictIdentityContext(ctx, conflictID)
+	if err != nil {
+		return nil, err
+	}
+	var resolved *CardDAVConflict
+	err = s.withTxContext(ctx, func(tx *loggedTx) error {
+		if _, err := s.lockCardDAVConflictResolutionBookTx(ctx, tx, identity.AddressBookID); err != nil {
+			return err
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		mapping, err := s.findCardDAVResourceTx(ctx, tx, identity.AddressBookID, identity.Href)
+		if err != nil || mapping.MappingRevision != expectedMappingRevision {
+			return ErrCardDAVConflictStale
+		}
+		conflict, err := getCardDAVConflictFrom(ctx, tx, conflictID, s.dialect.SelectForUpdate())
+		if err != nil {
+			if errors.Is(err, ErrCardDAVConflictNotFound) {
+				return ErrCardDAVConflictStale
+			}
+			return err
+		}
+		if conflict.Status != CardDAVConflictUnresolved || !conflict.LocalTombstone ||
+			conflict.AddressBookID != identity.AddressBookID || conflict.Href != identity.Href ||
+			conflict.MappingRevision != expectedMappingRevision ||
+			mapping.AddressBookID != conflict.AddressBookID || mapping.Href != conflict.Href {
+			return ErrCardDAVConflictStale
+		}
+		if err := s.validateCardDAVConflictLocalTombstoneMappingTx(ctx, tx, conflict, mapping); err != nil {
+			return err
+		}
+		resolved, err = s.completeCardDAVConflictLocalTombstoneTx(ctx, tx, conflict, mapping)
+		return err
+	})
+	return resolved, err
+}
+
+func resolveCardDAVConflictAuditTx(
+	ctx context.Context, tx *loggedTx, dialect Dialect, id int64,
+	resolution CardDAVConflictResolution,
+) (*CardDAVConflict, error) {
+	if resolution != CardDAVResolutionKeepLocal && resolution != CardDAVResolutionKeepRemote {
+		return nil, ErrCardDAVConflictResolution
+	}
+	conflict, err := scanCardDAVConflict(tx.QueryRowContext(ctx, `UPDATE carddav_conflicts SET
+		status = 'resolved', resolution = ?, resolved_at = `+dialect.Now()+`,
+		pending_operation = NULL, connection_generation = NULL, book_sync_revision = NULL,
+		previous_mapping_revision = NULL, pending_started_at = NULL,
+		updated_at = `+dialect.Now()+`
+		WHERE id = ? AND status = 'unresolved' RETURNING `+cardDAVConflictColumns,
+		resolution, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVConflictStale
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve CardDAV conflict audit: %w", err)
+	}
+	return conflict, nil
+}
+
+func (s *Store) SweepResolvedCardDAVConflictsContext(
+	ctx context.Context, now time.Time,
+) (int64, error) {
+	cutoff := now.UTC().Add(-30 * 24 * time.Hour)
+	query := `DELETE FROM carddav_conflicts
+		WHERE status = 'resolved' AND resolved_at < ?`
+	parameter := any(cutoff)
+	if s.dialect.DriverName() != postgresDriverName {
+		query = `DELETE FROM carddav_conflicts
+			WHERE status = 'resolved' AND datetime(resolved_at) < datetime(?)`
+		parameter = cutoff.Format(time.RFC3339Nano)
+	}
+	result, err := s.db.ExecContext(ctx, query, parameter)
+	if err != nil {
+		return 0, fmt.Errorf("sweep resolved CardDAV conflicts: %w", err)
+	}
+	removed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("count swept CardDAV conflicts: %w", err)
+	}
+	return removed, nil
+}
+
+func getCardDAVConflictFrom(
+	ctx context.Context, queryer contextRowQuerier, id int64, suffix string,
+) (*CardDAVConflict, error) {
+	conflict, err := scanCardDAVConflict(queryer.QueryRowContext(ctx,
+		`SELECT `+cardDAVConflictColumns+` FROM carddav_conflicts WHERE id = ?`+suffix, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVConflictNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load CardDAV conflict: %w", err)
+	}
+	return conflict, nil
+}
+
+const cardDAVConflictColumns = `id, address_book_id, href, base_local_hash, local_hash,
+	base_remote_hash, base_remote_etag, remote_etag, mapping_revision,
+	local_body, remote_body, local_tombstone, remote_tombstone, pending_operation,
+	connection_generation, book_sync_revision, previous_mapping_revision, pending_started_at, status,
+	resolution, resolved_at, created_at, updated_at`
+
+func scanCardDAVConflict(row scanner) (*CardDAVConflict, error) {
+	var conflict CardDAVConflict
+	var remoteETag, resolution sql.NullString
+	var pendingOperation sql.NullString
+	var connectionGeneration, bookSyncRevision, previousMappingRevision sql.NullInt64
+	var localBody, remoteBody []byte
+	var pendingStartedAt, resolvedAt sql.NullTime
+	if err := row.Scan(&conflict.ID, &conflict.AddressBookID, &conflict.Href,
+		&conflict.BaseLocalHash, &conflict.LocalHash, &conflict.BaseRemoteHash, &conflict.BaseRemoteETag,
+		&remoteETag, &conflict.MappingRevision, &localBody, &remoteBody,
+		&conflict.LocalTombstone, &conflict.RemoteTombstone, &pendingOperation,
+		&connectionGeneration, &bookSyncRevision, &previousMappingRevision, &pendingStartedAt,
+		&conflict.Status,
+		&resolution, &resolvedAt, &conflict.CreatedAt, &conflict.UpdatedAt); err != nil {
+		return nil, err
+	}
+	conflict.RemoteETag = remoteETag.String
+	conflict.PendingOperation = CardDAVMutationOperation(pendingOperation.String)
+	conflict.ConnectionGeneration = connectionGeneration.Int64
+	conflict.BookSyncRevision = bookSyncRevision.Int64
+	conflict.PreviousMappingRevision = previousMappingRevision.Int64
+	if pendingStartedAt.Valid {
+		value := pendingStartedAt.Time.UTC()
+		conflict.PendingStartedAt = &value
+	}
+	conflict.Resolution = CardDAVConflictResolution(resolution.String)
+	conflict.LocalBody = append([]byte(nil), localBody...)
+	conflict.RemoteBody = append([]byte(nil), remoteBody...)
+	if resolvedAt.Valid {
+		value := resolvedAt.Time.UTC()
+		conflict.ResolvedAt = &value
+	}
+	return &conflict, nil
+}

--- a/internal/store/carddav_conflicts_test.go
+++ b/internal/store/carddav_conflicts_test.go
@@ -1,0 +1,584 @@
+package store_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func seededCardDAVConflictMapping(
+	t *testing.T,
+) (*store.Store, store.CardDAVAccount, store.CardDAVAddressBook, *store.CardDAVResource) {
+	t.Helper()
+	st, account, book := newCardDAVResourceStore(t)
+	remote := remoteResource(
+		book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`,
+	)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, NextSyncToken: "token-1",
+		Upserts: []store.CardDAVRemoteResource{remote},
+	})
+	require.NoError(t, err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+	require.NoError(t, err)
+	return st, account, book, mapping
+}
+
+func conflictCapture(mapping *store.CardDAVResource) store.CardDAVConflictCapture {
+	return store.CardDAVConflictCapture{
+		AddressBookID: mapping.AddressBookID,
+		Href:          mapping.Href, ExpectedMappingRevision: mapping.MappingRevision,
+		BaseLocalHash: mapping.LocalHash, LocalHash: mapping.LocalHash,
+		BaseRemoteHash: mapping.RemoteSemanticHash,
+		BaseRemoteETag: mapping.RemoteETag, RemoteETag: `"two"`,
+		LocalBody:  []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-alice\r\nFN:Local\r\nEND:VCARD\r\n"),
+		RemoteBody: []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-alice\r\nFN:Remote\r\nEND:VCARD\r\n"),
+	}
+}
+
+func seededCardDAVTombstoneConflict(
+	t *testing.T, mappedPerson bool,
+) (*store.Store, store.CardDAVAccount, store.CardDAVAddressBook, *store.CardDAVResource, *store.CardDAVConflict, store.CardDAVRemoteResource) {
+	t.Helper()
+	st, account, book, mapping := seededCardDAVConflictMapping(t)
+	if mappedPerson {
+		require.NotNil(t, mapping.PersonID)
+		snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *mapping.PersonID)
+		require.NoError(t, err)
+		_, err = st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+			PersonID: *mapping.PersonID, Desired: true, AddressBookID: book.ID, Href: mapping.Href,
+			OutgoingBody: mapping.RemoteBody, OutgoingSemanticHash: mapping.RemoteSemanticHash,
+			LocalHash: snapshot.Fingerprint,
+		})
+		require.NoError(t, err)
+		pending, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+			PersonID: *mapping.PersonID, Desired: false, AddressBookID: book.ID, Href: mapping.Href,
+		})
+		require.NoError(t, err)
+		mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+		require.NoError(t, err)
+		remote := remoteResource(mapping.Href, "remote-alice", "Alice Remote", "remote@example.test", `"two"`)
+		remote.SemanticHash = "semantic-remote-two"
+		conflict, err := st.RecordCardDAVPublicationConflictContext(t.Context(), *pending,
+			store.CardDAVConflictCapture{
+				AddressBookID: book.ID, Href: mapping.Href,
+				ExpectedMappingRevision: mapping.MappingRevision,
+				BaseLocalHash:           mapping.LocalHash, LocalHash: pending.LocalHash,
+				BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+				RemoteETag: remote.RemoteETag, RemoteBody: remote.RemoteBody,
+				LocalTombstone: true,
+			})
+		require.NoError(t, err)
+		mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+		require.NoError(t, err)
+		return st, account, book, mapping, conflict, remote
+	}
+
+	require.NotNil(t, mapping.PersonID)
+	person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+	require.NoError(t, err)
+	require.NoError(t, st.DeletePersonContext(t.Context(), person.ID, person.Revision))
+	mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(t, err)
+	remote := remoteResource(mapping.Href, "remote-alice", "Alice Remote", "remote@example.test", `"two"`)
+	remote.SemanticHash = "semantic-remote-two"
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), store.CardDAVConflictCapture{
+		AddressBookID: book.ID, Href: mapping.Href,
+		ExpectedMappingRevision: mapping.MappingRevision,
+		BaseLocalHash:           mapping.LocalHash, LocalHash: mapping.LocalHash,
+		BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+		RemoteETag: remote.RemoteETag, RemoteBody: remote.RemoteBody,
+		LocalTombstone: true,
+	})
+	require.NoError(t, err)
+	mapping, err = st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(t, err)
+	return st, account, book, mapping, conflict, remote
+}
+
+func refreshedCardDAVTombstonePlan(
+	t *testing.T, st *store.Store, account store.CardDAVAccount, book store.CardDAVAddressBook,
+	mapping *store.CardDAVResource,
+) (store.CardDAVSyncPlan, store.CardDAVRemoteResource) {
+	t.Helper()
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(t, err)
+	require.Len(t, books, 1)
+	latest := remoteResource(mapping.Href, "remote-alice", "Alice Latest", "latest@example.test", `"latest"`)
+	latest.SemanticHash = "semantic-remote-latest"
+	return store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, NextSyncToken: "latest-token",
+		Upserts: []store.CardDAVRemoteResource{latest},
+		Conflicts: []store.CardDAVConflictCapture{{
+			AddressBookID: book.ID, Href: mapping.Href,
+			ExpectedMappingRevision: mapping.MappingRevision,
+			BaseLocalHash:           mapping.LocalHash, LocalHash: mapping.LocalHash,
+			BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+			RemoteETag: latest.RemoteETag, RemoteBody: latest.RemoteBody,
+			LocalTombstone: true,
+		}},
+	}, latest
+}
+
+func TestCardDAVOversizedConflictDoesNotAdvanceMapping(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, _, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	capture.LocalBody = bytes.Repeat([]byte("x"), store.MaxCardDAVConflictSnapshotBytes)
+	capture.RemoteBody = []byte("y")
+
+	_, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.ErrorIs(err, store.ErrCardDAVConflictTooLarge)
+
+	after, err := st.GetCardDAVResourceContext(t.Context(), mapping.AddressBookID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(mapping.MappingRevision, after.MappingRevision)
+	conflicts, err := st.ListCardDAVConflictsContext(t.Context(), true)
+	require.NoError(err)
+	assert.Empty(conflicts)
+}
+
+func TestCardDAVConflictRefreshKeepsOneUnresolvedRowPerMapping(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, _, mapping := seededCardDAVConflictMapping(t)
+	first, err := st.RecordCardDAVConflictContext(t.Context(), conflictCapture(mapping))
+	require.NoError(err)
+
+	refreshedCapture := conflictCapture(mapping)
+	refreshedCapture.ExpectedMappingRevision = first.MappingRevision
+	refreshedCapture.RemoteETag = `"three"`
+	refreshedCapture.RemoteBody = []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-alice\r\nFN:Latest Remote\r\nEND:VCARD\r\n")
+	second, err := st.RecordCardDAVConflictContext(t.Context(), refreshedCapture)
+	require.NoError(err)
+
+	assert.Equal(first.ID, second.ID)
+	assert.Equal(first.MappingRevision+1, second.MappingRevision)
+	assert.Equal(refreshedCapture.RemoteETag, second.RemoteETag)
+	assert.Equal(refreshedCapture.RemoteBody, second.RemoteBody)
+	conflicts, err := st.ListCardDAVConflictsContext(t.Context(), true)
+	require.NoError(err)
+	require.Len(conflicts, 1)
+}
+
+func TestCardDAVKeepRemoteResolutionAppliesRetainedSnapshotAndAuditsChoice(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, _, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	retained := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+		Remote: retained,
+	})
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictResolved, resolved.Status)
+	assert.Equal(store.CardDAVResolutionKeepRemote, resolved.Resolution)
+	assert.NotNil(resolved.ResolvedAt)
+
+	after, err := st.GetCardDAVResourceContext(t.Context(), mapping.AddressBookID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(capture.RemoteBody, after.RemoteBody)
+	assert.Equal(capture.RemoteETag, after.RemoteETag)
+	require.NotNil(after.PersonID)
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *after.PersonID)
+	require.NoError(err)
+	assert.Equal(snapshot.Fingerprint, after.LocalHash)
+}
+
+func TestCardDAVKeepLocalUsesCapableSubscribedSourceBook(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, book, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET
+		is_write_target = FALSE, is_subscribed = TRUE, can_update = FALSE WHERE id = ?`), book.ID)
+	require.NoError(err)
+
+	plan := store.CardDAVConflictLocalPlan{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+		RemoteETag: conflict.RemoteETag, OutgoingSemanticHash: "local-semantic",
+	}
+	_, err = st.PrepareCardDAVConflictLocalContext(t.Context(), plan)
+	require.ErrorIs(err, store.ErrCardDAVNoWriteTarget)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET can_update = TRUE WHERE id = ?`), book.ID)
+	require.NoError(err)
+
+	prepared, err := st.PrepareCardDAVConflictLocalContext(t.Context(), plan)
+	require.NoError(err)
+	require.NotNil(prepared)
+	assert.Equal(book.ID, prepared.AddressBookID)
+	assert.Equal(mapping.Href, prepared.Href)
+	assert.Equal(store.CardDAVMutationUpdate, prepared.PendingOperation)
+}
+
+func TestCardDAVKeepRemoteRevalidatesAfterUnlockedConflictIdentityRead(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, _, mapping := seededCardDAVConflictMapping(t)
+	firstCapture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), firstCapture)
+	require.NoError(err)
+	retained := parseCardDAVRemoteForStoreTest(mapping.Href, firstCapture.RemoteETag, firstCapture.RemoteBody)
+
+	snapshotRead := make(chan struct{})
+	resume := make(chan struct{})
+	st.SetCardDAVConflictResolutionSnapshotHookForTest(func() {
+		close(snapshotRead)
+		<-resume
+	})
+	t.Cleanup(func() { st.SetCardDAVConflictResolutionSnapshotHookForTest(nil) })
+	resolved := make(chan error, 1)
+	go func() {
+		_, resolveErr := st.ResolveCardDAVConflictRemoteContext(context.Background(), store.CardDAVConflictRemoteResolution{
+			ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+			Remote: retained,
+		})
+		resolved <- resolveErr
+	}()
+	select {
+	case <-snapshotRead:
+	case <-time.After(5 * time.Second):
+		require.FailNow("keep-remote did not reach the unlocked identity snapshot")
+	}
+
+	current, err := st.GetCardDAVResourceContext(t.Context(), mapping.AddressBookID, mapping.Href)
+	require.NoError(err)
+	latestCapture := conflictCapture(current)
+	latestCapture.RemoteETag = `"latest"`
+	latestCapture.RemoteBody = []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-alice\r\nFN:Latest Remote\r\nEND:VCARD\r\n")
+	latest, err := st.RecordCardDAVConflictContext(t.Context(), latestCapture)
+	require.NoError(err)
+	close(resume)
+
+	select {
+	case resolveErr := <-resolved:
+		require.ErrorIs(resolveErr, store.ErrCardDAVConflictStale)
+	case <-time.After(5 * time.Second):
+		require.FailNow("keep-remote did not finish after conflict refresh")
+	}
+	after, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, after.Status)
+	assert.Equal(latest.MappingRevision, after.MappingRevision)
+	assert.Equal(latestCapture.RemoteBody, after.RemoteBody)
+}
+
+func TestCardDAVTombstonePreparationRevalidatesAfterUnlockedConflictIdentityRead(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		mappedPerson bool
+	}{
+		{name: "deleted person", mappedPerson: false},
+		{name: "mapped unpublish", mappedPerson: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, account, book, mapping, conflict, remote := seededCardDAVTombstoneConflict(t, test.mappedPerson)
+			snapshotRead := make(chan struct{})
+			resume := make(chan struct{})
+			st.SetCardDAVConflictTombstonePreparationSnapshotHookForTest(func() {
+				close(snapshotRead)
+				<-resume
+			})
+			t.Cleanup(func() { st.SetCardDAVConflictTombstonePreparationSnapshotHookForTest(nil) })
+			prepared := make(chan error, 1)
+			go func() {
+				_, prepareErr := st.PrepareCardDAVConflictLocalTombstoneContext(
+					context.Background(), conflict.ID, conflict.MappingRevision, remote)
+				prepared <- prepareErr
+			}()
+			select {
+			case <-snapshotRead:
+			case <-time.After(5 * time.Second):
+				require.FailNow("tombstone preparation did not reach the unlocked identity snapshot")
+			}
+
+			plan, latestRemote := refreshedCardDAVTombstonePlan(t, st, account, book, mapping)
+			_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), plan)
+			require.NoError(err)
+			close(resume)
+
+			select {
+			case prepareErr := <-prepared:
+				require.ErrorIs(prepareErr, store.ErrCardDAVConflictStale)
+			case <-time.After(5 * time.Second):
+				require.FailNow("tombstone preparation did not finish after conflict refresh")
+			}
+			after, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+			require.NoError(err)
+			assert.Equal(store.CardDAVConflictUnresolved, after.Status)
+			assert.Empty(after.PendingOperation)
+			assert.Equal(latestRemote.RemoteBody, after.RemoteBody)
+			afterMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+			require.NoError(err)
+			assert.Equal(after.MappingRevision, afterMapping.MappingRevision)
+		})
+	}
+}
+
+func TestCardDAVTombstonePreparationAndPullUseCanonicalPostgresLockOrder(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book, mapping, conflict, remote := seededCardDAVTombstoneConflict(t, true)
+	if !st.IsPostgreSQL() {
+		t.Skip("PostgreSQL row locks are required for the CardDAV tombstone preparation/pull deadlock regression")
+	}
+	plan, latestRemote := refreshedCardDAVTombstonePlan(t, st, account, book, mapping)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	blocker, err := st.DB().BeginTx(ctx, nil)
+	require.NoError(err)
+	t.Cleanup(func() { _ = blocker.Rollback() })
+	var lockedBookID int64
+	require.NoError(blocker.QueryRowContext(ctx,
+		`SELECT id FROM carddav_address_books WHERE id = $1 FOR UPDATE`, book.ID).Scan(&lockedBookID))
+	waitingBefore := postgreSQLWaitingLockCount(t, st)
+
+	pullDone := make(chan error, 1)
+	go func() {
+		_, pullErr := st.ApplyCardDAVSyncPlanContext(ctx, plan)
+		pullDone <- pullErr
+	}()
+	require.Eventually(func() bool {
+		return postgreSQLWaitingLockCount(t, st) >= waitingBefore+1
+	}, 5*time.Second, 10*time.Millisecond, "pull did not wait on the held book lock")
+
+	prepareDone := make(chan error, 1)
+	go func() {
+		_, prepareErr := st.PrepareCardDAVConflictLocalTombstoneContext(
+			ctx, conflict.ID, conflict.MappingRevision, remote)
+		prepareDone <- prepareErr
+	}()
+	require.Eventually(func() bool {
+		return postgreSQLWaitingLockCount(t, st) >= waitingBefore+2
+	}, 5*time.Second, 10*time.Millisecond, "preparation did not wait behind the pull lock order")
+	require.NoError(blocker.Commit())
+
+	select {
+	case pullErr := <-pullDone:
+		require.NoError(pullErr, "pull must win the canonical lock order without a deadlock")
+	case <-ctx.Done():
+		require.FailNow("pull did not finish", ctx.Err())
+	}
+	select {
+	case prepareErr := <-prepareDone:
+		require.ErrorIs(prepareErr, store.ErrCardDAVConflictStale)
+	case <-ctx.Done():
+		require.FailNow("tombstone preparation did not finish", ctx.Err())
+	}
+
+	after, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(latestRemote.RemoteBody, after.RemoteBody)
+	afterMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(after.MappingRevision, afterMapping.MappingRevision)
+}
+
+func TestCardDAVKeepRemoteAndPullUseCanonicalPostgresLockOrder(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book, mapping := seededCardDAVConflictMapping(t)
+	if !st.IsPostgreSQL() {
+		t.Skip("PostgreSQL row locks are required for the CardDAV resolution/pull deadlock regression")
+	}
+	firstCapture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), firstCapture)
+	require.NoError(err)
+	retained := parseCardDAVRemoteForStoreTest(mapping.Href, firstCapture.RemoteETag, firstCapture.RemoteBody)
+	current, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	latestRemote := remoteResource(mapping.Href, "remote-alice", "Latest Remote", "latest@example.test", `"latest"`)
+	latestRemote.SemanticHash = "latest-semantic"
+	latestCapture := conflictCapture(current)
+	latestCapture.RemoteETag = latestRemote.RemoteETag
+	latestCapture.RemoteBody = latestRemote.RemoteBody
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	blocker, err := st.DB().BeginTx(ctx, nil)
+	require.NoError(err)
+	t.Cleanup(func() { _ = blocker.Rollback() })
+	var lockedBookID int64
+	require.NoError(blocker.QueryRowContext(ctx,
+		`SELECT id FROM carddav_address_books WHERE id = $1 FOR UPDATE`, book.ID).Scan(&lockedBookID))
+	waitingBefore := postgreSQLWaitingLockCount(t, st)
+
+	pullDone := make(chan error, 1)
+	go func() {
+		_, pullErr := st.ApplyCardDAVSyncPlanContext(ctx, store.CardDAVSyncPlan{
+			AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+			SyncRevision: books[0].SyncRevision, NextSyncToken: "latest-token",
+			Upserts:   []store.CardDAVRemoteResource{latestRemote},
+			Conflicts: []store.CardDAVConflictCapture{latestCapture},
+		})
+		pullDone <- pullErr
+	}()
+	require.Eventually(func() bool {
+		return postgreSQLWaitingLockCount(t, st) >= waitingBefore+1
+	}, 5*time.Second, 10*time.Millisecond, "pull did not wait on the held book lock")
+
+	resolveDone := make(chan error, 1)
+	go func() {
+		_, resolveErr := st.ResolveCardDAVConflictRemoteContext(ctx, store.CardDAVConflictRemoteResolution{
+			ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+			Remote: retained,
+		})
+		resolveDone <- resolveErr
+	}()
+	require.Eventually(func() bool {
+		return postgreSQLWaitingLockCount(t, st) >= waitingBefore+2
+	}, 5*time.Second, 10*time.Millisecond, "resolution did not wait behind the pull book lock")
+	require.NoError(blocker.Commit())
+
+	select {
+	case pullErr := <-pullDone:
+		require.NoError(pullErr, "pull must win the canonical lock order without a deadlock")
+	case <-ctx.Done():
+		require.FailNow("pull did not finish", ctx.Err())
+	}
+	select {
+	case resolveErr := <-resolveDone:
+		require.ErrorIs(resolveErr, store.ErrCardDAVConflictStale,
+			"resolution must revalidate to stale, got %v", resolveErr)
+	case <-ctx.Done():
+		require.FailNow("resolution did not finish", ctx.Err())
+	}
+
+	after, err := st.GetCardDAVConflictContext(t.Context(), conflict.ID)
+	require.NoError(err)
+	assert.Equal(store.CardDAVConflictUnresolved, after.Status)
+	assert.Equal(latestRemote.RemoteBody, after.RemoteBody)
+	afterMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, mapping.Href)
+	require.NoError(err)
+	assert.Equal(after.MappingRevision, afterMapping.MappingRevision)
+}
+
+func TestCardDAVKeepRemoteReconcilesUnboundMappingByBookRole(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		subscribed bool
+	}{
+		{name: "subscribed reimports", subscribed: true},
+		{name: "lookup-only stays unbound", subscribed: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st, account, book := newCardDAVResourceStore(t)
+			base := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`)
+			_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+				AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+				SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{base},
+			})
+			require.NoError(err)
+			mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, base.Href)
+			require.NoError(err)
+			require.NotNil(mapping.PersonID)
+			person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+			require.NoError(err)
+			require.NoError(st.DeletePersonContext(t.Context(), person.ID, person.Revision))
+			if !test.subscribed {
+				_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_address_books SET
+					is_write_target = FALSE, is_subscribed = FALSE,
+					is_lookup_source = TRUE WHERE id = ?`), book.ID)
+				require.NoError(err)
+			}
+			unbound, err := st.GetCardDAVResourceContext(t.Context(), book.ID, base.Href)
+			require.NoError(err)
+			require.Nil(unbound.PersonID)
+			latest := remoteResource(base.Href, "remote-alice", "Alice Retained", "alice-new@example.test", `"two"`)
+			latest.SemanticHash = "semantic-latest"
+			conflict, err := st.RecordCardDAVConflictContext(t.Context(), store.CardDAVConflictCapture{
+				AddressBookID: book.ID, Href: unbound.Href,
+				ExpectedMappingRevision: unbound.MappingRevision,
+				BaseLocalHash:           unbound.LocalHash, LocalHash: unbound.LocalHash,
+				BaseRemoteHash: unbound.RemoteSemanticHash, BaseRemoteETag: unbound.RemoteETag,
+				RemoteETag: latest.RemoteETag, RemoteBody: latest.RemoteBody,
+				LocalTombstone: true,
+			})
+			require.NoError(err)
+
+			_, err = st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+				ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision,
+				Remote: latest,
+			})
+			require.NoError(err)
+			after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, base.Href)
+			require.NoError(err)
+			assert.Equal(latest.RemoteBody, after.RemoteBody)
+			if test.subscribed {
+				require.NotNil(after.PersonID)
+				assert.NotEqual(person.ID, *after.PersonID)
+				assert.Equal(store.CardDAVGovernanceRemote, after.Governance)
+				envelope, envelopeErr := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", base.Href)
+				require.NoError(envelopeErr)
+				assert.Equal(latest.RemoteBody, envelope.StoredBody)
+				assert.Equal(*after.PersonID, envelope.PersonID)
+			} else {
+				assert.Nil(after.PersonID)
+				assert.Equal(store.CardDAVMappingUnbound, after.MappingStatus)
+			}
+			publicationIDs, err := st.ListCardDAVPublicationPersonIDsContext(t.Context())
+			require.NoError(err)
+			assert.Empty(publicationIDs, "keep-remote must not synthesize publication replay state")
+		})
+	}
+}
+
+func TestCardDAVResolvedConflictSweepKeepsThirtyDayAuditWindow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, _, _, mapping := seededCardDAVConflictMapping(t)
+	capture := conflictCapture(mapping)
+	conflict, err := st.RecordCardDAVConflictContext(t.Context(), capture)
+	require.NoError(err)
+	retained := parseCardDAVRemoteForStoreTest(mapping.Href, capture.RemoteETag, capture.RemoteBody)
+	resolved, err := st.ResolveCardDAVConflictRemoteContext(t.Context(), store.CardDAVConflictRemoteResolution{
+		ConflictID: conflict.ID, ExpectedMappingRevision: conflict.MappingRevision, Remote: retained,
+	})
+	require.NoError(err)
+	require.NotNil(resolved.ResolvedAt)
+
+	removed, err := st.SweepResolvedCardDAVConflictsContext(t.Context(), resolved.ResolvedAt.Add(30*24*time.Hour))
+	require.NoError(err)
+	assert.Equal(int64(0), removed)
+	removed, err = st.SweepResolvedCardDAVConflictsContext(t.Context(), resolved.ResolvedAt.Add(30*24*time.Hour+time.Second))
+	require.NoError(err)
+	assert.Equal(int64(1), removed)
+}
+
+func parseCardDAVRemoteForStoreTest(href, etag string, body []byte) store.CardDAVRemoteResource {
+	return store.CardDAVRemoteResource{
+		Href: href, RemoteUID: "remote-alice", RemoteETag: etag,
+		RemoteBody: body, SemanticHash: "retained-remote-hash", DisplayName: "Remote",
+	}
+}

--- a/internal/store/carddav_migrations_test.go
+++ b/internal/store/carddav_migrations_test.go
@@ -1,0 +1,271 @@
+package store_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestCardDAVSyncTokenUpgradeSQLite(t *testing.T) {
+	st := testutil.NewSQLiteTestStore(t)
+	assertCardDAVSyncTokenUpgrade(t, st)
+}
+
+func TestCardDAVSyncTokenUpgradePostgreSQL(t *testing.T) {
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("CardDAV PostgreSQL upgrade test requires MSGVAULT_TEST_DB")
+	}
+	st := testutil.NewTestStore(t)
+	require.True(t, st.IsPostgreSQL())
+	assertCardDAVSyncTokenUpgrade(t, st)
+}
+
+func TestCardDAVRoleReconcileUpgradeSQLite(t *testing.T) {
+	st := testutil.NewSQLiteTestStore(t)
+	assertCardDAVRoleReconcileUpgrade(t, st)
+}
+
+func TestCardDAVRoleReconcileUpgradePostgreSQL(t *testing.T) {
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("CardDAV PostgreSQL role upgrade test requires MSGVAULT_TEST_DB")
+	}
+	st := testutil.NewTestStore(t)
+	require.True(t, st.IsPostgreSQL())
+	assertCardDAVRoleReconcileUpgrade(t, st)
+}
+
+func TestCardDAVConflictPendingUpgradeSQLite(t *testing.T) {
+	st := testutil.NewSQLiteTestStore(t)
+	assertCardDAVConflictPendingUpgrade(t, st)
+}
+
+func TestCardDAVConflictPendingUpgradePostgreSQL(t *testing.T) {
+	testDB := os.Getenv("MSGVAULT_TEST_DB")
+	if !strings.HasPrefix(testDB, "postgres://") && !strings.HasPrefix(testDB, "postgresql://") {
+		t.Skip("CardDAV PostgreSQL conflict upgrade test requires MSGVAULT_TEST_DB")
+	}
+	st := testutil.NewTestStore(t)
+	require.True(t, st.IsPostgreSQL())
+	assertCardDAVConflictPendingUpgrade(t, st)
+}
+
+func assertCardDAVConflictPendingUpgrade(t *testing.T, st *store.Store) {
+	t.Helper()
+	allowed := true
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+			DisplayName:  "Personal", CanCreate: &allowed,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, books, 1)
+	book := books[0]
+	remote := remoteResource(
+		book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`,
+	)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{remote},
+	})
+	require.NoError(t, err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+	require.NoError(t, err)
+	require.NotNil(t, mapping.PersonID)
+	person, err := st.GetPersonContext(t.Context(), *mapping.PersonID)
+	require.NoError(t, err)
+	require.NoError(t, st.DeletePersonContext(t.Context(), person.ID, person.Revision))
+
+	require.NoError(t, recreateE7CardDAVConflicts(t, st))
+	var conflictID int64
+	err = st.DB().QueryRow(st.Rebind(`INSERT INTO carddav_conflicts (
+		address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+		base_remote_etag, remote_etag, mapping_revision, local_body, remote_body,
+		local_tombstone, remote_tombstone
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, TRUE, FALSE) RETURNING id`),
+		book.ID, mapping.Href, mapping.LocalHash, mapping.LocalHash,
+		mapping.RemoteSemanticHash, mapping.RemoteETag, `"two"`, mapping.MappingRevision,
+		remoteResource(mapping.Href, "remote-alice", "Alice Remote", "remote@example.test", `"two"`).RemoteBody,
+	).Scan(&conflictID)
+	require.NoError(t, err, "seed an e7-era unresolved tombstone conflict")
+
+	require.NoError(t, st.InitSchema(), "upgrade the e7-era CardDAV conflict table")
+	conflict, err := st.GetCardDAVConflictContext(t.Context(), conflictID)
+	require.NoError(t, err)
+	assert.Equal(t, store.CardDAVConflictUnresolved, conflict.Status)
+	assert.True(t, conflict.LocalTombstone)
+	assert.Empty(t, conflict.PendingOperation)
+	assertCardDAVConflictIndexes(t, st)
+
+	_, err = st.DB().Exec(st.Rebind(`UPDATE carddav_conflicts
+		SET pending_operation = 'delete' WHERE id = ?`), conflictID)
+	require.Error(t, err, "the upgraded table must enforce the complete pending-intent invariant")
+
+	retained := remoteResource(
+		mapping.Href, "remote-alice", "Alice Remote", "remote@example.test", `"two"`,
+	)
+	retained.SemanticHash = "semantic-remote-two"
+	prepared, err := st.PrepareCardDAVConflictLocalTombstoneContext(
+		t.Context(), conflictID, mapping.MappingRevision, retained,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, store.CardDAVMutationDelete, prepared.PendingOperation)
+	assert.NotNil(t, prepared.PendingStartedAt)
+
+	recovered, err := st.PrepareCardDAVConflictLocalTombstoneContext(
+		t.Context(), conflictID, prepared.MappingRevision, retained,
+	)
+	require.NoError(t, err)
+	assert.True(t, recovered.RecoveryOnly)
+	assert.Equal(t, prepared.MappingRevision, recovered.MappingRevision)
+	assert.Equal(t, prepared.PreviousMappingRevision, recovered.PreviousMappingRevision)
+
+	require.NoError(t, st.InitSchema(), "the conflict upgrade must be idempotent")
+	after, err := st.GetCardDAVConflictContext(t.Context(), conflictID)
+	require.NoError(t, err)
+	assert.Equal(t, store.CardDAVMutationDelete, after.PendingOperation)
+	assert.Equal(t, prepared.MappingRevision, after.MappingRevision)
+	assertCardDAVConflictIndexes(t, st)
+}
+
+func recreateE7CardDAVConflicts(t *testing.T, st *store.Store) error {
+	t.Helper()
+	drop := `DROP TABLE carddav_conflicts`
+	if _, err := st.DB().Exec(drop); err != nil {
+		return err
+	}
+	id := "INTEGER PRIMARY KEY AUTOINCREMENT"
+	body := "BLOB"
+	timestamp := "DATETIME"
+	integer := "INTEGER"
+	if st.IsPostgreSQL() {
+		id = "BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY"
+		body = "BYTEA"
+		timestamp = "TIMESTAMPTZ"
+		integer = "BIGINT"
+	}
+	ddl := `CREATE TABLE carddav_conflicts (
+		id ` + id + `,
+		address_book_id ` + integer + ` NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+		href TEXT NOT NULL,
+		base_local_hash TEXT NOT NULL,
+		local_hash TEXT NOT NULL,
+		base_remote_hash TEXT NOT NULL,
+		base_remote_etag TEXT NOT NULL,
+		remote_etag TEXT,
+		mapping_revision ` + integer + ` NOT NULL CHECK (mapping_revision > 0),
+		local_body ` + body + `,
+		remote_body ` + body + `,
+		local_tombstone BOOLEAN NOT NULL DEFAULT FALSE,
+		remote_tombstone BOOLEAN NOT NULL DEFAULT FALSE,
+		status TEXT NOT NULL DEFAULT 'unresolved' CHECK (status IN ('unresolved', 'resolved')),
+		resolution TEXT CHECK (resolution IN ('keep_local', 'keep_remote')),
+		resolved_at ` + timestamp + `,
+		created_at ` + timestamp + ` NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at ` + timestamp + ` NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		CHECK (local_tombstone OR local_body IS NOT NULL),
+		CHECK (remote_tombstone OR remote_body IS NOT NULL),
+		CHECK ((status = 'unresolved' AND resolution IS NULL AND resolved_at IS NULL) OR
+		       (status = 'resolved' AND resolution IS NOT NULL AND resolved_at IS NOT NULL))
+	)`
+	if _, err := st.DB().Exec(ddl); err != nil {
+		return err
+	}
+	for _, statement := range []string{
+		`CREATE UNIQUE INDEX idx_carddav_one_unresolved_conflict
+		 ON carddav_conflicts(address_book_id, href) WHERE status = 'unresolved'`,
+		`CREATE INDEX idx_carddav_conflicts_resolved_at
+		 ON carddav_conflicts(status, resolved_at)`,
+	} {
+		if _, err := st.DB().Exec(statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func assertCardDAVConflictIndexes(t *testing.T, st *store.Store) {
+	t.Helper()
+	var count int
+	query := `SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'index' AND name IN (
+			'idx_carddav_one_unresolved_conflict', 'idx_carddav_conflicts_resolved_at'
+		)`
+	if st.IsPostgreSQL() {
+		query = `SELECT COUNT(*) FROM pg_indexes
+			WHERE schemaname = current_schema() AND indexname IN (
+				'idx_carddav_one_unresolved_conflict', 'idx_carddav_conflicts_resolved_at'
+			)`
+	}
+	require.NoError(t, st.DB().QueryRow(query).Scan(&count))
+	assert.Equal(t, 2, count)
+}
+
+func assertCardDAVRoleReconcileUpgrade(t *testing.T, st *store.Store) {
+	t.Helper()
+	allowed := true
+	_, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+			DisplayName:  "Personal", CanCreate: &allowed,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, books, 1)
+
+	_, err = st.DB().Exec(`ALTER TABLE carddav_address_books DROP COLUMN needs_full_reconcile`)
+	require.NoError(t, err, "recreate the pre-role-reconcile address book schema")
+	require.NoError(t, st.InitSchema(), "upgrade legacy CardDAV role state")
+
+	upgraded, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(t, err)
+	require.Len(t, upgraded, 1)
+	assert.False(t, upgraded[0].NeedsFullReconcile)
+}
+
+func assertCardDAVSyncTokenUpgrade(t *testing.T, st *store.Store) {
+	t.Helper()
+	allowed := true
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+			DisplayName:  "Personal", CanCreate: &allowed,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, books, 1)
+
+	_, err = st.DB().Exec(`ALTER TABLE carddav_address_books DROP COLUMN sync_token`)
+	require.NoError(t, err, "recreate the pre-sync-token address book schema")
+	require.NoError(t, st.InitSchema(), "upgrade legacy CardDAV address books")
+
+	upgraded, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(t, err)
+	require.Len(t, upgraded, 1)
+	assert.Empty(t, upgraded[0].SyncToken)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: books[0].ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: upgraded[0].SyncRevision, NextSyncToken: "token-after-upgrade",
+	})
+	require.NoError(t, err)
+	upgraded, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "token-after-upgrade", upgraded[0].SyncToken)
+}

--- a/internal/store/carddav_publication.go
+++ b/internal/store/carddav_publication.go
@@ -1,0 +1,766 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type CardDAVMutationOperation string
+
+const (
+	CardDAVMutationCreate CardDAVMutationOperation = "create"
+	CardDAVMutationUpdate CardDAVMutationOperation = "update"
+	CardDAVMutationDelete CardDAVMutationOperation = "delete"
+)
+
+var (
+	ErrCardDAVPublicationNotFound = errors.New("CardDAV publication not found")
+	ErrCardDAVPublicationPending  = errors.New("CardDAV publication mutation is pending")
+	ErrCardDAVPublicationMismatch = errors.New("CardDAV canonical resource does not match publication intent")
+	ErrCardDAVResourceAmbiguous   = errors.New("multiple CardDAV resources are mapped to this person")
+	ErrCardDAVNoWriteTarget       = errors.New("CardDAV write target is unavailable")
+	ErrCardDAVRetryAfter          = errors.New("CardDAV account is throttled")
+)
+
+type CardDAVPublicationPlan struct {
+	PersonID             int64
+	Desired              bool
+	AddressBookID        int64
+	Href                 string
+	OutgoingBody         []byte
+	OutgoingSemanticHash string
+	LocalHash            string
+}
+
+type CardDAVPublication struct {
+	PersonID                int64
+	Desired                 bool
+	AddressBookID           int64
+	Href                    string
+	PendingOperation        CardDAVMutationOperation
+	OutgoingBody            []byte
+	OutgoingSemanticHash    string
+	LocalHash               string
+	RemoteETag              string
+	ConnectionGeneration    int64
+	BookSyncRevision        int64
+	MappingRevision         int64
+	PreviousMappingRevision int64
+	CreateRecoveryUsed      bool
+	MutationRevision        int64
+	PendingStartedAt        *time.Time
+	RecoveryOnly            bool
+	Noop                    bool
+	ResolutionConflictID    int64
+}
+
+type CardDAVCanonicalMutation struct {
+	Publication CardDAVPublication
+	Remote      CardDAVRemoteResource
+	Tombstone   bool
+}
+
+func (s *Store) PrepareCardDAVPublicationContext(
+	ctx context.Context, plan CardDAVPublicationPlan,
+) (*CardDAVPublication, error) {
+	if plan.PersonID <= 0 || plan.AddressBookID <= 0 || strings.TrimSpace(plan.Href) == "" {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	if plan.Desired && (len(plan.OutgoingBody) == 0 || plan.OutgoingSemanticHash == "" || plan.LocalHash == "") {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	var prepared *CardDAVPublication
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if gate, err := getCardDAVRetryAfterFrom(ctx, tx); err != nil {
+			return err
+		} else if gate != nil && gate.After(time.Now()) {
+			return ErrCardDAVRetryAfter
+		}
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVNoWriteTarget
+			}
+			return fmt.Errorf("lock CardDAV publication account: %w", err)
+		}
+		var bookRevision int64
+		var canCreate, canUpdate, canDelete sql.NullBool
+		if err := tx.QueryRowContext(ctx, `SELECT sync_revision, can_create, can_update, can_delete
+			FROM carddav_address_books
+			WHERE id = ? AND is_write_target = TRUE AND is_subscribed = TRUE`+
+			s.dialect.SelectForUpdate(), plan.AddressBookID).Scan(
+			&bookRevision, &canCreate, &canUpdate, &canDelete,
+		); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVNoWriteTarget
+			}
+			return fmt.Errorf("lock CardDAV publication book: %w", err)
+		}
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, plan.PersonID)
+		if err != nil {
+			return err
+		}
+		if plan.Desired && snapshot.Fingerprint != plan.LocalHash {
+			return ErrCardDAVStalePlan
+		}
+		current, err := getCardDAVPublicationFrom(ctx, tx, plan.PersonID, s.dialect.SelectForUpdate())
+		if err != nil && !errors.Is(err, ErrCardDAVPublicationNotFound) {
+			return err
+		}
+		if err == nil && current.PendingOperation != "" {
+			if current.Desired != plan.Desired {
+				return ErrCardDAVPublicationPending
+			}
+			current.RecoveryOnly = true
+			prepared = current
+			return nil
+		}
+
+		resource, err := findCardDAVResourceForPersonTx(ctx, tx, plan.AddressBookID, plan.PersonID, s.dialect.SelectForUpdate())
+		if err != nil && !errors.Is(err, ErrCardDAVResourceNotFound) {
+			return err
+		}
+		if plan.Desired && resource == nil {
+			_, hrefErr := s.findCardDAVResourceTx(ctx, tx, plan.AddressBookID, plan.Href)
+			if hrefErr == nil {
+				return ErrCardDAVPublicationMismatch
+			}
+			if !errors.Is(hrefErr, ErrCardDAVResourceNotFound) {
+				return hrefErr
+			}
+		}
+		if !plan.Desired && errors.Is(err, ErrCardDAVResourceNotFound) {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM carddav_publications WHERE person_id = ?`, plan.PersonID); err != nil {
+				return fmt.Errorf("clear absent CardDAV publication: %w", err)
+			}
+			prepared = &CardDAVPublication{PersonID: plan.PersonID, Desired: false, Noop: true}
+			return nil
+		}
+
+		operation := CardDAVMutationCreate
+		remoteETag := ""
+		mappingRevision, previousMappingRevision := int64(0), int64(0)
+		if resource != nil {
+			if resource.MappingStatus != CardDAVMappingMapped || resource.PersonID == nil || *resource.PersonID != plan.PersonID {
+				return ErrCardDAVPublicationMismatch
+			}
+			if resource.Href != plan.Href {
+				return ErrCardDAVPublicationMismatch
+			}
+			if etag := strings.TrimSpace(resource.RemoteETag); etag == "" || etag == "*" {
+				return ErrCardDAVInvalidPlan
+			}
+			if plan.Desired && plan.OutgoingSemanticHash == resource.RemoteSemanticHash {
+				if _, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+					local_hash = ?, updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+					snapshot.Fingerprint, resource.ID); err != nil {
+					return fmt.Errorf("refresh unchanged CardDAV publication ledger: %w", err)
+				}
+				_, err = tx.ExecContext(ctx, `INSERT INTO carddav_publications (
+					person_id, desired, address_book_id, href
+				) VALUES (?, TRUE, ?, ?)
+				ON CONFLICT(person_id) DO UPDATE SET
+					desired = TRUE, address_book_id = excluded.address_book_id,
+					href = excluded.href, pending_operation = NULL,
+					outgoing_body = NULL, outgoing_semantic_hash = NULL,
+					local_hash = NULL, remote_etag = NULL,
+					connection_generation = NULL, book_sync_revision = NULL,
+					mapping_revision = NULL, previous_mapping_revision = NULL,
+					create_recovery_used = FALSE, pending_started_at = NULL,
+					updated_at = `+s.dialect.Now(), plan.PersonID, plan.AddressBookID, plan.Href)
+				if err != nil {
+					return fmt.Errorf("persist unchanged CardDAV publication: %w", err)
+				}
+				prepared, err = getCardDAVPublicationFrom(ctx, tx, plan.PersonID, "")
+				if err == nil {
+					prepared.Noop = true
+				}
+				return err
+			}
+			if plan.Desired {
+				operation = CardDAVMutationUpdate
+			} else {
+				operation = CardDAVMutationDelete
+			}
+			remoteETag = resource.RemoteETag
+			previousMappingRevision = resource.MappingRevision
+			mappingRevision = resource.MappingRevision + 1
+		}
+		var requiredCapability sql.NullBool
+		switch operation {
+		case CardDAVMutationCreate:
+			requiredCapability = canCreate
+		case CardDAVMutationUpdate:
+			requiredCapability = canUpdate
+		case CardDAVMutationDelete:
+			requiredCapability = canDelete
+		}
+		if cardDAVCapabilityDenied(requiredCapability) {
+			return ErrCardDAVReadOnlyAddressBook
+		}
+		if resource != nil {
+			result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+				mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+				WHERE id = ? AND mapping_revision = ?`, mappingRevision, resource.ID, resource.MappingRevision)
+			if err != nil {
+				return fmt.Errorf("advance CardDAV mutation fence: %w", err)
+			}
+			if affected, _ := result.RowsAffected(); affected != 1 {
+				return ErrCardDAVStalePlan
+			}
+		}
+		outgoingBody, outgoingHash := plan.OutgoingBody, plan.OutgoingSemanticHash
+		if operation == CardDAVMutationDelete {
+			outgoingBody, outgoingHash = nil, ""
+		}
+		nextMutationRevision := int64(1)
+		if current != nil {
+			nextMutationRevision = current.MutationRevision + 1
+		}
+		now := time.Now().UTC()
+		_, err = tx.ExecContext(ctx, `INSERT INTO carddav_publications (
+			person_id, desired, address_book_id, href, pending_operation,
+			outgoing_body, outgoing_semantic_hash, local_hash, remote_etag,
+			connection_generation, book_sync_revision, mapping_revision,
+			previous_mapping_revision, create_recovery_used, mutation_revision,
+			pending_started_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, NULLIF(?, ''), ?, ?, ?, ?, FALSE, ?, ?, `+s.dialect.Now()+`)
+		ON CONFLICT(person_id) DO UPDATE SET
+			desired = excluded.desired, address_book_id = excluded.address_book_id,
+			href = excluded.href, pending_operation = excluded.pending_operation,
+			outgoing_body = excluded.outgoing_body,
+			outgoing_semantic_hash = excluded.outgoing_semantic_hash,
+			local_hash = excluded.local_hash, remote_etag = excluded.remote_etag,
+			connection_generation = excluded.connection_generation,
+			book_sync_revision = excluded.book_sync_revision,
+			mapping_revision = excluded.mapping_revision,
+			previous_mapping_revision = excluded.previous_mapping_revision,
+			create_recovery_used = FALSE, mutation_revision = excluded.mutation_revision,
+			pending_started_at = excluded.pending_started_at, updated_at = `+s.dialect.Now(),
+			plan.PersonID, plan.Desired, plan.AddressBookID, plan.Href, operation,
+			outgoingBody, outgoingHash, snapshot.Fingerprint, remoteETag,
+			generation, bookRevision, mappingRevision, previousMappingRevision,
+			nextMutationRevision, timeValue(&now))
+		if err != nil {
+			return fmt.Errorf("persist CardDAV publication intent: %w", err)
+		}
+		prepared, err = getCardDAVPublicationFrom(ctx, tx, plan.PersonID, "")
+		return err
+	})
+	return prepared, err
+}
+
+func (s *Store) GetCardDAVPublicationContext(ctx context.Context, personID int64) (*CardDAVPublication, error) {
+	return getCardDAVPublicationFrom(ctx, s.db, personID, "")
+}
+
+func (s *Store) RefreshCardDAVPublicationFenceContext(
+	ctx context.Context, personID int64,
+) (*CardDAVPublication, error) {
+	var publication *CardDAVPublication
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, personID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.PendingOperation == "" {
+			return ErrCardDAVPublicationNotFound
+		}
+		var generation, bookRevision int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts WHERE id = 1`).Scan(&generation); err != nil {
+			return err
+		}
+		if generation != current.ConnectionGeneration {
+			return ErrCardDAVStalePlan
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT sync_revision FROM carddav_address_books WHERE id = ?`, current.AddressBookID).Scan(&bookRevision); err != nil {
+			return err
+		}
+		mappingRevision := int64(0)
+		resource, resourceErr := findCardDAVResourceForPersonTx(ctx, tx, current.AddressBookID, personID, s.dialect.SelectForUpdate())
+		if current.PreviousMappingRevision > 0 {
+			if resourceErr != nil && (current.PendingOperation != CardDAVMutationDelete || !errors.Is(resourceErr, ErrCardDAVResourceNotFound)) {
+				return resourceErr
+			}
+		} else if resourceErr != nil && !errors.Is(resourceErr, ErrCardDAVResourceNotFound) {
+			return resourceErr
+		}
+		if resource != nil {
+			if resource.Href != current.Href {
+				return ErrCardDAVPublicationMismatch
+			}
+			mappingRevision = resource.MappingRevision
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE carddav_publications SET
+			book_sync_revision = ?, mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND mutation_revision = ?`,
+			bookRevision, mappingRevision, personID, current.MutationRevision)
+		if err != nil {
+			return err
+		}
+		publication, err = getCardDAVPublicationFrom(ctx, tx, personID, "")
+		return err
+	})
+	return publication, err
+}
+
+// FenceCardDAVCreateCollisionContext materializes the canonical resource that
+// won a conditional create race. The mapping gives the normal conflict ledger
+// a durable base revision instead of leaving an unresolvable create intent.
+func (s *Store) FenceCardDAVCreateCollisionContext(
+	ctx context.Context, pending CardDAVPublication, remote CardDAVRemoteResource,
+) (*CardDAVPublication, error) {
+	if pending.PersonID <= 0 || pending.PendingOperation != CardDAVMutationCreate ||
+		remote.Href != pending.Href || remote.RemoteETag == "" || len(remote.RemoteBody) == 0 ||
+		remote.SemanticHash == "" || remote.SemanticHash == pending.OutgoingSemanticHash {
+		return nil, ErrCardDAVInvalidPlan
+	}
+	var fenced *CardDAVPublication
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, pending.PersonID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.MutationRevision != pending.MutationRevision ||
+			current.PendingOperation != CardDAVMutationCreate || current.AddressBookID != pending.AddressBookID ||
+			current.Href != remote.Href || current.MappingRevision != 0 {
+			return ErrCardDAVStalePlan
+		}
+		var generation, bookRevision int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts
+			WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT sync_revision FROM carddav_address_books
+			WHERE id = ?`+s.dialect.SelectForUpdate(), current.AddressBookID).Scan(&bookRevision); err != nil {
+			return err
+		}
+		if generation != current.ConnectionGeneration || bookRevision != current.BookSyncRevision {
+			return ErrCardDAVStalePlan
+		}
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, current.PersonID)
+		if err != nil {
+			return err
+		}
+		if snapshot.Fingerprint != current.LocalHash {
+			return ErrCardDAVPublicationMismatch
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		resource, err := s.findCardDAVResourceTx(ctx, tx, current.AddressBookID, current.Href)
+		if errors.Is(err, ErrCardDAVResourceNotFound) {
+			var personRevision, resourceID int64
+			if err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`, current.PersonID).
+				Scan(&personRevision); err != nil {
+				return err
+			}
+			if err := tx.QueryRowContext(ctx, `INSERT INTO carddav_resources (
+				address_book_id, href, remote_uid, remote_etag, remote_body,
+				remote_semantic_hash, local_hash, mapping_status, mapping_revision,
+				governance, person_id, person_revision_at_bind
+			) VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, 1, ?, ?, ?) RETURNING id`,
+				current.AddressBookID, remote.Href, remote.RemoteUID, remote.RemoteETag,
+				remote.RemoteBody, remote.SemanticHash, current.LocalHash,
+				CardDAVMappingMapped, CardDAVGovernanceLocal, current.PersonID, personRevision).
+				Scan(&resourceID); err != nil {
+				return fmt.Errorf("materialize CardDAV create collision: %w", err)
+			}
+			resource, err = s.findCardDAVResourceTx(ctx, tx, current.AddressBookID, current.Href)
+		}
+		if err != nil {
+			return err
+		}
+		if resource.PersonID == nil || *resource.PersonID != current.PersonID ||
+			resource.MappingStatus != CardDAVMappingMapped {
+			return ErrCardDAVPublicationMismatch
+		}
+		if err := s.putCardDAVEnvelopeTx(ctx, tx, current.AddressBookID, current.PersonID, remote); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET
+			mapping_revision = ?, previous_mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND mutation_revision = ? AND pending_operation = ?`,
+			resource.MappingRevision, resource.MappingRevision, current.PersonID,
+			current.MutationRevision, CardDAVMutationCreate)
+		if err != nil {
+			return fmt.Errorf("fence CardDAV create collision: %w", err)
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVStalePlan
+		}
+		fenced, err = getCardDAVPublicationFrom(ctx, tx, current.PersonID, "")
+		return err
+	})
+	return fenced, err
+}
+
+func (s *Store) CommitCardDAVPublicationContext(
+	ctx context.Context, input CardDAVCanonicalMutation,
+) error {
+	pending := input.Publication
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, pending.PersonID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.MutationRevision != pending.MutationRevision || current.PendingOperation != pending.PendingOperation {
+			return ErrCardDAVStalePlan
+		}
+		var generation, bookRevision int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation FROM carddav_accounts WHERE id = 1`+
+			s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT sync_revision FROM carddav_address_books WHERE id = ?`+
+			s.dialect.SelectForUpdate(), current.AddressBookID).Scan(&bookRevision); err != nil {
+			return err
+		}
+		if generation != current.ConnectionGeneration || bookRevision != current.BookSyncRevision {
+			return ErrCardDAVStalePlan
+		}
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, current.PersonID)
+		if err != nil {
+			return err
+		}
+		if snapshot.Fingerprint != current.LocalHash {
+			return ErrCardDAVPublicationMismatch
+		}
+		if current.PendingOperation == CardDAVMutationDelete {
+			if !input.Tombstone {
+				return ErrCardDAVPublicationMismatch
+			}
+			resource, err := findCardDAVResourceForPersonTx(ctx, tx, current.AddressBookID, current.PersonID, s.dialect.SelectForUpdate())
+			if errors.Is(err, ErrCardDAVResourceNotFound) && current.MappingRevision == 0 {
+				_, err = tx.ExecContext(ctx, `DELETE FROM carddav_publications WHERE person_id = ?`, current.PersonID)
+				return err
+			}
+			if err != nil {
+				return err
+			}
+			if resource.MappingRevision != current.MappingRevision || resource.Href != current.Href {
+				return ErrCardDAVStalePlan
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+				WHERE (left_kind = ? AND left_id = ?) OR (right_kind = ? AND right_id = ?)`,
+				IdentityMatchCardDAVResource, resource.ID, IdentityMatchCardDAVResource, resource.ID); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM vcard_resource_envelopes
+				WHERE source_ref = ? AND source_resource_uid = ?`, fmt.Sprintf("carddav:%d", current.AddressBookID), current.Href); err != nil {
+				return err
+			}
+			if _, err := tx.ExecContext(ctx, `DELETE FROM carddav_resources WHERE id = ?`, resource.ID); err != nil {
+				return err
+			}
+			if _, err = tx.ExecContext(ctx, `DELETE FROM carddav_publications WHERE person_id = ?`, current.PersonID); err != nil {
+				return err
+			}
+			return s.resolvePublicationConflictAuditTx(ctx, tx, pending)
+		}
+		if input.Tombstone || input.Remote.Href != current.Href || input.Remote.SemanticHash != current.OutgoingSemanticHash ||
+			len(input.Remote.RemoteBody) == 0 || input.Remote.RemoteETag == "" {
+			return ErrCardDAVPublicationMismatch
+		}
+		var resource *CardDAVResource
+		if current.PendingOperation == CardDAVMutationCreate {
+			resource, err = findCardDAVResourceForPersonTx(ctx, tx, current.AddressBookID, current.PersonID, s.dialect.SelectForUpdate())
+			if errors.Is(err, ErrCardDAVResourceNotFound) && current.MappingRevision == 0 {
+				var personRevision int64
+				if err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`, current.PersonID).Scan(&personRevision); err != nil {
+					return err
+				}
+				var resourceID int64
+				if err := tx.QueryRowContext(ctx, `INSERT INTO carddav_resources (
+				address_book_id, href, remote_uid, remote_etag, remote_body,
+				remote_semantic_hash, local_hash, mapping_status, mapping_revision,
+				governance, person_id, person_revision_at_bind
+			) VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, 1, ?, ?, ?) RETURNING id`,
+					current.AddressBookID, input.Remote.Href, input.Remote.RemoteUID,
+					input.Remote.RemoteETag, input.Remote.RemoteBody, input.Remote.SemanticHash,
+					current.LocalHash, CardDAVMappingMapped, CardDAVGovernanceLocal,
+					current.PersonID, personRevision).Scan(&resourceID); err != nil {
+					return fmt.Errorf("commit CardDAV remote create: %w", err)
+				}
+			} else {
+				if err != nil {
+					return err
+				}
+				if resource.Href != current.Href || resource.MappingRevision != current.MappingRevision {
+					return ErrCardDAVStalePlan
+				}
+				_, err = tx.ExecContext(ctx, `UPDATE carddav_resources SET
+					remote_uid = NULLIF(?, ''), remote_etag = ?, remote_body = ?,
+					remote_semantic_hash = ?, local_hash = ?, mapping_status = ?,
+					governance = ?, updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+					input.Remote.RemoteUID, input.Remote.RemoteETag, input.Remote.RemoteBody,
+					input.Remote.SemanticHash, current.LocalHash, CardDAVMappingMapped,
+					CardDAVGovernanceLocal, resource.ID)
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			resource, err = findCardDAVResourceForPersonTx(ctx, tx, current.AddressBookID, current.PersonID, s.dialect.SelectForUpdate())
+			if err != nil {
+				return err
+			}
+			if resource.MappingRevision != current.MappingRevision || resource.Href != current.Href {
+				return ErrCardDAVStalePlan
+			}
+			_, err = tx.ExecContext(ctx, `UPDATE carddav_resources SET
+				remote_uid = NULLIF(?, ''), remote_etag = ?, remote_body = ?,
+				remote_semantic_hash = ?, local_hash = ?, mapping_status = ?,
+				governance = ?, updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+				input.Remote.RemoteUID, input.Remote.RemoteETag, input.Remote.RemoteBody,
+				input.Remote.SemanticHash, current.LocalHash, CardDAVMappingMapped,
+				CardDAVGovernanceLocal, resource.ID)
+			if err != nil {
+				return err
+			}
+		}
+		if err := s.putCardDAVEnvelopeTx(ctx, tx, current.AddressBookID, current.PersonID, input.Remote); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET desired = TRUE,
+			pending_operation = NULL, outgoing_body = NULL,
+			outgoing_semantic_hash = NULL, local_hash = NULL, remote_etag = NULL,
+			connection_generation = NULL, book_sync_revision = NULL,
+			mapping_revision = NULL, previous_mapping_revision = NULL,
+			create_recovery_used = FALSE, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+` WHERE person_id = ? AND mutation_revision = ?`,
+			current.PersonID, current.MutationRevision)
+		if err != nil {
+			return err
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVStalePlan
+		}
+		return s.resolvePublicationConflictAuditTx(ctx, tx, pending)
+	})
+}
+
+func (s *Store) resolvePublicationConflictAuditTx(
+	ctx context.Context, tx *loggedTx, pending CardDAVPublication,
+) error {
+	if pending.ResolutionConflictID == 0 {
+		return nil
+	}
+	_, err := resolveCardDAVConflictAuditTx(ctx, tx, s.dialect,
+		pending.ResolutionConflictID, CardDAVResolutionKeepLocal)
+	return err
+}
+
+func (s *Store) RollbackCardDAVPublicationThrottleContext(
+	ctx context.Context, pending *CardDAVPublication, retryAfter time.Time,
+) error {
+	return s.rollbackCardDAVPublicationContext(ctx, pending, &retryAfter)
+}
+
+// RollbackCardDAVPublicationContext clears a definitively rejected remote
+// mutation and restores the mapping fence advanced while preparing it.
+func (s *Store) RollbackCardDAVPublicationContext(
+	ctx context.Context, pending *CardDAVPublication,
+) error {
+	return s.rollbackCardDAVPublicationContext(ctx, pending, nil)
+}
+
+func (s *Store) rollbackCardDAVPublicationContext(
+	ctx context.Context, pending *CardDAVPublication, retryAfter *time.Time,
+) error {
+	if pending == nil {
+		return ErrCardDAVInvalidPlan
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		current, err := getCardDAVPublicationFrom(ctx, tx, pending.PersonID, s.dialect.SelectForUpdate())
+		if err != nil {
+			return err
+		}
+		if current.MutationRevision != pending.MutationRevision || current.PendingOperation != pending.PendingOperation {
+			return ErrCardDAVStalePlan
+		}
+		if current.PendingOperation != CardDAVMutationCreate {
+			result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+				mapping_revision = ?, updated_at = `+s.dialect.Now()+`
+				WHERE address_book_id = ? AND person_id = ? AND href = ? AND mapping_revision = ?`,
+				current.PreviousMappingRevision, current.AddressBookID, current.PersonID,
+				current.Href, current.MappingRevision)
+			if err != nil {
+				return err
+			}
+			if affected, _ := result.RowsAffected(); affected != 1 {
+				return ErrCardDAVStalePlan
+			}
+		}
+		if retryAfter == nil && current.PendingOperation == CardDAVMutationCreate &&
+			current.PreviousMappingRevision == 0 && pending.ResolutionConflictID == 0 {
+			result, err := tx.ExecContext(ctx, `DELETE FROM carddav_publications
+				WHERE person_id = ? AND mutation_revision = ?`, current.PersonID, current.MutationRevision)
+			if err != nil {
+				return err
+			}
+			if affected, _ := result.RowsAffected(); affected != 1 {
+				return ErrCardDAVStalePlan
+			}
+			return nil
+		}
+		desired := true
+		if retryAfter != nil {
+			desired = current.Desired
+		}
+		result, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET
+			desired = ?,
+			pending_operation = NULL, outgoing_body = NULL,
+			outgoing_semantic_hash = NULL, local_hash = NULL, remote_etag = NULL,
+			connection_generation = NULL, book_sync_revision = NULL,
+			mapping_revision = NULL, previous_mapping_revision = NULL,
+			create_recovery_used = FALSE, pending_started_at = NULL,
+			updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND mutation_revision = ?`, desired, current.PersonID, current.MutationRevision)
+		if err != nil {
+			return err
+		}
+		if affected, _ := result.RowsAffected(); affected != 1 {
+			return ErrCardDAVStalePlan
+		}
+		if retryAfter != nil {
+			return s.setCardDAVRetryAfterFrom(ctx, tx, *retryAfter)
+		}
+		return nil
+	})
+}
+
+func (s *Store) GetCardDAVRetryAfterContext(ctx context.Context) (*time.Time, error) {
+	return getCardDAVRetryAfterFrom(ctx, s.db)
+}
+
+func (s *Store) CheckCardDAVRetryAfterContext(ctx context.Context) error {
+	gate, err := s.GetCardDAVRetryAfterContext(ctx)
+	if err != nil {
+		return err
+	}
+	if gate != nil && gate.After(time.Now()) {
+		return ErrCardDAVRetryAfter
+	}
+	return nil
+}
+
+func (s *Store) SetCardDAVRetryAfterContext(ctx context.Context, retryAfter time.Time) error {
+	err := s.setCardDAVRetryAfterFrom(ctx, s.db, retryAfter)
+	if err != nil {
+		return fmt.Errorf("set CardDAV retry gate: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) setCardDAVRetryAfterFrom(
+	ctx context.Context, execer contextQuerier, retryAfter time.Time,
+) error {
+	gate := retryAfter.UTC()
+	_, err := execer.ExecContext(ctx, `INSERT INTO carddav_retry_gate (account_id, retry_after_at, updated_at)
+		VALUES (1, ?, `+s.dialect.Now()+`) ON CONFLICT(account_id) DO UPDATE SET
+		retry_after_at = CASE
+			WHEN carddav_retry_gate.retry_after_at < excluded.retry_after_at THEN excluded.retry_after_at
+			ELSE carddav_retry_gate.retry_after_at
+		END,
+		updated_at = `+s.dialect.Now(), timeValue(&gate))
+	return err
+}
+
+func (s *Store) ListCardDAVPublicationPersonIDsContext(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT person_id FROM carddav_publications ORDER BY person_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	ids := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func getCardDAVRetryAfterFrom(ctx context.Context, queryer contextRowQuerier) (*time.Time, error) {
+	var value sql.NullTime
+	err := queryer.QueryRowContext(ctx, `SELECT retry_after_at FROM carddav_retry_gate WHERE account_id = 1`).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil //nolint:nilnil // No retry-gate row means synchronization is not throttled.
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get CardDAV retry gate: %w", err)
+	}
+	if !value.Valid {
+		return nil, nil //nolint:nilnil // A cleared nullable gate is equivalent to no throttle.
+	}
+	gate := value.Time.UTC()
+	return &gate, nil
+}
+
+func getCardDAVPublicationFrom(
+	ctx context.Context, queryer contextRowQuerier, personID int64, suffix string,
+) (*CardDAVPublication, error) {
+	var result CardDAVPublication
+	var bookID, generation, bookRevision, mappingRevision, previousMapping sql.NullInt64
+	var href, operation, outgoingHash, localHash, remoteETag sql.NullString
+	var outgoing []byte
+	var pendingAt sql.NullTime
+	err := queryer.QueryRowContext(ctx, `SELECT person_id, desired, address_book_id, href,
+		pending_operation, outgoing_body, outgoing_semantic_hash, local_hash,
+		remote_etag, connection_generation, book_sync_revision, mapping_revision,
+		previous_mapping_revision, create_recovery_used, mutation_revision,
+		pending_started_at FROM carddav_publications WHERE person_id = ?`+suffix, personID).Scan(
+		&result.PersonID, &result.Desired, &bookID, &href, &operation, &outgoing,
+		&outgoingHash, &localHash, &remoteETag, &generation, &bookRevision,
+		&mappingRevision, &previousMapping, &result.CreateRecoveryUsed,
+		&result.MutationRevision, &pendingAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVPublicationNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get CardDAV publication: %w", err)
+	}
+	result.AddressBookID, result.Href = bookID.Int64, href.String
+	result.PendingOperation = CardDAVMutationOperation(operation.String)
+	result.OutgoingBody = append([]byte(nil), outgoing...)
+	result.OutgoingSemanticHash, result.LocalHash, result.RemoteETag = outgoingHash.String, localHash.String, remoteETag.String
+	result.ConnectionGeneration, result.BookSyncRevision = generation.Int64, bookRevision.Int64
+	result.MappingRevision, result.PreviousMappingRevision = mappingRevision.Int64, previousMapping.Int64
+	if pendingAt.Valid {
+		value := pendingAt.Time.UTC()
+		result.PendingStartedAt = &value
+	}
+	return &result, nil
+}
+
+func findCardDAVResourceForPersonTx(
+	ctx context.Context, queryer contextRowQuerier,
+	bookID, personID int64, suffix string,
+) (*CardDAVResource, error) {
+	var count int
+	if err := queryer.QueryRowContext(ctx, `SELECT COUNT(*) FROM carddav_resources
+		WHERE address_book_id = ? AND person_id = ?`, bookID, personID).Scan(&count); err != nil {
+		return nil, fmt.Errorf("count CardDAV resources for person: %w", err)
+	}
+	if count > 1 {
+		return nil, ErrCardDAVResourceAmbiguous
+	}
+	resource, err := scanCardDAVResource(queryer.QueryRowContext(ctx,
+		cardDAVResourceSelect+` WHERE address_book_id = ? AND person_id = ?`+suffix,
+		bookID, personID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVResourceNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find CardDAV resource for person: %w", err)
+	}
+	return resource, nil
+}

--- a/internal/store/carddav_publication_test.go
+++ b/internal/store/carddav_publication_test.go
@@ -1,0 +1,190 @@
+package store_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestCardDAVPublicationPreparePersistsExactCreateIntent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('local-person', 'Local Person') RETURNING id`).Scan(&personID))
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	body := []byte("BEGIN:VCARD\r\nVERSION:3.0\r\nUID:local-person\r\nFN:Local Person\r\nEND:VCARD\r\n")
+
+	prepared, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID,
+		Href: book.CanonicalURL + "local-person.vcf", OutgoingBody: body,
+		OutgoingSemanticHash: "semantic", LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	assert.Equal(store.CardDAVMutationCreate, prepared.PendingOperation)
+	assert.Equal(account.ConnectionGeneration, prepared.ConnectionGeneration)
+	assert.Equal(book.SyncRevision, prepared.BookSyncRevision)
+	assert.Equal(body, prepared.OutgoingBody)
+	assert.True(prepared.Desired)
+}
+
+func TestDeletePersonRejectsCardDAVPublicationState(t *testing.T) {
+	for _, pending := range []bool{false, true} {
+		t.Run(fmt.Sprintf("pending=%t", pending), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, account, book := newCardDAVResourceStore(t)
+			remote := remoteResource(book.CanonicalURL+"published.vcf", "published", "Published",
+				"published@example.test", `"one"`)
+			_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+				AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+				SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{remote},
+			})
+			require.NoError(err)
+			resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+			require.NoError(err)
+			require.NotNil(resource.PersonID)
+			snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *resource.PersonID)
+			require.NoError(err)
+			semanticHash := remote.SemanticHash
+			if pending {
+				semanticHash += "-changed"
+			}
+			publication, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+				PersonID: *resource.PersonID, Desired: true, AddressBookID: book.ID, Href: remote.Href,
+				OutgoingBody: remote.RemoteBody, OutgoingSemanticHash: semanticHash,
+				LocalHash: snapshot.Fingerprint,
+			})
+			require.NoError(err)
+			assert.Equal(pending, publication.PendingOperation != "")
+
+			person, err := st.GetPersonContext(t.Context(), *resource.PersonID)
+			require.NoError(err)
+			err = st.DeletePersonContext(t.Context(), person.ID, person.Revision)
+			require.ErrorIs(err, store.ErrPersonCardDAVPublished)
+			_, err = st.GetPersonContext(t.Context(), person.ID)
+			require.NoError(err)
+			_, err = st.GetCardDAVPublicationContext(t.Context(), person.ID)
+			require.NoError(err)
+		})
+	}
+}
+
+func TestCardDAVPublicationPrepareNoopsWhenMappedSemanticHashMatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"same.vcf", "same", "Same", "same@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *resource.PersonID)
+	require.NoError(err)
+
+	prepared, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: *resource.PersonID, Desired: true, AddressBookID: book.ID, Href: input.Href,
+		OutgoingBody: input.RemoteBody, OutgoingSemanticHash: input.SemanticHash,
+		LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	assert.True(prepared.Noop)
+	assert.Empty(prepared.PendingOperation)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Equal(resource.MappingRevision, after.MappingRevision)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), *resource.PersonID)
+	require.NoError(err)
+	assert.True(publication.Desired)
+	assert.Empty(publication.PendingOperation)
+}
+
+func TestCardDAVPublicationRejectsAmbiguousMappedResource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	first := remoteResource(book.CanonicalURL+"first.vcf", "first", "Duplicate",
+		"duplicate@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{first},
+	})
+	require.NoError(err)
+	firstResource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, first.Href)
+	require.NoError(err)
+	require.NotNil(firstResource.PersonID)
+	second := remoteResource(book.CanonicalURL+"second.vcf", "second", "Duplicate",
+		"duplicate@example.test", `"two"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{second},
+	})
+	require.NoError(err)
+	secondResource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, second.Href)
+	require.NoError(err)
+	require.NotNil(secondResource.PersonID)
+	assert.Equal(*firstResource.PersonID, *secondResource.PersonID)
+
+	_, err = st.GetCardDAVResourceForPersonContext(t.Context(), book.ID, *firstResource.PersonID)
+	require.ErrorIs(err, store.ErrCardDAVResourceAmbiguous)
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *firstResource.PersonID)
+	require.NoError(err)
+	_, err = st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: *firstResource.PersonID, Desired: true, AddressBookID: book.ID,
+		Href: first.Href, OutgoingBody: first.RemoteBody,
+		OutgoingSemanticHash: "updated", LocalHash: snapshot.Fingerprint,
+	})
+	require.ErrorIs(err, store.ErrCardDAVResourceAmbiguous)
+}
+
+func TestCardDAVPublicationThrottleRollbackRestoresMappedRevisionAndPreservesLongestGate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"local-person.vcf", "local-person", "Local Person", "local@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *resource.PersonID)
+	require.NoError(err)
+	prepared, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: *resource.PersonID, Desired: true, AddressBookID: book.ID,
+		Href: input.Href, OutgoingBody: input.RemoteBody,
+		OutgoingSemanticHash: "semantic-update", LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	assert.Equal(resource.MappingRevision+1, prepared.MappingRevision)
+
+	longGate := time.Now().Add(time.Hour).UTC()
+	require.NoError(st.SetCardDAVRetryAfterContext(t.Context(), longGate))
+	require.NoError(st.RollbackCardDAVPublicationThrottleContext(t.Context(), prepared, time.Now().Add(time.Minute)))
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Equal(resource.MappingRevision, after.MappingRevision)
+	publication, err := st.GetCardDAVPublicationContext(t.Context(), *resource.PersonID)
+	require.NoError(err)
+	assert.Empty(publication.PendingOperation)
+	gate, err := st.GetCardDAVRetryAfterContext(t.Context())
+	require.NoError(err)
+	require.NotNil(gate)
+	assert.WithinDuration(longGate, *gate, time.Second)
+}

--- a/internal/store/carddav_resources.go
+++ b/internal/store/carddav_resources.go
@@ -1,0 +1,1455 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/vcard"
+)
+
+type CardDAVMappingStatus string
+
+const (
+	CardDAVMappingMapped    CardDAVMappingStatus = "mapped"
+	CardDAVMappingUnbound   CardDAVMappingStatus = "unbound"
+	CardDAVMappingAmbiguous CardDAVMappingStatus = "ambiguous"
+)
+
+type CardDAVGovernance string
+
+const (
+	CardDAVGovernanceRemote CardDAVGovernance = "remote"
+	CardDAVGovernanceLocal  CardDAVGovernance = "local"
+	CardDAVGovernanceNone   CardDAVGovernance = "none"
+)
+
+var (
+	ErrCardDAVResourceNotFound = errors.New("CardDAV resource not found")
+	ErrCardDAVStalePlan        = errors.New("CardDAV sync plan is stale")
+	ErrCardDAVInvalidPlan      = errors.New("invalid CardDAV sync plan")
+)
+
+type CardDAVResource struct {
+	ID                   int64
+	AddressBookID        int64
+	Href                 string
+	RemoteUID            string
+	RemoteETag           string
+	RemoteBody           []byte
+	RemoteSemanticHash   string
+	LocalHash            string
+	MappingStatus        CardDAVMappingStatus
+	MappingRevision      int64
+	Governance           CardDAVGovernance
+	PersonID             *int64
+	PersonRevisionAtBind *int64
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+// CardDAVRemoteResource is one complete network result. Contact values are
+// already decoded from the same body and are used only for safe person
+// binding; RemoteBody remains the authoritative lossless payload.
+type CardDAVRemoteResource struct {
+	Href                string
+	PreviousHref        string
+	RemoteUID           string
+	RemoteETag          string
+	RemoteBody          []byte
+	SemanticHash        string
+	DisplayName         string
+	DisplayNameIdentity VCardIdentity
+	Emails              []string
+	EmailIdentities     []VCardIdentity
+	Phones              []string
+	PhoneIdentities     []VCardIdentity
+	// EquivalentLocalHash is sync-plan evidence that the current local
+	// projection and this remote body have the same CardDAV semantic hash.
+	EquivalentLocalHash string
+}
+
+type CardDAVSyncPlan struct {
+	AddressBookID          int64
+	ConnectionGeneration   int64
+	SyncRevision           int64
+	ReplaceAll             bool
+	NextSyncToken          string
+	Upserts                []CardDAVRemoteResource
+	RemovedHrefs           []string
+	Conflicts              []CardDAVConflictCapture
+	CompletesFullReconcile bool
+}
+
+type CardDAVApplyResult struct {
+	Created int
+	Updated int
+	Removed int
+}
+
+// ApplyCardDAVSyncPlanContext applies a fully fetched network plan in one
+// transaction. Both account and book fences are checked before ledger or
+// person state is read, and the network client is intentionally absent from
+// this API.
+func (s *Store) ApplyCardDAVSyncPlanContext(
+	ctx context.Context, plan CardDAVSyncPlan,
+) (*CardDAVApplyResult, error) {
+	if err := validateCardDAVSyncPlan(plan); err != nil {
+		return nil, err
+	}
+	result := &CardDAVApplyResult{}
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		var generation int64
+		if err := tx.QueryRowContext(ctx, `SELECT connection_generation
+			FROM carddav_accounts WHERE id = 1`+s.dialect.SelectForUpdate()).Scan(&generation); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVStalePlan
+			}
+			return fmt.Errorf("lock CardDAV account sync fence: %w", err)
+		}
+		if generation != plan.ConnectionGeneration {
+			return ErrCardDAVStalePlan
+		}
+		var book CardDAVAddressBook
+		if err := tx.QueryRowContext(ctx, `SELECT id, account_id, canonical_url,
+			is_subscribed, is_lookup_source, sync_token, sync_revision
+			FROM carddav_address_books WHERE id = ?`+s.dialect.SelectForUpdate(),
+			plan.AddressBookID,
+		).Scan(&book.ID, &book.AccountID, &book.CanonicalURL,
+			&book.IsSubscribed, &book.IsLookupSource, &book.SyncToken, &book.SyncRevision); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrCardDAVStalePlan
+			}
+			return fmt.Errorf("lock CardDAV address book sync fence: %w", err)
+		}
+		if book.SyncRevision != plan.SyncRevision ||
+			(!book.IsSubscribed && !book.IsLookupSource) {
+			return ErrCardDAVStalePlan
+		}
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+
+		seen := make(map[string]bool, len(plan.Upserts))
+		conflicts := make(map[string]CardDAVConflictCapture, len(plan.Conflicts))
+		for _, capture := range plan.Conflicts {
+			conflicts[capture.Href] = capture
+		}
+		for _, input := range plan.Upserts {
+			var moveHashes cardDAVHrefMoveHashes
+			if input.PreviousHref != "" {
+				var moveErr error
+				moveHashes, moveErr = s.moveCardDAVResourceHrefTx(ctx, tx, book.ID, input)
+				if moveErr != nil {
+					return moveErr
+				}
+				if input.EquivalentLocalHash != "" && moveHashes.hasPerson {
+					if input.EquivalentLocalHash != moveHashes.currentBefore {
+						return ErrCardDAVStalePlan
+					}
+					input.EquivalentLocalHash = moveHashes.currentAfter
+				}
+			}
+			seen[input.Href] = true
+			capture, supplied := conflicts[input.Href]
+			if supplied && input.PreviousHref != "" && moveHashes.hasPerson {
+				if capture.BaseLocalHash != moveHashes.baseBefore {
+					return ErrCardDAVStalePlan
+				}
+				capture.BaseLocalHash = moveHashes.baseAfter
+				if capture.LocalTombstone {
+					if capture.LocalHash != moveHashes.baseBefore {
+						return ErrCardDAVStalePlan
+					}
+					capture.LocalHash = moveHashes.baseAfter
+				} else {
+					if capture.LocalHash != moveHashes.currentBefore {
+						return ErrCardDAVStalePlan
+					}
+					capture.LocalHash = moveHashes.currentAfter
+				}
+			}
+			needsConflict, err := s.cardDAVResourceNeedsConflictTx(ctx, tx, book.ID, input.Href,
+				input.SemanticHash, input.EquivalentLocalHash)
+			if err != nil {
+				return err
+			}
+			if supplied != needsConflict {
+				return ErrCardDAVStalePlan
+			}
+			if supplied {
+				if capture.AddressBookID != book.ID || capture.RemoteTombstone ||
+					capture.RemoteETag != input.RemoteETag || !bytes.Equal(capture.RemoteBody, input.RemoteBody) {
+					return ErrCardDAVInvalidPlan
+				}
+				if _, err := s.recordCardDAVConflictTx(ctx, tx, capture, cardDAVConflictRecordOptions{
+					supersedePendingIntent:         true,
+					preserveExistingLocalTombstone: true,
+				}); err != nil {
+					return err
+				}
+				delete(conflicts, input.Href)
+				continue
+			}
+			created, changed, err := s.applyCardDAVResourceTx(
+				ctx, tx, book, input, plan.CompletesFullReconcile,
+			)
+			if err != nil {
+				return err
+			}
+			if created {
+				result.Created++
+			} else if changed {
+				result.Updated++
+			}
+		}
+
+		removed := make(map[string]bool, len(plan.RemovedHrefs))
+		for _, href := range plan.RemovedHrefs {
+			removed[href] = true
+		}
+		if plan.ReplaceAll {
+			rows, err := tx.QueryContext(ctx, `SELECT href FROM carddav_resources
+				WHERE address_book_id = ? ORDER BY href`, book.ID)
+			if err != nil {
+				return fmt.Errorf("list CardDAV snapshot tombstones: %w", err)
+			}
+			for rows.Next() {
+				var href string
+				if err := rows.Scan(&href); err != nil {
+					_ = rows.Close()
+					return fmt.Errorf("scan CardDAV snapshot tombstone: %w", err)
+				}
+				if !seen[href] {
+					removed[href] = true
+				}
+			}
+			if err := rows.Close(); err != nil {
+				return fmt.Errorf("close CardDAV snapshot tombstones: %w", err)
+			}
+		}
+		for href := range removed {
+			capture, supplied := conflicts[href]
+			needsConflict, err := s.cardDAVResourceNeedsConflictTx(ctx, tx, book.ID, href, "", "")
+			if err != nil {
+				return err
+			}
+			if supplied != needsConflict {
+				return ErrCardDAVStalePlan
+			}
+			if supplied {
+				if capture.AddressBookID != book.ID || !capture.RemoteTombstone {
+					return ErrCardDAVInvalidPlan
+				}
+				completed, err := s.completePendingCardDAVConflictTombstoneFromPullTx(
+					ctx, tx, book, generation, capture)
+				if err != nil {
+					return err
+				}
+				if completed {
+					result.Removed++
+					delete(conflicts, href)
+					continue
+				}
+				if _, err := s.recordCardDAVConflictTx(ctx, tx, capture, cardDAVConflictRecordOptions{}); err != nil {
+					return err
+				}
+				delete(conflicts, href)
+				continue
+			}
+			wasRemoved, err := s.removeCardDAVResourceTx(ctx, tx, book.ID, href)
+			if err != nil {
+				return err
+			}
+			if wasRemoved {
+				result.Removed++
+			}
+		}
+		if len(conflicts) != 0 {
+			return ErrCardDAVInvalidPlan
+		}
+
+		updated, err := tx.ExecContext(ctx, `UPDATE carddav_address_books SET
+			sync_token = ?, sync_revision = sync_revision + 1,
+			needs_full_reconcile = CASE WHEN ? THEN FALSE ELSE needs_full_reconcile END,
+			updated_at = `+s.dialect.Now()+`
+			WHERE id = ? AND sync_revision = ?`,
+			plan.NextSyncToken, plan.CompletesFullReconcile, book.ID, plan.SyncRevision)
+		if err != nil {
+			return fmt.Errorf("advance CardDAV address book sync fence: %w", err)
+		}
+		affected, err := updated.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("count CardDAV address book fence update: %w", err)
+		}
+		if affected != 1 {
+			return ErrCardDAVStalePlan
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func validateCardDAVSyncPlan(plan CardDAVSyncPlan) error {
+	if plan.AddressBookID <= 0 || plan.ConnectionGeneration <= 0 || plan.SyncRevision <= 0 {
+		return ErrCardDAVInvalidPlan
+	}
+	if plan.CompletesFullReconcile && !plan.ReplaceAll {
+		return ErrCardDAVInvalidPlan
+	}
+	seen := make(map[string]bool, len(plan.Upserts))
+	for _, resource := range plan.Upserts {
+		if strings.TrimSpace(resource.Href) == "" || strings.TrimSpace(resource.RemoteETag) == "" ||
+			len(resource.RemoteBody) == 0 || strings.TrimSpace(resource.SemanticHash) == "" {
+			return ErrCardDAVInvalidPlan
+		}
+		if seen[resource.Href] {
+			return fmt.Errorf("%w: duplicate href", ErrCardDAVInvalidPlan)
+		}
+		if resource.PreviousHref != "" && (resource.PreviousHref == resource.Href ||
+			strings.TrimSpace(resource.RemoteUID) == "") {
+			return ErrCardDAVInvalidPlan
+		}
+		seen[resource.Href] = true
+	}
+	for _, href := range plan.RemovedHrefs {
+		if strings.TrimSpace(href) == "" || seen[href] {
+			return fmt.Errorf("%w: contradictory removal", ErrCardDAVInvalidPlan)
+		}
+	}
+	conflicts := make(map[string]bool, len(plan.Conflicts))
+	for _, capture := range plan.Conflicts {
+		if err := validateCardDAVConflictCapture(capture); err != nil {
+			return err
+		}
+		if capture.AddressBookID != plan.AddressBookID || conflicts[capture.Href] {
+			return ErrCardDAVInvalidPlan
+		}
+		conflicts[capture.Href] = true
+	}
+	return nil
+}
+
+type cardDAVHrefMoveHashes struct {
+	hasPerson     bool
+	baseBefore    string
+	baseAfter     string
+	currentBefore string
+	currentAfter  string
+}
+
+func (s *Store) moveCardDAVResourceHrefTx(
+	ctx context.Context, tx *loggedTx, bookID int64, input CardDAVRemoteResource,
+) (cardDAVHrefMoveHashes, error) {
+	hashes := cardDAVHrefMoveHashes{}
+	resource, err := s.findCardDAVResourceTx(ctx, tx, bookID, input.PreviousHref)
+	if err != nil || resource.RemoteUID != input.RemoteUID {
+		return hashes, ErrCardDAVStalePlan
+	}
+	if _, err := s.findCardDAVResourceTx(ctx, tx, bookID, input.Href); err == nil {
+		return hashes, ErrCardDAVStalePlan
+	} else if !errors.Is(err, ErrCardDAVResourceNotFound) {
+		return hashes, err
+	}
+	if resource.PersonID != nil {
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, *resource.PersonID)
+		if err != nil {
+			return hashes, err
+		}
+		hashes = cardDAVHrefMoveHashes{
+			hasPerson: true, baseBefore: resource.LocalHash, baseAfter: resource.LocalHash,
+			currentBefore: snapshot.Fingerprint, currentAfter: snapshot.Fingerprint,
+		}
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET href = ?, updated_at = `+
+		s.dialect.Now()+` WHERE id = ? AND href = ?`, input.Href, resource.ID, input.PreviousHref)
+	if err != nil {
+		return hashes, fmt.Errorf("move CardDAV resource href: %w", err)
+	}
+	if affected, _ := result.RowsAffected(); affected != 1 {
+		return hashes, ErrCardDAVStalePlan
+	}
+	sourceRef := fmt.Sprintf("carddav:%d", bookID)
+	if err := s.rewriteVCardSourceResourceProvenanceTx(
+		ctx, tx, sourceRef, input.PreviousHref, input.Href,
+	); err != nil {
+		return hashes, err
+	}
+	if resource.PersonID != nil {
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, *resource.PersonID)
+		if err != nil {
+			return hashes, err
+		}
+		hashes.currentAfter = snapshot.Fingerprint
+		if hashes.currentBefore == hashes.baseBefore {
+			hashes.baseAfter = snapshot.Fingerprint
+			if _, err := tx.ExecContext(ctx, `UPDATE carddav_resources
+				SET local_hash = ?, updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+				snapshot.Fingerprint, resource.ID); err != nil {
+				return hashes, fmt.Errorf("rebase moved CardDAV resource local hash: %w", err)
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE vcard_resource_envelopes SET
+		source_resource_uid = ?, href = ?, revision = revision + 1,
+		updated_at = `+s.dialect.Now()+`
+		WHERE source_ref = ? AND source_resource_uid = ?`,
+		input.Href, input.Href, sourceRef, input.PreviousHref); err != nil {
+		return hashes, fmt.Errorf("move CardDAV resource envelope href: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE carddav_publications SET href = ?, updated_at = `+
+		s.dialect.Now()+` WHERE address_book_id = ? AND href = ?`,
+		input.Href, bookID, input.PreviousHref); err != nil {
+		return hashes, fmt.Errorf("move CardDAV publication href: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE carddav_conflicts SET href = ?, updated_at = `+
+		s.dialect.Now()+` WHERE address_book_id = ? AND href = ?`,
+		input.Href, bookID, input.PreviousHref); err != nil {
+		return hashes, fmt.Errorf("move CardDAV conflict href: %w", err)
+	}
+	return hashes, nil
+}
+
+func (s *Store) cardDAVResourceNeedsConflictTx(
+	ctx context.Context, tx *loggedTx, bookID int64, href, remoteHash, equivalentLocalHash string,
+) (bool, error) {
+	resource, err := s.findCardDAVResourceTx(ctx, tx, bookID, href)
+	if errors.Is(err, ErrCardDAVResourceNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	var unresolved int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM carddav_conflicts
+		WHERE address_book_id = ? AND href = ? AND status = 'unresolved'`, bookID, href).Scan(&unresolved); err != nil {
+		return false, fmt.Errorf("check unresolved CardDAV mapping conflict: %w", err)
+	}
+	if unresolved > 0 {
+		return true, nil
+	}
+	if resource.MappingStatus != CardDAVMappingMapped {
+		return false, nil
+	}
+	localChanged := resource.PersonID == nil
+	localHash := ""
+	if resource.PersonID != nil {
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, *resource.PersonID)
+		if err != nil {
+			return false, err
+		}
+		localHash = snapshot.Fingerprint
+		localChanged = localHash != resource.LocalHash
+	}
+	remoteChanged := remoteHash == "" || remoteHash != resource.RemoteSemanticHash
+	if localChanged && remoteChanged {
+		if resource.PersonID == nil && remoteHash == "" {
+			return false, nil
+		}
+		if equivalentLocalHash != "" && localHash == equivalentLocalHash {
+			return false, nil
+		}
+	}
+	return localChanged && remoteChanged, nil
+}
+
+func (s *Store) applyCardDAVResourceTx(
+	ctx context.Context, tx *loggedTx, book CardDAVAddressBook,
+	input CardDAVRemoteResource, reconcileBinding bool,
+) (bool, bool, error) {
+	current, err := s.findCardDAVResourceTx(ctx, tx, book.ID, input.Href)
+	created := errors.Is(err, ErrCardDAVResourceNotFound)
+	if err != nil && !created {
+		return false, false, err
+	}
+	unchangedRemote := !created && current.RemoteETag == input.RemoteETag &&
+		bytes.Equal(current.RemoteBody, input.RemoteBody)
+	bindingNeedsReconcile := !created && (current.MappingStatus == CardDAVMappingUnbound ||
+		current.MappingStatus == CardDAVMappingAmbiguous)
+	if unchangedRemote && (!reconcileBinding || !bindingNeedsReconcile) {
+		return false, false, nil
+	}
+
+	var personID *int64
+	personRevision := (*int64)(nil)
+	status := CardDAVMappingUnbound
+	governance := CardDAVGovernanceNone
+	var ambiguous []cardDAVPersonMatch
+	projectionRebased := false
+	remoteOwnsDisplay := false
+	preserveLocalTombstone := !created && current.MappingStatus == CardDAVMappingMapped &&
+		current.PersonID == nil && current.RemoteSemanticHash == input.SemanticHash
+	if preserveLocalTombstone {
+		status, governance = current.MappingStatus, current.Governance
+	} else if !created && current.PersonID != nil {
+		personID = current.PersonID
+		personRevision = current.PersonRevisionAtBind
+		status, governance = current.MappingStatus, current.Governance
+	} else {
+		resourceID := int64(0)
+		if !created {
+			resourceID = current.ID
+		}
+		personID, ambiguous, err = s.resolveCardDAVPersonTx(ctx, tx, resourceID, input)
+		if err != nil {
+			return false, false, err
+		}
+		switch {
+		case personID != nil:
+			status, governance = CardDAVMappingMapped, CardDAVGovernanceLocal
+		case len(ambiguous) > 0:
+			status, governance = CardDAVMappingAmbiguous, CardDAVGovernanceNone
+		case book.IsSubscribed:
+			personID, personRevision, err = s.createCardDAVImportedPersonTx(ctx, tx, book.ID, input)
+			if err != nil {
+				return false, false, err
+			}
+			status, governance = CardDAVMappingMapped, CardDAVGovernanceRemote
+		}
+	}
+	semanticRemoteChanged := !created && current.RemoteSemanticHash != input.SemanticHash
+	if semanticRemoteChanged && current.Governance == CardDAVGovernanceRemote &&
+		current.MappingStatus == CardDAVMappingMapped && personID != nil &&
+		current.PersonRevisionAtBind != nil {
+		hasUserOwnedState, err := s.personHasUserOwnedStateTx(
+			ctx, tx, *personID, *current.PersonRevisionAtBind,
+		)
+		if err != nil {
+			return false, false, err
+		}
+		if !hasUserOwnedState {
+			remoteOwnsDisplay, err = s.rebaseCardDAVImportedProjectionTx(
+				ctx, tx, book.ID, *personID, input,
+			)
+			if err != nil {
+				return false, false, err
+			}
+			projectionRebased = true
+			personRevision = nil
+		}
+	}
+	if personID != nil && personRevision == nil {
+		var revision int64
+		if err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`, *personID).Scan(&revision); err != nil {
+			return false, false, fmt.Errorf("load CardDAV-bound person revision: %w", err)
+		}
+		personRevision = &revision
+	}
+	localHash := input.SemanticHash
+	if !created {
+		localHash = current.LocalHash
+	}
+	if personID != nil {
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, *personID)
+		if err != nil {
+			return false, false, fmt.Errorf("hash CardDAV-bound local person: %w", err)
+		}
+		localHash = snapshot.Fingerprint
+	}
+
+	var resourceID int64
+	if created {
+		err = tx.QueryRowContext(ctx, `INSERT INTO carddav_resources (
+			address_book_id, href, remote_uid, remote_etag, remote_body,
+			remote_semantic_hash, local_hash, mapping_status, mapping_revision,
+			governance, person_id, person_revision_at_bind
+		) VALUES (?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, 1, ?, ?, ?) RETURNING id`,
+			book.ID, input.Href, input.RemoteUID, input.RemoteETag, input.RemoteBody,
+			input.SemanticHash, localHash, status, governance,
+			nullableVCardInt64(personID), nullableVCardInt64(personRevision),
+		).Scan(&resourceID)
+	} else {
+		resourceID = current.ID
+		_, err = tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			remote_uid = NULLIF(?, ''), remote_etag = ?, remote_body = ?,
+			remote_semantic_hash = ?, local_hash = ?, mapping_status = ?,
+			mapping_revision = mapping_revision + 1, governance = ?, person_id = ?,
+			person_revision_at_bind = ?, updated_at = `+s.dialect.Now()+`
+			WHERE id = ?`, input.RemoteUID, input.RemoteETag, input.RemoteBody,
+			input.SemanticHash, localHash, status, governance,
+			nullableVCardInt64(personID), nullableVCardInt64(personRevision), resourceID)
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("save CardDAV resource ledger: %w", err)
+	}
+	sourceRef := fmt.Sprintf("carddav:%d", book.ID)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+		WHERE source = ? AND source_ref = ?
+		  AND state IN (?, ?)
+		  AND decided_at IS NULL
+		  AND ((left_kind = ? AND left_id = ?)
+		    OR (right_kind = ? AND right_id = ?))`,
+		ProvenanceCardDAVImport, sourceRef,
+		IdentityMatchStateCandidate, IdentityMatchStateConflict,
+		IdentityMatchCardDAVResource, resourceID,
+		IdentityMatchCardDAVResource, resourceID,
+	); err != nil {
+		return false, false, fmt.Errorf("reconcile CardDAV identity candidates: %w", err)
+	}
+	if personID != nil {
+		if err := s.putCardDAVEnvelopeTx(ctx, tx, book.ID, *personID, input); err != nil {
+			return false, false, err
+		}
+	}
+	if projectionRebased {
+		if err := s.refreshCardDAVImportedPersonBindBaselineTx(
+			ctx, tx, resourceID, *personID, remoteOwnsDisplay,
+		); err != nil {
+			return false, false, err
+		}
+	}
+	for _, match := range ambiguous {
+		normalized := match.NormalizedValue
+		_, _, err := s.upsertIdentityMatchCandidateTx(ctx, tx, IdentityMatchCandidateInput{
+			LeftKind: IdentityMatchCardDAVResource, LeftID: resourceID,
+			RightKind: IdentityMatchPerson, RightID: match.PersonID,
+			Basis: match.Basis, NormalizedValue: &normalized,
+			State: IdentityMatchStateConflict, Source: ProvenanceCardDAVImport,
+			SourceRef: &sourceRef,
+		}, IdentityMatchCardDAVResource, resourceID, IdentityMatchPerson,
+			match.PersonID, nil, false)
+		if err != nil {
+			return false, false, err
+		}
+	}
+	return created, true, nil
+}
+
+// acceptCardDAVIdentityMatchCandidateContext records the explicit review
+// decision and binds the resource to the chosen person in one transaction.
+// Competing generated candidates are rejected as part of the same decision;
+// subsequent reconciliation preserves every accepted or rejected row.
+func (s *Store) acceptCardDAVIdentityMatchCandidateContext(
+	ctx context.Context, candidateID int64, decidedBy string, notes *string,
+) (*IdentityMatchCandidate, int64, error) {
+	if decidedBy != string(ProvenanceUser) {
+		return nil, 0, ErrIdentityMatchNotAcceptable
+	}
+	var accepted *IdentityMatchCandidate
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := s.lockIdentityMutationTxContext(ctx, tx); err != nil {
+			return err
+		}
+		candidate, err := getIdentityMatchCandidateTx(ctx, tx, candidateID)
+		if err != nil {
+			return err
+		}
+		if candidate.LeftKind != IdentityMatchCardDAVResource ||
+			candidate.RightKind != IdentityMatchPerson {
+			return ErrIdentityMatchEndpointUnsupported
+		}
+		resource, err := scanCardDAVResource(tx.QueryRowContext(ctx,
+			cardDAVResourceSelect+` WHERE id = ?`+s.dialect.SelectForUpdate(),
+			candidate.LeftID,
+		))
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrIdentityMatchEndpointNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("lock CardDAV candidate resource: %w", err)
+		}
+		if resource.PersonID != nil && *resource.PersonID != candidate.RightID {
+			return ErrIdentityMatchAlreadyApplied
+		}
+		var personRevision int64
+		if err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`+
+			s.dialect.SelectForUpdate(), candidate.RightID).Scan(&personRevision); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrIdentityMatchEndpointNotFound
+			}
+			return fmt.Errorf("lock CardDAV candidate person: %w", err)
+		}
+		snapshot, err := s.loadPersonVCardSnapshotTx(ctx, tx, candidate.RightID)
+		if err != nil {
+			return fmt.Errorf("hash accepted CardDAV candidate person: %w", err)
+		}
+		if resource.PersonID == nil {
+			if _, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+				mapping_status = ?, mapping_revision = mapping_revision + 1,
+				governance = ?, person_id = ?, person_revision_at_bind = ?,
+				local_hash = ?, updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+				CardDAVMappingMapped, CardDAVGovernanceLocal, candidate.RightID,
+				personRevision, snapshot.Fingerprint, resource.ID,
+			); err != nil {
+				return fmt.Errorf("bind accepted CardDAV identity candidate: %w", err)
+			}
+			if err := s.putCardDAVEnvelopeTx(ctx, tx, resource.AddressBookID,
+				candidate.RightID, CardDAVRemoteResource{
+					Href: resource.Href, RemoteBody: resource.RemoteBody,
+				}); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE identity_match_candidates SET
+			state = ?, decided_by = ?, decided_at = `+s.dialect.Now()+`, notes = ?,
+			pre_conflict_state = NULL, application_pending = FALSE,
+			updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+			IdentityMatchStateAccepted, decidedBy, stringValue(notes), candidate.ID,
+		); err != nil {
+			return fmt.Errorf("accept CardDAV identity candidate: %w", err)
+		}
+		peerNote := "another CardDAV identity candidate was accepted"
+		if _, err := tx.ExecContext(ctx, `UPDATE identity_match_candidates SET
+			state = ?, decided_by = ?, decided_at = `+s.dialect.Now()+`, notes = ?,
+			pre_conflict_state = NULL, application_pending = FALSE,
+			updated_at = `+s.dialect.Now()+`
+			WHERE id <> ? AND source = ? AND state IN (?, ?)
+			  AND left_kind = ? AND left_id = ? AND right_kind = ?`,
+			IdentityMatchStateRejected, decidedBy, peerNote, candidate.ID,
+			ProvenanceCardDAVImport, IdentityMatchStateCandidate,
+			IdentityMatchStateConflict, IdentityMatchCardDAVResource,
+			resource.ID, IdentityMatchPerson,
+		); err != nil {
+			return fmt.Errorf("reject competing CardDAV identity candidates: %w", err)
+		}
+		accepted, err = getIdentityMatchCandidateTx(ctx, tx, candidate.ID)
+		return err
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	revision, err := readIdentityRevisionContext(ctx, s.db)
+	if err != nil {
+		return nil, 0, err
+	}
+	return accepted, revision, nil
+}
+
+type cardDAVPersonMatch struct {
+	PersonID        int64
+	Basis           IdentityMatchBasis
+	NormalizedValue string
+}
+
+func (s *Store) resolveCardDAVPersonTx(
+	ctx context.Context, tx *loggedTx, resourceID int64, input CardDAVRemoteResource,
+) (*int64, []cardDAVPersonMatch, error) {
+	rejected := map[int64]struct{}{}
+	if resourceID != 0 {
+		rows, err := tx.QueryContext(ctx, `SELECT right_id, state FROM identity_match_candidates
+			WHERE left_kind = ? AND left_id = ? AND right_kind = ?
+			  AND state IN (?, ?) ORDER BY right_id`,
+			IdentityMatchCardDAVResource, resourceID, IdentityMatchPerson,
+			IdentityMatchStateAccepted, IdentityMatchStateRejected)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load reviewed CardDAV identity candidates: %w", err)
+		}
+		var accepted []int64
+		for rows.Next() {
+			var personID int64
+			var state IdentityMatchState
+			if err := rows.Scan(&personID, &state); err != nil {
+				_ = rows.Close()
+				return nil, nil, fmt.Errorf("scan reviewed CardDAV identity candidate: %w", err)
+			}
+			if state == IdentityMatchStateAccepted {
+				accepted = append(accepted, personID)
+			} else {
+				rejected[personID] = struct{}{}
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return nil, nil, fmt.Errorf("close reviewed CardDAV identity candidates: %w", err)
+		}
+		if len(accepted) > 1 {
+			return nil, nil, errors.New("CardDAV resource has multiple accepted identity candidates")
+		}
+		if len(accepted) == 1 {
+			return &accepted[0], nil, nil
+		}
+	}
+	if uid := strings.TrimSpace(input.RemoteUID); uid != "" {
+		var id int64
+		err := tx.QueryRowContext(ctx, `SELECT id FROM persons WHERE vcard_uid = ?`, uid).Scan(&id)
+		if err == nil {
+			if _, wasRejected := rejected[id]; !wasRejected {
+				return &id, nil, nil
+			}
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, fmt.Errorf("match CardDAV canonical UID: %w", err)
+		}
+		var surviving sql.NullInt64
+		err = tx.QueryRowContext(ctx, `SELECT surviving_person_id
+			FROM person_uid_aliases WHERE retired_uid = ?`, uid).Scan(&surviving)
+		if err == nil && surviving.Valid {
+			id = surviving.Int64
+			if _, wasRejected := rejected[id]; !wasRejected {
+				return &id, nil, nil
+			}
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, fmt.Errorf("match CardDAV retired UID: %w", err)
+		}
+	}
+
+	matches := map[int64]cardDAVPersonMatch{}
+	for _, candidate := range []struct {
+		kind   ContactAddressKind
+		basis  IdentityMatchBasis
+		values []string
+	}{{ContactAddressEmail, IdentityMatchEmail, input.Emails},
+		{ContactAddressPhone, IdentityMatchPhone, input.Phones}} {
+		for _, raw := range candidate.values {
+			normalized, err := NormalizeServiceValue(nil, candidate.kind, raw)
+			if err != nil {
+				continue
+			}
+			rows, err := tx.QueryContext(ctx, `SELECT person_id FROM person_contact_points
+				WHERE address_kind = ? AND service_id IS NULL
+				  AND normalized_value = ? AND active_until IS NULL AND superseded_at IS NULL
+				ORDER BY person_id`, candidate.kind, normalized)
+			if err != nil {
+				return nil, nil, fmt.Errorf("match CardDAV contact point: %w", err)
+			}
+			for rows.Next() {
+				var personID int64
+				if err := rows.Scan(&personID); err != nil {
+					_ = rows.Close()
+					return nil, nil, fmt.Errorf("scan CardDAV contact match: %w", err)
+				}
+				if _, wasRejected := rejected[personID]; !wasRejected {
+					matches[personID] = cardDAVPersonMatch{PersonID: personID, Basis: candidate.basis, NormalizedValue: normalized}
+				}
+			}
+			if err := rows.Close(); err != nil {
+				return nil, nil, fmt.Errorf("close CardDAV contact matches: %w", err)
+			}
+		}
+	}
+	if len(matches) == 1 {
+		for id := range matches {
+			return &id, nil, nil
+		}
+	}
+	ambiguous := make([]cardDAVPersonMatch, 0, len(matches))
+	for _, match := range matches {
+		ambiguous = append(ambiguous, match)
+	}
+	slices.SortFunc(ambiguous, func(left, right cardDAVPersonMatch) int {
+		return int(left.PersonID - right.PersonID)
+	})
+	return nil, ambiguous, nil
+}
+
+func (s *Store) createCardDAVImportedPersonTx(
+	ctx context.Context, tx *loggedTx, bookID int64, input CardDAVRemoteResource,
+) (*int64, *int64, error) {
+	uid, err := newVCardUID()
+	if err != nil {
+		return nil, nil, err
+	}
+	var personID int64
+	if err := tx.QueryRowContext(ctx, `INSERT INTO persons (vcard_uid, display_name)
+		VALUES (?, NULLIF(?, '')) RETURNING id`, uid, input.DisplayName).Scan(&personID); err != nil {
+		return nil, nil, fmt.Errorf("create CardDAV imported person: %w", err)
+	}
+	if err := s.addCardDAVImportedProjectionTx(ctx, tx, bookID, personID, input); err != nil {
+		return nil, nil, err
+	}
+	revision := int64(1)
+	return &personID, &revision, nil
+}
+
+func (s *Store) addCardDAVImportedProjectionTx(
+	ctx context.Context, tx *loggedTx, bookID, personID int64, input CardDAVRemoteResource,
+) error {
+	sourceRef := fmt.Sprintf("carddav:%d", bookID)
+	baseEnvelope := ValueEnvelopeInput{
+		Source: ProvenanceCardDAVImport, SourceRef: &sourceRef,
+		SourceResourceUID: &input.Href,
+	}
+	if strings.TrimSpace(input.DisplayName) != "" {
+		envelope := baseEnvelope
+		envelope.VCard = input.DisplayNameIdentity
+		if _, err := s.addPersonNameTx(ctx, tx, personID, PersonNameInput{
+			NameKind: PersonNameFormatted, Formatted: &input.DisplayName,
+			OriginalValue: input.DisplayName, Envelope: envelope,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, point := range []struct {
+		kind       ContactAddressKind
+		values     []string
+		identities []VCardIdentity
+	}{
+		{ContactAddressEmail, input.Emails, input.EmailIdentities},
+		{ContactAddressPhone, input.Phones, input.PhoneIdentities},
+	} {
+		for index, value := range point.values {
+			envelope := baseEnvelope
+			if index < len(point.identities) {
+				envelope.VCard = point.identities[index]
+			}
+			if _, err := s.addPersonContactPointTx(ctx, tx, personID, PersonContactPointInput{
+				AddressKind: point.kind, OriginalValue: value, Envelope: envelope,
+			}); err != nil {
+				if point.kind == ContactAddressPhone && errors.Is(err, ErrNormalizationRejected) {
+					continue
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rebaseCardDAVImportedProjectionTx replaces only the fields owned by this
+// CardDAV resource. Explicit user rows survive untouched. The scalar display
+// label is replaced only while it still equals the prior imported FN; a local
+// rename therefore remains user-owned even as the imported formatted name
+// advances underneath it.
+func (s *Store) rebaseCardDAVImportedProjectionTx(
+	ctx context.Context, tx *loggedTx, bookID, personID int64, input CardDAVRemoteResource,
+) (bool, error) {
+	sourceRef := fmt.Sprintf("carddav:%d", bookID)
+	var currentDisplay, priorImportedDisplay sql.NullString
+	if err := tx.QueryRowContext(ctx, `SELECT display_name FROM persons WHERE id = ?`+
+		s.dialect.SelectForUpdate(), personID).Scan(&currentDisplay); err != nil {
+		return false, fmt.Errorf("lock CardDAV projection person: %w", err)
+	}
+	err := tx.QueryRowContext(ctx, `SELECT formatted FROM person_names
+		WHERE person_id = ? AND source = ? AND source_ref = ? AND source_resource_uid = ?
+		  AND name_kind = ? AND active_until IS NULL AND superseded_at IS NULL
+		ORDER BY id LIMIT 1`, personID, ProvenanceCardDAVImport, sourceRef, input.Href,
+		PersonNameFormatted).Scan(&priorImportedDisplay)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("load prior CardDAV display projection: %w", err)
+	}
+	remoteOwnsDisplay := !currentDisplay.Valid ||
+		(priorImportedDisplay.Valid && currentDisplay.String == priorImportedDisplay.String)
+
+	for _, table := range []string{"person_names", "person_contact_points"} {
+		if _, err := tx.ExecContext(ctx, `UPDATE `+table+` SET
+			superseded_at = `+s.dialect.Now()+`, updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND source = ? AND source_ref = ? AND source_resource_uid = ?
+			  AND active_until IS NULL AND superseded_at IS NULL`,
+			personID, ProvenanceCardDAVImport, sourceRef, input.Href); err != nil {
+			return false, fmt.Errorf("supersede %s CardDAV projection: %w", table, err)
+		}
+	}
+	if err := s.addCardDAVImportedProjectionTx(ctx, tx, bookID, personID, input); err != nil {
+		return false, err
+	}
+	displayChanged := false
+	if remoteOwnsDisplay {
+		result, err := tx.ExecContext(ctx, `UPDATE persons SET display_name = NULLIF(?, '')
+			WHERE id = ? AND display_name IS DISTINCT FROM NULLIF(?, '')`,
+			strings.TrimSpace(input.DisplayName), personID, strings.TrimSpace(input.DisplayName))
+		if err != nil {
+			return false, fmt.Errorf("rebase CardDAV display label: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return false, fmt.Errorf("count rebased CardDAV display label: %w", err)
+		}
+		displayChanged = affected > 0
+	}
+	if err := s.bumpPersonRevisionsTx(ctx, tx, personID); err != nil {
+		return false, err
+	}
+	if displayChanged {
+		if err := s.bumpDisplayNameCounterpartVCardProjectionsTx(ctx, tx, personID); err != nil {
+			return false, err
+		}
+	}
+	return remoteOwnsDisplay, nil
+}
+
+// retireCardDAVImportedProjectionTx removes one resource's current semantic
+// projection while retaining its history. The scalar display label is cleared
+// only when it still matches the imported formatted name being retired.
+func (s *Store) retireCardDAVImportedProjectionTx(
+	ctx context.Context, tx *loggedTx, bookID, personID int64, href string,
+) error {
+	sourceRef := fmt.Sprintf("carddav:%d", bookID)
+	var currentDisplay, importedDisplay sql.NullString
+	if err := tx.QueryRowContext(ctx, `SELECT display_name FROM persons WHERE id = ?`+
+		s.dialect.SelectForUpdate(), personID).Scan(&currentDisplay); err != nil {
+		return fmt.Errorf("lock retired CardDAV projection person: %w", err)
+	}
+	err := tx.QueryRowContext(ctx, `SELECT formatted FROM person_names
+		WHERE person_id = ? AND source = ? AND source_ref = ? AND source_resource_uid = ?
+		  AND name_kind = ? AND active_until IS NULL AND superseded_at IS NULL
+		ORDER BY id LIMIT 1`, personID, ProvenanceCardDAVImport, sourceRef, href,
+		PersonNameFormatted).Scan(&importedDisplay)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("load retired CardDAV display projection: %w", err)
+	}
+	remoteOwnsDisplay := currentDisplay.Valid && importedDisplay.Valid &&
+		currentDisplay.String == importedDisplay.String
+
+	for _, table := range []string{"person_names", "person_contact_points"} {
+		if _, err := tx.ExecContext(ctx, `UPDATE `+table+` SET
+			superseded_at = `+s.dialect.Now()+`, updated_at = `+s.dialect.Now()+`
+			WHERE person_id = ? AND source = ? AND source_ref = ? AND source_resource_uid = ?
+			  AND active_until IS NULL AND superseded_at IS NULL`,
+			personID, ProvenanceCardDAVImport, sourceRef, href); err != nil {
+			return fmt.Errorf("retire %s CardDAV projection: %w", table, err)
+		}
+	}
+	if remoteOwnsDisplay {
+		if _, err := tx.ExecContext(ctx, `UPDATE persons SET display_name = NULL
+			WHERE id = ? AND display_name = ?`, personID, importedDisplay.String); err != nil {
+			return fmt.Errorf("clear retired CardDAV display label: %w", err)
+		}
+	}
+	if err := s.bumpPersonRevisionsTx(ctx, tx, personID); err != nil {
+		return err
+	}
+	if remoteOwnsDisplay {
+		if err := s.bumpDisplayNameCounterpartVCardProjectionsTx(ctx, tx, personID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// refreshCardDAVImportedPersonBindBaselineTx records the revision produced by
+// a remote-owned rebase only when the rebase left no user-owned state behind.
+// A locally changed display label has no separate provenance row, so the
+// caller supplies whether the imported display still owned that scalar.
+func (s *Store) refreshCardDAVImportedPersonBindBaselineTx(
+	ctx context.Context, tx *loggedTx, resourceID, personID int64, remoteOwnsDisplay bool,
+) error {
+	if !remoteOwnsDisplay {
+		return nil
+	}
+	var revision int64
+	if err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`+
+		s.dialect.SelectForUpdate(), personID).Scan(&revision); err != nil {
+		return fmt.Errorf("load rebased CardDAV person revision: %w", err)
+	}
+	hasUserOwnedState, err := s.personHasUserOwnedStateTx(ctx, tx, personID, revision)
+	if err != nil {
+		return err
+	}
+	if hasUserOwnedState {
+		return nil
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE carddav_resources
+		SET person_revision_at_bind = ?
+		WHERE id = ? AND person_id = ? AND governance = ?`,
+		revision, resourceID, personID, CardDAVGovernanceRemote)
+	if err != nil {
+		return fmt.Errorf("refresh rebased CardDAV person revision: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("count refreshed CardDAV person revision: %w", err)
+	}
+	if affected != 1 {
+		return ErrCardDAVConflictStale
+	}
+	return nil
+}
+
+func (s *Store) putCardDAVEnvelopeTx(
+	ctx context.Context, tx *loggedTx, bookID, personID int64,
+	input CardDAVRemoteResource,
+) error {
+	envelope, err := vcard.ParseResourceEnvelope(input.RemoteBody)
+	if err != nil {
+		return fmt.Errorf("parse CardDAV resource envelope: %w", err)
+	}
+	envelope.SourceRef = fmt.Sprintf("carddav:%d", bookID)
+	envelope.SourceResourceUID = input.Href
+	envelope.Href = input.Href
+	canonicalUID, err := vcardCanonicalUIDTx(ctx, tx, personID)
+	if err != nil {
+		return err
+	}
+	envelope.CanonicalPersonUID = canonicalUID
+	prepared, err := prepareVCardEnvelope(envelope)
+	if err != nil {
+		return err
+	}
+	current, err := s.findVCardResourceEnvelopeTx(ctx, tx, envelope.SourceRef, input.Href)
+	if errors.Is(err, ErrVCardResourceNotFound) {
+		_, err = s.insertVCardResourceEnvelopeTx(ctx, tx,
+			VCardResourceEnvelopeInput{PersonID: personID}, prepared)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	expected := current.Revision
+	_, err = s.updateVCardResourceEnvelopeTx(ctx, tx, VCardResourceEnvelopeInput{
+		PersonID: personID, ExpectedRevision: &expected,
+	}, prepared, current)
+	return err
+}
+
+func (s *Store) removeCardDAVResourceTx(
+	ctx context.Context, tx *loggedTx, bookID int64, href string,
+) (bool, error) {
+	return s.removeCardDAVResourceWithPersonRetentionTx(ctx, tx, bookID, href, false)
+}
+
+func (s *Store) removeCardDAVResourceWithPersonRetentionTx(
+	ctx context.Context, tx *loggedTx, bookID int64, href string, retainPerson bool,
+) (bool, error) {
+	return s.removeCardDAVResourceWithModeTx(
+		ctx, tx, bookID, href, retainPerson, cardDAVRemovalPreserveProjection,
+	)
+}
+
+type cardDAVResourceRemovalMode uint8
+
+const (
+	cardDAVRemovalPreserveProjection cardDAVResourceRemovalMode = iota
+	cardDAVRemovalRetireProjection
+)
+
+func (s *Store) removeCardDAVResourceWithModeTx(
+	ctx context.Context, tx *loggedTx, bookID int64, href string, retainPerson bool,
+	mode cardDAVResourceRemovalMode,
+) (bool, error) {
+	resource, err := s.findCardDAVResourceTx(ctx, tx, bookID, href)
+	if errors.Is(err, ErrCardDAVResourceNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	cleanupImportedPerson := false
+	personHasUserOwnedState := false
+	if !retainPerson && resource.PersonID != nil && resource.PersonRevisionAtBind != nil {
+		cleanupImportedPerson, err = s.personHasCardDAVImportedProjectionTx(
+			ctx, tx, *resource.PersonID,
+		)
+		if err != nil {
+			return false, err
+		}
+	}
+	if cleanupImportedPerson {
+		personHasUserOwnedState, err = s.personHasUserOwnedStateTx(
+			ctx, tx, *resource.PersonID, *resource.PersonRevisionAtBind,
+		)
+		if err != nil {
+			return false, err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+		WHERE left_kind = ? AND left_id = ?`, IdentityMatchCardDAVResource, resource.ID); err != nil {
+		return false, fmt.Errorf("delete CardDAV identity candidates: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM vcard_resource_envelopes
+		WHERE source_ref = ? AND source_resource_uid = ?`, fmt.Sprintf("carddav:%d", bookID), href); err != nil {
+		return false, fmt.Errorf("delete CardDAV resource envelope: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM carddav_resources WHERE id = ?`, resource.ID); err != nil {
+		return false, fmt.Errorf("delete CardDAV resource ledger row: %w", err)
+	}
+	if err := s.transferCardDAVImportedPersonCleanupBaselineTx(
+		ctx, tx, resource, personHasUserOwnedState,
+	); err != nil {
+		return false, err
+	}
+	if mode == cardDAVRemovalRetireProjection && personHasUserOwnedState {
+		if err := s.retireCardDAVImportedProjectionTx(
+			ctx, tx, bookID, *resource.PersonID, href,
+		); err != nil {
+			return false, err
+		}
+	}
+	if !retainPerson {
+		if err := s.deleteUntouchedCardDAVImportedPersonTx(
+			ctx, tx, resource, cleanupImportedPerson, personHasUserOwnedState,
+		); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (s *Store) demoteCardDAVBookResourcesTx(ctx context.Context, tx *loggedTx, bookID int64) error {
+	rows, err := tx.QueryContext(ctx, `SELECT href FROM carddav_resources
+		WHERE address_book_id = ? ORDER BY href`, bookID)
+	if err != nil {
+		return fmt.Errorf("list CardDAV resources for demotion: %w", err)
+	}
+	var hrefs []string
+	for rows.Next() {
+		var href string
+		if err := rows.Scan(&href); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan CardDAV resource for demotion: %w", err)
+		}
+		hrefs = append(hrefs, href)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate CardDAV resources for demotion: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close CardDAV resources for demotion: %w", err)
+	}
+	for _, href := range hrefs {
+		resource, err := s.findCardDAVResourceTx(ctx, tx, bookID, href)
+		if err != nil {
+			return err
+		}
+		cleanupImportedPerson := false
+		personHasUserOwnedState := false
+		if resource.PersonID != nil && resource.PersonRevisionAtBind != nil {
+			cleanupImportedPerson, err = s.personHasCardDAVImportedProjectionTx(
+				ctx, tx, *resource.PersonID,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		if cleanupImportedPerson {
+			personHasUserOwnedState, err = s.personHasUserOwnedStateTx(
+				ctx, tx, *resource.PersonID, *resource.PersonRevisionAtBind,
+			)
+			if err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+			WHERE left_kind = ? AND left_id = ? AND source = ?
+			  AND state IN (?, ?) AND decided_at IS NULL`,
+			IdentityMatchCardDAVResource, resource.ID, ProvenanceCardDAVImport,
+			IdentityMatchStateCandidate, IdentityMatchStateConflict); err != nil {
+			return fmt.Errorf("delete demoted CardDAV identity candidates: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM vcard_resource_envelopes
+			WHERE source_ref = ? AND source_resource_uid = ?`, fmt.Sprintf("carddav:%d", bookID), href); err != nil {
+			return fmt.Errorf("delete demoted CardDAV resource envelope: %w", err)
+		}
+		demotedStatus := CardDAVMappingUnbound
+		if resource.MappingStatus == CardDAVMappingMapped && resource.PersonID == nil {
+			demotedStatus = CardDAVMappingMapped
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE carddav_resources SET
+			mapping_status = ?, mapping_revision = mapping_revision + 1,
+			governance = ?, person_id = NULL, person_revision_at_bind = NULL,
+			updated_at = `+s.dialect.Now()+` WHERE id = ?`,
+			demotedStatus, CardDAVGovernanceNone, resource.ID); err != nil {
+			return fmt.Errorf("demote CardDAV resource: %w", err)
+		}
+		if err := s.transferCardDAVImportedPersonCleanupBaselineTx(
+			ctx, tx, resource, personHasUserOwnedState,
+		); err != nil {
+			return err
+		}
+		if err := s.deleteUntouchedCardDAVImportedPersonTx(
+			ctx, tx, resource, cleanupImportedPerson, personHasUserOwnedState,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) dropCardDAVBookResourcesTx(ctx context.Context, tx *loggedTx, bookID int64) error {
+	return s.dropCardDAVBookResourcesWithModeTx(
+		ctx, tx, bookID, cardDAVRemovalPreserveProjection,
+	)
+}
+
+func (s *Store) dropCardDAVBookResourcesForIdentityChangeTx(
+	ctx context.Context, tx *loggedTx, bookID int64,
+) error {
+	return s.dropCardDAVBookResourcesWithModeTx(
+		ctx, tx, bookID, cardDAVRemovalRetireProjection,
+	)
+}
+
+func (s *Store) dropCardDAVBookResourcesWithModeTx(
+	ctx context.Context, tx *loggedTx, bookID int64, mode cardDAVResourceRemovalMode,
+) error {
+	rows, err := tx.QueryContext(ctx, `SELECT href FROM carddav_resources
+		WHERE address_book_id = ? ORDER BY href`, bookID)
+	if err != nil {
+		return fmt.Errorf("list ignored CardDAV resources: %w", err)
+	}
+	var hrefs []string
+	for rows.Next() {
+		var href string
+		if err := rows.Scan(&href); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan ignored CardDAV resource: %w", err)
+		}
+		hrefs = append(hrefs, href)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate ignored CardDAV resources: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close ignored CardDAV resources: %w", err)
+	}
+	for _, href := range hrefs {
+		if _, err := s.removeCardDAVResourceWithModeTx(
+			ctx, tx, bookID, href, false, mode,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) deleteUntouchedCardDAVImportedPersonTx(
+	ctx context.Context, tx *loggedTx, resource *CardDAVResource,
+	cleanupImportedPerson, personHasUserOwnedState bool,
+) error {
+	if resource.PersonID == nil || resource.PersonRevisionAtBind == nil ||
+		!cleanupImportedPerson || personHasUserOwnedState {
+		return nil
+	}
+	var revision, otherMappings int64
+	err := tx.QueryRowContext(ctx, `SELECT revision,
+		(SELECT COUNT(*) FROM carddav_resources WHERE person_id = persons.id)
+		FROM persons WHERE id = ?`, *resource.PersonID).Scan(&revision, &otherMappings)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check CardDAV imported person tombstone: %w", err)
+	}
+	if revision != *resource.PersonRevisionAtBind || otherMappings != 0 {
+		return nil
+	}
+	if err := s.deleteIdentityMatchCandidatesForPersonTx(ctx, tx, *resource.PersonID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM persons WHERE id = ? AND revision = ?`,
+		*resource.PersonID, revision); err != nil {
+		return fmt.Errorf("delete untouched CardDAV imported person: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) personHasCardDAVImportedProjectionTx(
+	ctx context.Context, tx *loggedTx, personID int64,
+) (bool, error) {
+	var imported bool
+	err := tx.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM person_names WHERE person_id = ? AND source = ?
+		UNION ALL
+		SELECT 1 FROM person_contact_points WHERE person_id = ? AND source = ?
+	)`, personID, ProvenanceCardDAVImport, personID, ProvenanceCardDAVImport).Scan(&imported)
+	if err != nil {
+		return false, fmt.Errorf("check CardDAV imported person projection: %w", err)
+	}
+	return imported, nil
+}
+
+// When a remotely governed resource disappears before another mapping for the
+// same imported person, carry its cleanup baseline forward. A nil baseline is
+// deliberately sticky once user-owned state is observed, so removing the last
+// duplicate cannot later erase that state using a newer local bind revision.
+func (s *Store) transferCardDAVImportedPersonCleanupBaselineTx(
+	ctx context.Context, tx *loggedTx, resource *CardDAVResource, personHasUserOwnedState bool,
+) error {
+	if resource.PersonID == nil || resource.Governance != CardDAVGovernanceRemote ||
+		resource.PersonRevisionAtBind == nil {
+		return nil
+	}
+	var baseline any = *resource.PersonRevisionAtBind
+	if personHasUserOwnedState {
+		baseline = nil
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE carddav_resources
+		SET person_revision_at_bind = ?, updated_at = `+s.dialect.Now()+`
+		WHERE person_id = ?`, baseline, *resource.PersonID); err != nil {
+		return fmt.Errorf("transfer CardDAV imported person cleanup baseline: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetCardDAVResourceContext(
+	ctx context.Context, bookID int64, href string,
+) (*CardDAVResource, error) {
+	resource, err := scanCardDAVResource(s.db.QueryRowContext(ctx,
+		cardDAVResourceSelect+` WHERE address_book_id = ? AND href = ?`, bookID, href))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVResourceNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get CardDAV resource: %w", err)
+	}
+	return resource, nil
+}
+
+// GetCardDAVResourceForPersonContext returns the person's mapping in one
+// address book. Task 6 will tighten role transitions; publication already
+// scopes this lookup to the configured write target.
+func (s *Store) GetCardDAVResourceForPersonContext(
+	ctx context.Context, bookID, personID int64,
+) (*CardDAVResource, error) {
+	return findCardDAVResourceForPersonTx(ctx, s.db, bookID, personID, "")
+}
+
+func (s *Store) ListCardDAVResourcesContext(
+	ctx context.Context, bookID int64,
+) ([]CardDAVResource, error) {
+	rows, err := s.db.QueryContext(ctx, cardDAVResourceSelect+`
+		WHERE address_book_id = ? ORDER BY href`, bookID)
+	if err != nil {
+		return nil, fmt.Errorf("list CardDAV resources: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	resources := []CardDAVResource{}
+	for rows.Next() {
+		resource, err := scanCardDAVResource(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan CardDAV resource list: %w", err)
+		}
+		resources = append(resources, *resource)
+	}
+	return resources, rows.Err()
+}
+
+func (s *Store) findCardDAVResourceTx(
+	ctx context.Context, tx *loggedTx, bookID int64, href string,
+) (*CardDAVResource, error) {
+	resource, err := scanCardDAVResource(tx.QueryRowContext(ctx,
+		cardDAVResourceSelect+` WHERE address_book_id = ? AND href = ?`+
+			s.dialect.SelectForUpdate(), bookID, href))
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCardDAVResourceNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find CardDAV resource: %w", err)
+	}
+	return resource, nil
+}
+
+const cardDAVResourceSelect = `SELECT id, address_book_id, href, remote_uid,
+	remote_etag, remote_body, remote_semantic_hash, local_hash, mapping_status,
+	mapping_revision, governance, person_id, person_revision_at_bind,
+	created_at, updated_at FROM carddav_resources`
+
+func scanCardDAVResource(row scanner) (*CardDAVResource, error) {
+	var resource CardDAVResource
+	var uid sql.NullString
+	var personID, personRevision sql.NullInt64
+	if err := row.Scan(&resource.ID, &resource.AddressBookID, &resource.Href, &uid,
+		&resource.RemoteETag, &resource.RemoteBody, &resource.RemoteSemanticHash,
+		&resource.LocalHash, &resource.MappingStatus, &resource.MappingRevision,
+		&resource.Governance, &personID, &personRevision,
+		&resource.CreatedAt, &resource.UpdatedAt); err != nil {
+		return nil, err
+	}
+	resource.RemoteUID = uid.String
+	if personID.Valid {
+		resource.PersonID = &personID.Int64
+	}
+	if personRevision.Valid {
+		resource.PersonRevisionAtBind = &personRevision.Int64
+	}
+	resource.RemoteBody = append([]byte(nil), resource.RemoteBody...)
+	return &resource, nil
+}

--- a/internal/store/carddav_resources_test.go
+++ b/internal/store/carddav_resources_test.go
@@ -1,0 +1,1084 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func newCardDAVResourceStore(t *testing.T) (*store.Store, store.CardDAVAccount, store.CardDAVAddressBook) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	allowed := true
+	account, books, err := st.ReplaceCardDAVDiscoveryContext(t.Context(), store.CardDAVDiscoveryInput{
+		BaseURL: "https://contacts.example/dav", Username: "alice",
+		PrincipalURL: "https://contacts.example/principal/alice/",
+		HomeURL:      "https://contacts.example/books/alice/",
+		Books: []store.CardDAVDiscoveredBook{{
+			CanonicalURL: "https://contacts.example/books/alice/personal/",
+			DisplayName:  "Personal", SupportsSyncCollection: true,
+			SupportsMultiget: true, CanCreate: &allowed,
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, books, 1)
+	return st, *account, books[0]
+}
+
+func remoteResource(href, uid, name, email, etag string) store.CardDAVRemoteResource {
+	body := []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:" + uid + "\r\nFN:" + name + "\r\nEMAIL:" + email + "\r\nEND:VCARD\r\n")
+	return store.CardDAVRemoteResource{
+		Href: href, RemoteUID: uid, RemoteETag: etag, RemoteBody: body,
+		SemanticHash: "semantic-" + uid, DisplayName: name, Emails: []string{email},
+	}
+}
+
+func TestCardDAVApplyPersistsLosslessEnvelopeAndMaterializesSubscribedPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Alice Example", "alice@example.test", `"one"`)
+
+	result, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, NextSyncToken: "token-1",
+		Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	assert.Equal(1, result.Created)
+
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(input.RemoteBody, resource.RemoteBody)
+	assert.Equal(store.CardDAVGovernanceRemote, resource.Governance)
+
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", input.Href)
+	require.NoError(err)
+	assert.Equal(input.RemoteBody, envelope.StoredBody)
+	assert.Equal(input.Href, envelope.SourceResourceUID)
+	assert.Equal(*resource.PersonID, envelope.PersonID)
+
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	assert.Equal("token-1", books[0].SyncToken)
+	assert.Equal(book.SyncRevision+1, books[0].SyncRevision)
+}
+
+func TestCardDAVResourceMoveRewritesProjectionProvenanceBeforeRemoteEdit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	oldHref := book.CanonicalURL + "alice-old.vcf"
+	initial := remoteResource(oldHref, "remote-alice", "Alice Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+
+	newHref := book.CanonicalURL + "alice-new.vcf"
+	moved := remoteResource(newHref, "remote-alice", "Alice Moved", "moved@example.test", `"two"`)
+	moved.PreviousHref = oldHref
+	moved.SemanticHash = "semantic-remote-alice-moved"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{moved},
+	})
+	require.NoError(err)
+
+	names, err := st.ListPersonNamesContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(names, 1)
+	require.NotNil(names[0].Formatted)
+	assert.Equal("Alice Moved", *names[0].Formatted)
+	points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(points, 1)
+	assert.Equal("moved@example.test", points[0].OriginalValue)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, newHref)
+	require.NoError(err)
+}
+
+func TestCardDAVResourceMovePreservesConcurrentLocalEditConflict(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	oldHref := book.CanonicalURL + "alice-old.vcf"
+	initial := remoteResource(oldHref, "remote-alice", "Alice Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, oldHref)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	_, err = st.AddPersonContactPointContext(t.Context(), *mapping.PersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "local-edit@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	beforeMove, err := st.LoadPersonVCardSnapshotContext(t.Context(), *mapping.PersonID)
+	require.NoError(err)
+	assert.NotEqual(mapping.LocalHash, beforeMove.Fingerprint)
+
+	newHref := book.CanonicalURL + "alice-new.vcf"
+	moved := remoteResource(newHref, "remote-alice", "Alice Remote Edit", "remote-edit@example.test", `"two"`)
+	moved.PreviousHref = oldHref
+	moved.SemanticHash = "semantic-remote-alice-moved"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{moved},
+		Conflicts: []store.CardDAVConflictCapture{{
+			AddressBookID: book.ID, Href: newHref,
+			ExpectedMappingRevision: mapping.MappingRevision,
+			BaseLocalHash:           mapping.LocalHash, LocalHash: beforeMove.Fingerprint,
+			BaseRemoteHash: mapping.RemoteSemanticHash, BaseRemoteETag: mapping.RemoteETag,
+			RemoteETag: moved.RemoteETag, LocalBody: []byte("local edit"), RemoteBody: moved.RemoteBody,
+		}},
+	})
+	require.NoError(err)
+
+	movedMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, newHref)
+	require.NoError(err)
+	assert.Equal(mapping.LocalHash, movedMapping.LocalHash,
+		"the href rewrite must not rebase away the genuine local edit")
+	afterMove, err := st.LoadPersonVCardSnapshotContext(t.Context(), *mapping.PersonID)
+	require.NoError(err)
+	assert.NotEqual(beforeMove.Fingerprint, afterMove.Fingerprint,
+		"rewritten provenance changes the projection fingerprint")
+	conflicts, err := st.ListCardDAVConflictsContext(t.Context(), true)
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.Equal(newHref, conflicts[0].Href)
+	assert.Equal(mapping.LocalHash, conflicts[0].BaseLocalHash)
+	assert.Equal(afterMove.Fingerprint, conflicts[0].LocalHash)
+}
+
+func TestCardDAVApplyRebasesUntouchedRemoteProjectionAndTombstoneBaseline(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	href := book.CanonicalURL + "alice.vcf"
+	initial := remoteResource(href, "remote-alice", "Alice Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+
+	updated := remoteResource(href, "remote-alice", "Alice Remote", "remote@example.test", `"two"`)
+	updated.SemanticHash = "semantic-remote-alice-updated"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{updated},
+	})
+	require.NoError(err)
+
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NotNil(person.DisplayName)
+	assert.Equal("Alice Remote", *person.DisplayName)
+	names, err := st.ListPersonNamesContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(names, 1)
+	require.NotNil(names[0].Formatted)
+	assert.Equal("Alice Remote", *names[0].Formatted)
+	points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(points, 1)
+	assert.Equal("remote@example.test", points[0].OriginalValue)
+	after, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	assert.Equal(updated.SemanticHash, after.RemoteSemanticHash)
+	assert.Equal(after.LocalHash, mustPersonSnapshot(t, st, personID).Fingerprint)
+	require.NotNil(after.PersonRevisionAtBind)
+	assert.Equal(person.Revision, *after.PersonRevisionAtBind)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", href)
+	require.NoError(err)
+	assert.Equal(updated.RemoteBody, envelope.StoredBody)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 2, RemovedHrefs: []string{href},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrPersonNotFound,
+		"a later tombstone must delete the still-untouched rebased import")
+}
+
+func TestCardDAVApplyDoesNotRebaseOnETagOnlyOrUserOwnedState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	href := book.CanonicalURL + "alice.vcf"
+	initial := remoteResource(href, "remote-alice", "Alice Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(mapping.PersonID)
+	personID := *mapping.PersonID
+	before, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+
+	etagOnly := initial
+	etagOnly.RemoteETag = `"two"`
+	etagOnly.RemoteBody = append([]byte(nil), initial.RemoteBody...)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{etagOnly},
+	})
+	require.NoError(err)
+	afterETag, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Equal(before.Revision, afterETag.Revision, "ETag churn must not rewrite the person projection")
+
+	var noteID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO daily_note_entries (local_date, ordinal, body)
+		VALUES ('2026-08-19', 1, 'synthetic note') RETURNING id`).Scan(&noteID))
+	_, err = st.DB().Exec(st.Rebind(
+		`INSERT INTO daily_note_entry_persons (entry_id, person_id) VALUES (?, ?)`), noteID, personID)
+	require.NoError(err)
+	remoteEdit := remoteResource(href, "remote-alice", "Alice Remote", "remote@example.test", `"three"`)
+	remoteEdit.SemanticHash = "semantic-remote-alice-updated"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 2, Upserts: []store.CardDAVRemoteResource{remoteEdit},
+	})
+	require.NoError(err)
+	afterUserState, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NotNil(afterUserState.DisplayName)
+	assert.Equal("Alice Initial", *afterUserState.DisplayName)
+	var links int
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM daily_note_entry_persons
+		WHERE entry_id = ? AND person_id = ?`), noteID, personID).Scan(&links))
+	assert.Equal(1, links)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", href)
+	require.NoError(err)
+	assert.Equal(remoteEdit.RemoteBody, envelope.StoredBody,
+		"the lossless remote ledger still advances while user-owned state blocks projection rebasing")
+}
+
+func TestCardDAVETagRefreshPreservesLocallyDeletedMapping(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+		"local-deleted-mapping").Scan(&personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "deleted@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	input := remoteResource(book.CanonicalURL+"deleted.vcf", "remote-deleted", "Deleted", "deleted@example.test", `"one"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NoError(st.DeletePersonContext(t.Context(), personID, person.Revision))
+
+	deleted, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Equal(store.CardDAVMappingMapped, deleted.MappingStatus)
+	assert.Nil(deleted.PersonID)
+	input.RemoteETag = `"two"`
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+
+	refreshed, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Equal(`"two"`, refreshed.RemoteETag)
+	assert.Equal(store.CardDAVMappingMapped, refreshed.MappingStatus)
+	assert.Nil(refreshed.PersonID)
+	var people int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM persons`).Scan(&people))
+	assert.Zero(people, "an ETag-only refresh must not recreate the locally deleted contact")
+}
+
+func mustPersonSnapshot(t *testing.T, st *store.Store, personID int64) *store.PersonVCardSnapshot {
+	t.Helper()
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(t, err)
+	return snapshot
+}
+
+func TestCardDAVApplyBindsExactCanonicalUIDBeforeContactPoints(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid) VALUES ('remote-alice') RETURNING id`).Scan(&personID))
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Remote Name", "new@example.test", `"one"`)
+
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(personID, *resource.PersonID)
+	assert.Equal(store.CardDAVGovernanceLocal, resource.Governance)
+}
+
+func TestCardDAVApplyNeverRebasesLocalGovernedProjection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid, display_name)
+		VALUES ('remote-alice', 'Local Name') RETURNING id`).Scan(&personID))
+	href := book.CanonicalURL + "alice.vcf"
+	initial := remoteResource(href, "remote-alice", "Remote Initial", "initial@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{initial},
+	})
+	require.NoError(err)
+	updated := remoteResource(href, "remote-alice", "Remote Updated", "updated@example.test", `"two"`)
+	updated.SemanticHash = "semantic-remote-alice-updated"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{updated},
+	})
+	require.NoError(err)
+
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NotNil(person.DisplayName)
+	assert.Equal("Local Name", *person.DisplayName)
+	names, err := st.ListPersonNamesContext(t.Context(), personID, true)
+	require.NoError(err)
+	assert.Empty(names)
+	points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+	require.NoError(err)
+	assert.Empty(points)
+	mapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	assert.Equal(store.CardDAVGovernanceLocal, mapping.Governance)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", href)
+	require.NoError(err)
+	assert.Equal(updated.RemoteBody, envelope.StoredBody)
+}
+
+func TestCardDAVEmailBindingStoresLocalCanonicalUIDInEnvelope(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	var personID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid) VALUES ('local-person-uid') RETURNING id`).Scan(&personID))
+	_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "alice@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-card-uid", "Remote Name", "alice@example.test", `"one"`)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", input.Href)
+	require.NoError(err)
+	assert.Equal(personID, envelope.PersonID)
+	assert.Equal("local-person-uid", envelope.CanonicalPersonUID)
+}
+
+func TestCardDAVLookupOnlyResourceRetainsBytesWithoutCreatingPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_write_target = FALSE, is_subscribed = FALSE, is_lookup_source = TRUE
+		WHERE id = ?`), book.ID)
+	require.NoError(err)
+	input := remoteResource(book.CanonicalURL+"directory.vcf", "directory-entry", "Directory Entry", "directory@example.test", `"one"`)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Nil(resource.PersonID)
+	assert.Equal(store.CardDAVMappingUnbound, resource.MappingStatus)
+	assert.Equal(input.RemoteBody, resource.RemoteBody)
+	people, err := st.ListPersonsContext(t.Context())
+	require.NoError(err)
+	assert.Empty(people)
+}
+
+func TestCardDAVAmbiguousContactMatchCreatesReviewCandidateWithoutMerging(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	personIDs := make([]int64, 2)
+	for index := range personIDs {
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+			"local-uid-"+string(rune('a'+index))).Scan(&personIDs[index]))
+		_, err := st.AddPersonContactPointContext(t.Context(), personIDs[index], store.PersonContactPointInput{
+			AddressKind: store.ContactAddressEmail, OriginalValue: "shared@example.test",
+			Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+		})
+		require.NoError(err)
+	}
+	input := remoteResource(book.CanonicalURL+"shared.vcf", "remote-shared", "Shared", "shared@example.test", `"one"`)
+
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Nil(resource.PersonID)
+	assert.Equal(store.CardDAVMappingAmbiguous, resource.MappingStatus)
+
+	candidates, err := st.ListIdentityMatchCandidatesContext(t.Context(), []store.IdentityMatchState{store.IdentityMatchStateConflict}, 10, 0)
+	require.NoError(err)
+	require.Len(candidates, 2)
+	for _, candidate := range candidates {
+		assert.Equal(store.IdentityMatchCardDAVResource, candidate.LeftKind)
+		assert.Equal(resource.ID, candidate.LeftID)
+		assert.Equal(store.IdentityMatchPerson, candidate.RightKind)
+	}
+}
+
+func TestCardDAVCandidateAcceptanceBindsPersonAndPreservesReviewedDecisions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	_, err := st.DB().Exec(st.Rebind(`UPDATE carddav_address_books
+		SET is_write_target = FALSE WHERE id = ?`), book.ID)
+	require.NoError(err)
+	personIDs := make([]int64, 2)
+	for index := range personIDs {
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+			"local-uid-"+string(rune('a'+index))).Scan(&personIDs[index]))
+		_, err := st.AddPersonContactPointContext(t.Context(), personIDs[index], store.PersonContactPointInput{
+			AddressKind: store.ContactAddressEmail, OriginalValue: "shared@example.test",
+			Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+		})
+		require.NoError(err)
+	}
+	input := remoteResource(book.CanonicalURL+"shared.vcf", "remote-shared", "Shared", "shared@example.test", `"one"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	candidates, err := st.ListIdentityMatchCandidatesContext(t.Context(),
+		[]store.IdentityMatchState{store.IdentityMatchStateConflict}, 10, 0)
+	require.NoError(err)
+	require.Len(candidates, 2)
+
+	_, _, err = st.AcceptIdentityMatchCandidateContext(t.Context(), candidates[0].ID, "system", nil)
+	require.ErrorIs(err, store.ErrIdentityMatchNotAcceptable)
+	accepted, _, err := st.AcceptIdentityMatchCandidateContext(t.Context(), candidates[0].ID, "user", nil)
+	require.NoError(err)
+	assert.Equal(store.IdentityMatchStateAccepted, accepted.State)
+
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(candidates[0].RightID, *resource.PersonID)
+	assert.Equal(store.CardDAVMappingMapped, resource.MappingStatus)
+	assert.Equal(store.CardDAVGovernanceLocal, resource.Governance)
+	envelope, err := st.GetVCardResourceEnvelopeContext(t.Context(), "carddav:1", input.Href)
+	require.NoError(err)
+	assert.Equal(candidates[0].RightID, envelope.PersonID)
+
+	refreshed := input
+	refreshed.RemoteETag = `"two"`
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{refreshed},
+	})
+	require.NoError(err)
+	reviewed, err := st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	require.Len(reviewed, 2)
+	states := map[int64]store.IdentityMatchState{}
+	for _, candidate := range reviewed {
+		states[candidate.ID] = candidate.State
+	}
+	assert.Equal(store.IdentityMatchStateAccepted, states[candidates[0].ID])
+	assert.Equal(store.IdentityMatchStateRejected, states[candidates[1].ID])
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsLookupSource: true,
+	}))
+	demoted, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	assert.Nil(demoted.PersonID)
+	for _, candidate := range candidates {
+		kept, getErr := st.GetIdentityMatchCandidateContext(t.Context(), candidate.ID)
+		require.NoError(getErr)
+		assert.Equal(states[candidate.ID], kept.State)
+	}
+
+	require.NoError(st.SetCardDAVBookRolesContext(t.Context(), book.ID, store.CardDAVBookRoles{
+		IsSubscribed: true, IsLookupSource: true,
+	}))
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, ReplaceAll: true,
+		CompletesFullReconcile: true, Upserts: []store.CardDAVRemoteResource{refreshed},
+	})
+	require.NoError(err)
+	rebound, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(rebound.PersonID)
+	assert.Equal(candidates[0].RightID, *rebound.PersonID,
+		"full reconciliation must honor the reviewed acceptance")
+}
+
+func TestCardDAVReconciliationPreservesRejectedCandidate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	for index := range 2 {
+		var personID int64
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+			"local-uid-"+string(rune('a'+index))).Scan(&personID))
+		_, err := st.AddPersonContactPointContext(t.Context(), personID, store.PersonContactPointInput{
+			AddressKind: store.ContactAddressEmail, OriginalValue: "shared@example.test",
+			Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+		})
+		require.NoError(err)
+	}
+	input := remoteResource(book.CanonicalURL+"shared.vcf", "remote-shared", "Shared", "shared@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	candidates, err := st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	require.Len(candidates, 2)
+	rejected, err := st.DecideIdentityMatchCandidateContext(t.Context(), candidates[0].ID,
+		store.IdentityMatchStateRejected, "user", nil)
+	require.NoError(err)
+	assert.Equal(store.IdentityMatchStateRejected, rejected.State)
+	otherPersonID := candidates[1].RightID
+	person, err := st.GetPersonContext(t.Context(), otherPersonID)
+	require.NoError(err)
+	require.NoError(st.DeletePersonContext(t.Context(), otherPersonID, person.Revision))
+
+	input.RemoteETag = `"two"`
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	refreshed, err := st.GetIdentityMatchCandidateContext(t.Context(), rejected.ID)
+	require.NoError(err)
+	assert.Equal(store.IdentityMatchStateRejected, refreshed.State)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.NotEqual(rejected.RightID, *resource.PersonID,
+		"a reviewed rejection must remain excluded when it becomes the sole local match")
+	assert.Equal(store.CardDAVGovernanceRemote, resource.Governance)
+	candidates, err = st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	assert.Len(candidates, 1)
+}
+
+func TestCardDAVResourceRefreshReconcilesAmbiguousCandidatesToUniqueMatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	personIDs := make([]int64, 2)
+	for index := range personIDs {
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+			"local-uid-"+string(rune('a'+index))).Scan(&personIDs[index]))
+		_, err := st.AddPersonContactPointContext(t.Context(), personIDs[index], store.PersonContactPointInput{
+			AddressKind: store.ContactAddressEmail, OriginalValue: "shared@example.test",
+			Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+		})
+		require.NoError(err)
+	}
+	_, err := st.AddPersonContactPointContext(t.Context(), personIDs[0], store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "unique@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	href := book.CanonicalURL + "shared.vcf"
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{
+			remoteResource(href, "remote-shared", "Shared", "shared@example.test", `"one"`),
+		},
+	})
+	require.NoError(err)
+	before, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	participantID, err := st.EnsureParticipantByIdentifier("example", "shared", "Shared")
+	require.NoError(err)
+	manualCandidate, _, err := st.UpsertIdentityMatchCandidateContext(t.Context(), store.IdentityMatchCandidateInput{
+		LeftKind: store.IdentityMatchCardDAVResource, LeftID: before.ID,
+		RightKind: store.IdentityMatchParticipant, RightID: participantID,
+		Basis: store.IdentityMatchDisplayName, State: store.IdentityMatchStateCandidate,
+		Source: store.ProvenanceSystem,
+	})
+	require.NoError(err)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{
+			remoteResource(href, "remote-shared", "Shared", "unique@example.test", `"two"`),
+		},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(personIDs[0], *resource.PersonID)
+	assert.Equal(store.CardDAVMappingMapped, resource.MappingStatus)
+	candidates, err := st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(manualCandidate.ID, candidates[0].ID)
+	assert.Equal(store.ProvenanceSystem, candidates[0].Source)
+}
+
+func TestCardDAVResourceRefreshReplacesThenRemovesAmbiguousCandidates(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	personIDs := make([]int64, 4)
+	for index := range personIDs {
+		require.NoError(st.DB().QueryRow(st.Rebind(
+			`INSERT INTO persons (vcard_uid) VALUES (?) RETURNING id`),
+			"local-uid-"+string(rune('a'+index))).Scan(&personIDs[index]))
+		email := "shared@example.test"
+		if index >= 2 {
+			email = "different@example.test"
+		}
+		_, err := st.AddPersonContactPointContext(t.Context(), personIDs[index], store.PersonContactPointInput{
+			AddressKind: store.ContactAddressEmail, OriginalValue: email,
+			Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+		})
+		require.NoError(err)
+	}
+	href := book.CanonicalURL + "shared.vcf"
+	for revision, input := range []store.CardDAVRemoteResource{
+		remoteResource(href, "remote-shared", "Shared", "shared@example.test", `"one"`),
+		remoteResource(href, "remote-shared", "Shared", "different@example.test", `"two"`),
+	} {
+		_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+			AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+			SyncRevision: book.SyncRevision + int64(revision), Upserts: []store.CardDAVRemoteResource{input},
+		})
+		require.NoError(err)
+	}
+	candidates, err := st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	require.Len(candidates, 2)
+	assert.ElementsMatch([]int64{personIDs[2], personIDs[3]},
+		[]int64{candidates[0].RightID, candidates[1].RightID})
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 2, Upserts: []store.CardDAVRemoteResource{
+			remoteResource(href, "remote-shared", "Shared", "none@example.test", `"three"`),
+		},
+	})
+	require.NoError(err)
+	candidates, err = st.ListIdentityMatchCandidatesContext(t.Context(), nil, 10, 0)
+	require.NoError(err)
+	assert.Empty(candidates)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	assert.Equal(store.CardDAVGovernanceRemote, resource.Governance)
+}
+
+func TestCardDAVApplyFenceRollsBackWholePlan(t *testing.T) {
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`)
+
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, ReplaceAll: true, NextSyncToken: "must-not-land",
+		Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.ErrorIs(err, store.ErrCardDAVStalePlan)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	books, listErr := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(listErr)
+	assert.Empty(t, books[0].SyncToken)
+}
+
+func TestCardDAVTombstoneDeletesOnlyUntouchedRemoteGovernedPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, ReplaceAll: true,
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+
+	// A canonical UID match is locally governed and is only unmapped.
+	var curatedID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO persons (vcard_uid) VALUES ('curated-uid') RETURNING id`).Scan(&curatedID))
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	curated := remoteResource(book.CanonicalURL+"curated.vcf", "curated-uid", "Curated", "curated@example.test", `"two"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{curated},
+	})
+	require.NoError(err)
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, ReplaceAll: true,
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), curatedID)
+	require.NoError(err)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, curated.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+
+	// A user edit changes the imported person's projection, so a concurrent
+	// remote deletion retains the mapping and records an edit/delete conflict.
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	edited := remoteResource(book.CanonicalURL+"edited.vcf", "remote-edited", "Edited", "edited@example.test", `"three"`)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, ReplaceAll: true, Upserts: []store.CardDAVRemoteResource{edited},
+	})
+	require.NoError(err)
+	editedResource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, edited.Href)
+	require.NoError(err)
+	require.NotNil(editedResource.PersonID)
+	_, err = st.AddPersonContactPointContext(t.Context(), *editedResource.PersonID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "user-edit@example.test",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	localSnapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), *editedResource.PersonID)
+	require.NoError(err)
+	books, err = st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, ReplaceAll: true,
+		Conflicts: []store.CardDAVConflictCapture{{
+			AddressBookID: book.ID, Href: editedResource.Href,
+			ExpectedMappingRevision: editedResource.MappingRevision,
+			BaseLocalHash:           editedResource.LocalHash, LocalHash: localSnapshot.Fingerprint,
+			BaseRemoteHash: editedResource.RemoteSemanticHash,
+			BaseRemoteETag: editedResource.RemoteETag,
+			LocalBody: []byte("BEGIN:VCARD\r\nVERSION:4.0\r\nUID:remote-edited\r\n" +
+				"FN:Edited\r\nEMAIL:user-edit@example.test\r\nEND:VCARD\r\n"),
+			RemoteTombstone: true,
+		}},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), *editedResource.PersonID)
+	require.NoError(err)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, editedResource.Href)
+	require.NoError(err)
+	conflicts, err := st.ListCardDAVConflictsContext(t.Context(), true)
+	require.NoError(err)
+	require.Len(conflicts, 1)
+	assert.True(conflicts[0].RemoteTombstone)
+}
+
+func TestCardDAVTombstoneDeletesImportedPersonAfterRemoteMappingBeforeLocalDuplicate(t *testing.T) {
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	remote := remoteResource(
+		book.CanonicalURL+"remote.vcf", "remote-owner", "Shared", "shared@example.test", `"one"`,
+	)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{remote},
+	})
+	require.NoError(err)
+	remoteMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+	require.NoError(err)
+	require.NotNil(remoteMapping.PersonID)
+	personID := *remoteMapping.PersonID
+	require.Equal(store.CardDAVGovernanceRemote, remoteMapping.Governance)
+
+	duplicate := remoteResource(
+		book.CanonicalURL+"duplicate.vcf", "local-duplicate", "Shared", "shared@example.test", `"two"`,
+	)
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, Upserts: []store.CardDAVRemoteResource{duplicate},
+	})
+	require.NoError(err)
+	duplicateMapping, err := st.GetCardDAVResourceContext(t.Context(), book.ID, duplicate.Href)
+	require.NoError(err)
+	require.NotNil(duplicateMapping.PersonID)
+	require.Equal(personID, *duplicateMapping.PersonID)
+	require.Equal(store.CardDAVGovernanceLocal, duplicateMapping.Governance)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 2, RemovedHrefs: []string{remote.Href},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 3, RemovedHrefs: []string{duplicate.Href},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+}
+
+func TestCardDAVTombstoneRetainsPublishedImportedPerson(t *testing.T) {
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	remote := remoteResource(
+		book.CanonicalURL+"published-import.vcf", "published-import", "Published", "published@example.test", `"one"`,
+	)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{remote},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+	snapshot, err := st.LoadPersonVCardSnapshotContext(t.Context(), personID)
+	require.NoError(err)
+	publication, err := st.PrepareCardDAVPublicationContext(t.Context(), store.CardDAVPublicationPlan{
+		PersonID: personID, Desired: true, AddressBookID: book.ID, Href: remote.Href,
+		OutgoingBody: remote.RemoteBody, OutgoingSemanticHash: remote.SemanticHash,
+		LocalHash: snapshot.Fingerprint,
+	})
+	require.NoError(err)
+	require.True(publication.Noop)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, RemovedHrefs: []string{remote.Href},
+	})
+	require.NoError(err)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, remote.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	after, err := st.GetCardDAVPublicationContext(t.Context(), personID)
+	require.NoError(err)
+	require.True(after.Desired)
+}
+
+func TestCardDAVTombstoneRetainsImportedProjectionForUserEditedPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"retained.vcf", "remote-retained", "Retained", "retained@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+	var noteID int64
+	require.NoError(st.DB().QueryRow(`INSERT INTO daily_note_entries (local_date, ordinal, body)
+		VALUES ('2026-08-20', 1, 'retain normal tombstone projection') RETURNING id`).Scan(&noteID))
+	_, err = st.DB().Exec(st.Rebind(
+		`INSERT INTO daily_note_entry_persons (entry_id, person_id) VALUES (?, ?)`), noteID, personID)
+	require.NoError(err)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, RemovedHrefs: []string{input.Href},
+	})
+	require.NoError(err)
+	person, err := st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	require.NotNil(person.DisplayName)
+	assert.Equal(input.DisplayName, *person.DisplayName)
+	names, err := st.ListPersonNamesContext(t.Context(), personID, true)
+	require.NoError(err)
+	require.Len(names, 1)
+	assert.Equal(input.DisplayName, names[0].OriginalValue)
+	points, err := st.ListPersonContactPointsContext(t.Context(), personID, true)
+	require.NoError(err)
+	assert.Equal([]string{input.Emails[0]}, contactPointValues(points))
+	var noteLinks int
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM daily_note_entry_persons
+		WHERE entry_id = ? AND person_id = ?`), noteID, personID).Scan(&noteLinks))
+	assert.Equal(1, noteLinks)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func TestCardDAVTombstoneRetainsTrackedImportedPerson(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"tracked.vcf", "remote-tracked", "Tracked", "tracked@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+	tracked, err := st.SetPersonTrackingContext(t.Context(), personID, true)
+	require.NoError(err)
+	assert.True(tracked.Tracked)
+	books, err := st.ListCardDAVAddressBooksContext(t.Context())
+	require.NoError(err)
+	require.Len(books, 1)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: books[0].SyncRevision, RemovedHrefs: []string{input.Href},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	retainedTracking, err := st.GetPersonTrackingContext(t.Context(), personID)
+	require.NoError(err)
+	assert.True(retainedTracking.Tracked)
+	_, err = st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.ErrorIs(err, store.ErrCardDAVResourceNotFound)
+}
+
+func contactPointValues(points []store.PersonContactPoint) []string {
+	values := make([]string, 0, len(points))
+	for _, point := range points {
+		values = append(values, point.OriginalValue)
+	}
+	return values
+}
+
+func TestCardDAVTombstoneRemovesIdentityCandidatesReferencingImportedPerson(t *testing.T) {
+	require := require.New(t)
+
+	st, account, book := newCardDAVResourceStore(t)
+	input := remoteResource(book.CanonicalURL+"alice.vcf", "remote-alice", "Alice", "alice@example.test", `"one"`)
+	_, err := st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision, Upserts: []store.CardDAVRemoteResource{input},
+	})
+	require.NoError(err)
+	resource, err := st.GetCardDAVResourceContext(t.Context(), book.ID, input.Href)
+	require.NoError(err)
+	require.NotNil(resource.PersonID)
+	personID := *resource.PersonID
+	participantID, err := st.EnsureParticipantByIdentifier("example", "alice", "Alice")
+	require.NoError(err)
+	candidate, _, err := st.UpsertIdentityMatchCandidateContext(t.Context(), store.IdentityMatchCandidateInput{
+		LeftKind: store.IdentityMatchPerson, LeftID: personID,
+		RightKind: store.IdentityMatchParticipant, RightID: participantID,
+		Basis: store.IdentityMatchDisplayName, State: store.IdentityMatchStateCandidate,
+		Source: store.ProvenanceSystem,
+	})
+	require.NoError(err)
+
+	_, err = st.ApplyCardDAVSyncPlanContext(t.Context(), store.CardDAVSyncPlan{
+		AddressBookID: book.ID, ConnectionGeneration: account.ConnectionGeneration,
+		SyncRevision: book.SyncRevision + 1, RemovedHrefs: []string{input.Href},
+	})
+	require.NoError(err)
+	_, err = st.GetPersonContext(t.Context(), personID)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+	_, err = st.GetIdentityMatchCandidateContext(t.Context(), candidate.ID)
+	require.ErrorIs(err, store.ErrIdentityMatchNotFound)
+	var dangling int
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM identity_match_candidates
+		WHERE (left_kind = 'person' AND left_id = ?)
+		   OR (right_kind = 'person' AND right_id = ?)`), personID, personID).Scan(&dangling))
+	assert.Zero(t, dangling)
+}

--- a/internal/store/daily_notes.go
+++ b/internal/store/daily_notes.go
@@ -161,7 +161,7 @@ func dailyNoteRetryable(ctx context.Context, s *Store, err error) bool {
 	if err == nil || ctx.Err() != nil {
 		return false
 	}
-	if s.dialect.DriverName() != "pgx" {
+	if s.dialect.DriverName() != postgresDriverName {
 		return s.dialect.IsBusyError(err)
 	}
 	var state sqlStateError

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -9,7 +9,10 @@ import (
 // CurrentFTSIndexingVersion identifies the PostgreSQL search_fts field-weight
 // layout. Version 2 assigns subject=A, sender=B, recipients=C, and body=D so
 // exact body-only queries can restrict tsquery matches to weight D.
-const CurrentFTSIndexingVersion = 2
+const (
+	CurrentFTSIndexingVersion = 2
+	postgresDriverName        = "pgx"
+)
 
 // FTSDoc is the set of fields the dialect needs to upsert a message into
 // the full-text search index.

--- a/internal/store/dialect_pg.go
+++ b/internal/store/dialect_pg.go
@@ -31,7 +31,7 @@ type PostgreSQLDialect struct {
 	fullyVisibleBound time.Time
 }
 
-func (d *PostgreSQLDialect) DriverName() string { return "pgx" }
+func (d *PostgreSQLDialect) DriverName() string { return postgresDriverName }
 
 // Rebind converts ? placeholders to PostgreSQL $1, $2, ... numbered
 // placeholders. Delegates to sqldialect so the query package's
@@ -587,6 +587,13 @@ func (d *PostgreSQLDialect) FTSRebuildSchema(ctx context.Context, q contextQueri
 //	TEXT → TEXT, DATETIME → TIMESTAMPTZ, JSON → JSONB.
 func (d *PostgreSQLDialect) LegacyColumnMigrations() []ColumnMigration {
 	return []ColumnMigration{
+		{`ALTER TABLE carddav_address_books ADD COLUMN IF NOT EXISTS needs_full_reconcile BOOLEAN NOT NULL DEFAULT FALSE`, "carddav_address_books.needs_full_reconcile"},
+		{`ALTER TABLE carddav_address_books ADD COLUMN IF NOT EXISTS sync_token TEXT NOT NULL DEFAULT ''`, "carddav_address_books.sync_token"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN IF NOT EXISTS pending_operation TEXT CHECK (pending_operation IN ('delete'))`, "carddav_conflicts.pending_operation"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN IF NOT EXISTS connection_generation BIGINT`, "carddav_conflicts.connection_generation"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN IF NOT EXISTS book_sync_revision BIGINT`, "carddav_conflicts.book_sync_revision"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN IF NOT EXISTS previous_mapping_revision BIGINT`, "carddav_conflicts.previous_mapping_revision"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN IF NOT EXISTS pending_started_at TIMESTAMPTZ`, "carddav_conflicts.pending_started_at"},
 		{`ALTER TABLE sources ADD COLUMN IF NOT EXISTS sync_config JSONB`, "sync_config"},
 		{`ALTER TABLE imap_folder_state ADD COLUMN IF NOT EXISTS highest_modseq NUMERIC(20, 0) NOT NULL DEFAULT 0`, "imap_folder_state.highest_modseq"},
 		{`ALTER TABLE messages ADD COLUMN IF NOT EXISTS rfc822_message_id TEXT`, "rfc822_message_id"},

--- a/internal/store/dialect_sqlite.go
+++ b/internal/store/dialect_sqlite.go
@@ -1542,6 +1542,13 @@ func (d *SQLiteDialect) contentChangedAtDefaultStamps(q querier) (bool, error) {
 // silences these when the column already exists (idempotent migrations).
 func (d *SQLiteDialect) LegacyColumnMigrations() []ColumnMigration {
 	return []ColumnMigration{
+		{`ALTER TABLE carddav_address_books ADD COLUMN needs_full_reconcile BOOLEAN NOT NULL DEFAULT FALSE`, "carddav_address_books.needs_full_reconcile"},
+		{`ALTER TABLE carddav_address_books ADD COLUMN sync_token TEXT NOT NULL DEFAULT ''`, "carddav_address_books.sync_token"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN pending_operation TEXT CHECK (pending_operation IN ('delete'))`, "carddav_conflicts.pending_operation"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN connection_generation INTEGER`, "carddav_conflicts.connection_generation"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN book_sync_revision INTEGER`, "carddav_conflicts.book_sync_revision"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN previous_mapping_revision INTEGER`, "carddav_conflicts.previous_mapping_revision"},
+		{`ALTER TABLE carddav_conflicts ADD COLUMN pending_started_at DATETIME`, "carddav_conflicts.pending_started_at"},
 		{`ALTER TABLE sources ADD COLUMN sync_config JSON`, "sync_config"},
 		{`ALTER TABLE imap_folder_state ADD COLUMN highest_modseq TEXT NOT NULL DEFAULT '0'`, "imap_folder_state.highest_modseq"},
 		{`ALTER TABLE messages ADD COLUMN rfc822_message_id TEXT`, "rfc822_message_id"},

--- a/internal/store/embedding_changes.go
+++ b/internal/store/embedding_changes.go
@@ -113,7 +113,7 @@ func (s *Store) LatestEmbeddingChangeSequence(ctx context.Context) (int64, error
 // can be in flight while the enable statement runs.
 func (s *Store) EnableEmbeddingChangeJournal(ctx context.Context) error {
 	const enable = `UPDATE embedding_change_clock SET enabled = TRUE WHERE singleton = 1`
-	if s.dialect.DriverName() != "pgx" {
+	if s.dialect.DriverName() != postgresDriverName {
 		if _, err := s.db.ExecContext(ctx, enable); err != nil {
 			return fmt.Errorf("enable embedding change journal: %w", err)
 		}

--- a/internal/store/export_test.go
+++ b/internal/store/export_test.go
@@ -41,6 +41,19 @@ func SetFTS5AvailableForTest(s *Store, v bool) {
 	s.fts5Available = v
 }
 
+// SetCardDAVConflictResolutionSnapshotHookForTest pauses keep-remote after its
+// unlocked routing snapshot and before the ordered resolution transaction.
+func (s *Store) SetCardDAVConflictResolutionSnapshotHookForTest(fn func()) {
+	s.cardDAVConflictResolveSnapshotHook = fn
+}
+
+// SetCardDAVConflictTombstonePreparationSnapshotHookForTest pauses keep-local
+// tombstone preparation after its unlocked routing snapshot and before the
+// ordered mutation transaction.
+func (s *Store) SetCardDAVConflictTombstonePreparationSnapshotHookForTest(fn func()) {
+	s.cardDAVTombstonePrepareSnapshotHook = fn
+}
+
 // SetBackfillFTSBatchErrHookForTest installs (or, with nil, clears) the
 // test-only hook that forces backfillFTSBatch to fail for a chosen id range.
 // Tests use it to deterministically trigger backfillFTSRowByRow's

--- a/internal/store/identity_match_apply.go
+++ b/internal/store/identity_match_apply.go
@@ -70,6 +70,12 @@ func (s *Store) AcceptIdentityMatchCandidateContext(
 	if err != nil {
 		return nil, 0, err
 	}
+	if candidate.LeftKind == IdentityMatchCardDAVResource &&
+		candidate.RightKind == IdentityMatchPerson {
+		return s.acceptCardDAVIdentityMatchCandidateContext(
+			ctx, candidateID, decidedBy, notes,
+		)
+	}
 	if candidate.LeftKind != IdentityMatchParticipant || candidate.RightKind != IdentityMatchParticipant {
 		return nil, 0, fmt.Errorf("candidate %d (%s to %s): %w",
 			candidateID, candidate.LeftKind, candidate.RightKind,

--- a/internal/store/identity_match_candidates.go
+++ b/internal/store/identity_match_candidates.go
@@ -13,16 +13,18 @@ import (
 type IdentityMatchEndpointKind string
 
 const (
-	IdentityMatchParticipant  IdentityMatchEndpointKind = "participant"
-	IdentityMatchPerson       IdentityMatchEndpointKind = "person"
-	IdentityMatchObservation  IdentityMatchEndpointKind = "observation"
-	IdentityMatchContactPoint IdentityMatchEndpointKind = "contact_point"
+	IdentityMatchParticipant     IdentityMatchEndpointKind = "participant"
+	IdentityMatchPerson          IdentityMatchEndpointKind = "person"
+	IdentityMatchObservation     IdentityMatchEndpointKind = "observation"
+	IdentityMatchContactPoint    IdentityMatchEndpointKind = "contact_point"
+	IdentityMatchCardDAVResource IdentityMatchEndpointKind = "carddav_resource"
 )
 
 func (k IdentityMatchEndpointKind) valid() bool {
 	switch k {
 	case IdentityMatchParticipant, IdentityMatchPerson,
-		IdentityMatchObservation, IdentityMatchContactPoint:
+		IdentityMatchObservation, IdentityMatchContactPoint,
+		IdentityMatchCardDAVResource:
 		return true
 	default:
 		return false
@@ -236,6 +238,8 @@ func validateIdentityMatchEndpointTx(
 		table = "participant_contact_observations"
 	case IdentityMatchContactPoint:
 		table = "person_contact_points"
+	case IdentityMatchCardDAVResource:
+		table = "carddav_resources"
 	default:
 		return ErrInvalidIdentityMatchEndpoint
 	}

--- a/internal/store/identity_match_candidates_test.go
+++ b/internal/store/identity_match_candidates_test.go
@@ -12,6 +12,26 @@ import (
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
+func TestIdentityMatchCardDAVResourceValidatesLedgerEndpoint(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := storetest.New(t).Store
+	participantID, err := st.EnsureParticipantByIdentifier("example", "person", "Person")
+	require.NoError(err)
+	person, _, err := st.CreatePersonFromParticipant(participantID)
+	require.NoError(err)
+
+	_, _, err = st.UpsertIdentityMatchCandidateContext(t.Context(), store.IdentityMatchCandidateInput{
+		LeftKind: store.IdentityMatchCardDAVResource, LeftID: 999,
+		RightKind: store.IdentityMatchPerson, RightID: person.ID,
+		Basis: store.IdentityMatchEmail, State: store.IdentityMatchStateConflict,
+		Source: store.ProvenanceCardDAVImport,
+	})
+	require.ErrorIs(err, store.ErrIdentityMatchEndpointNotFound)
+	assert.NotErrorIs(err, store.ErrInvalidIdentityMatchEndpoint)
+}
+
 func TestAddIdentityMatchEvidenceConcurrentCallsConverge(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -835,7 +835,7 @@ func (s *Store) UpsertMessage(msg *Message) (int64, error) {
 	}
 	var id int64
 	err := s.withTx(func(tx *loggedTx) error {
-		if s.dialect.DriverName() != "pgx" {
+		if s.dialect.DriverName() != postgresDriverName {
 			// Acquire SQLite's writer slot before the prior-state read. This
 			// prevents a deferred read transaction from failing to upgrade when
 			// another writer commits between the read and the message upsert.
@@ -991,7 +991,7 @@ func appendBodylessMessageChange(
 	newType := sql.NullString{String: msg.MessageType, Valid: msg.MessageType != ""}
 	newConversation := nullInt64(msg.ConversationID)
 	newSentAt := canonicalMessageTime(msg.SentAt, msg.ReceivedAt, msg.InternalDate)
-	if dialect.DriverName() == "pgx" {
+	if dialect.DriverName() == postgresDriverName {
 		if _, err := q.Exec(`
 			SELECT pg_advisory_xact_lock_shared(hashtextextended('msgvault.embedding_change_clock', 0)),
 			       append_embedding_change(?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
@@ -1392,7 +1392,7 @@ func (s *Store) persistMessageWithParticipantsContext(
 ) (int64, error) {
 	var messageID int64
 	err := s.withTxContext(ctx, func(tx *loggedTx) error {
-		if s.dialect.DriverName() != "pgx" {
+		if s.dialect.DriverName() != postgresDriverName {
 			// Reserve SQLite's writer slot before any prior-state or related
 			// snapshot reads. Otherwise a concurrent commit can leave this
 			// deferred WAL transaction unable to upgrade to a writer.
@@ -4197,7 +4197,7 @@ func replaceConversationParticipantsTx(
 	participants []ConversationParticipantRef,
 ) error {
 	q := boundQuerier{ctx: ctx, q: tx}
-	if dialect.DriverName() != "pgx" {
+	if dialect.DriverName() != postgresDriverName {
 		// Acquire SQLite's writer slot before taking the journal snapshot. A
 		// deferred transaction that reads first cannot upgrade its stale WAL
 		// snapshot if another writer commits before the membership DELETE.

--- a/internal/store/migrate_carddav_conflicts.go
+++ b/internal/store/migrate_carddav_conflicts.go
@@ -1,0 +1,127 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const cardDAVConflictPendingInvariant = `pending_operation IS NULL OR
+	(status = 'unresolved' AND local_tombstone AND remote_etag IS NOT NULL AND
+	 connection_generation IS NOT NULL AND book_sync_revision IS NOT NULL AND
+	 previous_mapping_revision IS NOT NULL AND pending_started_at IS NOT NULL)`
+
+// ensureCardDAVConflictPendingInvariant finishes the legacy conflict-table
+// upgrade after the dialect's ADD COLUMN statements. PostgreSQL can add the
+// table constraint in place. SQLite cannot, so an old table is rebuilt in one
+// transaction with all rows and the two public indexes restored before commit.
+func (s *Store) ensureCardDAVConflictPendingInvariant(ctx context.Context) error {
+	if s.IsPostgreSQL() {
+		var present bool
+		if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (
+			SELECT 1 FROM pg_constraint
+			WHERE conrelid = 'carddav_conflicts'::regclass
+			  AND contype = 'c'
+			  AND pg_get_constraintdef(oid) ILIKE '%pending_started_at IS NOT NULL%'
+		)`).Scan(&present); err != nil {
+			return fmt.Errorf("inspect PostgreSQL pending constraint: %w", err)
+		}
+		if present {
+			return nil
+		}
+		if _, err := s.db.ExecContext(ctx, `DO $migration$
+			BEGIN
+				ALTER TABLE carddav_conflicts
+					ADD CONSTRAINT carddav_conflicts_pending_invariant CHECK (`+
+			cardDAVConflictPendingInvariant+`);
+			EXCEPTION WHEN duplicate_object THEN NULL;
+			END;
+		$migration$;`); err != nil {
+			return fmt.Errorf("add PostgreSQL pending constraint: %w", err)
+		}
+		return nil
+	}
+
+	var tableSQL sql.NullString
+	if err := s.db.QueryRowContext(ctx, `SELECT sql FROM sqlite_master
+		WHERE type = 'table' AND name = 'carddav_conflicts'`).Scan(&tableSQL); err != nil {
+		return fmt.Errorf("inspect SQLite conflict table: %w", err)
+	}
+	if tableSQL.Valid && strings.Contains(strings.ToLower(tableSQL.String),
+		"pending_started_at is not null") {
+		return nil
+	}
+
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		if _, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS carddav_conflicts_pending_upgrade`); err != nil {
+			return fmt.Errorf("clear stale SQLite conflict upgrade table: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `CREATE TABLE carddav_conflicts_pending_upgrade (
+			id                         INTEGER PRIMARY KEY AUTOINCREMENT,
+			address_book_id            INTEGER NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+			href                       TEXT NOT NULL,
+			base_local_hash            TEXT NOT NULL,
+			local_hash                 TEXT NOT NULL,
+			base_remote_hash           TEXT NOT NULL,
+			base_remote_etag           TEXT NOT NULL,
+			remote_etag                TEXT,
+			mapping_revision           INTEGER NOT NULL CHECK (mapping_revision > 0),
+			local_body                 BLOB,
+			remote_body                BLOB,
+			local_tombstone            BOOLEAN NOT NULL DEFAULT FALSE,
+			remote_tombstone           BOOLEAN NOT NULL DEFAULT FALSE,
+			pending_operation          TEXT CHECK (pending_operation IN ('delete')),
+			connection_generation      INTEGER,
+			book_sync_revision         INTEGER,
+			previous_mapping_revision  INTEGER,
+			pending_started_at         DATETIME,
+			status                     TEXT NOT NULL DEFAULT 'unresolved' CHECK (status IN ('unresolved', 'resolved')),
+			resolution                 TEXT CHECK (resolution IN ('keep_local', 'keep_remote')),
+			resolved_at                DATETIME,
+			created_at                 DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at                 DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			CHECK (local_tombstone OR local_body IS NOT NULL),
+			CHECK (remote_tombstone OR remote_body IS NOT NULL),
+			CONSTRAINT carddav_conflicts_pending_invariant CHECK (`+
+			cardDAVConflictPendingInvariant+`),
+			CHECK ((status = 'unresolved' AND resolution IS NULL AND resolved_at IS NULL) OR
+			       (status = 'resolved' AND resolution IS NOT NULL AND resolved_at IS NOT NULL))
+		)`); err != nil {
+			return fmt.Errorf("create SQLite conflict upgrade table: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO carddav_conflicts_pending_upgrade (
+			id, address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+			base_remote_etag, remote_etag, mapping_revision, local_body, remote_body,
+			local_tombstone, remote_tombstone, pending_operation, connection_generation,
+			book_sync_revision, previous_mapping_revision, pending_started_at, status,
+			resolution, resolved_at, created_at, updated_at
+		) SELECT
+			id, address_book_id, href, base_local_hash, local_hash, base_remote_hash,
+			base_remote_etag, remote_etag, mapping_revision, local_body, remote_body,
+			local_tombstone, remote_tombstone, pending_operation, connection_generation,
+			book_sync_revision, previous_mapping_revision, pending_started_at, status,
+			resolution, resolved_at, created_at, updated_at
+		FROM carddav_conflicts`); err != nil {
+			return fmt.Errorf("copy SQLite conflict rows: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `DROP TABLE carddav_conflicts`); err != nil {
+			return fmt.Errorf("replace SQLite conflict table: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `ALTER TABLE carddav_conflicts_pending_upgrade
+			RENAME TO carddav_conflicts`); err != nil {
+			return fmt.Errorf("rename SQLite conflict table: %w", err)
+		}
+		for _, statement := range []string{
+			`CREATE UNIQUE INDEX idx_carddav_one_unresolved_conflict
+			 ON carddav_conflicts(address_book_id, href) WHERE status = 'unresolved'`,
+			`CREATE INDEX idx_carddav_conflicts_resolved_at
+			 ON carddav_conflicts(status, resolved_at)`,
+		} {
+			if _, err := tx.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("restore SQLite conflict index: %w", err)
+			}
+		}
+		return nil
+	})
+}

--- a/internal/store/packs.go
+++ b/internal/store/packs.go
@@ -854,7 +854,7 @@ func (s *Store) ClearAttachmentPackMetadata() error {
 
 func (s *Store) tableExists(name string) (bool, error) {
 	query := `SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`
-	if s.dialect.DriverName() == "pgx" {
+	if s.dialect.DriverName() == postgresDriverName {
 		query = `SELECT COUNT(*) FROM information_schema.tables
 		         WHERE table_schema = current_schema() AND table_name = ?`
 	}

--- a/internal/store/person_user_owned_state.go
+++ b/internal/store/person_user_owned_state.go
@@ -1,0 +1,92 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// personHasUserOwnedStateTx reports whether deleting personID would discard
+// state that is user-authored, user-reviewed, or changed since the supplied
+// baseline revision. Import cleanup calls this before removing identity-match
+// candidates because their decisions and evidence are part of the contract.
+func (s *Store) personHasUserOwnedStateTx(
+	ctx context.Context, tx *loggedTx, personID, baselineRevision int64,
+) (bool, error) {
+	var revision int64
+	err := tx.QueryRowContext(ctx, `SELECT revision FROM persons WHERE id = ?`+
+		s.dialect.SelectForUpdate(), personID).Scan(&revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("lock person %d user-owned state: %w", personID, err)
+	}
+	if revision != baselineRevision {
+		return true, nil
+	}
+	var hasUserOwnedState bool
+	err = tx.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM persons
+		WHERE id = ? AND (
+			EXISTS (SELECT 1 FROM person_tracking
+				WHERE person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM carddav_publications
+				WHERE person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM person_participants
+				WHERE person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM person_names
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_contact_points
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_addresses
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_dates
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_categories
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_media
+				WHERE person_id = persons.id AND source = 'user')
+			OR EXISTS (SELECT 1 FROM person_relationships
+				WHERE source_person_id = persons.id OR target_person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM person_relationship_reviews
+				WHERE (person_id = persons.id OR matched_person_id = persons.id)
+				  AND (status IN ('accepted', 'rejected')
+				    OR reviewed_by IS NOT NULL OR reviewed_at IS NOT NULL))
+			OR EXISTS (SELECT 1 FROM employments
+				WHERE source = 'user' AND person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM person_attribute_values
+				WHERE source = 'user' AND person_id = persons.id)
+			OR EXISTS (SELECT 1 FROM daily_note_entry_persons
+				WHERE person_id = persons.id)
+			OR EXISTS (
+				SELECT 1 FROM identity_match_candidates candidate
+				WHERE (
+					(candidate.left_kind = 'person' AND candidate.left_id = persons.id)
+					OR (candidate.right_kind = 'person' AND candidate.right_id = persons.id)
+					OR (candidate.left_kind = 'contact_point' AND EXISTS (
+						SELECT 1 FROM person_contact_points point
+						WHERE point.id = candidate.left_id AND point.person_id = persons.id
+					))
+					OR (candidate.right_kind = 'contact_point' AND EXISTS (
+						SELECT 1 FROM person_contact_points point
+						WHERE point.id = candidate.right_id AND point.person_id = persons.id
+					))
+				) AND (
+					candidate.state IN ('accepted', 'rejected', 'conflict')
+					OR candidate.decided_by IS NOT NULL
+					OR candidate.decided_at IS NOT NULL
+					OR candidate.notes IS NOT NULL
+					OR candidate.source = 'user'
+					OR EXISTS (SELECT 1 FROM identity_match_evidence evidence
+						WHERE evidence.candidate_id = candidate.id AND evidence.source = 'user')
+				)
+			)
+		)
+	)`, personID).Scan(&hasUserOwnedState)
+	if err != nil {
+		return false, fmt.Errorf("check person %d user-owned state: %w", personID, err)
+	}
+	return hasUserOwnedState, nil
+}

--- a/internal/store/persons.go
+++ b/internal/store/persons.go
@@ -16,6 +16,7 @@ var (
 	ErrPersonRevisionConflict = errors.New("person revision conflict")
 	ErrPersonBindingConflict  = errors.New("participant clusters belong to different persons")
 	ErrPersonReferenced       = errors.New("person is referenced by another profile")
+	ErrPersonCardDAVPublished = errors.New("person has CardDAV publication state")
 )
 
 // PersonBindingConflictError reports the curated people that would be
@@ -167,7 +168,8 @@ func (s *Store) DeletePerson(id, expectedRevision int64) error {
 // vCard UID forever: UIDs are random and never reused, so re-promoting the
 // same cluster afterwards creates a new person with a new UID. Returns
 // ErrPersonNotFound if no such person exists and ErrPersonRevisionConflict
-// if expectedRevision is stale.
+// if expectedRevision is stale. ErrPersonCardDAVPublished requires callers to
+// recover and explicitly unpublish remote-owned state before deletion.
 func (s *Store) DeletePersonContext(ctx context.Context, id, expectedRevision int64) error {
 	// The deletion locks this person and then, through the counterpart bump,
 	// everyone they share an edge with; relationship writes bump the same
@@ -196,6 +198,15 @@ func (s *Store) deletePersonOnce(ctx context.Context, id, expectedRevision int64
 		if revision != expectedRevision {
 			return ErrPersonRevisionConflict
 		}
+		var hasCardDAVPublication bool
+		if err := tx.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM carddav_publications WHERE person_id = ?)`, id,
+		).Scan(&hasCardDAVPublication); err != nil {
+			return fmt.Errorf("check CardDAV publication for person %d: %w", id, err)
+		}
+		if hasCardDAVPublication {
+			return fmt.Errorf("delete person %d: %w", id, ErrPersonCardDAVPublished)
+		}
 		var references int
 		if err := tx.QueryRowContext(ctx, `
 			SELECT COUNT(*)
@@ -220,20 +231,8 @@ func (s *Store) deletePersonOnce(ctx context.Context, id, expectedRevision int64
 		if references > 0 {
 			return fmt.Errorf("delete person %d: %w", id, ErrPersonReferenced)
 		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
-			WHERE (left_kind = ? AND left_id = ?)
-			   OR (right_kind = ? AND right_id = ?)
-			   OR (left_kind = ? AND left_id IN (
-				SELECT id FROM person_contact_points WHERE person_id = ?
-			   ))
-			   OR (right_kind = ? AND right_id IN (
-				SELECT id FROM person_contact_points WHERE person_id = ?
-			   ))`,
-			IdentityMatchPerson, id, IdentityMatchPerson, id,
-			IdentityMatchContactPoint, id,
-			IdentityMatchContactPoint, id,
-		); err != nil {
-			return fmt.Errorf("delete identity match candidates for person %d: %w", id, err)
+		if err := s.deleteIdentityMatchCandidatesForPersonTx(ctx, tx, id); err != nil {
+			return err
 		}
 		// Before the cascade: the edges this person stands at either end of
 		// and the reviews that matched them are projected onto the surviving
@@ -254,6 +253,27 @@ func (s *Store) deletePersonOnce(ctx context.Context, id, expectedRevision int64
 		_, err = s.bumpIdentityRevisionContext(ctx, tx)
 		return err
 	})
+}
+
+func (s *Store) deleteIdentityMatchCandidatesForPersonTx(
+	ctx context.Context, tx *loggedTx, personID int64,
+) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM identity_match_candidates
+		WHERE (left_kind = ? AND left_id = ?)
+		   OR (right_kind = ? AND right_id = ?)
+		   OR (left_kind = ? AND left_id IN (
+			SELECT id FROM person_contact_points WHERE person_id = ?
+		   ))
+		   OR (right_kind = ? AND right_id IN (
+			SELECT id FROM person_contact_points WHERE person_id = ?
+		   ))`,
+		IdentityMatchPerson, personID, IdentityMatchPerson, personID,
+		IdentityMatchContactPoint, personID,
+		IdentityMatchContactPoint, personID,
+	); err != nil {
+		return fmt.Errorf("delete identity match candidates for person %d: %w", personID, err)
+	}
+	return nil
 }
 
 func (s *Store) GetPerson(id int64) (*Person, error) {

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -103,6 +103,80 @@ CREATE TABLE IF NOT EXISTS sources (
     UNIQUE(source_type, identifier)
 );
 
+-- One external CardDAV connection. Passwords never enter this schema; the
+-- account row contains only non-secret connection identity and discovery
+-- fences used by remote-first synchronization.
+CREATE TABLE IF NOT EXISTS carddav_discovery_lock (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1)
+);
+INSERT OR IGNORE INTO carddav_discovery_lock(singleton) VALUES (1);
+
+CREATE TABLE IF NOT EXISTS carddav_accounts (
+    id                    INTEGER PRIMARY KEY CHECK (id = 1),
+    base_url              TEXT NOT NULL,
+    username              TEXT NOT NULL,
+    principal_url         TEXT NOT NULL,
+    home_url              TEXT NOT NULL,
+    connection_generation INTEGER NOT NULL DEFAULT 1 CHECK (connection_generation > 0),
+    discovery_revision    INTEGER NOT NULL DEFAULT 0 CHECK (discovery_revision >= 0),
+    discovered_at         DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS carddav_account_home_urls (
+    account_id      INTEGER NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    home_url        TEXT NOT NULL,
+    discovery_index INTEGER NOT NULL CHECK (discovery_index >= 0),
+    PRIMARY KEY (account_id, home_url),
+    UNIQUE (account_id, discovery_index)
+);
+
+-- A server throttle is account-wide. Keeping the gate separate makes this an
+-- additive migration for databases that already have the account table.
+CREATE TABLE IF NOT EXISTS carddav_retry_gate (
+    account_id     INTEGER PRIMARY KEY REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    retry_after_at DATETIME NOT NULL,
+    updated_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS carddav_address_books (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_id               INTEGER NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    canonical_url            TEXT NOT NULL,
+    discovery_alias_url      TEXT,
+    display_name             TEXT NOT NULL,
+    discovery_index          INTEGER NOT NULL CHECK (discovery_index >= 0),
+    supports_sync_collection BOOLEAN NOT NULL DEFAULT FALSE,
+    supports_multiget        BOOLEAN NOT NULL DEFAULT FALSE,
+    supported_vcard_versions TEXT NOT NULL DEFAULT '[]',
+    can_create               BOOLEAN,
+    can_update               BOOLEAN,
+    can_delete               BOOLEAN,
+    is_write_target          BOOLEAN NOT NULL DEFAULT FALSE,
+    is_subscribed            BOOLEAN NOT NULL DEFAULT FALSE,
+    is_lookup_source         BOOLEAN NOT NULL DEFAULT TRUE,
+    sync_token               TEXT NOT NULL DEFAULT '',
+    sync_revision            INTEGER NOT NULL DEFAULT 1 CHECK (sync_revision > 0),
+    needs_full_reconcile     BOOLEAN NOT NULL DEFAULT FALSE,
+    last_seen_revision       INTEGER NOT NULL CHECK (last_seen_revision >= 0),
+    created_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (NOT is_write_target OR is_subscribed)
+);
+
+-- Canonical and discovery-alias URLs share one normalized identity namespace.
+-- Raw URLs remain on the book for lossless round-tripping; this child table is
+-- replaced atomically with each complete discovery snapshot.
+CREATE TABLE IF NOT EXISTS carddav_address_book_urls (
+    account_id       INTEGER NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    address_book_id  INTEGER NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    url_role         TEXT NOT NULL CHECK (url_role IN ('canonical', 'alias')),
+    normalized_url   TEXT NOT NULL,
+    PRIMARY KEY (address_book_id, url_role),
+    UNIQUE (account_id, normalized_url)
+);
+
 -- Participants (unified contacts across platforms)
 CREATE TABLE IF NOT EXISTS participants (
     id INTEGER PRIMARY KEY,
@@ -281,6 +355,96 @@ CREATE TABLE IF NOT EXISTS person_uid_aliases (
     surviving_person_id  INTEGER REFERENCES persons(id) ON DELETE SET NULL,
     reason               TEXT NOT NULL,
     created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Lossless remote CardDAV ledger. The href, not the remote UID, is the
+-- durable resource identity. Remote bytes remain available even when a
+-- lookup-only card is deliberately left unbound.
+CREATE TABLE IF NOT EXISTS carddav_resources (
+    id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+    address_book_id         INTEGER NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                    TEXT NOT NULL,
+    remote_uid              TEXT,
+    remote_etag             TEXT NOT NULL,
+    remote_body             BLOB NOT NULL,
+    remote_semantic_hash    TEXT NOT NULL,
+    local_hash              TEXT NOT NULL,
+    mapping_status          TEXT NOT NULL CHECK (mapping_status IN ('mapped', 'unbound', 'ambiguous')),
+    mapping_revision        INTEGER NOT NULL DEFAULT 1 CHECK (mapping_revision > 0),
+    governance              TEXT NOT NULL CHECK (governance IN ('remote', 'local', 'none')),
+    person_id               INTEGER REFERENCES persons(id) ON DELETE SET NULL,
+    person_revision_at_bind INTEGER,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (address_book_id, href)
+);
+
+-- Explicit publication state and the durable remote-first intent. The row
+-- exists before a create has a remote ledger object, so it cannot live only
+-- on carddav_resources. Nullable pending fields are cleared together after a
+-- canonical read proves the remote outcome.
+CREATE TABLE IF NOT EXISTS carddav_publications (
+    person_id                   INTEGER PRIMARY KEY REFERENCES persons(id) ON DELETE RESTRICT,
+    desired                     BOOLEAN NOT NULL DEFAULT TRUE,
+    address_book_id             INTEGER REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                        TEXT,
+    pending_operation           TEXT CHECK (pending_operation IN ('create', 'update', 'delete')),
+    outgoing_body               BLOB,
+    outgoing_semantic_hash      TEXT,
+    local_hash                  TEXT,
+    remote_etag                 TEXT,
+    connection_generation       INTEGER,
+    book_sync_revision          INTEGER,
+    mapping_revision            INTEGER,
+    previous_mapping_revision   INTEGER,
+    create_recovery_used        BOOLEAN NOT NULL DEFAULT FALSE,
+    mutation_revision           INTEGER NOT NULL DEFAULT 0 CHECK (mutation_revision >= 0),
+    pending_started_at          DATETIME,
+    created_at                  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK ((pending_operation IS NULL) OR
+           (address_book_id IS NOT NULL AND href IS NOT NULL AND
+            local_hash IS NOT NULL AND connection_generation IS NOT NULL AND
+            book_sync_revision IS NOT NULL AND mapping_revision IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_carddav_publications_pending
+    ON carddav_publications(pending_operation, person_id);
+
+-- Durable, bounded snapshots for CardDAV edit/edit and edit/delete conflicts.
+-- Resolved rows deliberately retain their book/href identity after a mapping
+-- is removed so the resolution remains auditable until the retention sweep.
+CREATE TABLE IF NOT EXISTS carddav_conflicts (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    address_book_id          INTEGER NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                     TEXT NOT NULL,
+    base_local_hash          TEXT NOT NULL,
+    local_hash               TEXT NOT NULL,
+    base_remote_hash         TEXT NOT NULL,
+    base_remote_etag         TEXT NOT NULL,
+    remote_etag              TEXT,
+    mapping_revision         INTEGER NOT NULL CHECK (mapping_revision > 0),
+    local_body               BLOB,
+    remote_body              BLOB,
+    local_tombstone          BOOLEAN NOT NULL DEFAULT FALSE,
+    remote_tombstone         BOOLEAN NOT NULL DEFAULT FALSE,
+    pending_operation        TEXT CHECK (pending_operation IN ('delete')),
+    connection_generation    INTEGER,
+    book_sync_revision       INTEGER,
+    previous_mapping_revision INTEGER,
+    pending_started_at       DATETIME,
+    status                   TEXT NOT NULL DEFAULT 'unresolved' CHECK (status IN ('unresolved', 'resolved')),
+    resolution               TEXT CHECK (resolution IN ('keep_local', 'keep_remote')),
+    resolved_at              DATETIME,
+    created_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (local_tombstone OR local_body IS NOT NULL),
+    CHECK (remote_tombstone OR remote_body IS NOT NULL),
+    CONSTRAINT carddav_conflicts_pending_invariant CHECK (pending_operation IS NULL OR
+           (status = 'unresolved' AND local_tombstone AND remote_etag IS NOT NULL AND
+            connection_generation IS NOT NULL AND book_sync_revision IS NOT NULL AND
+            previous_mapping_revision IS NOT NULL AND pending_started_at IS NOT NULL)),
+    CHECK ((status = 'unresolved' AND resolution IS NULL AND resolved_at IS NULL) OR
+           (status = 'resolved' AND resolution IS NOT NULL AND resolved_at IS NOT NULL))
 );
 CREATE INDEX IF NOT EXISTS idx_person_uid_aliases_survivor
     ON person_uid_aliases(surviving_person_id)

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -100,6 +100,76 @@ CREATE TABLE IF NOT EXISTS sources (
     UNIQUE(source_type, identifier)
 );
 
+-- One external CardDAV connection. Passwords remain in the private token file
+-- and are never persisted here.
+CREATE TABLE IF NOT EXISTS carddav_discovery_lock (
+    singleton SMALLINT PRIMARY KEY CHECK (singleton = 1)
+);
+INSERT INTO carddav_discovery_lock(singleton) VALUES (1) ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS carddav_accounts (
+    id                    SMALLINT PRIMARY KEY CHECK (id = 1),
+    base_url              TEXT NOT NULL,
+    username              TEXT NOT NULL,
+    principal_url         TEXT NOT NULL,
+    home_url              TEXT NOT NULL,
+    connection_generation BIGINT NOT NULL DEFAULT 1 CHECK (connection_generation > 0),
+    discovery_revision    BIGINT NOT NULL DEFAULT 0 CHECK (discovery_revision >= 0),
+    discovered_at         TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS carddav_account_home_urls (
+    account_id      SMALLINT NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    home_url        TEXT NOT NULL,
+    discovery_index INTEGER NOT NULL CHECK (discovery_index >= 0),
+    PRIMARY KEY (account_id, home_url),
+    UNIQUE (account_id, discovery_index)
+);
+
+CREATE TABLE IF NOT EXISTS carddav_retry_gate (
+    account_id     SMALLINT PRIMARY KEY REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    retry_after_at TIMESTAMPTZ NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS carddav_address_books (
+    id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    account_id               SMALLINT NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    canonical_url            TEXT NOT NULL,
+    discovery_alias_url      TEXT,
+    display_name             TEXT NOT NULL,
+    discovery_index          INTEGER NOT NULL CHECK (discovery_index >= 0),
+    supports_sync_collection BOOLEAN NOT NULL DEFAULT FALSE,
+    supports_multiget        BOOLEAN NOT NULL DEFAULT FALSE,
+    supported_vcard_versions JSONB NOT NULL DEFAULT '[]'::jsonb,
+    can_create               BOOLEAN,
+    can_update               BOOLEAN,
+    can_delete               BOOLEAN,
+    is_write_target          BOOLEAN NOT NULL DEFAULT FALSE,
+    is_subscribed            BOOLEAN NOT NULL DEFAULT FALSE,
+    is_lookup_source         BOOLEAN NOT NULL DEFAULT TRUE,
+    sync_token               TEXT NOT NULL DEFAULT '',
+    sync_revision            BIGINT NOT NULL DEFAULT 1 CHECK (sync_revision > 0),
+    needs_full_reconcile     BOOLEAN NOT NULL DEFAULT FALSE,
+    last_seen_revision       BIGINT NOT NULL CHECK (last_seen_revision >= 0),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (NOT is_write_target OR is_subscribed)
+);
+
+CREATE TABLE IF NOT EXISTS carddav_address_book_urls (
+    account_id       SMALLINT NOT NULL REFERENCES carddav_accounts(id) ON DELETE CASCADE,
+    address_book_id  BIGINT NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    url_role         TEXT NOT NULL CHECK (url_role IN ('canonical', 'alias')),
+    normalized_url   TEXT NOT NULL,
+    PRIMARY KEY (address_book_id, url_role),
+    UNIQUE (account_id, normalized_url)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_carddav_one_write_target
+    ON carddav_address_books(account_id) WHERE is_write_target = TRUE;
 CREATE TABLE IF NOT EXISTS participants (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     email_address TEXT,
@@ -268,6 +338,90 @@ CREATE TABLE IF NOT EXISTS person_uid_aliases (
     reason               TEXT NOT NULL,
     created_at           TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS carddav_resources (
+    id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    address_book_id         BIGINT NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                    TEXT NOT NULL,
+    remote_uid              TEXT,
+    remote_etag             TEXT NOT NULL,
+    remote_body             BYTEA NOT NULL,
+    remote_semantic_hash    TEXT NOT NULL,
+    local_hash              TEXT NOT NULL,
+    mapping_status          TEXT NOT NULL CHECK (mapping_status IN ('mapped', 'unbound', 'ambiguous')),
+    mapping_revision        BIGINT NOT NULL DEFAULT 1 CHECK (mapping_revision > 0),
+    governance              TEXT NOT NULL CHECK (governance IN ('remote', 'local', 'none')),
+    person_id               BIGINT REFERENCES persons(id) ON DELETE SET NULL,
+    person_revision_at_bind BIGINT,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (address_book_id, href)
+);
+CREATE TABLE IF NOT EXISTS carddav_publications (
+    person_id                   BIGINT PRIMARY KEY REFERENCES persons(id) ON DELETE RESTRICT,
+    desired                     BOOLEAN NOT NULL DEFAULT TRUE,
+    address_book_id             BIGINT REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                        TEXT,
+    pending_operation           TEXT CHECK (pending_operation IN ('create', 'update', 'delete')),
+    outgoing_body               BYTEA,
+    outgoing_semantic_hash      TEXT,
+    local_hash                  TEXT,
+    remote_etag                 TEXT,
+    connection_generation       BIGINT,
+    book_sync_revision          BIGINT,
+    mapping_revision            BIGINT,
+    previous_mapping_revision   BIGINT,
+    create_recovery_used        BOOLEAN NOT NULL DEFAULT FALSE,
+    mutation_revision           BIGINT NOT NULL DEFAULT 0 CHECK (mutation_revision >= 0),
+    pending_started_at          TIMESTAMPTZ,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK ((pending_operation IS NULL) OR
+           (address_book_id IS NOT NULL AND href IS NOT NULL AND
+            local_hash IS NOT NULL AND connection_generation IS NOT NULL AND
+            book_sync_revision IS NOT NULL AND mapping_revision IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_carddav_publications_pending
+    ON carddav_publications(pending_operation, person_id);
+CREATE TABLE IF NOT EXISTS carddav_conflicts (
+    id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    address_book_id          BIGINT NOT NULL REFERENCES carddav_address_books(id) ON DELETE CASCADE,
+    href                     TEXT NOT NULL,
+    base_local_hash          TEXT NOT NULL,
+    local_hash               TEXT NOT NULL,
+    base_remote_hash         TEXT NOT NULL,
+    base_remote_etag         TEXT NOT NULL,
+    remote_etag              TEXT,
+    mapping_revision         BIGINT NOT NULL CHECK (mapping_revision > 0),
+    local_body               BYTEA,
+    remote_body              BYTEA,
+    local_tombstone          BOOLEAN NOT NULL DEFAULT FALSE,
+    remote_tombstone         BOOLEAN NOT NULL DEFAULT FALSE,
+    pending_operation        TEXT CHECK (pending_operation IN ('delete')),
+    connection_generation    BIGINT,
+    book_sync_revision       BIGINT,
+    previous_mapping_revision BIGINT,
+    pending_started_at       TIMESTAMPTZ,
+    status                   TEXT NOT NULL DEFAULT 'unresolved' CHECK (status IN ('unresolved', 'resolved')),
+    resolution               TEXT CHECK (resolution IN ('keep_local', 'keep_remote')),
+    resolved_at              TIMESTAMPTZ,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (local_tombstone OR local_body IS NOT NULL),
+    CHECK (remote_tombstone OR remote_body IS NOT NULL),
+    CONSTRAINT carddav_conflicts_pending_invariant CHECK (pending_operation IS NULL OR
+           (status = 'unresolved' AND local_tombstone AND remote_etag IS NOT NULL AND
+            connection_generation IS NOT NULL AND book_sync_revision IS NOT NULL AND
+            previous_mapping_revision IS NOT NULL AND pending_started_at IS NOT NULL)),
+    CHECK ((status = 'unresolved' AND resolution IS NULL AND resolved_at IS NULL) OR
+           (status = 'resolved' AND resolution IS NOT NULL AND resolved_at IS NOT NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_carddav_one_unresolved_conflict
+    ON carddav_conflicts(address_book_id, href) WHERE status = 'unresolved';
+CREATE INDEX IF NOT EXISTS idx_carddav_conflicts_resolved_at
+    ON carddav_conflicts(status, resolved_at);
+CREATE INDEX IF NOT EXISTS idx_carddav_resources_person
+    ON carddav_resources(person_id) WHERE person_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_person_uid_aliases_survivor
     ON person_uid_aliases(surviving_person_id)
     WHERE surviving_person_id IS NOT NULL;

--- a/internal/store/schema_sqlite.sql
+++ b/internal/store/schema_sqlite.sql
@@ -5,6 +5,20 @@ CREATE TABLE IF NOT EXISTS archive_metadata (
     value TEXT NOT NULL
 );
 
+-- Role uniqueness is a SQLite partial index. CardDAV URL identity uniqueness
+-- lives in schema.sql's carddav_address_book_urls table so canonical and alias
+-- URLs cannot collide across columns.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_carddav_one_write_target
+    ON carddav_address_books(account_id) WHERE is_write_target = TRUE;
+CREATE INDEX IF NOT EXISTS idx_carddav_resources_person
+    ON carddav_resources(person_id) WHERE person_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_carddav_publications_pending
+    ON carddav_publications(pending_operation, person_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_carddav_one_unresolved_conflict
+    ON carddav_conflicts(address_book_id, href) WHERE status = 'unresolved';
+CREATE INDEX IF NOT EXISTS idx_carddav_conflicts_resolved_at
+    ON carddav_conflicts(status, resolved_at);
+
 -- Full-text search index for messages
 -- This is a standalone FTS table (not contentless) that stores its own copy
 -- of searchable text. Updates are managed via Store.upsert_fts().

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,7 +50,7 @@ type Store struct {
 	fts5Available bool // Whether FTS5 is available for full-text search
 	closeCleanup  func()
 
-	// Test-only seams into the migration and backfill paths, nil in
+	// Test-only seams into migration, backfill, and transaction paths, nil in
 	// production and settable only from export_test.go. They belong to the
 	// Store rather than the package because more than one Store can be
 	// migrating at once inside a single test binary — test fixtures build
@@ -58,11 +58,13 @@ type Store struct {
 	// never fire on another Store's migration. As package-level variables
 	// they were also a data race between a test that installs one and any
 	// concurrent migration that reads it.
-	initSchemaWindowHook             func()
-	attributeSeedReadHook            func(slug string)
-	contentChangedBackfillBatchHook  func(fromID, toID int64) error
-	backfillFTSBatchErrHook          func(fromID, toID int64) error
-	attachmentRoleRepairPreparedHook func()
+	initSchemaWindowHook                func()
+	attributeSeedReadHook               func(slug string)
+	contentChangedBackfillBatchHook     func(fromID, toID int64) error
+	backfillFTSBatchErrHook             func(fromID, toID int64) error
+	attachmentRoleRepairPreparedHook    func()
+	cardDAVConflictResolveSnapshotHook  func()
+	cardDAVTombstonePrepareSnapshotHook func()
 
 	// Zero means "use the production batch size"; see
 	// contentChangedBackfillBatch. Per-Store for the same reason.
@@ -387,7 +389,7 @@ func openPostgresDB(dbURL string, readOnly bool) (*sql.DB, func(), error) {
 
 	dsn := stdlib.RegisterConnConfig(connConfig)
 	cleanup := func() { stdlib.UnregisterConnConfig(dsn) }
-	db, err := sql.Open("pgx", dsn)
+	db, err := sql.Open(postgresDriverName, dsn)
 	if err != nil {
 		cleanup()
 		return nil, nil, fmt.Errorf("open PostgreSQL: %w", err)
@@ -498,7 +500,7 @@ func (s *Store) BackupDatabaseContext(ctx context.Context, dst string) (returnEr
 // Engine factories use this to choose between the SQLite and PostgreSQL
 // query paths.
 func (s *Store) IsPostgreSQL() bool {
-	return s.dialect.DriverName() == "pgx"
+	return s.dialect.DriverName() == postgresDriverName
 }
 
 // WithExclusiveLock executes fn while holding an exclusive write lock on the
@@ -1139,6 +1141,9 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 		} else if m.Desc == "last_modified" && !s.IsPostgreSQL() {
 			lastModifiedColumnAdded = true
 		}
+	}
+	if err := s.ensureCardDAVConflictPendingInvariant(ctx); err != nil {
+		return fmt.Errorf("migrate CardDAV conflict pending state: %w", err)
 	}
 	if err := s.ensureVCardSourceResourceIdentityIndexes(ctx); err != nil {
 		return fmt.Errorf("scope vCard identities to source resources: %w", err)

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -103,6 +103,50 @@ type ClientInterface interface {
 	EndBackupFreeze(ctx context.Context, options *EndBackupFreezeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EndBackupFreezeResponse, error)
 	EndBackupFreezeWithResponse(ctx context.Context, options *EndBackupFreezeRequestOptions, reqEditors ...runtime.RequestEditorFn) (*EndBackupFreezeResp, error)
 
+	// SaveCardDAVAccount Discover and save a CardDAV account
+	SaveCardDAVAccount(ctx context.Context, options *SaveCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SaveCardDAVAccountResponse, error)
+	SaveCardDAVAccountWithResponse(ctx context.Context, options *SaveCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SaveCardDAVAccountResp, error)
+
+	// TestCardDAVAccount Test a CardDAV account
+	TestCardDAVAccount(ctx context.Context, options *TestCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*TestCardDAVAccountResponse, error)
+	TestCardDAVAccountWithResponse(ctx context.Context, options *TestCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*TestCardDAVAccountResp, error)
+
+	// ListCardDAVBooks List CardDAV address books
+	ListCardDAVBooks(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVBooksResponse, error)
+	ListCardDAVBooksWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVBooksResp, error)
+
+	// UpdateCardDAVBookRoles Update CardDAV address book roles
+	UpdateCardDAVBookRoles(ctx context.Context, options *UpdateCardDAVBookRolesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCardDAVBookRolesResponse, error)
+	UpdateCardDAVBookRolesWithResponse(ctx context.Context, options *UpdateCardDAVBookRolesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCardDAVBookRolesResp, error)
+
+	// ListCardDAVConflicts List unresolved CardDAV conflicts
+	ListCardDAVConflicts(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVConflictsResponse, error)
+	ListCardDAVConflictsWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVConflictsResp, error)
+
+	// GetCardDAVConflict Inspect a CardDAV conflict
+	GetCardDAVConflict(ctx context.Context, options *GetCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVConflictResponse, error)
+	GetCardDAVConflictWithResponse(ctx context.Context, options *GetCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVConflictResp, error)
+
+	// ResolveCardDAVConflict Resolve a CardDAV conflict
+	ResolveCardDAVConflict(ctx context.Context, options *ResolveCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveCardDAVConflictResponse, error)
+	ResolveCardDAVConflictWithResponse(ctx context.Context, options *ResolveCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveCardDAVConflictResp, error)
+
+	// UnpublishCardDAVPerson Unpublish a person from CardDAV
+	UnpublishCardDAVPerson(ctx context.Context, options *UnpublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnpublishCardDAVPersonResponse, error)
+	UnpublishCardDAVPersonWithResponse(ctx context.Context, options *UnpublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnpublishCardDAVPersonResp, error)
+
+	// GetCardDAVPublication Get CardDAV publication state
+	GetCardDAVPublication(ctx context.Context, options *GetCardDAVPublicationRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVPublicationResponse, error)
+	GetCardDAVPublicationWithResponse(ctx context.Context, options *GetCardDAVPublicationRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVPublicationResp, error)
+
+	// PublishCardDAVPerson Publish a person to CardDAV
+	PublishCardDAVPerson(ctx context.Context, options *PublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PublishCardDAVPersonResponse, error)
+	PublishCardDAVPersonWithResponse(ctx context.Context, options *PublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PublishCardDAVPersonResp, error)
+
+	// SyncCardDAV Trigger CardDAV synchronization
+	SyncCardDAV(ctx context.Context, options *SyncCardDAVRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SyncCardDAVResponse, error)
+	SyncCardDAVWithResponse(ctx context.Context, options *SyncCardDAVRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SyncCardDAVResp, error)
+
 	// UpdateCLIAccount Update an account for CLI use
 	UpdateCLIAccount(ctx context.Context, options *UpdateCLIAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCLIAccountResponse, error)
 	UpdateCLIAccountWithResponse(ctx context.Context, options *UpdateCLIAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCLIAccountResp, error)
@@ -1873,6 +1917,702 @@ func (c *Client) EndBackupFreeze(ctx context.Context, options *EndBackupFreezeRe
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/backup/freeze/end")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SaveCardDAVAccount Discover and save a CardDAV account
+func (c *Client) SaveCardDAVAccount(ctx context.Context, options *SaveCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SaveCardDAVAccountResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/account",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SaveCardDAVAccountResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SaveCardDAVAccountErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SaveCardDAVAccountErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SaveCardDAVAccountResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SaveCardDAVAccountResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/account")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// TestCardDAVAccount Test a CardDAV account
+func (c *Client) TestCardDAVAccount(ctx context.Context, options *TestCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*TestCardDAVAccountResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/account/test",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*TestCardDAVAccountResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(TestCardDAVAccountErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "TestCardDAVAccountErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(TestCardDAVAccountResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "TestCardDAVAccountResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/account/test")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListCardDAVBooks List CardDAV address books
+func (c *Client) ListCardDAVBooks(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVBooksResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/books",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListCardDAVBooksResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListCardDAVBooksErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListCardDAVBooksErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListCardDAVBooksResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListCardDAVBooksResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/books")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// UpdateCardDAVBookRoles Update CardDAV address book roles
+func (c *Client) UpdateCardDAVBookRoles(ctx context.Context, options *UpdateCardDAVBookRolesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCardDAVBookRolesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/books/{id}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*UpdateCardDAVBookRolesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(UpdateCardDAVBookRolesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UpdateCardDAVBookRolesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(UpdateCardDAVBookRolesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UpdateCardDAVBookRolesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/books/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ListCardDAVConflicts List unresolved CardDAV conflicts
+func (c *Client) ListCardDAVConflicts(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVConflictsResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ListCardDAVConflictsResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ListCardDAVConflictsErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ListCardDAVConflictsErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ListCardDAVConflictsResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ListCardDAVConflictsResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetCardDAVConflict Inspect a CardDAV conflict
+func (c *Client) GetCardDAVConflict(ctx context.Context, options *GetCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVConflictResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts/{id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetCardDAVConflictResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetCardDAVConflictErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetCardDAVConflictErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetCardDAVConflictResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetCardDAVConflictResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// ResolveCardDAVConflict Resolve a CardDAV conflict
+func (c *Client) ResolveCardDAVConflict(ctx context.Context, options *ResolveCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveCardDAVConflictResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts/{id}/resolve",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*ResolveCardDAVConflictResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(ResolveCardDAVConflictErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "ResolveCardDAVConflictErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(ResolveCardDAVConflictResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "ResolveCardDAVConflictResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts/{id}/resolve")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// UnpublishCardDAVPerson Unpublish a person from CardDAV
+func (c *Client) UnpublishCardDAVPerson(ctx context.Context, options *UnpublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnpublishCardDAVPersonResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*UnpublishCardDAVPersonResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(UnpublishCardDAVPersonErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "UnpublishCardDAVPersonErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(UnpublishCardDAVPersonResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "UnpublishCardDAVPersonResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetCardDAVPublication Get CardDAV publication state
+func (c *Client) GetCardDAVPublication(ctx context.Context, options *GetCardDAVPublicationRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVPublicationResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetCardDAVPublicationResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetCardDAVPublicationErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetCardDAVPublicationErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetCardDAVPublicationResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetCardDAVPublicationResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// PublishCardDAVPerson Publish a person to CardDAV
+func (c *Client) PublishCardDAVPerson(ctx context.Context, options *PublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PublishCardDAVPersonResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "POST",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*PublishCardDAVPersonResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(PublishCardDAVPersonErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "PublishCardDAVPersonErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(PublishCardDAVPersonResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "PublishCardDAVPersonResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SyncCardDAV Trigger CardDAV synchronization
+func (c *Client) SyncCardDAV(ctx context.Context, options *SyncCardDAVRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SyncCardDAVResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/sync",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SyncCardDAVResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SyncCardDAVErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SyncCardDAVErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SyncCardDAVResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SyncCardDAVResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/sync")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -614,6 +614,420 @@ func (o *EndBackupFreezeRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// SaveCardDAVAccountRequestOptions is the options needed to make a request to SaveCardDAVAccount.
+type SaveCardDAVAccountRequestOptions struct {
+	Body *SaveCardDAVAccountBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SaveCardDAVAccountRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SaveCardDAVAccountRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *SaveCardDAVAccountRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SaveCardDAVAccountRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SaveCardDAVAccountRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// TestCardDAVAccountRequestOptions is the options needed to make a request to TestCardDAVAccount.
+type TestCardDAVAccountRequestOptions struct {
+	Body *TestCardDAVAccountBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *TestCardDAVAccountRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *TestCardDAVAccountRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *TestCardDAVAccountRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *TestCardDAVAccountRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *TestCardDAVAccountRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// UpdateCardDAVBookRolesRequestOptions is the options needed to make a request to UpdateCardDAVBookRoles.
+type UpdateCardDAVBookRolesRequestOptions struct {
+	PathParams *UpdateCardDAVBookRolesPath
+	Body       *UpdateCardDAVBookRolesBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *UpdateCardDAVBookRolesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *UpdateCardDAVBookRolesRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *UpdateCardDAVBookRolesRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *UpdateCardDAVBookRolesRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *UpdateCardDAVBookRolesRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetCardDAVConflictRequestOptions is the options needed to make a request to GetCardDAVConflict.
+type GetCardDAVConflictRequestOptions struct {
+	PathParams *GetCardDAVConflictPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetCardDAVConflictRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetCardDAVConflictRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetCardDAVConflictRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetCardDAVConflictRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetCardDAVConflictRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// ResolveCardDAVConflictRequestOptions is the options needed to make a request to ResolveCardDAVConflict.
+type ResolveCardDAVConflictRequestOptions struct {
+	PathParams *ResolveCardDAVConflictPath
+	Body       *ResolveCardDAVConflictBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *ResolveCardDAVConflictRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *ResolveCardDAVConflictRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *ResolveCardDAVConflictRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *ResolveCardDAVConflictRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *ResolveCardDAVConflictRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// UnpublishCardDAVPersonRequestOptions is the options needed to make a request to UnpublishCardDAVPerson.
+type UnpublishCardDAVPersonRequestOptions struct {
+	PathParams *UnpublishCardDAVPersonPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *UnpublishCardDAVPersonRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *UnpublishCardDAVPersonRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *UnpublishCardDAVPersonRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *UnpublishCardDAVPersonRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *UnpublishCardDAVPersonRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetCardDAVPublicationRequestOptions is the options needed to make a request to GetCardDAVPublication.
+type GetCardDAVPublicationRequestOptions struct {
+	PathParams *GetCardDAVPublicationPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetCardDAVPublicationRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetCardDAVPublicationRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetCardDAVPublicationRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetCardDAVPublicationRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetCardDAVPublicationRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// PublishCardDAVPersonRequestOptions is the options needed to make a request to PublishCardDAVPerson.
+type PublishCardDAVPersonRequestOptions struct {
+	PathParams *PublishCardDAVPersonPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *PublishCardDAVPersonRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *PublishCardDAVPersonRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *PublishCardDAVPersonRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *PublishCardDAVPersonRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *PublishCardDAVPersonRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// SyncCardDAVRequestOptions is the options needed to make a request to SyncCardDAV.
+type SyncCardDAVRequestOptions struct {
+	Body *SyncCardDAVBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SyncCardDAVRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SyncCardDAVRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *SyncCardDAVRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SyncCardDAVRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SyncCardDAVRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // UpdateCLIAccountRequestOptions is the options needed to make a request to UpdateCLIAccount.
 type UpdateCLIAccountRequestOptions struct {
 	Body *UpdateCLIAccountBody

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -1214,6 +1214,1343 @@ func (c *Client) EndBackupFreezeWithResponse(ctx context.Context, options *EndBa
 	}
 }
 
+// SaveCardDAVAccount Discover and save a CardDAV account
+func (c *Client) SaveCardDAVAccountWithResponse(ctx context.Context, options *SaveCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SaveCardDAVAccountResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/account",
+		Method:      "PUT",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/account")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SaveCardDAVAccountResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SaveCardDAVAccountResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(SaveCardDAVAccountErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SaveCardDAVAccountErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(SaveCardDAVAccountErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(SaveCardDAVAccountErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(SaveCardDAVAccountErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SaveCardDAVAccountErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &SaveCardDAVAccountResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// TestCardDAVAccount Test a CardDAV account
+func (c *Client) TestCardDAVAccountWithResponse(ctx context.Context, options *TestCardDAVAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*TestCardDAVAccountResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/account/test",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/account/test")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &TestCardDAVAccountResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(TestCardDAVAccountResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "TestCardDAVAccountResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(TestCardDAVAccountErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "TestCardDAVAccountErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(TestCardDAVAccountErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "TestCardDAVAccountErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(TestCardDAVAccountErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "TestCardDAVAccountErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(TestCardDAVAccountErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "TestCardDAVAccountErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &TestCardDAVAccountResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ListCardDAVBooks List CardDAV address books
+func (c *Client) ListCardDAVBooksWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVBooksResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/books",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/books")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListCardDAVBooksResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListCardDAVBooksResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVBooksResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		out.JSON500 = new(ListCardDAVBooksErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVBooksErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ListCardDAVBooksErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVBooksErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &ListCardDAVBooksResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// UpdateCardDAVBookRoles Update CardDAV address book roles
+func (c *Client) UpdateCardDAVBookRolesWithResponse(ctx context.Context, options *UpdateCardDAVBookRolesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCardDAVBookRolesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/books/{id}",
+		Method:      "PATCH",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/books/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &UpdateCardDAVBookRolesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(UpdateCardDAVBookRolesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(UpdateCardDAVBookRolesErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(UpdateCardDAVBookRolesErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(UpdateCardDAVBookRolesErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(UpdateCardDAVBookRolesErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(UpdateCardDAVBookRolesErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UpdateCardDAVBookRolesErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &UpdateCardDAVBookRolesResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ListCardDAVConflicts List unresolved CardDAV conflicts
+func (c *Client) ListCardDAVConflictsWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*ListCardDAVConflictsResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts",
+		Method:     "GET",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ListCardDAVConflictsResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ListCardDAVConflictsResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVConflictsResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 500:
+		out.JSON500 = new(ListCardDAVConflictsErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVConflictsErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ListCardDAVConflictsErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ListCardDAVConflictsErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &ListCardDAVConflictsResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// GetCardDAVConflict Inspect a CardDAV conflict
+func (c *Client) GetCardDAVConflictWithResponse(ctx context.Context, options *GetCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVConflictResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts/{id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts/{id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetCardDAVConflictResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetCardDAVConflictResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVConflictResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(GetCardDAVConflictErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVConflictErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(GetCardDAVConflictErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVConflictErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(GetCardDAVConflictErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVConflictErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(GetCardDAVConflictErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVConflictErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &GetCardDAVConflictResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// ResolveCardDAVConflict Resolve a CardDAV conflict
+func (c *Client) ResolveCardDAVConflictWithResponse(ctx context.Context, options *ResolveCardDAVConflictRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ResolveCardDAVConflictResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/conflicts/{id}/resolve",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/conflicts/{id}/resolve")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &ResolveCardDAVConflictResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(ResolveCardDAVConflictResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(ResolveCardDAVConflictErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(ResolveCardDAVConflictErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(ResolveCardDAVConflictErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(ResolveCardDAVConflictErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(ResolveCardDAVConflictErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(ResolveCardDAVConflictErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "ResolveCardDAVConflictErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &ResolveCardDAVConflictResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// UnpublishCardDAVPerson Unpublish a person from CardDAV
+func (c *Client) UnpublishCardDAVPersonWithResponse(ctx context.Context, options *UnpublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UnpublishCardDAVPersonResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "DELETE",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &UnpublishCardDAVPersonResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(UnpublishCardDAVPersonResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(UnpublishCardDAVPersonErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(UnpublishCardDAVPersonErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(UnpublishCardDAVPersonErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(UnpublishCardDAVPersonErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(UnpublishCardDAVPersonErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(UnpublishCardDAVPersonErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "UnpublishCardDAVPersonErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &UnpublishCardDAVPersonResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// GetCardDAVPublication Get CardDAV publication state
+func (c *Client) GetCardDAVPublicationWithResponse(ctx context.Context, options *GetCardDAVPublicationRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetCardDAVPublicationResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetCardDAVPublicationResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetCardDAVPublicationResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVPublicationResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(GetCardDAVPublicationErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVPublicationErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(GetCardDAVPublicationErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVPublicationErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(GetCardDAVPublicationErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVPublicationErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(GetCardDAVPublicationErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetCardDAVPublicationErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &GetCardDAVPublicationResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// PublishCardDAVPerson Publish a person to CardDAV
+func (c *Client) PublishCardDAVPersonWithResponse(ctx context.Context, options *PublishCardDAVPersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*PublishCardDAVPersonResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/carddav/publications/{person_id}",
+		Method:     "POST",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/publications/{person_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &PublishCardDAVPersonResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(PublishCardDAVPersonResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(PublishCardDAVPersonErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(PublishCardDAVPersonErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(PublishCardDAVPersonErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(PublishCardDAVPersonErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(PublishCardDAVPersonErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(PublishCardDAVPersonErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "PublishCardDAVPersonErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &PublishCardDAVPersonResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// SyncCardDAV Trigger CardDAV synchronization
+func (c *Client) SyncCardDAVWithResponse(ctx context.Context, options *SyncCardDAVRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SyncCardDAVResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/carddav/sync",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/carddav/sync")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SyncCardDAVResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SyncCardDAVResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(SyncCardDAVErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SyncCardDAVErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(SyncCardDAVErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 502:
+		out.JSON502 = new(SyncCardDAVErrorResponseJSON502)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON502); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVErrorResponseJSON502",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(SyncCardDAVErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SyncCardDAVErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		out.Headers503 = &SyncCardDAVResp503Headers{
+			RetryAfter: resp.Headers.Get("Retry-After"),
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // UpdateCLIAccount Update an account for CLI use
 func (c *Client) UpdateCLIAccountWithResponse(ctx context.Context, options *UpdateCLIAccountRequestOptions, reqEditors ...runtime.RequestEditorFn) (*UpdateCLIAccountResp, error) {
 	var err error

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -43,6 +43,23 @@ func (c CandidateClassification) Validate() error {
 	}
 }
 
+type CardDAVResolveRequestChoice string
+
+const (
+	KeepLocal  CardDAVResolveRequestChoice = "keep_local"
+	KeepRemote CardDAVResolveRequestChoice = "keep_remote"
+)
+
+// Validate checks if the CardDAVResolveRequestChoice value is valid
+func (c CardDAVResolveRequestChoice) Validate() error {
+	switch c {
+	case KeepLocal, KeepRemote:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid CardDAVResolveRequestChoice value, got: %v", c))
+	}
+}
+
 type CreateAttributeDefinitionRequestCardinality string
 
 const (

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -44,6 +44,54 @@ func (u UploadTokenPath) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(u))
 }
 
+type UpdateCardDAVBookRolesPath struct {
+	ID int64 `json:"id" validate:"gte=1"`
+}
+
+func (u UpdateCardDAVBookRolesPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(u))
+}
+
+type GetCardDAVConflictPath struct {
+	ID int64 `json:"id" validate:"gte=1"`
+}
+
+func (g GetCardDAVConflictPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
+type ResolveCardDAVConflictPath struct {
+	ID int64 `json:"id" validate:"gte=1"`
+}
+
+func (r ResolveCardDAVConflictPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(r))
+}
+
+type UnpublishCardDAVPersonPath struct {
+	PersonID int64 `json:"person_id" validate:"gte=1"`
+}
+
+func (u UnpublishCardDAVPersonPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(u))
+}
+
+type GetCardDAVPublicationPath struct {
+	PersonID int64 `json:"person_id" validate:"gte=1"`
+}
+
+func (g GetCardDAVPublicationPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
+type PublishCardDAVPersonPath struct {
+	PersonID int64 `json:"person_id" validate:"gte=1"`
+}
+
+func (p PublishCardDAVPersonPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
 type DeleteCLICollectionPath struct {
 	// Name Collection name
 	Name string `json:"name" validate:"required"`

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -14,6 +14,16 @@ type UploadTokenBody = TokenUploadRequest
 
 type EndBackupFreezeBody = BackupFreezeEndRequest
 
+type SaveCardDAVAccountBody = CardDAVAccountRequest
+
+type TestCardDAVAccountBody = CardDAVAccountRequest
+
+type UpdateCardDAVBookRolesBody = CardDAVBookRolesRequest
+
+type ResolveCardDAVConflictBody = CardDAVResolveRequest
+
+type SyncCardDAVBody = CardDAVSyncRequest
+
 type UpdateCLIAccountBody = UpdateRequest
 
 type PlanCLIAddCalendarBody = CLIAddCalendarPlanRequest

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -111,6 +111,126 @@ type EndBackupFreezeResponse = BackupFreezeEndResponse
 
 type EndBackupFreezeErrorResponse = ErrorResponse
 
+type SaveCardDAVAccountResponse = CardDAVAccountResponse
+
+type SaveCardDAVAccountErrorResponse = ErrorResponse
+
+type SaveCardDAVAccountErrorResponseJSON = ErrorResponse
+
+type SaveCardDAVAccountErrorResponseJSON500 = ErrorResponse
+
+type SaveCardDAVAccountErrorResponseJSON502 = ErrorResponse
+
+type SaveCardDAVAccountErrorResponseJSON503 = ErrorResponse
+
+type TestCardDAVAccountResponse = CardDAVAccountResponse
+
+type TestCardDAVAccountErrorResponse = ErrorResponse
+
+type TestCardDAVAccountErrorResponseJSON = ErrorResponse
+
+type TestCardDAVAccountErrorResponseJSON502 = ErrorResponse
+
+type TestCardDAVAccountErrorResponseJSON503 = ErrorResponse
+
+type ListCardDAVBooksResponse = CardDAVBooksResponse
+
+type ListCardDAVBooksErrorResponse = ErrorResponse
+
+type ListCardDAVBooksErrorResponseJSON = ErrorResponse
+
+type UpdateCardDAVBookRolesResponse = CardDAVBookResponse
+
+type UpdateCardDAVBookRolesErrorResponse = ErrorResponse
+
+type UpdateCardDAVBookRolesErrorResponseJSON = ErrorResponse
+
+type UpdateCardDAVBookRolesErrorResponseJSON409 = ErrorResponse
+
+type UpdateCardDAVBookRolesErrorResponseJSON500 = ErrorResponse
+
+type UpdateCardDAVBookRolesErrorResponseJSON503 = ErrorResponse
+
+type ListCardDAVConflictsResponse = CardDAVConflictsResponse
+
+type ListCardDAVConflictsErrorResponse = ErrorResponse
+
+type ListCardDAVConflictsErrorResponseJSON = ErrorResponse
+
+type GetCardDAVConflictResponse = CardDAVConflictDetailResponse
+
+type GetCardDAVConflictErrorResponse = ErrorResponse
+
+type GetCardDAVConflictErrorResponseJSON = ErrorResponse
+
+type GetCardDAVConflictErrorResponseJSON500 = ErrorResponse
+
+type GetCardDAVConflictErrorResponseJSON503 = ErrorResponse
+
+type ResolveCardDAVConflictResponse = CardDAVConflictResolutionResponse
+
+type ResolveCardDAVConflictErrorResponse = ErrorResponse
+
+type ResolveCardDAVConflictErrorResponseJSON = ErrorResponse
+
+type ResolveCardDAVConflictErrorResponseJSON409 = ErrorResponse
+
+type ResolveCardDAVConflictErrorResponseJSON500 = ErrorResponse
+
+type ResolveCardDAVConflictErrorResponseJSON502 = ErrorResponse
+
+type ResolveCardDAVConflictErrorResponseJSON503 = ErrorResponse
+
+type UnpublishCardDAVPersonResponse = CardDAVPublicationResponse
+
+type UnpublishCardDAVPersonErrorResponse = ErrorResponse
+
+type UnpublishCardDAVPersonErrorResponseJSON = ErrorResponse
+
+type UnpublishCardDAVPersonErrorResponseJSON409 = ErrorResponse
+
+type UnpublishCardDAVPersonErrorResponseJSON500 = ErrorResponse
+
+type UnpublishCardDAVPersonErrorResponseJSON502 = ErrorResponse
+
+type UnpublishCardDAVPersonErrorResponseJSON503 = ErrorResponse
+
+type GetCardDAVPublicationResponse = CardDAVPublicationResponse
+
+type GetCardDAVPublicationErrorResponse = ErrorResponse
+
+type GetCardDAVPublicationErrorResponseJSON = ErrorResponse
+
+type GetCardDAVPublicationErrorResponseJSON500 = ErrorResponse
+
+type GetCardDAVPublicationErrorResponseJSON503 = ErrorResponse
+
+type PublishCardDAVPersonResponse = CardDAVPublicationResponse
+
+type PublishCardDAVPersonErrorResponse = ErrorResponse
+
+type PublishCardDAVPersonErrorResponseJSON = ErrorResponse
+
+type PublishCardDAVPersonErrorResponseJSON409 = ErrorResponse
+
+type PublishCardDAVPersonErrorResponseJSON500 = ErrorResponse
+
+type PublishCardDAVPersonErrorResponseJSON502 = ErrorResponse
+
+type PublishCardDAVPersonErrorResponseJSON503 = ErrorResponse
+
+type SyncCardDAVResponse = SyncResult
+
+type SyncCardDAVErrorResponse = ErrorResponse
+
+type SyncCardDAVErrorResponseJSON = ErrorResponse
+
+type SyncCardDAVErrorResponseJSON500 = ErrorResponse
+
+type SyncCardDAVErrorResponseJSON502 = ErrorResponse
+
+type SyncCardDAVErrorResponseJSON503 = ErrorResponse
+
 type UpdateCLIAccountResponse = UpdateResult
 
 type UpdateCLIAccountErrorResponse = APIHTTPError
@@ -2334,6 +2454,187 @@ type EndBackupFreezeResp struct {
 	Body         []byte
 	StatusCode   int
 	JSON200      *EndBackupFreezeResponse
+}
+
+type SaveCardDAVAccountResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type SaveCardDAVAccountResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SaveCardDAVAccountResponse
+	JSON400      *SaveCardDAVAccountErrorResponse
+	JSON409      *SaveCardDAVAccountErrorResponseJSON
+	JSON500      *SaveCardDAVAccountErrorResponseJSON500
+	JSON502      *SaveCardDAVAccountErrorResponseJSON502
+	JSON503      *SaveCardDAVAccountErrorResponseJSON503
+	Headers503   *SaveCardDAVAccountResp503Headers
+}
+
+type TestCardDAVAccountResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type TestCardDAVAccountResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *TestCardDAVAccountResponse
+	JSON400      *TestCardDAVAccountErrorResponse
+	JSON500      *TestCardDAVAccountErrorResponseJSON
+	JSON502      *TestCardDAVAccountErrorResponseJSON502
+	JSON503      *TestCardDAVAccountErrorResponseJSON503
+	Headers503   *TestCardDAVAccountResp503Headers
+}
+
+type ListCardDAVBooksResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type ListCardDAVBooksResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListCardDAVBooksResponse
+	JSON500      *ListCardDAVBooksErrorResponse
+	JSON503      *ListCardDAVBooksErrorResponseJSON
+	Headers503   *ListCardDAVBooksResp503Headers
+}
+
+type UpdateCardDAVBookRolesResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type UpdateCardDAVBookRolesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *UpdateCardDAVBookRolesResponse
+	JSON400      *UpdateCardDAVBookRolesErrorResponse
+	JSON404      *UpdateCardDAVBookRolesErrorResponseJSON
+	JSON409      *UpdateCardDAVBookRolesErrorResponseJSON409
+	JSON500      *UpdateCardDAVBookRolesErrorResponseJSON500
+	JSON503      *UpdateCardDAVBookRolesErrorResponseJSON503
+	Headers503   *UpdateCardDAVBookRolesResp503Headers
+}
+
+type ListCardDAVConflictsResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type ListCardDAVConflictsResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ListCardDAVConflictsResponse
+	JSON500      *ListCardDAVConflictsErrorResponse
+	JSON503      *ListCardDAVConflictsErrorResponseJSON
+	Headers503   *ListCardDAVConflictsResp503Headers
+}
+
+type GetCardDAVConflictResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type GetCardDAVConflictResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetCardDAVConflictResponse
+	JSON400      *GetCardDAVConflictErrorResponse
+	JSON404      *GetCardDAVConflictErrorResponseJSON
+	JSON500      *GetCardDAVConflictErrorResponseJSON500
+	JSON503      *GetCardDAVConflictErrorResponseJSON503
+	Headers503   *GetCardDAVConflictResp503Headers
+}
+
+type ResolveCardDAVConflictResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type ResolveCardDAVConflictResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *ResolveCardDAVConflictResponse
+	JSON400      *ResolveCardDAVConflictErrorResponse
+	JSON404      *ResolveCardDAVConflictErrorResponseJSON
+	JSON409      *ResolveCardDAVConflictErrorResponseJSON409
+	JSON500      *ResolveCardDAVConflictErrorResponseJSON500
+	JSON502      *ResolveCardDAVConflictErrorResponseJSON502
+	JSON503      *ResolveCardDAVConflictErrorResponseJSON503
+	Headers503   *ResolveCardDAVConflictResp503Headers
+}
+
+type UnpublishCardDAVPersonResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type UnpublishCardDAVPersonResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *UnpublishCardDAVPersonResponse
+	JSON400      *UnpublishCardDAVPersonErrorResponse
+	JSON404      *UnpublishCardDAVPersonErrorResponseJSON
+	JSON409      *UnpublishCardDAVPersonErrorResponseJSON409
+	JSON500      *UnpublishCardDAVPersonErrorResponseJSON500
+	JSON502      *UnpublishCardDAVPersonErrorResponseJSON502
+	JSON503      *UnpublishCardDAVPersonErrorResponseJSON503
+	Headers503   *UnpublishCardDAVPersonResp503Headers
+}
+
+type GetCardDAVPublicationResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type GetCardDAVPublicationResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetCardDAVPublicationResponse
+	JSON400      *GetCardDAVPublicationErrorResponse
+	JSON404      *GetCardDAVPublicationErrorResponseJSON
+	JSON500      *GetCardDAVPublicationErrorResponseJSON500
+	JSON503      *GetCardDAVPublicationErrorResponseJSON503
+	Headers503   *GetCardDAVPublicationResp503Headers
+}
+
+type PublishCardDAVPersonResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type PublishCardDAVPersonResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *PublishCardDAVPersonResponse
+	JSON400      *PublishCardDAVPersonErrorResponse
+	JSON404      *PublishCardDAVPersonErrorResponseJSON
+	JSON409      *PublishCardDAVPersonErrorResponseJSON409
+	JSON500      *PublishCardDAVPersonErrorResponseJSON500
+	JSON502      *PublishCardDAVPersonErrorResponseJSON502
+	JSON503      *PublishCardDAVPersonErrorResponseJSON503
+	Headers503   *PublishCardDAVPersonResp503Headers
+}
+
+type SyncCardDAVResp503Headers struct {
+	RetryAfter string `header:"Retry-After"`
+}
+
+type SyncCardDAVResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SyncCardDAVResponse
+	JSON400      *SyncCardDAVErrorResponse
+	JSON409      *SyncCardDAVErrorResponseJSON
+	JSON500      *SyncCardDAVErrorResponseJSON500
+	JSON502      *SyncCardDAVErrorResponseJSON502
+	JSON503      *SyncCardDAVErrorResponseJSON503
+	Headers503   *SyncCardDAVResp503Headers
 }
 
 type UpdateCLIAccountResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -766,6 +766,153 @@ func (c Candidate) Validate() error {
 	return errors
 }
 
+type CardDAVAccountRequest struct {
+	BaseURL  string  `json:"base_url" validate:"required"`
+	Enabled  bool    `json:"enabled"`
+	Password *string `json:"password,omitempty"`
+	Schedule *string `json:"schedule,omitempty"`
+	Username string  `json:"username" validate:"required"`
+}
+
+func (c CardDAVAccountRequest) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVAccountResponse struct {
+	BaseURL  string  `json:"base_url" validate:"required"`
+	Books    int64   `json:"books"`
+	Enabled  bool    `json:"enabled"`
+	Schedule *string `json:"schedule,omitempty"`
+	Username string  `json:"username" validate:"required"`
+}
+
+func (c CardDAVAccountResponse) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVBookResponse struct {
+	ID                 int64  `json:"id"`
+	LookupSource       bool   `json:"lookup_source"`
+	Name               string `json:"name" validate:"required"`
+	NeedsFullReconcile bool   `json:"needs_full_reconcile"`
+	Subscribed         bool   `json:"subscribed"`
+	URL                string `json:"url" validate:"required"`
+	WriteTarget        bool   `json:"write_target"`
+}
+
+func (c CardDAVBookResponse) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVBookRolesRequest struct {
+	LookupSource bool `json:"lookup_source"`
+	Subscribed   bool `json:"subscribed"`
+	WriteTarget  bool `json:"write_target"`
+}
+
+type CardDAVBooksResponse struct {
+	Books []CardDAVBookResponse `json:"books,omitempty" validate:"required"`
+}
+
+func (c CardDAVBooksResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range c.Books {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Books[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type CardDAVConflictDetailResponse struct {
+	AddressBookID   int64   `json:"address_book_id"`
+	Href            string  `json:"href" validate:"required"`
+	ID              int64   `json:"id"`
+	LocalTombstone  bool    `json:"local_tombstone"`
+	LocalVcard      *string `json:"local_vcard,omitempty"`
+	RemoteTombstone bool    `json:"remote_tombstone"`
+	RemoteVcard     *string `json:"remote_vcard,omitempty"`
+	Status          string  `json:"status" validate:"required"`
+}
+
+func (c CardDAVConflictDetailResponse) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVConflictResolutionResponse struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status" validate:"required"`
+}
+
+func (c CardDAVConflictResolutionResponse) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVConflictResponse struct {
+	AddressBookID   int64  `json:"address_book_id"`
+	Href            string `json:"href" validate:"required"`
+	ID              int64  `json:"id"`
+	LocalTombstone  bool   `json:"local_tombstone"`
+	RemoteTombstone bool   `json:"remote_tombstone"`
+	Status          string `json:"status" validate:"required"`
+}
+
+func (c CardDAVConflictResponse) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CardDAVConflictsResponse struct {
+	Conflicts []CardDAVConflictResponse `json:"conflicts,omitempty" validate:"required"`
+}
+
+func (c CardDAVConflictsResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range c.Conflicts {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Conflicts[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type CardDAVPublicationResponse struct {
+	Desired          bool    `json:"desired"`
+	Href             *string `json:"href,omitempty"`
+	PendingOperation *string `json:"pending_operation,omitempty"`
+	PersonID         int64   `json:"person_id"`
+}
+
+type CardDAVResolveRequest struct {
+	Choice CardDAVResolveRequestChoice `json:"choice" validate:"required"`
+}
+
+func (c CardDAVResolveRequest) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(c.Choice).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Choice", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type CardDAVSyncRequest struct {
+	Full *bool `json:"full,omitempty"`
+}
+
 type ChangedMessageJSON struct {
 	AttachmentCount     int64      `json:"attachment_count"`
 	ContentChangedAt    time.Time  `json:"content_changed_at" validate:"required"`
@@ -7779,6 +7926,13 @@ func (s Summary) Validate() error {
 		return nil
 	}
 	return errors
+}
+
+type SyncResult struct {
+	Books   int64 `json:"books"`
+	Created int64 `json:"created"`
+	Removed int64 `json:"removed"`
+	Updated int64 `json:"updated"`
 }
 
 type SyncRunItemStatus struct {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -930,6 +930,199 @@ components:
         - first_seen_at
         - last_seen_at
       type: object
+    CardDAVAccountRequest:
+      additionalProperties: false
+      properties:
+        base_url:
+          type: string
+        enabled:
+          type: boolean
+        password:
+          type: string
+          writeOnly: true
+        schedule:
+          type: string
+        username:
+          type: string
+      required:
+        - base_url
+        - username
+        - enabled
+      type: object
+    CardDAVAccountResponse:
+      properties:
+        base_url:
+          type: string
+        books:
+          format: int64
+          type: integer
+        enabled:
+          type: boolean
+        schedule:
+          type: string
+        username:
+          type: string
+      required:
+        - base_url
+        - username
+        - enabled
+        - books
+      type: object
+    CardDAVBookResponse:
+      properties:
+        id:
+          format: int64
+          type: integer
+        lookup_source:
+          type: boolean
+        name:
+          type: string
+        needs_full_reconcile:
+          type: boolean
+        subscribed:
+          type: boolean
+        url:
+          type: string
+        write_target:
+          type: boolean
+      required:
+        - id
+        - name
+        - url
+        - write_target
+        - subscribed
+        - lookup_source
+        - needs_full_reconcile
+      type: object
+    CardDAVBookRolesRequest:
+      additionalProperties: false
+      properties:
+        lookup_source:
+          type: boolean
+        subscribed:
+          type: boolean
+        write_target:
+          type: boolean
+      required:
+        - write_target
+        - subscribed
+        - lookup_source
+      type: object
+    CardDAVBooksResponse:
+      properties:
+        books:
+          items:
+            $ref: "#/components/schemas/CardDAVBookResponse"
+          nullable: true
+          type: array
+      required:
+        - books
+      type: object
+    CardDAVConflictDetailResponse:
+      properties:
+        address_book_id:
+          format: int64
+          type: integer
+        href:
+          type: string
+        id:
+          format: int64
+          type: integer
+        local_tombstone:
+          type: boolean
+        local_vcard:
+          type: string
+        remote_tombstone:
+          type: boolean
+        remote_vcard:
+          type: string
+        status:
+          type: string
+      required:
+        - id
+        - address_book_id
+        - href
+        - local_tombstone
+        - remote_tombstone
+        - status
+      type: object
+    CardDAVConflictResolutionResponse:
+      properties:
+        id:
+          format: int64
+          type: integer
+        status:
+          type: string
+      required:
+        - id
+        - status
+      type: object
+    CardDAVConflictResponse:
+      properties:
+        address_book_id:
+          format: int64
+          type: integer
+        href:
+          type: string
+        id:
+          format: int64
+          type: integer
+        local_tombstone:
+          type: boolean
+        remote_tombstone:
+          type: boolean
+        status:
+          type: string
+      required:
+        - id
+        - address_book_id
+        - href
+        - local_tombstone
+        - remote_tombstone
+        - status
+      type: object
+    CardDAVConflictsResponse:
+      properties:
+        conflicts:
+          items:
+            $ref: "#/components/schemas/CardDAVConflictResponse"
+          nullable: true
+          type: array
+      required:
+        - conflicts
+      type: object
+    CardDAVPublicationResponse:
+      properties:
+        desired:
+          type: boolean
+        href:
+          type: string
+        pending_operation:
+          type: string
+        person_id:
+          format: int64
+          type: integer
+      required:
+        - person_id
+        - desired
+      type: object
+    CardDAVResolveRequest:
+      additionalProperties: false
+      properties:
+        choice:
+          enum:
+            - keep_local
+            - keep_remote
+          type: string
+      required:
+        - choice
+      type: object
+    CardDAVSyncRequest:
+      additionalProperties: false
+      properties:
+        full:
+          type: boolean
+      type: object
     ChangedMessageJSON:
       properties:
         attachment_count:
@@ -8164,6 +8357,26 @@ components:
         - accounts
         - top_senders
       type: object
+    SyncResult:
+      properties:
+        books:
+          format: int64
+          type: integer
+        created:
+          format: int64
+          type: integer
+        removed:
+          format: int64
+          type: integer
+        updated:
+          format: int64
+          type: integer
+      required:
+        - books
+        - created
+        - updated
+        - removed
+      type: object
     SyncRunItemStatus:
       properties:
         created_at:
@@ -8851,7 +9064,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.7.0
+  version: 2.8.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -9643,6 +9856,684 @@ paths:
       security:
         - apiKey: []
       summary: End a backup freeze window
+      tags:
+        - API
+  /api/v1/carddav/account:
+    put:
+      operationId: saveCardDAVAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVAccountRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVAccountResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Discover and save a CardDAV account
+      tags:
+        - API
+  /api/v1/carddav/account/test:
+    post:
+      operationId: testCardDAVAccount
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVAccountRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVAccountResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Test a CardDAV account
+      tags:
+        - API
+  /api/v1/carddav/books:
+    get:
+      operationId: listCardDAVBooks
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVBooksResponse"
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List CardDAV address books
+      tags:
+        - API
+  /api/v1/carddav/books/{id}:
+    patch:
+      operationId: updateCardDAVBookRoles
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVBookRolesRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVBookResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Update CardDAV address book roles
+      tags:
+        - API
+  /api/v1/carddav/conflicts:
+    get:
+      operationId: listCardDAVConflicts
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictsResponse"
+          description: OK
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: List unresolved CardDAV conflicts
+      tags:
+        - API
+  /api/v1/carddav/conflicts/{id}:
+    get:
+      operationId: getCardDAVConflict
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictDetailResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Inspect a CardDAV conflict
+      tags:
+        - API
+  /api/v1/carddav/conflicts/{id}/resolve:
+    post:
+      operationId: resolveCardDAVConflict
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVResolveRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVConflictResolutionResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Resolve a CardDAV conflict
+      tags:
+        - API
+  /api/v1/carddav/publications/{person_id}:
+    delete:
+      operationId: unpublishCardDAVPerson
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Unpublish a person from CardDAV
+      tags:
+        - API
+    get:
+      operationId: getCardDAVPublication
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get CardDAV publication state
+      tags:
+        - API
+    post:
+      operationId: publishCardDAVPerson
+      parameters:
+        - in: path
+          name: person_id
+          required: true
+          schema:
+            format: int64
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardDAVPublicationResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Publish a person to CardDAV
+      tags:
+        - API
+  /api/v1/carddav/sync:
+    post:
+      operationId: syncCardDAV
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CardDAVSyncRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SyncResult"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "502":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+          headers:
+            Retry-After:
+              description: Seconds until CardDAV retry is safe
+              schema:
+                format: int64
+                minimum: 0
+                type: integer
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Trigger CardDAV synchronization
       tags:
         - API
   /api/v1/cli/account:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -230,6 +230,161 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/carddav/account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Discover and save a CardDAV account */
+        put: operations["saveCardDAVAccount"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/account/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Test a CardDAV account */
+        post: operations["testCardDAVAccount"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/books": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List CardDAV address books */
+        get: operations["listCardDAVBooks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/books/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update CardDAV address book roles */
+        patch: operations["updateCardDAVBookRoles"];
+        trace?: never;
+    };
+    "/api/v1/carddav/conflicts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List unresolved CardDAV conflicts */
+        get: operations["listCardDAVConflicts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/conflicts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Inspect a CardDAV conflict */
+        get: operations["getCardDAVConflict"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/conflicts/{id}/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resolve a CardDAV conflict */
+        post: operations["resolveCardDAVConflict"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/publications/{person_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get CardDAV publication state */
+        get: operations["getCardDAVPublication"];
+        put?: never;
+        /** Publish a person to CardDAV */
+        post: operations["publishCardDAVPerson"];
+        /** Unpublish a person from CardDAV */
+        delete: operations["unpublishCardDAVPerson"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/carddav/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger CardDAV synchronization */
+        post: operations["syncCardDAV"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cli/account": {
         parameters: {
             query?: never;
@@ -3154,6 +3309,99 @@ export interface components {
             signals: string[] | null;
         } & {
             [key: string]: unknown;
+        };
+        CardDAVAccountRequest: {
+            base_url: string;
+            enabled: boolean;
+            password?: string;
+            schedule?: string;
+            username: string;
+        };
+        CardDAVAccountResponse: {
+            base_url: string;
+            /** Format: int64 */
+            books: number;
+            enabled: boolean;
+            schedule?: string;
+            username: string;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVBookResponse: {
+            /** Format: int64 */
+            id: number;
+            lookup_source: boolean;
+            name: string;
+            needs_full_reconcile: boolean;
+            subscribed: boolean;
+            url: string;
+            write_target: boolean;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVBookRolesRequest: {
+            lookup_source: boolean;
+            subscribed: boolean;
+            write_target: boolean;
+        };
+        CardDAVBooksResponse: {
+            books: components["schemas"]["CardDAVBookResponse"][] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVConflictDetailResponse: {
+            /** Format: int64 */
+            address_book_id: number;
+            href: string;
+            /** Format: int64 */
+            id: number;
+            local_tombstone: boolean;
+            local_vcard?: string;
+            remote_tombstone: boolean;
+            remote_vcard?: string;
+            status: string;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVConflictResolutionResponse: {
+            /** Format: int64 */
+            id: number;
+            status: string;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVConflictResponse: {
+            /** Format: int64 */
+            address_book_id: number;
+            href: string;
+            /** Format: int64 */
+            id: number;
+            local_tombstone: boolean;
+            remote_tombstone: boolean;
+            status: string;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVConflictsResponse: {
+            conflicts: components["schemas"]["CardDAVConflictResponse"][] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVPublicationResponse: {
+            desired: boolean;
+            href?: string;
+            pending_operation?: string;
+            /** Format: int64 */
+            person_id: number;
+        } & {
+            [key: string]: unknown;
+        };
+        CardDAVResolveRequest: {
+            /** @enum {string} */
+            choice: "keep_local" | "keep_remote";
+        };
+        CardDAVSyncRequest: {
+            full?: boolean;
         };
         ChangedMessageJSON: {
             /** Format: int64 */
@@ -6306,6 +6554,18 @@ export interface components {
             /** Format: int64 */
             total_size_bytes: number;
         };
+        SyncResult: {
+            /** Format: int64 */
+            books: number;
+            /** Format: int64 */
+            created: number;
+            /** Format: int64 */
+            removed: number;
+            /** Format: int64 */
+            updated: number;
+        } & {
+            [key: string]: unknown;
+        };
         SyncRunItemStatus: {
             created_at: string;
             error_kind: string;
@@ -7489,6 +7749,820 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BackupFreezeEndResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    saveCardDAVAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardDAVAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVAccountResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    testCardDAVAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardDAVAccountRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVAccountResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listCardDAVBooks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVBooksResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    updateCardDAVBookRoles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardDAVBookRolesRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVBookResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    listCardDAVConflicts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVConflictsResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getCardDAVConflict: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVConflictDetailResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    resolveCardDAVConflict: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardDAVResolveRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVConflictResolutionResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getCardDAVPublication: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                person_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVPublicationResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    publishCardDAVPerson: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                person_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVPublicationResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    unpublishCardDAVPerson: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                person_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CardDAVPublicationResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    syncCardDAV: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CardDAVSyncRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncResult"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    /** @description Seconds until CardDAV retry is safe */
+                    "Retry-After"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/components/settings/CardDAVAccountSettings.svelte
+++ b/web/src/lib/components/settings/CardDAVAccountSettings.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  import type { APIClient } from '../../api/client';
+  import type { components } from '../../api/generated/schema';
+  import type { SettingState } from '../../settings/catalog';
+
+  type CardDAVAccountRequest = components['schemas']['CardDAVAccountRequest'];
+  type CardDAVAccountPayload = Omit<CardDAVAccountRequest, 'password'> & { password?: string };
+  type Action = 'test' | 'save';
+
+  let { client, settings }: { client: APIClient; settings: SettingState[] } = $props();
+
+  let baseURL = $state(settingString('carddav.base_url'));
+  let username = $state(settingString('carddav.username'));
+  let password = $state('');
+  let persistedBaseURL = $state(settingString('carddav.base_url'));
+  let persistedUsername = $state(settingString('carddav.username'));
+  let persistedPasswordConfigured = $state(settingSecretConfigured('carddav.password'));
+  let enabled = $state(settingBoolean('carddav.enabled'));
+  let schedule = $state(settingString('carddav.schedule'));
+  let activeAction = $state<Action | undefined>();
+  let error = $state('');
+  let status = $state('');
+
+  function settingString(key: string): string {
+    const value = settings.find((setting) => setting.key === key)?.value;
+    return value && 'string' in value ? value.string : '';
+  }
+
+  function settingBoolean(key: string): boolean {
+    const value = settings.find((setting) => setting.key === key)?.value;
+    return Boolean(value && 'boolean' in value && value.boolean);
+  }
+
+  function settingSecretConfigured(key: string): boolean {
+    return settings.find((setting) => setting.key === key)?.secret?.configured === true;
+  }
+
+  function requestBody(): CardDAVAccountPayload {
+    const body: CardDAVAccountPayload = {
+      base_url: baseURL,
+      username,
+      enabled,
+      schedule
+    };
+    if (password !== '') body.password = password;
+    return body;
+  }
+
+  function canReusePersistedPassword(): boolean {
+    return (
+      persistedPasswordConfigured &&
+      baseURL === persistedBaseURL &&
+      username === persistedUsername
+    );
+  }
+
+  function validatePassword(): boolean {
+    if (canReusePersistedPassword() || password !== '') return true;
+    status = '';
+    error = 'Password is required for a new or changed CardDAV account.';
+    return false;
+  }
+
+  async function testConnection() {
+    if (!validatePassword()) return;
+    activeAction = 'test';
+    error = '';
+    status = '';
+    try {
+      const { data, error: responseError } = await client.POST('/api/v1/carddav/account/test', {
+        // The server keeps the stored credential when password is omitted; generated types may lag that contract.
+        body: requestBody() as CardDAVAccountRequest
+      });
+      if (!data) throw new Error(apiErrorMessage(responseError, 'Unable to test the CardDAV connection.'));
+      status = `Connection successful. Found ${data.books} address ${data.books === 1 ? 'book' : 'books'}.`;
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : 'Unable to test the CardDAV connection.';
+    } finally {
+      activeAction = undefined;
+    }
+  }
+
+  async function saveAccount() {
+    if (!validatePassword()) return;
+    activeAction = 'save';
+    error = '';
+    status = '';
+    try {
+      const { data, error: responseError } = await client.PUT('/api/v1/carddav/account', {
+        // The server keeps the stored credential when password is omitted; generated types may lag that contract.
+        body: requestBody() as CardDAVAccountRequest
+      });
+      if (!data) throw new Error(apiErrorMessage(responseError, 'Unable to save the CardDAV account.'));
+      baseURL = data.base_url;
+      username = data.username;
+      enabled = data.enabled;
+      schedule = data.schedule ?? '';
+      persistedBaseURL = data.base_url;
+      persistedUsername = data.username;
+      persistedPasswordConfigured = true;
+      password = '';
+      status = `CardDAV account saved. Found ${data.books} address ${data.books === 1 ? 'book' : 'books'}.`;
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : 'Unable to save the CardDAV account.';
+    } finally {
+      activeAction = undefined;
+    }
+  }
+
+  function apiErrorMessage(responseError: unknown, fallback: string): string {
+    if (typeof responseError === 'object' && responseError !== null && 'message' in responseError) {
+      const message = (responseError as { message?: unknown }).message;
+      if (typeof message === 'string' && message) return message;
+    }
+    return fallback;
+  }
+</script>
+
+<section class="carddav" aria-labelledby="carddav-account-heading">
+  <h2 id="carddav-account-heading">CardDAV account</h2>
+  <p>
+    Connect an address-book account.
+    {#if canReusePersistedPassword()}Leave the password blank to keep the stored credential.{:else}A password is required for a new or changed account.{/if}
+  </p>
+
+  {#if error}<p class="error" role="alert">{error}</p>{/if}
+  {#if status}<p class="status" role="status">{status}</p>{/if}
+
+  <form onsubmit={(event) => { event.preventDefault(); void saveAccount(); }}>
+    <label>
+      Base URL
+      <input type="url" bind:value={baseURL} required />
+    </label>
+    <label>
+      Username
+      <input type="text" autocomplete="username" bind:value={username} required />
+    </label>
+    <label>
+      Password
+      <input
+        type="password"
+        autocomplete="current-password"
+        bind:value={password}
+        required={!canReusePersistedPassword()}
+        placeholder={canReusePersistedPassword() ? 'Leave blank to keep current password' : ''}
+      />
+    </label>
+    <label class="checkbox">
+      <input type="checkbox" bind:checked={enabled} />
+      Enabled
+    </label>
+    <label>
+      Schedule
+      <input type="text" bind:value={schedule} placeholder="0 2 * * *" />
+    </label>
+
+    <div class="actions">
+      <button type="button" disabled={activeAction !== undefined} onclick={() => void testConnection()}>
+        {activeAction === 'test' ? 'Testing…' : 'Test CardDAV connection'}
+      </button>
+      <button type="submit" disabled={activeAction !== undefined}>
+        {activeAction === 'save' ? 'Saving…' : 'Save CardDAV account'}
+      </button>
+    </div>
+  </form>
+</section>
+
+<style>
+  .carddav { margin-block: 2rem; padding-block-start: 1rem; border-top: 1px solid var(--border-default); }
+  form { display: grid; max-width: 40rem; gap: 1rem; }
+  label { display: grid; gap: 0.35rem; }
+  input:not([type='checkbox']) { width: 100%; min-height: 2.25rem; }
+  .checkbox { display: flex; align-items: center; gap: 0.5rem; }
+  .actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+  .error, .status { padding: 0.75rem 1rem; border-left: 0.25rem solid; }
+  .error { border-left-color: var(--status-error-ink); background: var(--status-error-bg); color: var(--status-error-ink); }
+  .status { border-left-color: var(--status-success-ink); background: var(--status-success-bg); color: var(--status-success-ink); }
+</style>

--- a/web/src/lib/components/settings/SettingsWorkspace.svelte
+++ b/web/src/lib/components/settings/SettingsWorkspace.svelte
@@ -3,6 +3,7 @@
 
   import type { APIClient } from '../../api/client';
   import type { components } from '../../api/generated/schema';
+  import CardDAVAccountSettings from './CardDAVAccountSettings.svelte';
   import {
     groupSettings,
     settingsCatalog,
@@ -300,6 +301,8 @@
 
       <button type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save settings'}</button>
     </form>
+
+    <CardDAVAccountSettings {client} {settings} />
   {/if}
 </main>
 

--- a/web/src/lib/components/settings/SettingsWorkspace.test.ts
+++ b/web/src/lib/components/settings/SettingsWorkspace.test.ts
@@ -179,7 +179,195 @@ describe('SettingsWorkspace', () => {
     expect((await screen.findByRole('alert')).textContent).toContain('network unavailable');
     expect((screen.getByRole('button', { name: 'Save settings' }) as HTMLButtonElement).disabled).toBe(false);
   });
+
+  it('tests CardDAV credentials through the dedicated account endpoint', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path === '/api/v1/settings') return settingsResponse(cardDAVSettings(), '"etag-a"');
+      if (path === '/api/v1/carddav/account/test') {
+        return Response.json({
+          base_url: 'https://dav.example.test/',
+          username: 'alice',
+          enabled: true,
+          schedule: '0 3 * * *',
+          books: 2
+        });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    });
+    render(SettingsWorkspace, { client: createAPIClient(fetchFn) });
+
+    expect(await screen.findByRole('heading', { name: 'CardDAV account' })).toBeDefined();
+    expect(screen.getByLabelText('Base URL')).toBeDefined();
+    expect(screen.getByLabelText('Username')).toBeDefined();
+    expect(screen.getByLabelText('Password')).toBeDefined();
+    expect(screen.getByLabelText('Enabled')).toBeDefined();
+    expect(screen.getByLabelText('Schedule')).toBeDefined();
+    expect(screen.queryByText('CardDAV server')).toBeNull();
+
+    await fireEvent.input(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://dav.example.test/' }
+    });
+    await fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'changed-password' } });
+    await fireEvent.click(screen.getByLabelText('Enabled'));
+    await fireEvent.input(screen.getByLabelText('Schedule'), { target: { value: '0 3 * * *' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Test CardDAV connection' }));
+
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+    const request = fetchFn.mock.calls[1]?.[0] as Request;
+    expect(request.method).toBe('POST');
+    expect(new URL(request.url).pathname).toBe('/api/v1/carddav/account/test');
+    await expect(request.clone().json()).resolves.toEqual({
+      base_url: 'https://dav.example.test/',
+      username: 'alice',
+      password: 'changed-password',
+      enabled: true,
+      schedule: '0 3 * * *'
+    });
+    expect((await screen.findByRole('status')).textContent).toContain('Found 2 address books');
+  });
+
+  it('saves CardDAV credentials through PUT without a generic settings PATCH', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path === '/api/v1/settings') return settingsResponse(cardDAVSettings(), '"etag-a"');
+      if (path === '/api/v1/carddav/account') {
+        return Response.json({
+          base_url: 'https://dav.example.test/',
+          username: 'alice',
+          enabled: false,
+          schedule: '0 2 * * *',
+          books: 1
+        });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    });
+    render(SettingsWorkspace, { client: createAPIClient(fetchFn) });
+
+    await screen.findByLabelText('Base URL');
+    expect((screen.getByLabelText('Password') as HTMLInputElement).required).toBe(false);
+    await fireEvent.click(screen.getByRole('button', { name: 'Save CardDAV account' }));
+
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(2));
+    const request = fetchFn.mock.calls[1]?.[0] as Request;
+    expect(request.method).toBe('PUT');
+    expect(new URL(request.url).pathname).toBe('/api/v1/carddav/account');
+    await expect(request.clone().json()).resolves.toEqual({
+      base_url: 'https://old.example.test/',
+      username: 'alice',
+      enabled: false,
+      schedule: '0 2 * * *'
+    });
+    expect(
+      fetchFn.mock.calls.some(([candidate]) => candidate instanceof Request && candidate.method === 'PATCH')
+    ).toBe(false);
+    expect((await screen.findByRole('status')).textContent).toContain('CardDAV account saved');
+  });
+
+  it('requires a password before testing an unconfigured CardDAV account', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path === '/api/v1/settings') return settingsResponse(initialSettings, '"etag-a"');
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    });
+    render(SettingsWorkspace, { client: createAPIClient(fetchFn) });
+
+    await fireEvent.input(await screen.findByLabelText('Base URL'), {
+      target: { value: 'https://dav.example.test/' }
+    });
+    await fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } });
+    const password = screen.getByLabelText('Password') as HTMLInputElement;
+    expect(password.required).toBe(true);
+    await fireEvent.click(screen.getByRole('button', { name: 'Test CardDAV connection' }));
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(screen.getByRole('alert').textContent).toContain('Password is required');
+  });
+
+  it('requires a password when a configured CardDAV identity changes', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path === '/api/v1/settings') return settingsResponse(cardDAVSettings(), '"etag-a"');
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    });
+    render(SettingsWorkspace, { client: createAPIClient(fetchFn) });
+
+    const baseURL = await screen.findByLabelText('Base URL');
+    const password = screen.getByLabelText('Password') as HTMLInputElement;
+    expect(password.required).toBe(false);
+
+    await fireEvent.input(baseURL, { target: { value: 'https://changed.example.test/' } });
+    expect(password.required).toBe(true);
+    await fireEvent.click(screen.getByRole('button', { name: 'Test CardDAV connection' }));
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(screen.getByRole('alert').textContent).toContain('Password is required');
+  });
+
+  it('reuses the persisted CardDAV password after the first successful save', async () => {
+    const requests: Request[] = [];
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path === '/api/v1/settings') return settingsResponse(initialSettings, '"etag-a"');
+      if (path === '/api/v1/carddav/account') {
+        requests.push(request);
+        const body = (await request.clone().json()) as Record<string, unknown>;
+        return Response.json({
+          base_url: body.base_url,
+          username: body.username,
+          enabled: body.enabled,
+          schedule: body.schedule,
+          books: 1
+        });
+      }
+      throw new Error(`Unexpected request: ${request.method} ${path}`);
+    });
+    render(SettingsWorkspace, { client: createAPIClient(fetchFn) });
+
+    await fireEvent.input(await screen.findByLabelText('Base URL'), {
+      target: { value: 'https://dav.example.test/' }
+    });
+    await fireEvent.input(screen.getByLabelText('Username'), { target: { value: 'alice' } });
+    await fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'first-password' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Save CardDAV account' }));
+    await waitFor(() => expect(requests).toHaveLength(1));
+    await screen.findByRole('status');
+
+    const password = screen.getByLabelText('Password') as HTMLInputElement;
+    expect(password.value).toBe('');
+    expect(password.required).toBe(false);
+    await fireEvent.input(screen.getByLabelText('Schedule'), { target: { value: '0 4 * * *' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Save CardDAV account' }));
+    await waitFor(() => expect(requests).toHaveLength(2));
+
+    await expect(requests[0].clone().json()).resolves.toMatchObject({ password: 'first-password' });
+    await expect(requests[1].clone().json()).resolves.toEqual({
+      base_url: 'https://dav.example.test/',
+      username: 'alice',
+      enabled: false,
+      schedule: '0 4 * * *'
+    });
+  });
 });
+
+function cardDAVSettings(): object {
+  return {
+    settings: [
+      ...initialSettings.settings,
+      setting('carddav.base_url', 'https://old.example.test/'),
+      setting('carddav.username', 'alice'),
+      setting('carddav.password', undefined, { kind: 'secret', secret: { configured: true } }),
+      setting('carddav.enabled', false, { kind: 'boolean' }),
+      setting('carddav.schedule', '0 2 * * *')
+    ],
+    pending_restart: false
+  };
+}
 
 function setting(
   key: string,


### PR DESCRIPTION
## What changed

- Add a guarded CardDAV client for one configured account, with standards-based discovery, bounded XML/HTTP handling, origin-safe credentials and redirects, and durable per-book capabilities and roles.
- Pull and push lossless vCard resources through snapshot or sync-token reconciliation, conditional ETag writes, persisted remote-first intents, explicit person publication, and reviewable keep-local/keep-remote conflicts. SQLite and PostgreSQL keep the same store contract.
- Expose account setup, sync, book roles, publication state, and conflicts through the CLI, daemon API, generated clients, scheduler, and settings UI. No new Go dependency is required.

## Why

Msgvault owns curated people, but every phone and laptop already talks to an external address-book server. Acting as a CardDAV client keeps one durable person model while letting those existing clients read and edit a portable projection, without turning msgvault into another internet-facing DAV server.

## Usage

```sh
msgvault add-carddav https://contacts.example/dav alice
msgvault sync-carddav
msgvault carddav books
msgvault carddav books set-role 1 --write-target --subscribed
msgvault person publish 42
msgvault carddav conflicts list
msgvault carddav conflicts resolve 7 keep_remote
```

`add-carddav` reads the password from the terminal or piped stdin. Newly discovered sibling books default to lookup-only; publication remains explicit per person.

Closes #627
