### PR TITLE
feat(people): add semantic person search

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6980,6 +6980,43 @@ components:
       required:
         - relationships
       type: object
+    PersonSearchRequest:
+      additionalProperties: false
+      properties:
+        limit:
+          default: 20
+          format: int64
+          maximum: 100
+          minimum: 0
+          type: integer
+        query:
+          minLength: 1
+          type: string
+      required:
+        - query
+      type: object
+    PersonSearchResponse:
+      additionalProperties: true
+      properties:
+        results:
+          items:
+            $ref: "#/components/schemas/PersonSearchResult"
+          type: array
+      required:
+        - results
+      type: object
+    PersonSearchResult:
+      additionalProperties: true
+      properties:
+        person:
+          $ref: "#/components/schemas/Person"
+        score:
+          format: double
+          type: number
+      required:
+        - person
+        - score
+      type: object
     PersonSummary:
       additionalProperties: true
       properties:
@@ -8402,10 +8439,14 @@ components:
         missing_embeddings_total:
           format: int64
           type: integer
+        person_coverage_rejected:
+          format: int64
+          type: integer
       required:
         - enabled
         - active_generation
         - missing_embeddings_total
+        - person_coverage_rejected
       type: object
     Status:
       additionalProperties: true
@@ -9309,7 +9350,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.5.0
+  version: 2.6.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -15528,6 +15569,40 @@ paths:
       security:
         - apiKey: []
       summary: Promote a participant cluster to a durable person
+      tags:
+        - API
+  /api/v1/people/search:
+    post:
+      description: Searches only the curated person vector corpus and returns durable person roots in relevance order.
+      operationId: searchPeople
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersonSearchRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonSearchResponse"
+          description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search durable people semantically
       tags:
         - API
   /api/v1/people/{id}:

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -159,7 +159,7 @@ func init() {
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireYes, "yes", false, "Skip confirmation prompt")
 	embeddingsRetireCmd.Flags().BoolVar(&embeddingsRetireForceActive, "force-active", false, "Allow retiring the active generation")
 	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateYes, "yes", false, "Skip confirmation prompt")
-	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateForce, "force", false, "Allow activation while messages still need embedding, or with a fingerprint mismatch")
+	embeddingsActivateCmd.Flags().BoolVar(&embeddingsActivateForce, "force", false, "Allow activation despite incomplete message or person coverage, or a fingerprint mismatch")
 	embeddingsCmd.AddCommand(embeddingsBuildCmd)
 	embeddingsCmd.AddCommand(embeddingsResumeCmd)
 	embeddingsCmd.AddCommand(embeddingsListCmd)

--- a/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
+++ b/cmd/msgvault/cmd/embed_scope_sqlitevec_test.go
@@ -9,7 +9,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -18,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
 )
 
 // fakeEmbeddingsServer answers OpenAI-compatible /embeddings requests with
@@ -160,6 +164,145 @@ func TestRunEmbed_AccountScopedBuildActivatesScopedGeneration(t *testing.T) {
 	require.Error(err, "a different account scope must not resume the src-1 generation")
 	assert.Contains(err.Error(), "src-", "stored vs configured scope is visible in the error")
 	assert.Contains(err.Error(), "full-rebuild", "error points at --full-rebuild")
+}
+
+// TestRunEmbedLivePersonGateStopsLaterBatchesAfterConfigDeletion drives the
+// complete manual build path. Deleting config after the first curated-person
+// request must prevent every later person request without rolling back message
+// progress or stranding activation of the completed message generation.
+func TestRunEmbedLivePersonGateStopsLaterBatchesAfterConfigDeletion(t *testing.T) {
+	var messageRequests atomic.Int32
+	var personRequests atomic.Int32
+	var configRemoved atomic.Bool
+	removeResult := make(chan error, 1)
+	dataDir := t.TempDir()
+
+	configured := config.NewDefaultConfig()
+	configured.HomeDir = dataDir
+	configured.Data.DataDir = dataDir
+	configured.Vector.Enabled = true
+	configured.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+	configured.Vector.Embeddings.Model = "manual-live-gate-model"
+	configured.Vector.Embeddings.Dimension = 4
+	configured.Vector.Embeddings.BatchSize = 1
+	configured.Vector.Embeddings.MaxRetries = 1
+	configured.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, "invalid synthetic request", http.StatusBadRequest)
+			return
+		}
+		for _, input := range request.Input {
+			if strings.HasPrefix(input, "Subject:") {
+				messageRequests.Add(1)
+				continue
+			}
+			personRequests.Add(1)
+			if configRemoved.CompareAndSwap(false, true) {
+				removeResult <- os.Remove(configured.ConfigFilePath())
+			}
+		}
+		data := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			data[i] = map[string]any{"embedding": []float32{1, 0, 0, 0}, "index": i}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": data, "model": "manual-live-gate-model",
+		})
+	}))
+	t.Cleanup(provider.Close)
+	configured.Vector.Embeddings.Endpoint = provider.URL
+	withTestConfig(t, configured)
+	require.NoError(t, configured.Save())
+
+	seedTwoAccountMainDB(t, dataDir)
+	mainStore, err := store.Open(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err)
+	profile, err := configured.Vector.SemanticPersonEmbeddingProfile()
+	require.NoError(t, err)
+	_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+	require.NoError(t, err)
+	_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), profile.Fingerprint, "test",
+	)
+	require.NoError(t, err)
+	for _, personSeed := range []struct {
+		email string
+		name  string
+	}{
+		{email: "first-curated@example.test", name: "First Curated Person"},
+		{email: "second-curated@example.test", name: "Second Curated Person"},
+	} {
+		participantID, err := mainStore.EnsureParticipantByIdentifier(
+			"email", personSeed.email, "Observed "+personSeed.name,
+		)
+		require.NoError(t, err)
+		person, _, err := mainStore.CreatePersonFromParticipantContext(t.Context(), participantID)
+		require.NoError(t, err)
+		_, err = mainStore.UpdatePersonDisplayNameContext(
+			t.Context(), person.ID, person.Revision, &personSeed.name,
+		)
+		require.NoError(t, err)
+	}
+	require.NoError(t, mainStore.Close())
+
+	oldRebuild, oldYes := embedFullRebuild, embedYes
+	oldAccounts, oldCollections := embedAccounts, embedCollections
+	oldBackstop := embedBackstop
+	t.Cleanup(func() {
+		embedFullRebuild, embedYes = oldRebuild, oldYes
+		embedAccounts, embedCollections = oldAccounts, oldCollections
+		embedBackstop = oldBackstop
+	})
+	embedFullRebuild = true
+	embedYes = true
+	embedBackstop = false
+	embedAccounts = nil
+	embedCollections = nil
+	command := &cobra.Command{}
+	command.SetContext(t.Context())
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	command.SetOut(stdout)
+	command.SetErr(stderr)
+
+	err = runEmbeddingsBuildLocal(command)
+
+	require.NoError(t, err, stderr.String())
+	require.True(t, configRemoved.Load(), "precondition: first curated-person request removed config")
+	require.NoError(t, <-removeResult)
+	assert.Contains(t, stdout.String(), "Generation 1 activated.",
+		"person authorization loss must not strand completed message activation")
+
+	// A later manual resume must still process newly arrived message work from
+	// the startup configuration while the live person policy remains absent.
+	mainStore, err = store.Open(filepath.Join(dataDir, "msgvault.db"))
+	require.NoError(t, err)
+	_, err = mainStore.DB().Exec(`
+		INSERT INTO messages
+			(id, conversation_id, source_id, source_message_id, message_type, subject)
+		VALUES (3, 1, 1, 'post-removal-message', 'email', 'post-removal message');
+		INSERT INTO message_bodies (message_id, body_text)
+		VALUES (3, 'post-removal body');`)
+	require.NoError(t, err)
+	require.NoError(t, mainStore.Close())
+	embedFullRebuild = false
+	resume := &cobra.Command{}
+	resume.SetContext(t.Context())
+	resumeOut, resumeErr := &bytes.Buffer{}, &bytes.Buffer{}
+	resume.SetOut(resumeOut)
+	resume.SetErr(resumeErr)
+	require.NoError(t, runEmbeddingsBuildLocal(resume), resumeErr.String())
+
+	assert.Equal(t, int32(3), messageRequests.Load(),
+		"message batches must continue through the separate ungated client after config removal")
+	assert.Equal(t, int32(1), personRequests.Load(),
+		"config deletion must fence every later curated-person batch")
 }
 
 // TestRunEmbed_AccountScopedRebuildRefusesEmptyScope guards the empty-scope

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -48,7 +48,9 @@ func TestEmbeddingsCommandRegistration(t *testing.T) {
 	require.NoError(err)
 	require.Equal("activate", activateCmd.Name())
 	require.NotNil(activateCmd.Flags().Lookup("yes"))
-	require.NotNil(activateCmd.Flags().Lookup("force"))
+	forceFlag := activateCmd.Flags().Lookup("force")
+	require.NotNil(forceFlag)
+	assert.Contains(t, forceFlag.Usage, "person coverage")
 
 	legacyCmd, _, err := rootCmd.Find([]string{"build-embeddings"})
 	require.NoError(err)
@@ -281,8 +283,8 @@ func TestListEmbeddingGenerationsIncludesActiveAndBuilding(t *testing.T) {
 	db := newEmbeddingMetadataTestDB(t)
 
 	// listEmbeddingGenerations reads only the generation metadata now;
-	// coverage (missing count) is filled separately from the main DB via
-	// fillCoverage, so it is not asserted here.
+	// Coverage is filled separately for the display path, so it is not
+	// asserted here.
 	rows, err := listEmbeddingGenerations(t.Context(), db, sqliteRebind)
 	require.NoError(err)
 	require.Len(rows, 2)
@@ -321,22 +323,6 @@ func TestRunEmbeddingsActivateRefusesMissingWithoutForce(t *testing.T) {
 	require.Error(err)
 	assert.Contains(err.Error(), "needing embedding")
 	assert.Contains(err.Error(), "msgvault embeddings resume --backstop")
-}
-
-func TestFillCoverageUsesEmbeddingScope(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	dataDir := t.TempDir()
-	dbPath := newEmbeddingMetadataTestDBFileAt(t, filepath.Join(dataDir, "vectors.db"))
-	seedMainDBWithScopedCoverageMessages(t, dataDir)
-	withEmbeddingCommandConfigDataDir(t, dbPath, dataDir)
-	cfg.Vector.Embed.Scope.MessageTypes = []string{"sms"}
-
-	row := embeddingGenerationRow{ID: 2}
-	require.NoError(fillCoverage(t.Context(), cfg.Vector.Embed.Scope.BuildScope(), &row))
-
-	assert.Equal(int64(1), row.LiveCount)
-	assert.Equal(int64(0), row.MissingCount)
 }
 
 // TestRetireEmbeddingGenerationRefusesActiveWithoutForce_PreCheck pins the
@@ -436,22 +422,6 @@ func seedMainDBWithLiveMessage(t *testing.T, dataDir string) {
 INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'me@example.com');
 INSERT INTO conversations (id, source_id, conversation_type) VALUES (1, 1, 'email_thread');
 INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, embed_gen) VALUES (1, 1, 1, 'm1', 'email', NULL);
-`)
-	require.NoError(t, err)
-}
-
-func seedMainDBWithScopedCoverageMessages(t *testing.T, dataDir string) {
-	t.Helper()
-	s, err := store.Open(filepath.Join(dataDir, "msgvault.db"))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, s.Close()) }()
-	require.NoError(t, s.InitSchema())
-	_, err = s.DB().Exec(`
-INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'me@example.com');
-INSERT INTO conversations (id, source_id, conversation_type) VALUES (1, 1, 'email_thread'), (2, 1, 'sms_thread');
-INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, embed_gen) VALUES
-	(1, 1, 1, 'email-missing', 'email', NULL),
-	(2, 2, 1, 'sms-stamped', 'sms', 2);
 `)
 	require.NoError(t, err)
 }

--- a/cmd/msgvault/cmd/embed_vector.go
+++ b/cmd/msgvault/cmd/embed_vector.go
@@ -147,19 +147,23 @@ func runEmbed(cmd *cobra.Command) error {
 		_, _ = fmt.Fprintln(errOut, "Embedding scope matched 0 live messages.")
 	}
 	totalPending := int(missing)
+	personGate := vector.NewPinnedExactSemanticPersonEmbeddingGate(
+		cfg.Vector, currentSemanticPersonVectorConfigSource(), s,
+	)
 
 	runtime, err := newEmbeddingRuntime(cfg.Vector, embeddingRuntimeDeps{
 		Backend: backend, VectorsDB: vectorsDB, MainDB: s.DB(), Store: s,
 		Rebind: rebind, LastModifiedExpr: lastModifiedExpr,
 		TotalPending: totalPending,
 		Progress:     newProgressPrinter(errOut, totalPending, cfg.Vector.Embeddings.ETAWindow),
+		PersonGate:   personGate,
 	})
 	if err != nil {
 		return fmt.Errorf("configure embedding runtime: %w", err)
 	}
 
 	res, err := runEmbeddingPasses(ctx, runtime.Runner, gen, embedBackstop,
-		cfg.Vector.Embeddings.EffectiveAPIFormat())
+		cfg.Vector.Embeddings.EffectiveAPIFormat(), errOut)
 	if err != nil {
 		return fmt.Errorf("embed run: %w", err)
 	}
@@ -189,6 +193,7 @@ func runEmbeddingPasses(
 	gen vector.GenerationID,
 	backstop bool,
 	apiFormat vector.EmbeddingAPIFormat,
+	stderr io.Writer,
 ) (embed.RunResult, error) {
 	var total embed.RunResult
 	first := true
@@ -199,6 +204,12 @@ func runEmbeddingPasses(
 			pass, err = runner.RunBackstop(ctx, gen)
 		} else {
 			pass, err = runner.RunOnce(ctx, gen)
+		}
+		if generationErr, ok := errors.AsType[*embed.GenerationRunError](err); ok {
+			if generationErr.Person != nil {
+				_, _ = fmt.Fprintf(stderr, "Person embedding run failed: %v\n", generationErr.Person)
+			}
+			err = generationErr.Message
 		}
 		if err != nil {
 			return total, err
@@ -232,7 +243,7 @@ func activateBuiltGeneration(
 		return false, fmt.Errorf("check generation convergence: %w", err)
 	}
 	if !state.Complete() {
-		if apiFormat == vector.APIFormatOpenAI {
+		if apiFormat == vector.APIFormatOpenAI && state.PersonCoverageComplete {
 			_, _ = fmt.Fprint(stderr, remainingCoverageHint(gen, state.MessageCoverageMissing))
 		} else {
 			_, _ = fmt.Fprintln(stderr, convergenceError(gen, state))

--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 	"go.kenn.io/msgvault/internal/vector/sqlitevec"
 )
 
@@ -54,13 +56,18 @@ type cliConvergenceChecker struct {
 
 type cliPassRunner struct {
 	results []embed.RunResult
+	errs    []error
 	calls   int
 }
 
 func (r *cliPassRunner) RunOnce(context.Context, vector.GenerationID) (embed.RunResult, error) {
-	result := r.results[min(r.calls, len(r.results)-1)]
+	call := r.calls
 	r.calls++
-	return result, nil
+	result := r.results[min(call, len(r.results)-1)]
+	if len(r.errs) == 0 {
+		return result, nil
+	}
+	return result, r.errs[min(call, len(r.errs)-1)]
 }
 
 func (r *cliPassRunner) RunBackstop(context.Context, vector.GenerationID) (embed.RunResult, error) {
@@ -76,7 +83,7 @@ func TestRunEmbeddingPasses_ContextualCLIContinuesUntilConverged(t *testing.T) {
 		{Claimed: 1, Succeeded: 1, Contextual: &embed.ContextConvergence{Converged: true}},
 	}}
 
-	result, err := runEmbeddingPasses(t.Context(), runner, 7, false, vector.APIFormatVoyageContextual)
+	result, err := runEmbeddingPasses(t.Context(), runner, 7, false, vector.APIFormatVoyageContextual, &bytes.Buffer{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, runner.calls)
 	assert.Equal(t, 6, result.Claimed)
@@ -90,9 +97,25 @@ func TestRunEmbeddingPasses_ContextualCLIRejectsNonProgress(t *testing.T) {
 		Contextual: &embed.ContextConvergence{Converged: false},
 	}}}
 
-	_, err := runEmbeddingPasses(t.Context(), runner, 7, false, vector.APIFormatVoyageContextual)
+	_, err := runEmbeddingPasses(t.Context(), runner, 7, false, vector.APIFormatVoyageContextual, &bytes.Buffer{})
 	require.ErrorContains(t, err, "made no progress")
 	assert.Equal(t, 1, runner.calls)
+}
+
+func TestRunEmbeddingPasses_PersonOnlyFailurePreservesMessageProgress(t *testing.T) {
+	personErr := errors.New("person provider failed")
+	runner := &cliPassRunner{
+		results: []embed.RunResult{{Claimed: 3, Succeeded: 3}},
+		errs:    []error{&embed.GenerationRunError{Person: personErr}},
+	}
+
+	var stderr bytes.Buffer
+	result, err := runEmbeddingPasses(t.Context(), runner, 7, false, vector.APIFormatOpenAI, &stderr)
+	require.NoError(t, err)
+	assert.Equal(t, 1, runner.calls)
+	assert.Equal(t, 3, result.Claimed)
+	assert.Equal(t, 3, result.Succeeded)
+	assert.Contains(t, stderr.String(), personErr.Error())
 }
 
 func (c cliConvergenceChecker) CheckConvergence(context.Context, vector.GenerationID) (scheduler.ConvergenceResult, error) {
@@ -102,6 +125,7 @@ func (c cliConvergenceChecker) CheckConvergence(context.Context, vector.Generati
 func TestActivateBuiltGeneration_ContextualBehavior(t *testing.T) {
 	complete := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   9,
 		ConsumedJournalSequence: 9,
 		ReconciliationComplete:  true,
@@ -115,6 +139,10 @@ func TestActivateBuiltGeneration_ContextualBehavior(t *testing.T) {
 			s.MessageCoverageComplete = false
 			s.MessageCoverageMissing = 2
 		}, want: "message_coverage_complete=false (missing=2)"},
+		{name: "person coverage incomplete", mutate: func(s *scheduler.ConvergenceResult) {
+			s.PersonCoverageComplete = false
+			s.PersonCoverageMismatched = 2
+		}, want: "person_coverage_complete=false (mismatched=2, rejected=0)"},
 		{name: "journal incomplete", mutate: func(s *scheduler.ConvergenceResult) {
 			s.ConsumedJournalSequence = 8
 		}, want: "journal=8/9"},
@@ -158,6 +186,7 @@ func TestActivateBuiltGeneration_OpenAILegacyHintUnchanged(t *testing.T) {
 	state := scheduler.ConvergenceResult{
 		MessageCoverageComplete: false,
 		MessageCoverageMissing:  3,
+		PersonCoverageComplete:  true,
 		ReconciliationComplete:  true,
 	}
 	var stdout, stderr bytes.Buffer
@@ -173,6 +202,7 @@ func TestActivateBuiltGeneration_OpenAICompleteUsesLegacyActivation(t *testing.T
 	backend := &cliActivationBackend{}
 	state := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		ReconciliationComplete:  true,
 	}
 	var stdout, stderr bytes.Buffer
@@ -186,9 +216,49 @@ func TestActivateBuiltGeneration_OpenAICompleteUsesLegacyActivation(t *testing.T
 	assert.Empty(t, stderr.String())
 }
 
+// TestActivateBuiltGenerationOpenAIReportsPersonCoverage catches the legacy
+// CLI claiming zero message stragglers while exact person revisions still
+// make the generation unsafe to activate.
+func TestActivateBuiltGenerationOpenAIReportsPersonCoverage(t *testing.T) {
+	backend := &cliActivationBackend{}
+	state := scheduler.ConvergenceResult{
+		MessageCoverageComplete:  true,
+		PersonCoverageComplete:   false,
+		PersonCoverageMismatched: 2,
+		ReconciliationComplete:   true,
+	}
+	var stdout, stderr bytes.Buffer
+	activated, err := activateBuiltGeneration(t.Context(), backend,
+		cliConvergenceChecker{state: state}, 7, vector.APIFormatOpenAI, &stdout, &stderr)
+	require.NoError(t, err)
+	assert.False(t, activated)
+	assert.Empty(t, backend.activateCalls)
+	assert.Contains(t, stderr.String(), "person_coverage_complete=false (mismatched=2, rejected=0)")
+}
+
+func TestRejectedOnlyPersonCoverageReportsTerminalRecoveryOptions(t *testing.T) {
+	state := scheduler.ConvergenceResult{
+		MessageCoverageComplete: true,
+		PersonCoverageComplete:  false,
+		PersonCoverageRejected:  2,
+		ReconciliationComplete:  true,
+	}
+	for name, err := range map[string]error{
+		"automatic activation": convergenceError(7, state),
+		"manual activation":    manualConvergenceError(7, state),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.NotContains(t, err.Error(), "resume --backstop")
+			assert.Contains(t, err.Error(), "source revision must change")
+			assert.Contains(t, err.Error(), "msgvault embeddings activate 7 --force")
+		})
+	}
+}
+
 func TestActivateBuiltGeneration_ContextualLifecycleErrorsDoNotActivateAnotherGeneration(t *testing.T) {
 	complete := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		ReconciliationComplete:  true,
 	}
 	t.Run("checker rejects retired generation", func(t *testing.T) {
@@ -244,24 +314,192 @@ func setupVectorFeaturesFixture(t *testing.T, apiFormat vector.EmbeddingAPIForma
 func TestSetupVectorFeatures_SelectsRunnerByAPIFormat(t *testing.T) {
 	t.Run("implicit OpenAI", func(t *testing.T) {
 		vf := setupVectorFeaturesFixture(t, "", false)
-		assert.IsType(t, &embed.Worker{}, vf.Runner)
+		assert.IsType(t, &embed.GenerationWorker{}, vf.Runner)
 		assert.IsType(t, &legacyConvergenceChecker{}, vf.Convergence)
+		assertConfiguredPersonSearchEngine(t, vf)
 	})
 	t.Run("explicit OpenAI", func(t *testing.T) {
 		vf := setupVectorFeaturesFixture(t, vector.APIFormatOpenAI, false)
-		assert.IsType(t, &embed.Worker{}, vf.Runner)
+		assert.IsType(t, &embed.GenerationWorker{}, vf.Runner)
 		assert.IsType(t, &legacyConvergenceChecker{}, vf.Convergence)
+		assertConfiguredPersonSearchEngine(t, vf)
 	})
 	t.Run("Voyage contextual", func(t *testing.T) {
 		vf := setupVectorFeaturesFixture(t, vector.APIFormatVoyageContextual, false)
-		assert.IsType(t, &embed.ContextWorker{}, vf.Runner)
+		assert.IsType(t, &embed.GenerationWorker{}, vf.Runner)
 		assert.IsType(t, &contextualConvergenceChecker{}, vf.Convergence)
+		assertConfiguredPersonSearchEngine(t, vf)
 	})
 }
 
 func TestSetupVectorFeatures_ReadOnlyContextualDoesNotStartRunnerWrites(t *testing.T) {
 	vf := setupVectorFeaturesFixture(t, vector.APIFormatVoyageContextual, true)
-	assert.IsType(t, &embed.ContextWorker{}, vf.Runner)
+	assert.IsType(t, &embed.GenerationWorker{}, vf.Runner)
+	assertConfiguredPersonSearchEngine(t, vf)
+}
+
+func assertConfiguredPersonSearchEngine(t *testing.T, vf *vectorFeatures) {
+	t.Helper()
+	require.NotNil(t, vf.PersonSearchEngine,
+		"every embedding API format must install semantic person search")
+	_, err := vf.PersonSearchEngine.Search(t.Context(), "synthetic person", 1)
+	require.ErrorIs(t, err, vector.ErrSemanticPersonEmbeddingsDisabled,
+		"the person engine must enforce the default-off curated-person policy")
+}
+
+func TestLegacyConvergenceTreatsAuthorizationUnavailableAsNoRequiredPersonCoverage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "disabled", err: vector.ErrSemanticPersonEmbeddingsDisabled},
+		{name: "revoked or unconsented", err: vector.ErrSemanticPersonEmbeddingConsentRequired},
+		{name: "runtime policy drift", err: vector.ErrSemanticPersonEmbeddingRuntimeStale},
+		{
+			name: "invalid or unavailable live policy",
+			err: fmt.Errorf("%w: synthetic config source unavailable",
+				vector.ErrSemanticPersonEmbeddingPolicyUnavailable),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checker := &legacyConvergenceChecker{
+				personGate: vector.SemanticPersonEmbeddingGateFunc(
+					func(context.Context) error { return test.err },
+				),
+			}
+
+			coverage, err := checker.CheckPersonCoverage(t.Context(), 7)
+
+			require.NoError(t, err)
+			assert.True(t, coverage.Complete())
+		})
+	}
+}
+
+// TestConfiguredConvergenceRequiresExactPersonRevisionsAndAllowsZeroPeople
+// catches activation checks that look only at message coverage, ignore stale
+// revisions/orphans, or treat an empty curated person corpus as incomplete.
+func TestConfiguredConvergenceRequiresExactPersonRevisionsAndAllowsZeroPeople(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "msgvault.db")
+	vectorPath := filepath.Join(dir, "vectors.db")
+	c := config.NewDefaultConfig()
+	c.Vector.Enabled = true
+	c.Vector.DBPath = vectorPath
+	c.Vector.Embeddings.Endpoint = "https://embedding.example.test/v1"
+	c.Vector.Embeddings.Model = "text-embedding-test"
+	c.Vector.Embeddings.Dimension = 2
+	c.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+
+	mainStore, err := store.Open(mainPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mainStore.Close() })
+	require.NoError(t, mainStore.InitSchema())
+	semanticProfile, err := c.Vector.SemanticPersonEmbeddingProfile()
+	require.NoError(t, err)
+	_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), semanticProfile)
+	require.NoError(t, err)
+	_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), semanticProfile.Fingerprint, "test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, sqlitevec.RegisterExtension())
+	backend, err := sqlitevec.Open(t.Context(), sqlitevec.Options{
+		Path: vectorPath, MainPath: mainPath, Dimension: 2, MainDB: mainStore.DB(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = backend.Close() })
+	gen, err := backend.CreateGeneration(t.Context(), c.Vector.Embeddings.Model, 2, c.Vector.GenerationFingerprint())
+	require.NoError(t, err)
+	personGate := vector.NewExactSemanticPersonEmbeddingGate(
+		func() (vector.Config, error) { return c.Vector, nil }, mainStore,
+	)
+	checker, err := newConvergenceChecker(c.Vector, mainStore, backend, personGate)
+	require.NoError(t, err)
+	personChecker, ok := checker.(personsearch.CoverageChecker)
+	require.True(t, ok, "configured convergence must expose the person-only readiness check")
+	_, err = mainStore.DB().Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'person-coverage@example.test');
+		INSERT INTO conversations (id, source_id, conversation_type) VALUES (1, 1, 'email_thread');
+		INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type)
+		VALUES (1, 1, 1, 'person-coverage-message', 'email');
+	`)
+	require.NoError(t, err)
+	personCoverage, err := personChecker.CheckPersonCoverage(t.Context(), gen)
+	require.NoError(t, err)
+	assert.True(t, personCoverage.Complete(),
+		"person search readiness must not scan or depend on unrelated message coverage")
+	state, err := checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.False(t, state.MessageCoverageComplete, "precondition: message coverage is incomplete")
+	_, err = mainStore.DB().Exec(`UPDATE messages SET embed_gen = ? WHERE id = 1`, gen)
+	require.NoError(t, err)
+
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.True(t, state.PersonCoverageComplete)
+	assert.Zero(t, state.PersonCoverageMismatched)
+	assert.True(t, state.Complete(), "zero-person archive must converge")
+	_, err = mainStore.DB().Exec(`INSERT INTO persons (vcard_uid) VALUES (?)`,
+		"urn:uuid:00000000-0000-0000-0000-000000000000")
+	require.NoError(t, err)
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.True(t, state.Complete(), "person without semantic text must not require a vector")
+	_, err = mainStore.DB().Exec(`DELETE FROM persons WHERE vcard_uid = ?`,
+		"urn:uuid:00000000-0000-0000-0000-000000000000")
+	require.NoError(t, err)
+
+	_, err = mainStore.DB().Exec(`INSERT INTO persons (vcard_uid, display_name) VALUES (?, ?)`,
+		"urn:uuid:00000000-0000-0000-0000-000000000001", "Synthetic Person")
+	require.NoError(t, err)
+	documents, err := mainStore.ListPersonSemanticDocumentsContext(t.Context())
+	require.NoError(t, err)
+	require.Len(t, documents, 1)
+
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.False(t, state.PersonCoverageComplete)
+	assert.Equal(t, int64(1), state.PersonCoverageMismatched)
+	assert.False(t, state.Complete(), "missing person vector must block activation")
+
+	require.NoError(t, backend.UpsertPersons(t.Context(), gen, []vector.PersonEmbedding{{
+		PersonID: documents[0].PersonID, Revision: documents[0].Revision,
+	}}))
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.False(t, state.PersonCoverageComplete)
+	assert.False(t, state.Complete(), "a terminal provider rejection must remain visible")
+
+	require.NoError(t, backend.UpsertPersons(t.Context(), gen, []vector.PersonEmbedding{{
+		PersonID: documents[0].PersonID, Revision: documents[0].Revision, Vector: []float32{1, 2},
+	}}))
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.True(t, state.Complete())
+
+	_, err = mainStore.DB().Exec(`UPDATE persons SET display_name = ? WHERE id = ?`,
+		"Synthetic Person Updated", documents[0].PersonID)
+	require.NoError(t, err)
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.False(t, state.PersonCoverageComplete)
+	assert.Equal(t, int64(1), state.PersonCoverageMismatched)
+	assert.False(t, state.Complete(), "stale exact digest must block activation")
+
+	_, err = mainStore.DB().Exec(`DELETE FROM persons WHERE id = ?`, documents[0].PersonID)
+	require.NoError(t, err)
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.False(t, state.PersonCoverageComplete)
+	assert.Equal(t, int64(1), state.PersonCoverageMismatched, "orphaned vector must block activation")
+	require.NoError(t, backend.DeletePersonsNotIn(t.Context(), gen, nil))
+	state, err = checker.CheckConvergence(t.Context(), gen)
+	require.NoError(t, err)
+	assert.True(t, state.Complete(), "reconciled zero-person archive must converge")
 }
 
 // openTestBackend opens a fresh in-memory-ish sqlitevec backend with a

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -42,7 +42,7 @@ type embeddingGenerationRow struct {
 	MessageCount int64
 	// Coverage counts for this generation over the live-message universe,
 	// computed from the main DB (live/stamped/missing) plus the vector
-	// backend (embedded). Filled by fillCoverage / fillFullCoverage. The
+	// backend (embedded). Filled by fillFullCoverage. The
 	// invariant LiveCount == EmbeddedCount + BlankCount + MissingCount holds.
 	//
 	//   - LiveCount:     total live messages (the embedding universe).
@@ -57,29 +57,6 @@ type embeddingGenerationRow struct {
 	EmbeddedCount int64
 	BlankCount    int64
 	MissingCount  int64
-}
-
-// fillCoverage populates row.LiveCount and row.MissingCount from the main
-// DB so the management commands can gate on how many live messages still
-// need embedding for the generation. This is the cheap, backend-free path
-// used by the activation gate (which only needs MissingCount). It leaves
-// EmbeddedCount/BlankCount at zero — use fillFullCoverage for the display
-// table where the embedded/blank split is wanted. A failure is surfaced to
-// the caller. The scope is passed in explicitly so daemon handlers can use
-// a per-request resolved copy instead of the shared global config.
-func fillCoverage(ctx context.Context, scope vector.BuildScope, row *embeddingGenerationRow) error {
-	s, err := store.Open(cfg.DatabaseDSN())
-	if err != nil {
-		return fmt.Errorf("open main db for coverage: %w", err)
-	}
-	defer func() { _ = s.Close() }()
-	live, _, _, missing, err := s.CoverageCountsScoped(ctx, int64(row.ID), scope.MessageTypes, scope.SourceIDs)
-	if err != nil {
-		return err
-	}
-	row.LiveCount = live
-	row.MissingCount = missing
-	return nil
 }
 
 // fillFullCoverage populates the complete live/embedded/blank/missing split
@@ -342,30 +319,22 @@ func runEmbeddingsActivate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("generation %d fingerprint=%q does not match config=%q; pass --force to activate anyway",
 			gen, row.Fingerprint, expected)
 	}
-	// The coverage gate is enforced inside backend.ActivateGeneration
-	// (atomically on PG; via a Go pre-check on SQLite). We still surface a
-	// friendly pre-flight error here (against the main-DB coverage) so the
-	// common case fails fast before opening a backend connection and before
-	// prompting — but the backend's gate is the authoritative guarantee.
+	// Check both message and exact curated-person coverage before prompting.
+	// Backends independently enforce message coverage during activation;
+	// person revisions span the source and vector stores, so read-time digest
+	// revalidation remains the stale-write/deletion safety boundary if source
+	// state changes after this convergence snapshot.
 	var contextualSequence *int64
 	if !embeddingsActivateForce {
+		state, err := configuredConvergenceState(cmd.Context(), cfg.Vector, gen)
+		if err != nil {
+			return err
+		}
+		if !state.Complete() {
+			return manualConvergenceError(gen, state)
+		}
 		if cfg.Vector.Embeddings.EffectiveAPIFormat() == vector.APIFormatVoyageContextual {
-			state, err := configuredConvergenceState(cmd.Context(), cfg.Vector, gen)
-			if err != nil {
-				return err
-			}
-			if !state.Complete() {
-				return convergenceError(gen, state)
-			}
 			contextualSequence = &state.LatestJournalSequence
-		} else {
-			if err := fillCoverage(cmd.Context(), cfg.Vector.Embed.Scope.BuildScope(), &row); err != nil {
-				return err
-			}
-			if row.MissingCount > 0 {
-				return fmt.Errorf("generation %d still has %d message(s) needing embedding; run `msgvault embeddings resume --backstop` to recover any below-watermark stragglers, or pass --force",
-					gen, row.MissingCount)
-			}
 		}
 	}
 
@@ -547,18 +516,8 @@ func planCLIEmbeddingsActivate(
 			gen, row.Fingerprint, expected)
 	}
 	if !force {
-		if cfg.Vector.Embeddings.EffectiveAPIFormat() == vector.APIFormatVoyageContextual {
-			if err := requireConfiguredConvergence(ctx, vecCfg, gen); err != nil {
-				return api.CLIEmbeddingsPlanResponse{}, err
-			}
-		} else {
-			if err := fillCoverage(ctx, vecCfg.Embed.Scope.BuildScope(), &row); err != nil {
-				return api.CLIEmbeddingsPlanResponse{}, err
-			}
-			if row.MissingCount > 0 {
-				return api.CLIEmbeddingsPlanResponse{}, fmt.Errorf("generation %d still has %d message(s) needing embedding; run `msgvault embeddings resume --backstop` to recover any below-watermark stragglers, or pass --force",
-					gen, row.MissingCount)
-			}
+		if err := requireConfiguredConvergence(ctx, vecCfg, gen); err != nil {
+			return api.CLIEmbeddingsPlanResponse{}, err
 		}
 	}
 
@@ -605,7 +564,10 @@ func configuredConvergenceState(ctx context.Context, vecCfg vector.Config, gen v
 		return scheduler.ConvergenceResult{}, err
 	}
 	defer closeBackend()
-	checker, err := newConvergenceChecker(vecCfg, mainStore, backend)
+	personGate := vector.NewPinnedExactSemanticPersonEmbeddingGate(
+		vecCfg, currentSemanticPersonVectorConfigSource(), mainStore,
+	)
+	checker, err := newConvergenceChecker(vecCfg, mainStore, backend, personGate)
 	if err != nil {
 		return scheduler.ConvergenceResult{}, err
 	}

--- a/cmd/msgvault/cmd/embeddings_manage_test.go
+++ b/cmd/msgvault/cmd/embeddings_manage_test.go
@@ -40,7 +40,13 @@ func TestContextualConvergenceCheckerRequiresExactJournalAndCompletedReconciliat
 		ChangeSequence: 12, ReconcileCursor: "done:12",
 	}}
 	checker := &contextualConvergenceChecker{
-		legacy: &legacyConvergenceChecker{store: mainStore}, publisher: publisher,
+		legacy: &legacyConvergenceChecker{
+			store: mainStore,
+			personGate: vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error {
+				return nil
+			}),
+		},
+		publisher: publisher,
 	}
 	state, err := checker.CheckConvergence(t.Context(), 3)
 	require.NoError(t, err)
@@ -65,6 +71,7 @@ func TestContextualConvergenceCheckerRequiresExactJournalAndCompletedReconciliat
 func TestConvergenceResultRefusesEachIncompleteDimension(t *testing.T) {
 	complete := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   4,
 		ConsumedJournalSequence: 4,
 		ReconciliationComplete:  true,
@@ -80,6 +87,12 @@ func TestConvergenceResultRefusesEachIncompleteDimension(t *testing.T) {
 	unreconciled := complete
 	unreconciled.ReconciliationComplete = false
 	assert.False(t, unreconciled.Complete())
+	peopleMissing := complete
+	peopleMissing.PersonCoverageComplete = false
+	assert.False(t, peopleMissing.Complete())
+	peopleRejected := complete
+	peopleRejected.PersonCoverageRejected = 1
+	assert.False(t, peopleRejected.Complete())
 }
 
 func TestRunEmbeddingsActivate_ContextualRequiresConvergenceUnlessForced(t *testing.T) {
@@ -133,6 +146,71 @@ func TestRunEmbeddingsActivate_ContextualRequiresConvergenceUnlessForced(t *test
 	embeddingsActivateForce = true
 	require.NoError(t, runEmbeddingsActivate(cmd, []string{genArg}))
 	assert.Contains(t, output.String(), "Generation "+genArg+" activated")
+}
+
+// TestRunEmbeddingsActivateOpenAIBlocksMissingPersonCoverage catches the
+// standalone activation command bypassing exact curated-person convergence
+// for an otherwise message-complete OpenAI-format generation.
+func TestRunEmbeddingsActivateOpenAIBlocksMissingPersonCoverage(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "msgvault.db")
+	vectorPath := filepath.Join(dir, "vectors.db")
+	c := config.NewDefaultConfig()
+	c.HomeDir = dir
+	c.Data.DataDir = dir
+	c.Vector.Enabled = true
+	c.Vector.DBPath = vectorPath
+	c.Vector.Embeddings.Endpoint = "https://example.invalid/v1"
+	c.Vector.Embeddings.Model = "text-embedding-test"
+	c.Vector.Embeddings.Dimension = 4
+	c.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+	withTestConfig(t, c)
+	require.NoError(t, c.Save())
+
+	mainStore, err := store.Open(mainPath)
+	require.NoError(t, err)
+	require.NoError(t, mainStore.InitSchema())
+	semanticProfile, err := c.Vector.SemanticPersonEmbeddingProfile()
+	require.NoError(t, err)
+	_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), semanticProfile)
+	require.NoError(t, err)
+	_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), semanticProfile.Fingerprint, "test",
+	)
+	require.NoError(t, err)
+	_, err = mainStore.DB().Exec(`INSERT INTO persons (vcard_uid, display_name) VALUES (?, ?)`,
+		"urn:uuid:00000000-0000-0000-0000-000000000002", "Synthetic Missing Person")
+	require.NoError(t, err)
+	require.NoError(t, sqlitevec.RegisterExtension())
+	backend, err := sqlitevec.Open(t.Context(), sqlitevec.Options{
+		Path: vectorPath, MainPath: mainPath, Dimension: 4, MainDB: mainStore.DB(),
+	})
+	require.NoError(t, err)
+	gen, err := backend.CreateGeneration(t.Context(), c.Vector.Embeddings.Model, 4, c.Vector.GenerationFingerprint())
+	require.NoError(t, err)
+	require.NoError(t, backend.Close())
+	require.NoError(t, mainStore.Close())
+
+	oldYes, oldForce := embeddingsActivateYes, embeddingsActivateForce
+	t.Cleanup(func() { embeddingsActivateYes, embeddingsActivateForce = oldYes, oldForce })
+	embeddingsActivateYes = true
+	embeddingsActivateForce = false
+	previousContext := embeddingsActivateCmd.Context()
+	embeddingsActivateCmd.SetContext(t.Context())
+	t.Cleanup(func() { embeddingsActivateCmd.SetContext(previousContext) })
+
+	err = runEmbeddingsActivate(embeddingsActivateCmd,
+		[]string{strconv.FormatInt(int64(gen), 10)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "person_coverage_complete=false")
+	assert.NotContains(t, err.Error(), "needing embedding",
+		"person-only incompleteness must not suggest message recovery")
+	assert.Contains(t, err.Error(), "msgvault embeddings resume --backstop")
+	assert.Contains(t, err.Error(), "--force")
+	assert.NotContains(t, err.Error(), "activate automatically")
+	assertManualGenerationState(t, gen, vector.GenerationBuilding)
 }
 
 func setupManualContextualGeneration(t *testing.T, fingerprint string, retire bool) vector.GenerationID {

--- a/cmd/msgvault/cmd/person.go
+++ b/cmd/msgvault/cmd/person.go
@@ -253,7 +253,7 @@ func init() {
 	personCmd.AddCommand(newPersonProviderCommand(defaultPersonProviderCommandDeps()))
 	personCmd.AddCommand(personPromoteCmd, personGetCmd, personListCmd,
 		personSetDisplayNameCmd, personDeleteCmd, personTrackCmd, personUntrackCmd,
-		newPersonFilesCommand(defaultPersonFilesCommandDeps()))
+		newPersonFilesCommand(defaultPersonFilesCommandDeps()), personSearchCmd)
 	for _, command := range []*cobra.Command{
 		personPromoteCmd, personGetCmd, personListCmd, personSetDisplayNameCmd,
 		personTrackCmd, personUntrackCmd,

--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -8,14 +8,19 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/peoplesweep"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
 )
 
-const personProviderConsentActor = "cli"
+const (
+	personProviderCommandName  = "provider"
+	personProviderConsentActor = "cli"
+)
 
 type personProviderStore interface {
 	EnsurePersonInferenceProfile(ctx context.Context, profile peoplesweep.ProviderProfile) (bool, error)
@@ -25,6 +30,13 @@ type personProviderStore interface {
 	RevokeAllPersonInferenceConsents(ctx context.Context, actor string) (int64, error)
 	GetPersonInferenceConsentStatus(ctx context.Context, fingerprint string) (*store.PersonInferenceConsentStatus, error)
 	HasActivePersonInferenceConsent(ctx context.Context, fingerprint string) (bool, error)
+	EnsurePersonSemanticEmbeddingProfile(ctx context.Context, profile vector.SemanticPersonEmbeddingProfile) (bool, error)
+	ListPersonSemanticEmbeddingProfiles(ctx context.Context) ([]vector.SemanticPersonEmbeddingProfile, error)
+	GrantPersonSemanticEmbeddingConsent(ctx context.Context, fingerprint, actor string) (*store.PersonSemanticEmbeddingConsent, bool, error)
+	RevokePersonSemanticEmbeddingConsent(ctx context.Context, fingerprint, actor string) (bool, error)
+	RevokeAllPersonSemanticEmbeddingConsents(ctx context.Context, actor string) (int64, error)
+	GetPersonSemanticEmbeddingConsentStatus(ctx context.Context, fingerprint string) (*store.PersonSemanticEmbeddingConsentStatus, error)
+	HasActivePersonSemanticEmbeddingConsent(ctx context.Context, fingerprint string) (bool, error)
 }
 
 type personProviderChecker interface {
@@ -33,6 +45,7 @@ type personProviderChecker interface {
 
 type personProviderCommandDeps struct {
 	config             func() peoplesweep.Config
+	vectorConfig       func() vector.Config
 	openStore          func() (personProviderStore, func(), error)
 	newChecker         func(peoplesweep.Config, personProviderStore) (personProviderChecker, error)
 	isDaemonSubprocess func() bool
@@ -61,6 +74,20 @@ type personProviderRevokeAllOutput struct {
 	Profiles []personProviderStatusOutput `json:"profiles"`
 }
 
+type personSemanticProviderStatusOutput struct {
+	Profile vector.SemanticPersonEmbeddingProfile      `json:"profile"`
+	Consent store.PersonSemanticEmbeddingConsentStatus `json:"consent"`
+}
+
+type personSemanticProviderStatusesOutput struct {
+	Profiles []personSemanticProviderStatusOutput `json:"profiles"`
+}
+
+type personSemanticProviderRevokeAllOutput struct {
+	Revoked  int64                                `json:"revoked"`
+	Profiles []personSemanticProviderStatusOutput `json:"profiles"`
+}
+
 func defaultPersonProviderCommandDeps() personProviderCommandDeps {
 	return personProviderCommandDeps{
 		config: func() peoplesweep.Config {
@@ -68,6 +95,12 @@ func defaultPersonProviderCommandDeps() personProviderCommandDeps {
 				return peoplesweep.Config{}
 			}
 			return cfg.People.Sweep
+		},
+		vectorConfig: func() vector.Config {
+			if cfg == nil {
+				return vector.Config{}
+			}
+			return cfg.Vector
 		},
 		openStore: func() (personProviderStore, func(), error) {
 			return openWritableStoreAndInit()
@@ -93,7 +126,7 @@ func defaultPersonProviderCommandDeps() personProviderCommandDeps {
 
 func newPersonProviderCommand(deps personProviderCommandDeps) *cobra.Command {
 	provider := &cobra.Command{
-		Use:   "provider",
+		Use:   personProviderCommandName,
 		Short: "Manage people-sweep inference",
 	}
 	provider.AddCommand(
@@ -108,6 +141,7 @@ func newPersonProviderCommand(deps personProviderCommandDeps) *cobra.Command {
 func newPersonProviderStatusCommand(deps personProviderCommandDeps) *cobra.Command {
 	var all bool
 	var jsonOutput bool
+	var semanticEmbeddings bool
 	command := &cobra.Command{
 		Use:   statusValue,
 		Short: "Show the exact people inference policy and consent state",
@@ -116,17 +150,20 @@ func newPersonProviderStatusCommand(deps personProviderCommandDeps) *cobra.Comma
 			if !deps.isDaemonSubprocess() {
 				return deps.proxy(command, args, nil)
 			}
-			return runPersonProviderStatus(command, deps, all, jsonOutput)
+			return runPersonProviderStatus(command, deps, all, jsonOutput, semanticEmbeddings)
 		},
 	}
 	command.Flags().BoolVar(&all, "all", false, "Show every stored provider policy and consent state")
 	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	command.Flags().BoolVar(&semanticEmbeddings, "semantic-embeddings", false,
+		"Select the curated-person semantic embedding policy")
 	return command
 }
 
 func newPersonProviderConsentCommand(deps personProviderCommandDeps) *cobra.Command {
 	var confirmed bool
 	var jsonOutput bool
+	var semanticEmbeddings bool
 	command := &cobra.Command{
 		Use:   "consent",
 		Short: "Consent to the exact people inference policy",
@@ -135,17 +172,20 @@ func newPersonProviderConsentCommand(deps personProviderCommandDeps) *cobra.Comm
 			if !deps.isDaemonSubprocess() {
 				return deps.proxy(command, args, nil)
 			}
-			return runPersonProviderConsent(command, deps, confirmed, jsonOutput)
+			return runPersonProviderConsent(command, deps, confirmed, jsonOutput, semanticEmbeddings)
 		},
 	}
 	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the disclosed provider policy")
 	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	command.Flags().BoolVar(&semanticEmbeddings, "semantic-embeddings", false,
+		"Select the curated-person semantic embedding policy")
 	return command
 }
 
 func newPersonProviderRevokeCommand(deps personProviderCommandDeps) *cobra.Command {
 	var all bool
 	var jsonOutput bool
+	var semanticEmbeddings bool
 	command := &cobra.Command{
 		Use:   "revoke",
 		Short: "Revoke consent for the exact people inference policy",
@@ -154,11 +194,13 @@ func newPersonProviderRevokeCommand(deps personProviderCommandDeps) *cobra.Comma
 			if !deps.isDaemonSubprocess() {
 				return deps.proxy(command, args, nil)
 			}
-			return runPersonProviderRevoke(command, deps, all, jsonOutput)
+			return runPersonProviderRevoke(command, deps, all, jsonOutput, semanticEmbeddings)
 		},
 	}
 	command.Flags().BoolVar(&all, "all", false, "Revoke consent for every stored provider policy")
 	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	command.Flags().BoolVar(&semanticEmbeddings, "semantic-embeddings", false,
+		"Select the curated-person semantic embedding policy")
 	return command
 }
 
@@ -185,7 +227,11 @@ func runPersonProviderStatus(
 	deps personProviderCommandDeps,
 	all bool,
 	jsonOutput bool,
+	semanticEmbeddings bool,
 ) error {
+	if semanticEmbeddings {
+		return runPersonSemanticProviderStatus(command, deps, all, jsonOutput)
+	}
 	if all {
 		st, cleanup, err := deps.openStore()
 		if err != nil {
@@ -219,7 +265,11 @@ func runPersonProviderConsent(
 	deps personProviderCommandDeps,
 	confirmed bool,
 	jsonOutput bool,
+	semanticEmbeddings bool,
 ) error {
+	if semanticEmbeddings {
+		return runPersonSemanticProviderConsent(command, deps, confirmed, jsonOutput)
+	}
 	profile, err := deps.config().Profile()
 	if err != nil {
 		return err
@@ -258,7 +308,11 @@ func runPersonProviderRevoke(
 	deps personProviderCommandDeps,
 	all bool,
 	jsonOutput bool,
+	semanticEmbeddings bool,
 ) error {
+	if semanticEmbeddings {
+		return runPersonSemanticProviderRevoke(command, deps, all, jsonOutput)
+	}
 	if all {
 		st, cleanup, err := deps.openStore()
 		if err != nil {
@@ -304,6 +358,141 @@ func runPersonProviderRevoke(
 	}
 	if jsonOutput {
 		return writePersonProviderStatus(command.OutOrStdout(), profile, status, true)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Consent revoked for %s\n", profile.Fingerprint)
+	return nil
+}
+
+func runPersonSemanticProviderStatus(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	all bool,
+	jsonOutput bool,
+) error {
+	if all {
+		st, cleanup, err := deps.openStore()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		profiles, err := st.ListPersonSemanticEmbeddingProfiles(command.Context())
+		if err != nil {
+			return err
+		}
+		statuses, err := personSemanticProviderStatuses(command.Context(), st, profiles)
+		if err != nil {
+			return err
+		}
+		return writePersonSemanticProviderStatuses(command.OutOrStdout(), statuses, jsonOutput)
+	}
+	profile, st, cleanup, err := openPersonSemanticProviderProfile(deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	status, err := st.GetPersonSemanticEmbeddingConsentStatus(
+		command.Context(), profile.Fingerprint,
+	)
+	if err != nil {
+		return err
+	}
+	return writePersonSemanticProviderStatus(command.OutOrStdout(), profile, status, jsonOutput)
+}
+
+func runPersonSemanticProviderConsent(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	confirmed bool,
+	jsonOutput bool,
+) error {
+	profile, err := currentPersonSemanticProviderProfile(deps)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		printPersonSemanticProviderDisclosure(command.OutOrStdout(), profile)
+		return errors.New("semantic person embedding consent requires --yes after reviewing the provider disclosure")
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.EnsurePersonSemanticEmbeddingProfile(command.Context(), profile); err != nil {
+		return err
+	}
+	if _, _, err := st.GrantPersonSemanticEmbeddingConsent(
+		command.Context(), profile.Fingerprint, personProviderConsentActor,
+	); err != nil {
+		return err
+	}
+	status, err := st.GetPersonSemanticEmbeddingConsentStatus(
+		command.Context(), profile.Fingerprint,
+	)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writePersonSemanticProviderStatus(command.OutOrStdout(), profile, status, true)
+	}
+	printPersonSemanticProviderDisclosure(command.OutOrStdout(), profile)
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "Consent: active (%s)\n", profile.Fingerprint)
+	return nil
+}
+
+func runPersonSemanticProviderRevoke(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	all bool,
+	jsonOutput bool,
+) error {
+	if all {
+		st, cleanup, err := deps.openStore()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		revoked, err := st.RevokeAllPersonSemanticEmbeddingConsents(
+			command.Context(), personProviderConsentActor,
+		)
+		if err != nil {
+			return err
+		}
+		profiles, err := st.ListPersonSemanticEmbeddingProfiles(command.Context())
+		if err != nil {
+			return err
+		}
+		statuses, err := personSemanticProviderStatuses(command.Context(), st, profiles)
+		if err != nil {
+			return err
+		}
+		if jsonOutput {
+			return json.NewEncoder(command.OutOrStdout()).Encode(personSemanticProviderRevokeAllOutput{
+				Revoked: revoked, Profiles: statuses,
+			})
+		}
+		_, _ = fmt.Fprintf(command.OutOrStdout(),
+			"Consent revoked for %d active semantic person embedding profile(s).\n", revoked)
+		return nil
+	}
+	profile, st, cleanup, err := openPersonSemanticProviderProfile(deps)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, err := st.RevokePersonSemanticEmbeddingConsent(
+		command.Context(), profile.Fingerprint, personProviderConsentActor,
+	); err != nil {
+		return err
+	}
+	status, err := st.GetPersonSemanticEmbeddingConsentStatus(
+		command.Context(), profile.Fingerprint,
+	)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writePersonSemanticProviderStatus(command.OutOrStdout(), profile, status, true)
 	}
 	_, _ = fmt.Fprintf(command.OutOrStdout(), "Consent revoked for %s\n", profile.Fingerprint)
 	return nil
@@ -359,6 +548,47 @@ func openPersonProviderProfile(
 	return profile, st, cleanup, nil
 }
 
+func currentPersonSemanticProviderProfile(
+	deps personProviderCommandDeps,
+) (vector.SemanticPersonEmbeddingProfile, error) {
+	if deps.vectorConfig == nil {
+		return vector.SemanticPersonEmbeddingProfile{}, errors.New(
+			"semantic person embedding configuration is unavailable",
+		)
+	}
+	config := deps.vectorConfig()
+	if !config.Enabled || !config.People.Enabled {
+		return vector.SemanticPersonEmbeddingProfile{}, vector.ErrSemanticPersonEmbeddingsDisabled
+	}
+	return config.SemanticPersonEmbeddingProfile()
+}
+
+func configuredPersonSemanticProviderProfile(
+	deps personProviderCommandDeps,
+) (vector.SemanticPersonEmbeddingProfile, error) {
+	if deps.vectorConfig == nil {
+		return vector.SemanticPersonEmbeddingProfile{}, errors.New(
+			"semantic person embedding configuration is unavailable",
+		)
+	}
+	config := deps.vectorConfig()
+	return config.SemanticPersonEmbeddingProfile()
+}
+
+func openPersonSemanticProviderProfile(
+	deps personProviderCommandDeps,
+) (vector.SemanticPersonEmbeddingProfile, personProviderStore, func(), error) {
+	profile, err := configuredPersonSemanticProviderProfile(deps)
+	if err != nil {
+		return vector.SemanticPersonEmbeddingProfile{}, nil, nil, err
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return vector.SemanticPersonEmbeddingProfile{}, nil, nil, err
+	}
+	return profile, st, cleanup, nil
+}
+
 func writePersonProviderStatus(
 	w io.Writer,
 	profile peoplesweep.ProviderProfile,
@@ -374,6 +604,31 @@ func writePersonProviderStatus(
 		})
 	}
 	printPersonProviderDisclosure(w, profile)
+	state := "inactive"
+	if status.Active {
+		state = "active"
+	} else if status.LastRevoked != nil {
+		state = "revoked"
+	}
+	_, _ = fmt.Fprintf(w, "Consent: %s\n", state)
+	return nil
+}
+
+func writePersonSemanticProviderStatus(
+	w io.Writer,
+	profile vector.SemanticPersonEmbeddingProfile,
+	status *store.PersonSemanticEmbeddingConsentStatus,
+	jsonOutput bool,
+) error {
+	if status == nil {
+		return errors.New("semantic person embedding consent status is empty")
+	}
+	if jsonOutput {
+		return json.NewEncoder(w).Encode(personSemanticProviderStatusOutput{
+			Profile: profile, Consent: *status,
+		})
+	}
+	printPersonSemanticProviderDisclosure(w, profile)
 	state := "inactive"
 	if status.Active {
 		state = "active"
@@ -403,6 +658,27 @@ func personProviderStatuses(
 	return statuses, nil
 }
 
+func personSemanticProviderStatuses(
+	ctx context.Context,
+	st personProviderStore,
+	profiles []vector.SemanticPersonEmbeddingProfile,
+) ([]personSemanticProviderStatusOutput, error) {
+	statuses := make([]personSemanticProviderStatusOutput, 0, len(profiles))
+	for _, profile := range profiles {
+		status, err := st.GetPersonSemanticEmbeddingConsentStatus(ctx, profile.Fingerprint)
+		if err != nil {
+			return nil, err
+		}
+		if status == nil {
+			return nil, errors.New("semantic person embedding consent status is empty")
+		}
+		statuses = append(statuses, personSemanticProviderStatusOutput{
+			Profile: profile, Consent: *status,
+		})
+	}
+	return statuses, nil
+}
+
 func writePersonProviderStatuses(
 	w io.Writer,
 	statuses []personProviderStatusOutput,
@@ -420,6 +696,30 @@ func writePersonProviderStatuses(
 			_, _ = fmt.Fprintln(w)
 		}
 		if err := writePersonProviderStatus(w, status.Profile, &status.Consent, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writePersonSemanticProviderStatuses(
+	w io.Writer,
+	statuses []personSemanticProviderStatusOutput,
+	jsonOutput bool,
+) error {
+	if jsonOutput {
+		return json.NewEncoder(w).Encode(personSemanticProviderStatusesOutput{Profiles: statuses})
+	}
+	if len(statuses) == 0 {
+		_, _ = fmt.Fprintln(w, "No stored semantic person embedding profiles.")
+		return nil
+	}
+	for i, status := range statuses {
+		if i > 0 {
+			_, _ = fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w)
+		}
+		if err := writePersonSemanticProviderStatus(w, status.Profile, &status.Consent, false); err != nil {
 			return err
 		}
 	}
@@ -453,6 +753,43 @@ func printPersonProviderDisclosure(w io.Writer, profile peoplesweep.ProviderProf
 	_, _ = fmt.Fprintf(w, "Allowed sources: %s\n", strings.Join(sources, ", "))
 	_, _ = fmt.Fprintf(w, "Source dates: %s\n", dateRange)
 	_, _ = fmt.Fprintf(w, "Sensitive content: %s\n", sensitive)
+}
+
+func printPersonSemanticProviderDisclosure(
+	w io.Writer,
+	profile vector.SemanticPersonEmbeddingProfile,
+) {
+	authentication := "none configured"
+	if profile.APIKeyEnv != "" {
+		authentication = "environment variable " + profile.APIKeyEnv
+	}
+	_, _ = fmt.Fprintln(w, "Semantic person embedding provider disclosure:")
+	_, _ = fmt.Fprintf(w, "Purpose: %s\n", profile.Purpose)
+	_, _ = fmt.Fprintf(w, "Fingerprint: %s\n", profile.Fingerprint)
+	_, _ = fmt.Fprintf(w, "Destination: %s\n", profile.Destination)
+	_, _ = fmt.Fprintf(w, "API format: %s\n", profile.APIFormat)
+	_, _ = fmt.Fprintf(w, "Model: %s\n", profile.Model)
+	_, _ = fmt.Fprintf(w, "Authentication: %s\n", authentication)
+	_, _ = fmt.Fprintf(w, "Provider assertions: retention=%s, training=%s\n",
+		profile.RetentionPosture, profile.TrainingPosture)
+	_, _ = fmt.Fprintf(w, "Renderer policy: %s\n", profile.RendererPolicy)
+	_, _ = fmt.Fprintln(w, "Disclosed curated document field classes:")
+	for _, field := range profile.DisclosedFieldClasses {
+		if field == vector.SemanticPersonSearchQueryDisclosedFieldClass {
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "- %s\n", field)
+	}
+	if slices.Contains(
+		profile.DisclosedFieldClasses,
+		vector.SemanticPersonSearchQueryDisclosedFieldClass,
+	) {
+		_, _ = fmt.Fprintln(w,
+			"Caller-supplied query egress: free-text semantic person search queries are sent to the embedding provider.")
+	}
+	_, _ = fmt.Fprintf(w, "Corpus scope: %s\n", profile.CorpusScope)
+	_, _ = fmt.Fprintln(w,
+		"Scope note: [vector.embed.scope] does not filter curated people; this policy covers every durable person.")
 }
 
 func personProviderForwardEnv(

--- a/cmd/msgvault/cmd/person_provider_routing_test.go
+++ b/cmd/msgvault/cmd/person_provider_routing_test.go
@@ -24,6 +24,8 @@ func TestPersonProviderFrontendRoutesExactCommandsAndCredential(t *testing.T) {
 			wantArgs: []string{"person", "provider", "consent", "--yes"}},
 		{name: "revoke", args: []string{"revoke"},
 			wantArgs: []string{"person", "provider", "revoke"}},
+		{name: "semantic consent", args: []string{"consent", "--semantic-embeddings", "--yes"},
+			wantArgs: []string{"person", "provider", "consent", "--semantic-embeddings", "--yes"}},
 		{name: "check without key", args: []string{"check", "--json"},
 			wantArgs: []string{"person", "provider", "check", "--json"}, wantLookups: 1},
 		{name: "check with key", args: []string{"check"}, keyValue: "caller-key",

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"go.kenn.io/msgvault/internal/peoplesweep"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/vector"
 )
 
 func personProviderTestConfig() peoplesweep.Config {
@@ -58,6 +59,52 @@ func localPersonProviderDeps(
 		},
 		isDaemonSubprocess: func() bool { return true },
 	}
+}
+
+func semanticPersonProviderTestConfig() vector.Config {
+	return vector.Config{
+		Enabled: true,
+		Backend: "sqlite-vec",
+		Embeddings: vector.EmbeddingsConfig{
+			Endpoint: "https://embedding.example.test/v1", APIFormat: vector.APIFormatOpenAI,
+			Model: "semantic-person-model", APIKeyEnv: "SEMANTIC_PERSON_KEY",
+			Dimension: 4, BatchSize: 8,
+		},
+		People: vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		},
+	}
+}
+
+func historicalSemanticPersonProviderProfile(t *testing.T) vector.SemanticPersonEmbeddingProfile {
+	t.Helper()
+	profile := vector.SemanticPersonEmbeddingProfile{
+		Fingerprint:      "f002512c98b050443ebd3c113fc18199c48ed6ef2d27d70b62328c6bbac3d250",
+		Purpose:          "semantic_person_embeddings",
+		Destination:      "https://embedding.example.test/v1/embeddings",
+		APIFormat:        vector.APIFormatOpenAI,
+		Model:            "semantic-person-model",
+		APIKeyEnv:        "SEMANTIC_PERSON_KEY",
+		RetentionPosture: "zero_data_retention",
+		TrainingPosture:  "no_training",
+		RendererPolicy:   "person-semantic-v1",
+		DisclosedFieldClasses: []string{
+			"active_relationship_counterpart_labels_and_display_names",
+			"current_employment_title_role_department_location_description",
+			"current_organization_alternate_names_categories_description_domain_kind",
+			"current_organization_coarse_locations",
+			"current_organization_name",
+			"person_alternate_names",
+			"person_categories",
+			"person_coarse_locations",
+			"person_display_name",
+			"person_searchable_non_sensitive_custom_attributes_excluding_email_phone_date_timestamp",
+		},
+		CorpusScope: "all_durable_people",
+		PolicyJSON:  json.RawMessage(`{"purpose":"semantic_person_embeddings","destination":"https://embedding.example.test/v1/embeddings","api_format":"openai","model":"semantic-person-model","api_key_env":"SEMANTIC_PERSON_KEY","retention_posture":"zero_data_retention","training_posture":"no_training","renderer_policy":"person-semantic-v1","disclosed_field_classes":["active_relationship_counterpart_labels_and_display_names","current_employment_title_role_department_location_description","current_organization_alternate_names_categories_description_domain_kind","current_organization_coarse_locations","current_organization_name","person_alternate_names","person_categories","person_coarse_locations","person_display_name","person_searchable_non_sensitive_custom_attributes_excluding_email_phone_date_timestamp"],"corpus_scope":"all_durable_people"}`),
+	}
+	require.NoError(t, profile.Validate())
+	return profile
 }
 
 func executePersonProviderCommand(
@@ -138,6 +185,151 @@ func TestPersonProviderConsentDisclosesBeforeConfirmationAndIsIdempotent(t *test
 	require.NoError(json.Unmarshal([]byte(second), &secondStatus))
 	require.NotNil(secondStatus.Consent.Consent)
 	assert.Equal(firstStatus.Consent.Consent.ID, secondStatus.Consent.Consent.ID)
+}
+
+// TestPersonProviderSemanticSelectorDisclosesGlobalCorpusAndPersistsOnlyExactPolicy
+// catches the CLI hiding curated egress scope or granting people-sweep consent
+// instead of the selected semantic-person policy.
+func TestPersonProviderSemanticSelectorDisclosesGlobalCorpusAndPersistsOnlyExactPolicy(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	deps := localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	semanticConfig := semanticPersonProviderTestConfig()
+	deps.vectorConfig = func() vector.Config { return semanticConfig }
+	t.Setenv("SEMANTIC_PERSON_KEY", "credential-value-must-not-be-disclosed")
+
+	disclosure, err := executePersonProviderCommand(
+		t, deps, "consent", "--semantic-embeddings",
+	)
+	must.ErrorContains(err, "--yes")
+	profile, profileErr := semanticConfig.SemanticPersonEmbeddingProfile()
+	must.NoError(profileErr)
+	check.Contains(disclosure, "Semantic person embedding provider disclosure")
+	check.Contains(disclosure, "Purpose: semantic_person_embeddings")
+	check.Contains(disclosure, "Fingerprint: "+profile.Fingerprint)
+	check.Contains(disclosure, "Destination: https://embedding.example.test/v1/embeddings")
+	check.Contains(disclosure, "API format: openai")
+	check.Contains(disclosure, "Model: semantic-person-model")
+	check.Contains(disclosure, "Authentication: environment variable SEMANTIC_PERSON_KEY")
+	check.Contains(disclosure, "Provider assertions: retention=zero_data_retention, training=no_training")
+	check.Contains(disclosure, "Renderer policy: person-semantic-v1")
+	check.Contains(disclosure, "Disclosed curated document field classes:")
+	check.Contains(disclosure,
+		"Caller-supplied query egress: free-text semantic person search queries are sent to the embedding provider.")
+	check.Contains(disclosure, "Corpus scope: all_durable_people")
+	check.Contains(disclosure, "[vector.embed.scope] does not filter curated people")
+	const queryDisclosureToken = "caller_supplied_free_text_query_for_semantic_person_search"
+	for _, field := range vector.SemanticPersonDisclosedFieldClasses() {
+		if field == queryDisclosureToken {
+			continue
+		}
+		check.Contains(disclosure, "- "+field)
+	}
+	check.NotContains(disclosure, "- "+queryDisclosureToken)
+	check.NotContains(disclosure, "credential-value-must-not-be-disclosed")
+	statusDisclosure, err := executePersonProviderCommand(
+		t, deps, "status", "--semantic-embeddings",
+	)
+	must.NoError(err)
+	check.Contains(statusDisclosure, "Corpus scope: all_durable_people")
+	check.Contains(statusDisclosure, "Consent: inactive")
+
+	status, err := st.GetPersonSemanticEmbeddingConsentStatus(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.False(status.ProfileExists, "disclosure without --yes must not persist")
+
+	output, err := executePersonProviderCommand(
+		t, deps, "consent", "--semantic-embeddings", "--yes", "--json",
+	)
+	must.NoError(err)
+	var got personSemanticProviderStatusOutput
+	must.NoError(json.Unmarshal([]byte(output), &got))
+	check.Equal(profile.Fingerprint, got.Profile.Fingerprint)
+	check.True(got.Consent.Active)
+	inferenceProfiles, err := st.ListPersonInferenceProfiles(t.Context())
+	must.NoError(err)
+	check.Empty(inferenceProfiles, "semantic selector must not create a people-sweep grant")
+
+	_, err = executePersonProviderCommand(
+		t, deps, "revoke", "--semantic-embeddings", "--json",
+	)
+	must.NoError(err)
+	active, err := st.HasActivePersonSemanticEmbeddingConsent(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.False(active)
+}
+
+// TestSemanticPersonProviderStatusAllPreservesHistoricalQueryDisclosure
+// catches status --all claiming that a stored pre-expansion profile disclosed
+// caller search queries when its immutable policy did not.
+func TestSemanticPersonProviderStatusAllPreservesHistoricalQueryDisclosure(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	st := testutil.NewSQLiteTestStore(t)
+	historical := historicalSemanticPersonProviderProfile(t)
+	_, err := st.EnsurePersonSemanticEmbeddingProfile(t.Context(), historical)
+	must.NoError(err)
+	deps := localPersonProviderDeps(personProviderTestConfig(), st, nil)
+
+	output, err := executePersonProviderCommand(
+		t, deps, "status", "--semantic-embeddings", "--all",
+	)
+	must.NoError(err)
+	check.Contains(output, "Fingerprint: "+historical.Fingerprint)
+	check.Contains(output, "Disclosed curated document field classes:")
+	check.NotContains(output, "Caller-supplied query egress:")
+	check.NotContains(output, "caller_supplied_free_text_query_for_semantic_person_search")
+
+	profiles, err := st.ListPersonSemanticEmbeddingProfiles(t.Context())
+	must.NoError(err)
+	must.Len(profiles, 1)
+	check.Equal(historical.Fingerprint, profiles[0].Fingerprint)
+	check.Equal(historical.DisclosedFieldClasses, profiles[0].DisclosedFieldClasses)
+	check.JSONEq(string(historical.PolicyJSON), string(profiles[0].PolicyJSON))
+}
+
+func TestSemanticPersonProviderStatusAndRevokeResolveDisabledCurrentPolicy(t *testing.T) {
+	checks := assert.New(t)
+	must := require.New(t)
+	semanticConfig := semanticPersonProviderTestConfig()
+	profile, err := semanticConfig.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	_, err = st.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+	must.NoError(err)
+	_, _, err = st.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), profile.Fingerprint, "cli",
+	)
+	must.NoError(err)
+	semanticConfig.Enabled = false
+	semanticConfig.People.Enabled = false
+	deps := localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	deps.vectorConfig = func() vector.Config { return semanticConfig }
+
+	statusOutput, err := executePersonProviderCommand(
+		t, deps, "status", "--semantic-embeddings", "--json",
+	)
+	must.NoError(err)
+	var status personSemanticProviderStatusOutput
+	must.NoError(json.Unmarshal([]byte(statusOutput), &status))
+	checks.Equal(profile.Fingerprint, status.Profile.Fingerprint)
+	checks.True(status.Consent.Active)
+
+	revokeOutput, err := executePersonProviderCommand(
+		t, deps, "revoke", "--semantic-embeddings", "--json",
+	)
+	must.NoError(err)
+	var revoked personSemanticProviderStatusOutput
+	must.NoError(json.Unmarshal([]byte(revokeOutput), &revoked))
+	checks.Equal(profile.Fingerprint, revoked.Profile.Fingerprint)
+	checks.False(revoked.Consent.Active)
+
+	_, err = executePersonProviderCommand(
+		t, deps, "consent", "--semantic-embeddings", "--yes",
+	)
+	must.ErrorIs(err, vector.ErrSemanticPersonEmbeddingsDisabled,
+		"only consent requires semantic person embeddings to be enabled")
 }
 
 func TestPersonProviderRevokeIsIdempotent(t *testing.T) {

--- a/cmd/msgvault/cmd/person_search.go
+++ b/cmd/msgvault/cmd/person_search.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+const (
+	defaultPersonSearchLimit = 20
+	maximumPersonSearchLimit = 100
+)
+
+var (
+	personSearchLimit = defaultPersonSearchLimit
+	personSearchJSON  bool
+)
+
+type personSearchCLIResult struct {
+	ID          int64   `json:"id"`
+	DisplayName *string `json:"display_name"`
+	Score       float64 `json:"score"`
+}
+
+type personSearchCLIResponse struct {
+	Results []personSearchCLIResult `json:"results"`
+}
+
+var personSearchCmd = &cobra.Command{
+	Use:   "search <free-text>",
+	Short: "Search durable person profiles semantically",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		query := strings.TrimSpace(strings.Join(args, " "))
+		if query == "" {
+			return usageErr(cmd, errors.New("query must contain non-whitespace text"))
+		}
+		if personSearchLimit < 1 || personSearchLimit > maximumPersonSearchLimit {
+			return usageErr(cmd, fmt.Errorf("--limit must be between 1 and 100, got %d", personSearchLimit))
+		}
+
+		client, _, err := OpenHTTPStore(cmd.Context())
+		if err != nil {
+			return err
+		}
+		defer func() { _ = client.Close() }()
+
+		limit := int64(personSearchLimit)
+		body := generated.SearchPeopleBody{Query: query, Limit: &limit}
+		response, err := daemonclient.APIResponse(client,
+			func(api *apiclient.Client) (*generated.SearchPeopleResp, error) {
+				return api.SearchPeopleWithResponse(cmd.Context(), &generated.SearchPeopleRequestOptions{
+					Body: &body,
+				})
+			})
+		if err != nil {
+			return err
+		}
+		if response.JSON200 == nil {
+			return errors.New("person search response was empty")
+		}
+
+		output := personSearchCLIResponse{Results: make([]personSearchCLIResult, len(response.JSON200.Results))}
+		for i, result := range response.JSON200.Results {
+			output.Results[i] = personSearchCLIResult{
+				ID: result.Person.ID, DisplayName: result.Person.DisplayName, Score: result.Score,
+			}
+		}
+		if personSearchJSON {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(output)
+		}
+
+		writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(writer, "ID\tDISPLAY NAME\tSCORE")
+		for _, result := range output.Results {
+			_, _ = fmt.Fprintf(writer, "%d\t%s\t%.6f\n",
+				result.ID, personDisplayName(result.DisplayName), result.Score)
+		}
+		return writer.Flush()
+	},
+}
+
+func init() {
+	personSearchCmd.Flags().IntVar(
+		&personSearchLimit, "limit", defaultPersonSearchLimit, "Maximum number of results",
+	)
+	personSearchCmd.Flags().BoolVar(&personSearchJSON, flagJSON, false, "Output as JSON")
+}

--- a/cmd/msgvault/cmd/person_search_test.go
+++ b/cmd/msgvault/cmd/person_search_test.go
@@ -1,0 +1,787 @@
+//go:build sqlite_vec
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+func TestPersonSearchCommandUsesGeneratedRouteWithoutOpeningLocalStore(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assertions.Equal(http.MethodPost, r.Method)
+		assertions.Equal("/api/v1/people/search", r.URL.Path)
+		assertions.Equal("application/json", r.Header.Get("Content-Type"))
+		assertions.Equal("synthetic-daemon-key", r.Header.Get("X-Api-Key"))
+		var body struct {
+			Query string `json:"query"`
+			Limit int64  `json:"limit"`
+		}
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assertions.Equal("synthetic systems architect", body.Query)
+		assertions.Equal(int64(2), body.Limit)
+		writePersonSearchCommandResponse(t, w)
+	}))
+	t.Cleanup(server.Close)
+
+	blockedDataDir := filepath.Join(t.TempDir(), "not-a-directory")
+	requirements.NoError(os.WriteFile(blockedDataDir, []byte("blocks direct database access"), 0o600))
+	withStoreResolverConfig(t, &config.Config{
+		HomeDir: blockedDataDir,
+		Data:    config.DataConfig{DataDir: blockedDataDir},
+		Remote: config.RemoteConfig{
+			URL: server.URL, APIKey: "synthetic-daemon-key", AllowInsecure: true,
+		},
+	})
+
+	command, stdout, stderr := newPersonSearchTestCommand(t)
+	command.SetArgs([]string{"--limit", "2", "synthetic", "systems", "architect"})
+	requirements.NoError(command.Execute())
+
+	assertions.Equal(int32(1), requests.Load())
+	output := stdout.String()
+	first := strings.Index(output, "Synthetic Architect")
+	second := strings.Index(output, "Test Researcher")
+	assertions.GreaterOrEqual(first, 0, "first ranked result")
+	assertions.Greater(second, first, "human output preserves daemon relevance order")
+	assertions.Regexp(`(?m)^9\s+Synthetic Architect\s+0\.910000$`, output)
+	assertions.Regexp(`(?m)^3\s+Test Researcher\s+0\.730000$`, output)
+	assertions.Empty(stderr.String(), "person search emits no progress noise")
+}
+
+func TestPersonSearchCommandJSONHasStableExplicitOrderedShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writePersonSearchCommandResponse(t, w)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{Remote: config.RemoteConfig{
+		URL: server.URL, AllowInsecure: true,
+	}})
+
+	command, stdout, stderr := newPersonSearchTestCommand(t)
+	command.SetArgs([]string{"--json", "synthetic", "architect"})
+	require.NoError(t, command.Execute())
+
+	assert.JSONEq(t, `{
+		"results": [
+			{"id": 9, "display_name": "Synthetic Architect", "score": 0.91},
+			{"id": 3, "display_name": "Test Researcher", "score": 0.73}
+		]
+	}`, stdout.String())
+	assert.Empty(t, stderr.String(), "JSON mode emits no progress noise")
+}
+
+func TestPersonSearchCommandJSONPreservesEmptyResultsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"results": []any{}}))
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{Remote: config.RemoteConfig{
+		URL: server.URL, AllowInsecure: true,
+	}})
+
+	command, stdout, stderr := newPersonSearchTestCommand(t)
+	command.SetArgs([]string{"--json", "nobody"})
+	require.NoError(t, command.Execute())
+
+	assert.JSONEq(t, `{"results":[]}`, stdout.String())
+	assert.Empty(t, stderr.String(), "empty JSON output emits no progress noise")
+}
+
+func TestPersonSearchCommandPreservesNilDisplayNameAcrossOutputModes(t *testing.T) {
+	assertions := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assertions.NoError(json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{
+			{
+				"person": map[string]any{
+					"id": 11, "vcard_uid": "00000000-0000-0000-0000-000000000011",
+					"revision": 1, "participant_ids": []int64{110},
+					"created_at": "2026-08-20T00:00:00Z", "updated_at": "2026-08-20T00:00:00Z",
+				},
+				"score": 0.82,
+			},
+			{
+				"person": map[string]any{
+					"id": 4, "vcard_uid": "00000000-0000-0000-0000-000000000004",
+					"display_name": "Synthetic Named Person", "revision": 2,
+					"participant_ids": []int64{40}, "created_at": "2026-08-19T00:00:00Z",
+					"updated_at": "2026-08-19T00:00:00Z",
+				},
+				"score": 0.61,
+			},
+		}}))
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{Remote: config.RemoteConfig{
+		URL: server.URL, AllowInsecure: true,
+	}})
+
+	t.Run("JSON null and order", func(t *testing.T) {
+		checks := assert.New(t)
+		requirements := require.New(t)
+		command, stdout, stderr := newPersonSearchTestCommand(t)
+		command.SetArgs([]string{"--json", "synthetic"})
+		requirements.NoError(command.Execute())
+
+		checks.JSONEq(`{"results":[
+			{"id":11,"display_name":null,"score":0.82},
+			{"id":4,"display_name":"Synthetic Named Person","score":0.61}
+		]}`, stdout.String())
+		checks.Empty(stderr.String(), "nil display-name JSON emits no progress noise")
+	})
+
+	t.Run("human dash and order", func(t *testing.T) {
+		checks := assert.New(t)
+		requirements := require.New(t)
+		command, stdout, stderr := newPersonSearchTestCommand(t)
+		command.SetArgs([]string{"synthetic"})
+		requirements.NoError(command.Execute())
+
+		output := stdout.String()
+		unnamed := strings.Index(output, "11")
+		named := strings.Index(output, "Synthetic Named Person")
+		checks.GreaterOrEqual(unnamed, 0, "unnamed result")
+		checks.Greater(named, unnamed, "human output preserves relevance order")
+		checks.Regexp(`(?m)^11\s+-\s+0\.820000$`, output)
+		checks.Regexp(`(?m)^4\s+Synthetic Named Person\s+0\.610000$`, output)
+		checks.Empty(stderr.String(), "nil display-name human output emits no progress noise")
+	})
+}
+
+func TestPersonSearchCommandRejectsInvalidInputBeforeDaemonRequest(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		writePersonSearchCommandResponse(t, w)
+	}))
+	t.Cleanup(server.Close)
+	withStoreResolverConfig(t, &config.Config{Remote: config.RemoteConfig{
+		URL: server.URL, AllowInsecure: true,
+	}})
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "whitespace query", args: []string{" \t "}, want: "query must contain non-whitespace text"},
+		{name: "zero limit", args: []string{"--limit", "0", "synthetic"}, want: "--limit must be between 1 and 100"},
+		{name: "oversized limit", args: []string{"--limit", "101", "synthetic"}, want: "--limit must be between 1 and 100"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command, _, _ := newPersonSearchTestCommand(t)
+			command.SetArgs(test.args)
+			err := command.Execute()
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+	assert.Zero(t, requests.Load(), "invalid input must not reach or start a daemon")
+}
+
+func TestPersonSearchCommandPropagatesDisabledAndStaleDaemonErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    string
+		message string
+	}{
+		{name: "disabled", code: "vector_not_enabled", message: "Vector search is not configured"},
+		{name: "stale", code: "index_stale", message: "The vector index does not match configured embedding settings"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				assertions.NoError(json.NewEncoder(w).Encode(map[string]string{
+					"error": test.code, "message": test.message,
+				}))
+			}))
+			t.Cleanup(server.Close)
+			withStoreResolverConfig(t, &config.Config{Remote: config.RemoteConfig{
+				URL: server.URL, AllowInsecure: true,
+			}})
+
+			command, _, _ := newPersonSearchTestCommand(t)
+			command.SetArgs([]string{"synthetic"})
+			err := command.Execute()
+			requirements.Error(err)
+			requirements.ErrorContains(err, "API error (503)")
+			requirements.ErrorContains(err, test.message)
+		})
+	}
+}
+
+// TestDefaultVectorConfigBlocksCuratedPeopleButKeepsMessageEmbedding catches
+// vector enablement alone authorizing curated person documents and person
+// queries at the configured embedding provider.
+func TestDefaultVectorConfigBlocksCuratedPeopleButKeepsMessageEmbedding(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var (
+		providerMu     sync.Mutex
+		providerInputs []string
+	)
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		providerMu.Lock()
+		providerInputs = append(providerInputs, request.Input...)
+		providerMu.Unlock()
+		data := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			data[i] = map[string]any{"embedding": []float32{1, 0, 0, 0}, "index": i}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assertions.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"data": data, "model": "synthetic-default-policy-model",
+		}))
+	}))
+	t.Cleanup(provider.Close)
+
+	dataDir := t.TempDir()
+	mainPath := filepath.Join(dataDir, "msgvault.db")
+	configured := config.NewDefaultConfig()
+	configured.HomeDir = dataDir
+	configured.Data.DataDir = dataDir
+	configured.Vector.Enabled = true
+	configured.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+	configured.Vector.Embeddings.Endpoint = provider.URL + "/v1"
+	configured.Vector.Embeddings.Model = "synthetic-default-policy-model"
+	configured.Vector.Embeddings.Dimension = 4
+	configured.Vector.Embeddings.MaxRetries = 1
+	withTestConfig(t, configured)
+	requirements.NoError(configured.Save())
+
+	mainStore, err := store.Open(mainPath)
+	requirements.NoError(err)
+	t.Cleanup(func() { _ = mainStore.Close() })
+	requirements.NoError(mainStore.InitSchema())
+	_, err = mainStore.DB().Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES (1, 'test', 'default-policy-source');
+		INSERT INTO conversations
+			(id, source_id, source_conversation_id, conversation_type)
+		VALUES (1, 1, 'default-policy-conversation', 'email_thread');
+		INSERT INTO messages
+			(id, conversation_id, source_id, source_message_id, message_type, subject)
+		VALUES (1, 1, 1, 'default-policy-message', 'email', 'Synthetic message subject');
+		INSERT INTO message_bodies (message_id, body_text) VALUES (1, 'Synthetic message body')`)
+	requirements.NoError(err)
+	participantID, err := mainStore.EnsureParticipantByIdentifier(
+		"email", "default-policy@example.test", "Observed Synthetic Name",
+	)
+	requirements.NoError(err)
+	person, _, err := mainStore.CreatePersonFromParticipantContext(t.Context(), participantID)
+	requirements.NoError(err)
+	displayName := "Synthetic Curated Person"
+	person, err = mainStore.UpdatePersonDisplayNameContext(
+		t.Context(), person.ID, person.Revision, &displayName,
+	)
+	requirements.NoError(err)
+
+	features, err := setupVectorFeatures(t.Context(), mainStore, mainPath, false)
+	requirements.NoError(err)
+	requirements.NotNil(features)
+	t.Cleanup(func() { _ = features.Close() })
+	generation, err := features.Backend.CreateGeneration(
+		t.Context(), features.Cfg.Embeddings.Model,
+		features.Cfg.Embeddings.Dimension, features.Cfg.GenerationFingerprint(),
+	)
+	requirements.NoError(err)
+	result, err := features.Runner.RunOnce(t.Context(), generation)
+	requirements.NoError(err)
+	assertions.Equal(1, result.Succeeded, "message embedding must continue while people are disabled")
+	convergence, err := features.Convergence.CheckConvergence(t.Context(), generation)
+	requirements.NoError(err)
+	assertions.True(convergence.PersonCoverageComplete,
+		"disabled person embeddings must not block a message generation")
+
+	providerMu.Lock()
+	inputsAfterWorker := append([]string(nil), providerInputs...)
+	providerMu.Unlock()
+	assertions.Equal([]string{"Subject: Synthetic message subject\n\nSynthetic message body"}, inputsAfterWorker,
+		"default vector config must not send curated person data")
+
+	requirements.NoError(features.Backend.ActivateGeneration(t.Context(), generation, false))
+	_, err = features.PersonSearchEngine.Search(t.Context(), "synthetic person", 5)
+	requirements.ErrorContains(err, "[vector.people] enabled = true")
+	providerMu.Lock()
+	assertions.Equal(inputsAfterWorker, providerInputs,
+		"disabled person search must fail before query embedding")
+	providerMu.Unlock()
+
+	configured.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+	requirements.NoError(configured.Save())
+	result, err = features.Runner.RunOnce(t.Context(), generation)
+	requirements.NoError(err)
+	assertions.Zero(result.Succeeded, "unconsented people must be skipped without blocking messages")
+	_, err = features.PersonSearchEngine.Search(t.Context(), "synthetic person", 5)
+	requirements.ErrorIs(err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	providerMu.Lock()
+	assertions.Equal(inputsAfterWorker, providerInputs,
+		"enabled but unconsented people and queries must make zero provider calls")
+	providerMu.Unlock()
+
+	semanticProfile, err := configured.Vector.SemanticPersonEmbeddingProfile()
+	requirements.NoError(err)
+	_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), semanticProfile)
+	requirements.NoError(err)
+	_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), semanticProfile.Fingerprint, "test",
+	)
+	requirements.NoError(err)
+	result, err = features.Runner.RunOnce(t.Context(), generation)
+	requirements.NoError(err)
+	assertions.Equal(1, result.Succeeded, "consented exact policy must run the person worker")
+	results, err := features.PersonSearchEngine.Search(t.Context(), "synthetic person", 5)
+	requirements.NoError(err)
+	requirements.Len(results, 1)
+	assertions.Equal(person.ID, results[0].Person.ID)
+
+	providerMu.Lock()
+	providerCallsAfterConsent := len(providerInputs)
+	providerMu.Unlock()
+	_, err = mainStore.RevokePersonSemanticEmbeddingConsent(
+		t.Context(), semanticProfile.Fingerprint, "test",
+	)
+	requirements.NoError(err)
+	updatedName := "Synthetic Curated Person Updated"
+	_, err = mainStore.UpdatePersonDisplayNameContext(
+		t.Context(), person.ID, person.Revision, &updatedName,
+	)
+	requirements.NoError(err)
+	_, err = features.Runner.RunOnce(t.Context(), generation)
+	requirements.NoError(err)
+	_, err = features.PersonSearchEngine.Search(t.Context(), "updated person", 5)
+	requirements.ErrorIs(err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	providerMu.Lock()
+	assertions.Len(providerInputs, providerCallsAfterConsent,
+		"revocation must stop worker and query provider calls without restart")
+	providerMu.Unlock()
+}
+
+// TestCurrentSemanticPersonVectorConfigSourceFailsClosedAfterConfigRemoval
+// catches deletion of a live config silently falling back to the authorized
+// startup snapshot.
+func TestCurrentSemanticPersonVectorConfigSourceFailsClosedAfterConfigRemoval(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	configured := config.NewDefaultConfig()
+	configured.HomeDir = t.TempDir()
+	configured.Data.DataDir = configured.HomeDir
+	configured.Vector.Enabled = true
+	configured.Vector.Embeddings.Endpoint = "https://embedding.example.test/v1"
+	configured.Vector.Embeddings.Model = "synthetic-config-source-model"
+	configured.Vector.Embeddings.Dimension = 4
+	configured.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+	withTestConfig(t, configured)
+	requirements.NoError(configured.Save())
+
+	source := currentSemanticPersonVectorConfigSource()
+	current, err := source()
+	requirements.NoError(err)
+	assertions.True(current.People.Enabled)
+	requirements.NoError(os.Remove(configured.ConfigFilePath()))
+
+	current, err = source()
+	requirements.NoError(err)
+	assertions.False(current.People.Enabled,
+		"a missing live config must not reuse the authorized startup policy")
+
+	cfg = nil
+	_, err = source()
+	requirements.ErrorContains(err, "configuration is unavailable",
+		"an absent runtime config must fail closed instead of using the startup policy")
+}
+
+// TestCompletedBuildActivatesWithoutPersonRequestsAfterLivePolicyDrift catches
+// convergence treating a fail-closed person authorization state as a fatal
+// message-generation error. The runtime must skip curated-person coverage,
+// keep all provider traffic fenced, and still activate the completed message
+// generation under routing, credential-source, or provider-posture drift.
+func TestCompletedBuildActivatesWithoutPersonRequestsAfterLivePolicyDrift(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*vector.Config)
+	}{
+		{
+			name: "endpoint",
+			mutate: func(config *vector.Config) {
+				config.Embeddings.Endpoint += "-drifted"
+			},
+		},
+		{
+			name: "api key environment",
+			mutate: func(config *vector.Config) {
+				config.Embeddings.APIKeyEnv = "DRIFTED_PERSON_EMBEDDING_KEY"
+			},
+		},
+		{
+			name: "provider posture",
+			mutate: func(config *vector.Config) {
+				config.People.TrainingPosture = "provider_may_train"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var providerRequests atomic.Int32
+			provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				providerRequests.Add(1)
+				var request struct {
+					Input []string `json:"input"`
+				}
+				if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+					http.Error(w, "invalid synthetic request", http.StatusBadRequest)
+					return
+				}
+				data := make([]map[string]any, len(request.Input))
+				for i := range request.Input {
+					data[i] = map[string]any{"embedding": []float32{1, 0}, "index": i}
+				}
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"data": data, "model": "synthetic-drift-model",
+				}))
+			}))
+			t.Cleanup(provider.Close)
+
+			dataDir := t.TempDir()
+			mainPath := filepath.Join(dataDir, "msgvault.db")
+			configured := config.NewDefaultConfig()
+			configured.HomeDir = dataDir
+			configured.Data.DataDir = dataDir
+			configured.Vector.Enabled = true
+			configured.Vector.DBPath = filepath.Join(dataDir, "vectors.db")
+			configured.Vector.Embeddings.Endpoint = provider.URL + "/v1"
+			configured.Vector.Embeddings.Model = "synthetic-drift-model"
+			configured.Vector.Embeddings.APIKeyEnv = "INITIAL_PERSON_EMBEDDING_KEY"
+			configured.Vector.Embeddings.Dimension = 2
+			configured.Vector.Embeddings.MaxRetries = 1
+			configured.Vector.People = vector.PeopleConfig{
+				Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+			}
+			withTestConfig(t, configured)
+			require.NoError(t, configured.Save())
+
+			mainStore, err := store.Open(mainPath)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = mainStore.Close() })
+			require.NoError(t, mainStore.InitSchema())
+			profile, err := configured.Vector.SemanticPersonEmbeddingProfile()
+			require.NoError(t, err)
+			_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+			require.NoError(t, err)
+			_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+				t.Context(), profile.Fingerprint, "test",
+			)
+			require.NoError(t, err)
+			participantID, err := mainStore.EnsureParticipantByIdentifier(
+				"email", "drift-person@example.test", "Observed Drift Person",
+			)
+			require.NoError(t, err)
+			person, _, err := mainStore.CreatePersonFromParticipantContext(t.Context(), participantID)
+			require.NoError(t, err)
+			displayName := "Synthetic Drift Person"
+			_, err = mainStore.UpdatePersonDisplayNameContext(
+				t.Context(), person.ID, person.Revision, &displayName,
+			)
+			require.NoError(t, err)
+
+			features, err := setupVectorFeatures(t.Context(), mainStore, mainPath, false)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = features.Close() })
+			generation, err := features.Backend.CreateGeneration(
+				t.Context(), features.Cfg.Embeddings.Model,
+				features.Cfg.Embeddings.Dimension, features.Cfg.GenerationFingerprint(),
+			)
+			require.NoError(t, err)
+
+			test.mutate(&configured.Vector)
+			require.NoError(t, configured.Save())
+			var stderr bytes.Buffer
+			_, err = runEmbeddingPasses(
+				t.Context(), features.Runner, generation, false,
+				vector.APIFormatOpenAI, &stderr,
+			)
+			require.NoError(t, err, stderr.String())
+			var stdout bytes.Buffer
+			activated, err := activateBuiltGeneration(
+				t.Context(), features.Backend, features.Convergence, generation,
+				vector.APIFormatOpenAI, &stdout, &stderr,
+			)
+			require.NoError(t, err, stderr.String())
+			assert.True(t, activated)
+			assert.Contains(t, stdout.String(), "activated")
+			assert.Zero(t, providerRequests.Load(),
+				"authorization drift must fence every curated-person provider request")
+		})
+	}
+}
+
+// TestPersonSearchProductionCompositionDoesNotPublishReadyWithoutThePersonEngine
+// catches runtime setup that marks vectors ready after installing only the
+// message engine. It drives the complete production path from a curated
+// profile document through the provider and SQLite person index to the
+// authenticated generated client used by the CLI.
+func TestPersonSearchProductionCompositionDoesNotPublishReadyWithoutThePersonEngine(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	var (
+		providerMu     sync.Mutex
+		providerInputs []string
+	)
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal("/v1/embeddings", r.URL.Path)
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		providerMu.Lock()
+		providerInputs = append(providerInputs, request.Input...)
+		providerMu.Unlock()
+		data := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			data[i] = map[string]any{"embedding": []float32{1, 0, 0, 0}, "index": i}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assertions.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"data": data, "model": "synthetic-person-model",
+		}))
+	}))
+	t.Cleanup(provider.Close)
+
+	dataDir := t.TempDir()
+	mainPath := filepath.Join(dataDir, "msgvault.db")
+	vectorPath := filepath.Join(dataDir, "vectors.db")
+	configured := config.NewDefaultConfig()
+	configured.HomeDir = dataDir
+	configured.Data.DataDir = dataDir
+	configured.Server.APIKey = "synthetic-person-search-key"
+	configured.Vector.Enabled = true
+	configured.Vector.DBPath = vectorPath
+	configured.Vector.Embeddings.Endpoint = provider.URL + "/v1"
+	configured.Vector.Embeddings.Model = "synthetic-person-model"
+	configured.Vector.Embeddings.Dimension = 4
+	configured.Vector.Embeddings.MaxRetries = 1
+	configured.Vector.People = vector.PeopleConfig{
+		Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+	}
+	withTestConfig(t, configured)
+	requirements.NoError(configured.Save())
+	savedUseLocal := useLocal
+	useLocal = false
+	t.Cleanup(func() { useLocal = savedUseLocal })
+
+	mainStore, err := store.Open(mainPath)
+	requirements.NoError(err)
+	t.Cleanup(func() { _ = mainStore.Close() })
+	requirements.NoError(mainStore.InitSchema())
+	semanticProfile, err := configured.Vector.SemanticPersonEmbeddingProfile()
+	requirements.NoError(err)
+	_, err = mainStore.EnsurePersonSemanticEmbeddingProfile(t.Context(), semanticProfile)
+	requirements.NoError(err)
+	_, _, err = mainStore.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), semanticProfile.Fingerprint, "test",
+	)
+	requirements.NoError(err)
+	participantID, err := mainStore.EnsureParticipantByIdentifier(
+		"email", "synthetic-architect@example.test", "Observed Synthetic Name",
+	)
+	requirements.NoError(err)
+	person, created, err := mainStore.CreatePersonFromParticipantContext(t.Context(), participantID)
+	requirements.NoError(err)
+	requirements.True(created)
+	displayName := "Synthetic Architect"
+	person, err = mainStore.UpdatePersonDisplayNameContext(
+		t.Context(), person.ID, person.Revision, &displayName,
+	)
+	requirements.NoError(err)
+	document, err := mainStore.LoadPersonSemanticDocumentContext(t.Context(), person.ID)
+	requirements.NoError(err)
+	requirements.Contains(document.Text, displayName)
+	requirements.NotContains(document.Text, "synthetic-architect@example.test")
+
+	features, err := setupVectorFeatures(t.Context(), mainStore, mainPath, false)
+	requirements.NoError(err)
+	requirements.NotNil(features)
+	t.Cleanup(func() { _ = features.Close() })
+	requirements.NotNil(features.PersonSearchEngine,
+		"runtime composition must build the concrete person engine")
+	generation, err := features.Backend.CreateGeneration(
+		t.Context(), features.Cfg.Embeddings.Model,
+		features.Cfg.Embeddings.Dimension, features.Cfg.GenerationFingerprint(),
+	)
+	requirements.NoError(err)
+	requirements.NoError(features.Backend.ActivateGeneration(t.Context(), generation, false),
+		"a pre-feature active generation can exist without person coverage")
+
+	apiServer := api.NewServerWithOptions(api.ServerOptions{
+		Config: configured, Store: &storeAPIAdapter{store: mainStore},
+		Logger: slog.New(slog.DiscardHandler), VectorStatus: api.VectorStatusInitializing,
+	})
+	apiServer.SetVectorFeatures(
+		features.HybridEngine, features.PersonSearchEngine, features.Backend, features.Cfg,
+	)
+	httpServer := httptest.NewServer(apiServer.Router())
+	t.Cleanup(httpServer.Close)
+
+	unauthorizedRequest, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, httpServer.URL+"/api/v1/people/search",
+		strings.NewReader(`{"query":"architect"}`),
+	)
+	requirements.NoError(err)
+	unauthorizedRequest.Header.Set("Content-Type", "application/json")
+	unauthorizedResponse, err := http.DefaultClient.Do(unauthorizedRequest)
+	requirements.NoError(err)
+	_ = unauthorizedResponse.Body.Close()
+	assertions.Equal(http.StatusUnauthorized, unauthorizedResponse.StatusCode,
+		"semantic person search route remains protected")
+
+	unindexedRequest, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, httpServer.URL+"/api/v1/people/search",
+		strings.NewReader(`{"query":"architect"}`),
+	)
+	requirements.NoError(err)
+	unindexedRequest.Header.Set("Content-Type", "application/json")
+	unindexedRequest.Header.Set("X-Api-Key", configured.Server.APIKey)
+	unindexedResponse, err := http.DefaultClient.Do(unindexedRequest)
+	requirements.NoError(err)
+	unindexedBody, err := io.ReadAll(unindexedResponse.Body)
+	requirements.NoError(err)
+	requirements.NoError(unindexedResponse.Body.Close())
+	assertions.Equal(http.StatusServiceUnavailable, unindexedResponse.StatusCode)
+	assertions.Contains(string(unindexedBody), `"error":"index_building"`)
+	assertions.Contains(string(unindexedBody), "msgvault embeddings resume --backstop",
+		"an upgraded corpus must tell the operator how to make progress")
+	providerMu.Lock()
+	assertions.Empty(providerInputs,
+		"an unindexed upgraded person corpus must not incur a query provider call")
+	providerMu.Unlock()
+
+	result, err := features.Runner.RunOnce(t.Context(), generation)
+	requirements.NoError(err)
+	assertions.Equal(1, result.Succeeded, "one curated person document embedded")
+
+	configured.Remote = config.RemoteConfig{
+		URL: httpServer.URL, APIKey: configured.Server.APIKey, AllowInsecure: true,
+	}
+	command, stdout, stderr := newPersonSearchTestCommand(t)
+	command.SetArgs([]string{"--json", "architect"})
+	requirements.NoError(command.Execute())
+	assertions.JSONEq(`{"results":[{"id":`+
+		jsonInt(person.ID)+`,"display_name":"Synthetic Architect","score":1}]}`, stdout.String())
+	assertions.Empty(stderr.String())
+
+	providerMu.Lock()
+	inputs := append([]string(nil), providerInputs...)
+	providerMu.Unlock()
+	assertions.Equal([]string{document.Text, "architect"}, inputs,
+		"canonical document and free-text query use the same configured provider")
+}
+
+func newPersonSearchTestCommand(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	savedLimit, savedJSON := personSearchLimit, personSearchJSON
+	personSearchLimit, personSearchJSON = defaultPersonSearchLimit, false
+	t.Cleanup(func() {
+		personSearchLimit, personSearchJSON = savedLimit, savedJSON
+	})
+	command := &cobra.Command{
+		Use: personSearchCmd.Use, Args: personSearchCmd.Args, RunE: personSearchCmd.RunE,
+	}
+	command.Flags().IntVar(&personSearchLimit, "limit", defaultPersonSearchLimit, "")
+	command.Flags().BoolVar(&personSearchJSON, flagJSON, false, "")
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	command.SetOut(stdout)
+	command.SetErr(stderr)
+	command.SetContext(context.Background())
+	return command, stdout, stderr
+}
+
+func TestPersonSearchProductionCommandRegistrationAndFlags(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+
+	command, remaining, err := personCmd.Find([]string{"search"})
+	must.NoError(err)
+	check.Same(personSearchCmd, command)
+	check.Empty(remaining)
+	limitFlag := command.Flags().Lookup("limit")
+	must.NotNil(limitFlag)
+	check.Equal(strconv.Itoa(defaultPersonSearchLimit), limitFlag.DefValue)
+	check.NotNil(command.Flags().Lookup(flagJSON))
+}
+
+func writePersonSearchCommandResponse(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{
+		{
+			"person": map[string]any{
+				"id": 9, "vcard_uid": "00000000-0000-0000-0000-000000000009",
+				"display_name": "Synthetic Architect", "revision": 4,
+				"participant_ids": []int64{90}, "created_at": "2026-08-20T00:00:00Z",
+				"updated_at": "2026-08-20T01:00:00Z",
+			},
+			"score": 0.91,
+		},
+		{
+			"person": map[string]any{
+				"id": 3, "vcard_uid": "00000000-0000-0000-0000-000000000003",
+				"display_name": "Test Researcher", "revision": 2,
+				"participant_ids": []int64{30}, "created_at": "2026-08-19T00:00:00Z",
+				"updated_at": "2026-08-19T01:00:00Z",
+			},
+			"score": 0.73,
+		},
+	}}))
+}
+
+func jsonInt(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/cmd/msgvault/cmd/person_vector_policy_source.go
+++ b/cmd/msgvault/cmd/person_vector_policy_source.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+func currentSemanticPersonVectorConfigSource() vector.SemanticPersonEmbeddingConfigSource {
+	return func() (vector.Config, error) {
+		if cfg == nil {
+			return vector.Config{}, errors.New("semantic person embedding runtime configuration is unavailable")
+		}
+		configPath := strings.TrimSpace(cfg.ConfigFilePath())
+		if configPath == "" {
+			return vector.Config{}, errors.New("semantic person embedding runtime configuration path is unavailable")
+		}
+		snapshot, err := config.ReadConfigFile(configPath)
+		if err != nil {
+			return vector.Config{}, err
+		}
+		if !snapshot.Exists {
+			return vector.Config{}, nil
+		}
+		loaded, err := config.LoadConfigFile(snapshot, cfg.HomeDir)
+		if err != nil {
+			return vector.Config{}, err
+		}
+		return loaded.Vector, nil
+	}
+}

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 	"go.kenn.io/msgvault/internal/vector/pgvector"
 	"go.kenn.io/msgvault/internal/vector/sqlitevec"
 	"go.kenn.io/msgvault/internal/vector/visual"
@@ -29,9 +30,11 @@ import (
 const contextualDocumentUTF8Limit = 100_000
 
 type embeddingRuntime struct {
-	Runner      scheduler.EmbedRunner
-	QueryClient hybrid.EmbeddingClient
-	Convergence scheduler.ConvergenceChecker
+	Runner            scheduler.EmbedRunner
+	QueryClient       hybrid.EmbeddingClient
+	PersonQueryClient personsearch.QueryEmbedder
+	Convergence       scheduler.ConvergenceChecker
+	PersonGate        vector.SemanticPersonEmbeddingGate
 }
 
 type embeddingRuntimeDeps struct {
@@ -44,11 +47,14 @@ type embeddingRuntimeDeps struct {
 	TotalPending     int
 	Progress         func(embed.ProgressReport)
 	Log              *slog.Logger
+	PersonGate       vector.SemanticPersonEmbeddingGate
 }
 
 type legacyConvergenceChecker struct {
-	store *store.Store
-	scope vector.BuildScope
+	store         *store.Store
+	scope         vector.BuildScope
+	personBackend vector.PersonBackend
+	personGate    vector.SemanticPersonEmbeddingGate
 }
 
 func (c *legacyConvergenceChecker) CheckConvergence(ctx context.Context, gen vector.GenerationID) (scheduler.ConvergenceResult, error) {
@@ -56,11 +62,66 @@ func (c *legacyConvergenceChecker) CheckConvergence(ctx context.Context, gen vec
 	if err != nil {
 		return scheduler.ConvergenceResult{}, fmt.Errorf("message coverage: %w", err)
 	}
-	return scheduler.ConvergenceResult{
+	state := scheduler.ConvergenceResult{
 		MessageCoverageComplete: missing == 0,
 		MessageCoverageMissing:  missing,
 		ReconciliationComplete:  true,
-	}, nil
+		PersonCoverageComplete:  true,
+	}
+	coverage, err := c.CheckPersonCoverage(ctx, gen)
+	if err != nil {
+		return scheduler.ConvergenceResult{}, err
+	}
+	state.PersonCoverageMismatched = coverage.Mismatched
+	state.PersonCoverageRejected = coverage.Rejected
+	state.PersonCoverageComplete = coverage.Complete()
+	return state, nil
+}
+
+func (c *legacyConvergenceChecker) CheckPersonCoverage(
+	ctx context.Context, gen vector.GenerationID,
+) (personsearch.Coverage, error) {
+	if c.personGate == nil {
+		return personsearch.Coverage{}, errors.New("semantic person embedding convergence gate is not configured")
+	}
+	if err := c.personGate.Check(ctx); err != nil {
+		if vector.SemanticPersonEmbeddingAuthorizationUnavailable(err) {
+			return personsearch.Coverage{}, nil
+		}
+		return personsearch.Coverage{}, fmt.Errorf("semantic person embedding convergence gate: %w", err)
+	}
+	if c.personBackend == nil {
+		return personsearch.Coverage{}, nil
+	}
+	documents, err := c.store.ListPersonSemanticDocumentsContext(ctx)
+	if err != nil {
+		return personsearch.Coverage{}, fmt.Errorf("person semantic documents: %w", err)
+	}
+	revisions, err := c.personBackend.ListPersonRevisions(ctx, gen)
+	if err != nil {
+		return personsearch.Coverage{}, fmt.Errorf("person vector revisions: %w", err)
+	}
+	rejected, err := c.personBackend.CountRejectedPersons(ctx, gen)
+	if err != nil {
+		return personsearch.Coverage{}, fmt.Errorf("rejected person vectors: %w", err)
+	}
+	coverage := personsearch.Coverage{Rejected: rejected}
+	current := make(map[int64]string, len(documents))
+	for _, document := range documents {
+		if document.Text == "" {
+			continue
+		}
+		current[document.PersonID] = document.Revision
+		if revisions[document.PersonID] != document.Revision {
+			coverage.Mismatched++
+		}
+	}
+	for personID := range revisions {
+		if _, ok := current[personID]; !ok {
+			coverage.Mismatched++
+		}
+	}
+	return coverage, nil
 }
 
 type contextualConvergenceChecker struct {
@@ -87,6 +148,12 @@ func (c *contextualConvergenceChecker) CheckConvergence(ctx context.Context, gen
 	return state, nil
 }
 
+func (c *contextualConvergenceChecker) CheckPersonCoverage(
+	ctx context.Context, gen vector.GenerationID,
+) (personsearch.Coverage, error) {
+	return c.legacy.CheckPersonCoverage(ctx, gen)
+}
+
 func contextualReconciliationComplete(cursor string) bool {
 	value, ok := strings.CutPrefix(cursor, "done:")
 	if !ok {
@@ -97,8 +164,50 @@ func contextualReconciliationComplete(cursor string) bool {
 }
 
 func convergenceError(gen vector.GenerationID, state scheduler.ConvergenceResult) error {
-	return fmt.Errorf("generation %d has not converged: message_coverage_complete=%t (missing=%d), journal=%d/%d, reconciliation_complete=%t",
-		gen, state.MessageCoverageComplete, state.MessageCoverageMissing, state.ConsumedJournalSequence,
+	message := convergenceStateMessage(gen, state)
+	if !state.MessageCoverageComplete {
+		message += "; " + strings.TrimSpace(remainingCoverageHint(gen, state.MessageCoverageMissing))
+	}
+	if guidance := personCoverageGuidance(gen, state); guidance != "" {
+		message += "; " + guidance
+	}
+	return errors.New(message)
+}
+
+func manualConvergenceError(gen vector.GenerationID, state scheduler.ConvergenceResult) error {
+	message := convergenceStateMessage(gen, state)
+	if !state.MessageCoverageComplete {
+		message += fmt.Sprintf("; generation still has %d message(s) needing embedding; run `msgvault embeddings resume --backstop` to process them",
+			state.MessageCoverageMissing)
+	}
+	if guidance := personCoverageGuidance(gen, state); guidance != "" {
+		message += "; " + guidance
+	}
+	if state.PersonCoverageRejected == 0 {
+		message += "; or pass `--force` to activate anyway"
+	}
+	return errors.New(message)
+}
+
+func personCoverageGuidance(gen vector.GenerationID, state scheduler.ConvergenceResult) string {
+	guidance := make([]string, 0, 2)
+	if state.PersonCoverageMismatched > 0 ||
+		(!state.PersonCoverageComplete && state.PersonCoverageRejected == 0) {
+		guidance = append(guidance,
+			"run `msgvault embeddings resume --backstop` to retry curated person profiles")
+	}
+	if state.PersonCoverageRejected > 0 {
+		guidance = append(guidance, fmt.Sprintf(
+			"%d terminal curated person profile(s) will not be retried at the same source revision; source revision must change before retrying, or run `msgvault embeddings activate %d --force` to activate anyway",
+			state.PersonCoverageRejected, gen))
+	}
+	return strings.Join(guidance, "; ")
+}
+
+func convergenceStateMessage(gen vector.GenerationID, state scheduler.ConvergenceResult) string {
+	return fmt.Sprintf("generation %d has not converged: message_coverage_complete=%t (missing=%d), person_coverage_complete=%t (mismatched=%d, rejected=%d), journal=%d/%d, reconciliation_complete=%t",
+		gen, state.MessageCoverageComplete, state.MessageCoverageMissing, state.PersonCoverageComplete,
+		state.PersonCoverageMismatched, state.PersonCoverageRejected, state.ConsumedJournalSequence,
 		state.LatestJournalSequence, state.ReconciliationComplete)
 }
 
@@ -116,26 +225,46 @@ func embeddingPreprocessConfig(cfg vector.Config) embed.PreprocessConfig {
 }
 
 func newEmbeddingRuntime(vectorCfg vector.Config, deps embeddingRuntimeDeps) (*embeddingRuntime, error) {
-	checker, err := newConvergenceChecker(vectorCfg, deps.Store, deps.Backend)
+	personBackend, ok := deps.Backend.(vector.PersonBackend)
+	if !ok {
+		return nil, errors.New("person embeddings require a person vector backend")
+	}
+	personGate := deps.PersonGate
+	if personGate == nil {
+		return nil, errors.New("semantic person embedding runtime gate is required")
+	}
+	checker, err := newConvergenceChecker(vectorCfg, deps.Store, deps.Backend, personGate)
 	if err != nil {
 		return nil, err
 	}
 	switch vectorCfg.Embeddings.EffectiveAPIFormat() {
 	case vector.APIFormatOpenAI:
-		client := embed.NewClient(embed.Config{
+		clientConfig := embed.Config{
 			Endpoint: vectorCfg.Embeddings.Endpoint, APIKey: vectorCfg.Embeddings.APIKey(),
 			Model: vectorCfg.Embeddings.Model, Dimension: vectorCfg.Embeddings.Dimension,
 			Timeout: vectorCfg.Embeddings.Timeout, MaxRetries: vectorCfg.Embeddings.MaxRetries,
-		})
-		worker := embed.NewWorker(embed.WorkerDeps{
+		}
+		messageClient := embed.NewClient(clientConfig)
+		clientConfig.BeforeRequest = personGate.Check
+		personClient := embed.NewClient(clientConfig)
+		messageWorker := embed.NewWorker(embed.WorkerDeps{
 			Backend: deps.Backend, VectorsDB: deps.VectorsDB, MainDB: deps.MainDB,
-			Store: deps.Store, Client: client, Preprocess: embeddingPreprocessConfig(vectorCfg),
+			Store: deps.Store, Client: messageClient, Preprocess: embeddingPreprocessConfig(vectorCfg),
 			MaxInputChars: vectorCfg.Embeddings.MaxInputChars,
 			BatchSize:     vectorCfg.Embeddings.BatchSize, BuildScope: vectorCfg.Embed.Scope.BuildScope(),
 			Rebind: deps.Rebind, LastModifiedExpr: deps.LastModifiedExpr,
 			TotalPending: deps.TotalPending, Progress: deps.Progress, Log: deps.Log,
 		})
-		return &embeddingRuntime{Runner: worker, QueryClient: client, Convergence: checker}, nil
+		personWorker := embed.NewPersonWorker(embed.PersonWorkerDeps{
+			Store: deps.Store, Backend: personBackend, Client: personClient,
+			Gate:      personGate,
+			BatchSize: vectorCfg.Embeddings.BatchSize, MaxInputChars: vectorCfg.Embeddings.MaxInputChars,
+		})
+		worker := embed.NewGenerationWorker(messageWorker, personWorker)
+		return &embeddingRuntime{
+			Runner: worker, QueryClient: messageClient, PersonQueryClient: personClient,
+			Convergence: checker, PersonGate: personGate,
+		}, nil
 	case vector.APIFormatVoyageContextual:
 		if vectorCfg.Embeddings.Model != "voyage-context-4" {
 			return nil, fmt.Errorf("vector.embeddings.model: api_format=%q requires %q, got %q",
@@ -145,33 +274,60 @@ func newEmbeddingRuntime(vectorCfg vector.Config, deps embeddingRuntimeDeps) (*e
 		if !ok {
 			return nil, errors.New("voyage contextual embeddings require a document publisher backend")
 		}
-		client := embed.NewVoyageClient(embed.VoyageConfig{
+		clientConfig := embed.VoyageConfig{
 			Endpoint: vectorCfg.Embeddings.Endpoint, APIKey: vectorCfg.Embeddings.APIKey(),
 			Model: vectorCfg.Embeddings.Model, Dimension: vectorCfg.Embeddings.Dimension,
 			Timeout: vectorCfg.Embeddings.Timeout, MaxRetries: vectorCfg.Embeddings.MaxRetries,
 			Limits: embed.RequestLimits{MaxDocuments: vectorCfg.Embeddings.BatchSize,
 				MaxChunks: 16_000, MaxUTF8Bytes: contextualDocumentUTF8Limit},
-		})
+		}
+		messageClient := embed.NewVoyageClient(clientConfig)
+		clientConfig.BeforeRequest = personGate.Check
+		personClient := embed.NewVoyageClient(clientConfig)
 		policy := embed.AssemblyPolicy{
 			MaxChunkRunes:        vectorCfg.Embeddings.MaxInputChars,
 			MaxDocumentUTF8Bytes: contextualDocumentUTF8Limit,
 			Preprocess:           embeddingPreprocessConfig(vectorCfg),
 		}
 		assembler := embed.CompositeAssembler{Policy: policy, Chat: embed.ChatWindowAssembler{Policy: policy}}
-		worker := embed.NewContextWorker(embed.ContextWorkerDeps{
+		messageWorker := embed.NewContextWorker(embed.ContextWorkerDeps{
 			Backend: deps.Backend, Publisher: publisher, Store: deps.Store,
-			Assembler: assembler, Client: client, BuildScope: vectorCfg.Embed.Scope.BuildScope(),
+			Assembler: assembler, Client: messageClient, BuildScope: vectorCfg.Embed.Scope.BuildScope(),
 			ChangeBatchSize:    vectorCfg.Embeddings.BatchSize,
 			ReconcileBatchSize: vectorCfg.Embeddings.BatchSize,
 		})
-		return &embeddingRuntime{Runner: worker, QueryClient: client, Convergence: checker}, nil
+		personWorker := embed.NewPersonWorker(embed.PersonWorkerDeps{
+			Store: deps.Store, Backend: personBackend, Client: personClient,
+			Gate:      personGate,
+			BatchSize: vectorCfg.Embeddings.BatchSize, MaxInputChars: vectorCfg.Embeddings.MaxInputChars,
+		})
+		worker := embed.NewGenerationWorker(messageWorker, personWorker)
+		return &embeddingRuntime{
+			Runner: worker, QueryClient: messageClient, PersonQueryClient: personClient,
+			Convergence: checker, PersonGate: personGate,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported embedding api format %q", vectorCfg.Embeddings.APIFormat)
 	}
 }
 
-func newConvergenceChecker(vectorCfg vector.Config, mainStore *store.Store, backend vector.Backend) (scheduler.ConvergenceChecker, error) {
-	legacy := &legacyConvergenceChecker{store: mainStore, scope: vectorCfg.Embed.Scope.BuildScope()}
+func newConvergenceChecker(
+	vectorCfg vector.Config,
+	mainStore *store.Store,
+	backend vector.Backend,
+	personGate vector.SemanticPersonEmbeddingGate,
+) (scheduler.ConvergenceChecker, error) {
+	personBackend, ok := backend.(vector.PersonBackend)
+	if !ok {
+		return nil, errors.New("person embeddings require a person vector backend")
+	}
+	if personGate == nil {
+		return nil, errors.New("semantic person embedding convergence gate is required")
+	}
+	legacy := &legacyConvergenceChecker{
+		store: mainStore, scope: vectorCfg.Embed.Scope.BuildScope(),
+		personBackend: personBackend, personGate: personGate,
+	}
 	if vectorCfg.Embeddings.EffectiveAPIFormat() != vector.APIFormatVoyageContextual {
 		return legacy, nil
 	}
@@ -342,9 +498,13 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 
 	features := &vectorFeatures{Backend: backend, Cfg: vecCfg, Close: closeFn}
 	if vecCfg.Enabled {
+		personGate := vector.NewPinnedExactSemanticPersonEmbeddingGate(
+			vecCfg, currentSemanticPersonVectorConfigSource(), mainStore,
+		)
 		runtime, err := newEmbeddingRuntime(vecCfg, embeddingRuntimeDeps{
 			Backend: backend, VectorsDB: vectorsDB, MainDB: mainDB, Store: mainStore,
 			Rebind: dialect.Rebind, LastModifiedExpr: lastModifiedExpr, Log: logger,
+			PersonGate: personGate,
 		})
 		if err != nil {
 			_ = closeFn()
@@ -364,6 +524,24 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 			Rebind:     dialect.Rebind,
 			BuildScope: vecCfg.Embed.Scope.BuildScope(),
 		})
+		personSearchBackend, ok := backend.(personsearch.Backend)
+		if !ok {
+			_ = closeFn()
+			return nil, errors.New("person search requires a person vector backend")
+		}
+		personCoverage, ok := runtime.Convergence.(personsearch.CoverageChecker)
+		if !ok {
+			_ = closeFn()
+			return nil, errors.New("person search requires a person coverage checker")
+		}
+		features.PersonSearchEngine = personsearch.NewEngine(
+			personSearchBackend, mainStore, runtime.PersonQueryClient,
+			personsearch.Config{
+				ExpectedFingerprint: vecCfg.GenerationFingerprint(),
+				PersonCoverage:      personCoverage.CheckPersonCoverage,
+				Gate:                runtime.PersonGate,
+			},
+		)
 	}
 	if vecCfg.Multimodal.Enabled && !readOnly {
 		if len(openers) == 0 || openers[0] == nil {

--- a/cmd/msgvault/cmd/serve_vector_init.go
+++ b/cmd/msgvault/cmd/serve_vector_init.go
@@ -138,7 +138,9 @@ func startVectorInit(
 		h.vf = vf
 		h.mu.Unlock()
 		if cfg.Vector.Enabled {
-			apiServer.SetVectorFeatures(vf.HybridEngine, vf.Backend, vf.Cfg)
+			apiServer.SetVectorFeatures(
+				vf.HybridEngine, vf.PersonSearchEngine, vf.Backend, vf.Cfg,
+			)
 			// Preflight drift detection: vector-search requests re-resolve the
 			// durable account scope (throttled) so drift latches index_stale
 			// even on daemons whose embed job never runs (empty cron,

--- a/cmd/msgvault/cmd/serve_vector_init_test.go
+++ b/cmd/msgvault/cmd/serve_vector_init_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +19,7 @@ import (
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
@@ -31,6 +35,31 @@ type fakeCmdVectorBackend struct {
 
 	active    *vector.Generation
 	activeErr error
+}
+
+type vectorInitPersonBackend struct {
+	*fakeCmdVectorBackend
+	vector.PersonBackend
+}
+
+func (b *vectorInitPersonBackend) SearchPeople(
+	context.Context, vector.GenerationID, []float32, int,
+) ([]vector.PersonHit, error) {
+	return nil, errors.New("synthetic installed person engine reached")
+}
+
+type vectorInitPersonStore struct{}
+
+func (vectorInitPersonStore) ResolvePersonSemanticCandidatesContext(
+	context.Context, []store.PersonSemanticCandidate,
+) ([]store.Person, error) {
+	return nil, nil
+}
+
+type vectorInitPersonEmbedder struct{}
+
+func (vectorInitPersonEmbedder) EmbedQuery(context.Context, string) ([]float32, error) {
+	return []float32{1, 0}, nil
 }
 
 func (b *fakeCmdVectorBackend) ActiveGeneration(context.Context) (vector.Generation, error) {
@@ -143,15 +172,24 @@ func TestStartVectorInitRunsForIndependentMultimodalLane(t *testing.T) {
 }
 
 func TestStartVectorInitInstallsFeaturesOnSuccess(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
 	c := config.NewDefaultConfig()
 	c.Vector.Enabled = true
 	withTestConfig(t, c)
 
 	closed := false
+	backend := &vectorInitPersonBackend{fakeCmdVectorBackend: &fakeCmdVectorBackend{
+		active: &vector.Generation{ID: 1, Fingerprint: c.Vector.GenerationFingerprint()},
+	}}
+	personEngine := personsearch.NewEngine(
+		backend, vectorInitPersonStore{}, vectorInitPersonEmbedder{},
+		personsearch.Config{ExpectedFingerprint: c.Vector.GenerationFingerprint()},
+	)
 	overrideSetupVectorFeatures(t, func(context.Context, *store.Store, string, bool) (*vectorFeatures, error) {
 		return &vectorFeatures{
-			Backend: &fakeCmdVectorBackend{},
-			Close:   func() error { closed = true; return nil },
+			Backend: backend, PersonSearchEngine: personEngine,
+			Cfg: c.Vector, Close: func() error { closed = true; return nil },
 		}, nil
 	})
 
@@ -159,10 +197,20 @@ func TestStartVectorInitInstallsFeaturesOnSuccess(t *testing.T) {
 	sched := scheduler.New(nil)
 	h := startVectorInit(context.Background(), nil, "/tmp/msgvault.db", nil, srv, sched)
 
-	require.True(t, h.WaitTimeout(5*time.Second))
+	requirements.True(h.WaitTimeout(5 * time.Second))
 	waitForVectorStatus(t, srv, api.VectorStatusReady)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/people/search",
+		strings.NewReader(`{"query":"synthetic"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, request)
+	assertions.Equal(http.StatusServiceUnavailable, response.Code)
+	assertions.Contains(response.Body.String(), "semantic_search_unavailable",
+		"ready status must publish the person engine in the same installation")
+	assertions.NotContains(response.Body.String(), "vector_not_enabled",
+		"ready status must never precede person engine installation")
 	h.CloseFeatures()
-	assert.True(t, closed, "CloseFeatures must close the opened backend")
+	assertions.True(closed, "CloseFeatures must close the opened backend")
 }
 
 func TestStartVectorInitFlagsStaleIndex(t *testing.T) {
@@ -266,8 +314,8 @@ func TestStartVectorInitAbortsQuietlyOnCancel(t *testing.T) {
 		"shutdown-cancelled init must not flip status to error")
 }
 
-func TestNewSchedulerEmbedJobThreadsContextRunnerAndConvergenceChecker(t *testing.T) {
-	runner := &embed.ContextWorker{}
+func TestNewSchedulerEmbedJobThreadsGenerationRunnerAndConvergenceChecker(t *testing.T) {
+	runner := &embed.GenerationWorker{}
 	checker := &registeredConvergenceChecker{}
 	vf := &vectorFeatures{
 		Backend: &fakeCmdVectorBackend{}, Runner: runner, Convergence: checker,
@@ -391,6 +439,7 @@ func TestRegisterEmbedJob_ContextualActivationRequiresEveryConvergenceDimension(
 	rootAssert := assert.New(t)
 	complete := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   5,
 		ConsumedJournalSequence: 5,
 		ReconciliationComplete:  true,
@@ -402,6 +451,10 @@ func TestRegisterEmbedJob_ContextualActivationRequiresEveryConvergenceDimension(
 		{name: "message coverage incomplete", mutate: func(s *scheduler.ConvergenceResult) {
 			s.MessageCoverageComplete = false
 			s.MessageCoverageMissing = 1
+		}},
+		{name: "person coverage incomplete", mutate: func(s *scheduler.ConvergenceResult) {
+			s.PersonCoverageComplete = false
+			s.PersonCoverageMismatched = 1
 		}},
 		{name: "journal incomplete", mutate: func(s *scheduler.ConvergenceResult) {
 			s.ConsumedJournalSequence = 4
@@ -432,6 +485,7 @@ func TestRegisterEmbedJob_ContextualActivationRequiresEveryConvergenceDimension(
 func TestRegisterEmbedJob_ContextualLifecycleRefusalsNeverActivateAnotherGeneration(t *testing.T) {
 	complete := scheduler.ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   5,
 		ConsumedJournalSequence: 5,
 		ReconciliationComplete:  true,

--- a/cmd/msgvault/cmd/serve_vector_stub.go
+++ b/cmd/msgvault/cmd/serve_vector_stub.go
@@ -12,11 +12,17 @@ import (
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
-func newConvergenceChecker(vector.Config, *store.Store, vector.Backend) (scheduler.ConvergenceChecker, error) {
+func newConvergenceChecker(
+	vector.Config, *store.Store, vector.Backend, vector.SemanticPersonEmbeddingGate,
+) (scheduler.ConvergenceChecker, error) {
 	return nil, errVectorBuildUnsupported(cfg.DatabaseDSN())
 }
 
 func convergenceError(vector.GenerationID, scheduler.ConvergenceResult) error {
+	return errVectorBuildUnsupported(cfg.DatabaseDSN())
+}
+
+func manualConvergenceError(vector.GenerationID, scheduler.ConvergenceResult) error {
 	return errVectorBuildUnsupported(cfg.DatabaseDSN())
 }
 

--- a/cmd/msgvault/cmd/vector_features.go
+++ b/cmd/msgvault/cmd/vector_features.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"context"
+
 	"go.kenn.io/msgvault/internal/scheduler"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
@@ -38,10 +40,13 @@ type visualFeatures struct {
 type vectorFeatures struct {
 	Backend      vector.Backend
 	HybridEngine *hybrid.Engine
-	Runner       scheduler.EmbedRunner
-	Convergence  scheduler.ConvergenceChecker
-	Cfg          vector.Config
-	Visual       *visualFeatures
+	// PersonSearchEngine shares Backend and Cfg with HybridEngine, but searches
+	// only the person-owned corpus through a separately gated provider client.
+	PersonSearchEngine *personsearch.Engine
+	Runner             scheduler.EmbedRunner
+	Convergence        scheduler.ConvergenceChecker
+	Cfg                vector.Config
+	Visual             *visualFeatures
 	// Close releases the backend's resources: on SQLite it closes the
 	// vectors.db handle (so WAL checkpoints complete); on PostgreSQL it is
 	// a no-op because the pgvector backend shares the main store's handle,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6772,6 +6772,7 @@ type fakeVectorBackend struct {
 	searchLimit   int
 	chunkHits     map[int64][]vector.ChunkHit
 	chunkScoreIDs []int64
+	rejected      int64
 }
 
 func (f *fakeVectorBackend) CreateGeneration(_ context.Context, _ string, _ int, _ string) (vector.GenerationID, error) {
@@ -6823,6 +6824,9 @@ func (f *fakeVectorBackend) ResetWatermarkBelow(_ context.Context, _ int64) erro
 func (f *fakeVectorBackend) EmbeddedMessageCount(_ context.Context, _ vector.GenerationID) (int64, error) {
 	return 0, errors.New("not implemented")
 }
+func (f *fakeVectorBackend) CountRejectedPersons(_ context.Context, _ vector.GenerationID) (int64, error) {
+	return f.rejected, nil
+}
 func (f *fakeVectorBackend) Close() error { return nil }
 
 func TestHandleStats_VectorDisabled(t *testing.T) {
@@ -6854,7 +6858,8 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 			Fingerprint: "nomic-embed:768",
 			State:       vector.GenerationActive,
 		},
-		stats: vector.Stats{EmbeddingCount: 100, PendingCount: 7, StorageBytes: 4096},
+		stats:    vector.Stats{EmbeddingCount: 100, PendingCount: 7, StorageBytes: 4096},
+		rejected: 3,
 	}
 
 	store := &mockStore{
@@ -6891,6 +6896,7 @@ func TestHandleStats_VectorEnabledWithActive(t *testing.T) {
 
 	assert.Equal(true, vs["enabled"], "enabled")
 	assert.InDelta(float64(7), vs["missing_embeddings_total"], 1e-9, "missing_embeddings_total")
+	assert.InDelta(float64(3), vs["person_coverage_rejected"], 1e-9, "person_coverage_rejected")
 
 	active, ok := vs["active_generation"].(map[string]any)
 	require.True(ok, "expected 'vector_search.active_generation' object, got %T", vs["active_generation"])
@@ -7524,7 +7530,7 @@ func TestStatsReportsTextLaneSeparatelyFromMultimodal(t *testing.T) {
 		Store:  &mockStore{},
 		Logger: testLogger(),
 	})
-	srv.SetVectorFeatures(nil, nil, vector.Config{Multimodal: vector.MultimodalConfig{Enabled: true}})
+	srv.SetVectorFeatures(nil, nil, nil, vector.Config{Multimodal: vector.MultimodalConfig{Enabled: true}})
 	srv.SetVisualSearch(&visual.SearchService{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -215,7 +215,11 @@ import (
 // clients check this version before asking a daemon to perform a scoped sync.
 // 2.5.0 adds durable-person attachment retrieval across metadata, document,
 // and visual lanes while keeping participant references compatible.
-const APISchemaVersion = "2.5.0"
+// 2.6.0 adds protected semantic search over durable curated people. Ranked
+// results contain only the durable person root and semantic score; person
+// projection text and raw profile details remain internal.
+// Additive (minor bump): existing person and participant routes are unchanged.
+const APISchemaVersion = "2.6.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.
@@ -247,8 +251,19 @@ func baseOpenAPIDocument() *huma.OpenAPI {
 	hardenSearchCoverageSchemas(doc)
 	hardenTaskLinkSchemas(doc)
 	hardenPersonRelationshipSchemas(doc)
+	hardenPersonSearchSchemas(doc)
 	hardenActivitySchemas(doc)
 	return doc
+}
+
+func hardenPersonSearchSchemas(doc *huma.OpenAPI) {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return
+	}
+	response := doc.Components.Schemas.Map()["PersonSearchResponse"]
+	if response != nil && response.Properties["results"] != nil {
+		response.Properties["results"].Nullable = false
+	}
 }
 
 func hardenPersonRelationshipSchemas(doc *huma.OpenAPI) {

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,7 +38,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.5.0", APISchemaVersion)
+	assert.Equal("2.6.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -55,16 +55,16 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	}
 	assert.NotContains(doc.Paths, "/api/v1/persons")
 	assert.NotContains(doc.Paths, "/api/v1/persons/{id}")
-	assert.Nil(doc.Paths["/api/v1/people/search"])
+	assert.NotNil(doc.Paths["/api/v1/people/search"])
 	assert.Nil(doc.Paths["/api/v1/people/{id}/summary"])
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.5.0", APISchemaVersion)
+	assert.Equal(t, "2.6.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.5.0", APISchemaVersion)
+	assert.Equal(t, "2.6.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -88,7 +88,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.5.0", APISchemaVersion,
+	assert.Equal(t, "2.6.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -100,6 +100,38 @@ func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 		require.NotNil(response)
 		require.Contains(response.Headers, "Location")
 		require.Equal(huma.TypeString, response.Headers["Location"].Schema.Type)
+	}
+}
+
+func TestOpenAPISemanticPersonSearchReturnsOnlyDurableRootsAndScores(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	for _, document := range []*huma.OpenAPI{OpenAPIDocument(), openAPIClientDocument()} {
+		path := document.Paths["/api/v1/people/search"]
+		requirements.NotNil(path)
+		requirements.NotNil(path.Post)
+		assertions.Equal("searchPeople", path.Post.OperationID)
+		requirements.Len(path.Post.Security, 1)
+		_, secured := path.Post.Security[0]["apiKey"]
+		assertions.True(secured)
+
+		request := operationBodySchema(t, document, path.Post)
+		assertions.Contains(request.Required, "query")
+		assertions.InDelta(100, *request.Properties["limit"].Maximum, 0)
+		assertions.Equal(defaultPersonSearchLimit, request.Properties["limit"].Default)
+
+		schemas := document.Components.Schemas.Map()
+		response := schemas["PersonSearchResponse"]
+		requirements.NotNil(response)
+		requirements.Contains(response.Properties, "results")
+		assertions.False(response.Properties["results"].Nullable,
+			"an empty search is an empty array, never null")
+		result := schemas["PersonSearchResult"]
+		requirements.NotNil(result)
+		assertions.ElementsMatch([]string{"person", "score"}, result.Required)
+		assertions.NotContains(result.Properties, "text")
+		assertions.NotContains(result.Properties, "revision")
+		assertions.Nil(schemas["PersonSemanticDocument"])
 	}
 }
 
@@ -367,7 +399,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.5.0", APISchemaVersion,
+	assert.Equal("2.6.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -440,7 +472,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.5.0", APISchemaVersion,
+	assertions.Equal("2.6.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -460,7 +492,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.5.0", APISchemaVersion,
+	assert.Equal("2.6.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -488,7 +520,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.5.0", APISchemaVersion,
+	assertions.Equal("2.6.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -532,8 +564,8 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// routes added in 1.42.0, cache-readiness responses added in 1.43.0,
 	// document search added in 1.44.0, participant/people separation added in
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
-	// 2.5.0 did not touch it.
-	assert.Equal("2.5.0", APISchemaVersion, "person retrieval is an additive schema release")
+	// 2.6.0 did not touch it.
+	assert.Equal("2.6.0", APISchemaVersion, "person search is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/person_profiles.go
+++ b/internal/api/person_profiles.go
@@ -13,9 +13,15 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 )
 
-const peoplePath = "/api/v1/people"
+const (
+	peoplePath               = "/api/v1/people"
+	defaultPersonSearchLimit = 20
+	maximumPersonSearchLimit = 100
+)
 
 // PersonProfileStore is the feature-local capability for durable curated
 // people. The daemon adapter passes these calls directly to *store.Store.
@@ -42,7 +48,36 @@ type PeopleResponse struct {
 	People []store.Person `json:"people"`
 }
 
+// PersonSearchEngine is the semantic people service consumed by the HTTP
+// route. Production installs the concrete personsearch engine with the vector
+// subsystem; tests can supply a focused service double.
+type PersonSearchEngine interface {
+	Search(ctx context.Context, query string, limit int) ([]personsearch.Result, error)
+}
+
+type PersonSearchRequest struct {
+	Query string `json:"query" minLength:"1"`
+	Limit int    `json:"limit,omitempty" minimum:"0" maximum:"100" default:"20"`
+}
+
+type PersonSearchResult struct {
+	Person store.Person `json:"person"`
+	Score  float64      `json:"score"`
+}
+
+type PersonSearchResponse struct {
+	Results []PersonSearchResult `json:"results"`
+}
+
 func (s *Server) registerPersonProfileRoutes(api huma.API) {
+	search := rawAPIV1Operation("searchPeople", http.MethodPost, "/people/search",
+		"Search durable people semantically")
+	search.Description = "Searches only the curated person vector corpus and returns durable person roots in relevance order."
+	search.RequestBody = jsonRequestBodyFor[PersonSearchRequest](api)
+	search.Responses = jsonResponsesFor[PersonSearchResponse](api)
+	addErrorResponses(api, search.Responses, http.StatusServiceUnavailable)
+	registerRawHumaRoute(api, search, s.handleSemanticPersonSearch)
+
 	list := rawAPIV1Operation("listPeople", http.MethodGet, "/people", "List durable person profiles")
 	list.Description = "Durable people are curated profiles; /api/v1/participants exposes observed analytical groupings. " +
 		"The listing is deliberately unpaginated: persons exist only through explicit promotion, so the set stays small."
@@ -88,6 +123,91 @@ func (s *Server) registerPersonProfileRoutes(api huma.API) {
 		http.StatusConflict, http.StatusNotFound, http.StatusPreconditionRequired,
 		http.StatusInternalServerError, http.StatusServiceUnavailable)
 	registerRawHumaRoute(api, remove, s.handleDeletePerson)
+}
+
+func (s *Server) handleSemanticPersonSearch(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	var request PersonSearchRequest
+	if !decodePersonRequest(w, r, &request) {
+		return
+	}
+	request.Query = strings.TrimSpace(request.Query)
+	if request.Query == "" {
+		writeError(w, http.StatusBadRequest, "invalid_query", "query must contain non-whitespace text")
+		return
+	}
+	if request.Limit < 0 || request.Limit > maximumPersonSearchLimit {
+		writeError(w, http.StatusBadRequest, "invalid_limit", "limit must be between 0 and 100")
+		return
+	}
+	if request.Limit == 0 {
+		request.Limit = defaultPersonSearchLimit
+	}
+
+	if !s.vectorSearchPreflight(r.Context(), w) {
+		return
+	}
+	status, _ := s.VectorStatus()
+	if status != VectorStatusReady {
+		s.writeVectorUnavailable(w)
+		return
+	}
+	engine := s.personSearchComponent()
+	if engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "vector_not_enabled",
+			"Semantic person search is not configured on this server")
+		return
+	}
+	results, err := engine.Search(r.Context(), request.Query, request.Limit)
+	if err != nil {
+		s.writePersonSearchError(w, err)
+		return
+	}
+	response := PersonSearchResponse{Results: make([]PersonSearchResult, len(results))}
+	for i, result := range results {
+		response.Results[i] = PersonSearchResult{Person: result.Person, Score: result.Score}
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) writePersonSearchError(w http.ResponseWriter, err error) {
+	if s.writeIfContextError(w, err) {
+		return
+	}
+	switch {
+	case errors.Is(err, vector.ErrSemanticPersonEmbeddingsDisabled):
+		writeError(w, http.StatusServiceUnavailable, "person_embeddings_disabled",
+			"Semantic person search requires [vector.people] enabled = true")
+	case errors.Is(err, vector.ErrSemanticPersonEmbeddingConsentRequired):
+		writeError(w, http.StatusServiceUnavailable, "person_embedding_consent_required",
+			"Semantic person search requires active exact consent; run `msgvault person provider consent --semantic-embeddings` to review and grant the current policy")
+	case errors.Is(err, vector.ErrSemanticPersonEmbeddingPolicyUnavailable):
+		s.logger.Error("semantic person embedding policy unavailable", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "person_embedding_policy_unavailable",
+			"Semantic person search cannot verify the current semantic person embedding policy or exact consent; check the live configuration and consent store")
+	case errors.Is(err, vector.ErrNotEnabled):
+		writeError(w, http.StatusServiceUnavailable, "vector_not_enabled", "Vector search is not configured")
+	case errors.Is(err, vector.ErrIndexStale):
+		writeError(w, http.StatusServiceUnavailable, "index_stale", "The vector index does not match configured embedding settings")
+	case errors.Is(err, personsearch.ErrPersonCoverageIncomplete):
+		var coverageErr *personsearch.CoverageIncompleteError
+		if errors.As(err, &coverageErr) && coverageErr.Rejected > 0 {
+			writeError(w, http.StatusServiceUnavailable, "index_building", fmt.Sprintf(
+				"The semantic person index has %d terminally rejected curated person profile record(s); run `msgvault embeddings resume --backstop` first to reconcile current profiles; if terminal rejections remain, correct or edit the affected current profiles so their source revisions change, then rerun the command",
+				coverageErr.Rejected))
+			return
+		}
+		writeError(w, http.StatusServiceUnavailable, "index_building",
+			"The semantic person index is incomplete; run `msgvault embeddings resume --backstop` to embed curated person profiles")
+	case errors.Is(err, vector.ErrIndexBuilding):
+		writeError(w, http.StatusServiceUnavailable, "index_building", "The vector index is still being built")
+	case errors.Is(err, vector.ErrEmbeddingTimeout):
+		writeError(w, http.StatusServiceUnavailable, "embedding_timeout", "The embedding endpoint did not respond in time")
+	default:
+		s.logger.Error("semantic person search failed", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "semantic_search_unavailable",
+			"Semantic person search could not resolve candidates")
+	}
 }
 
 func (s *Server) handleCreatePerson(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/person_profiles_test.go
+++ b/internal/api/person_profiles_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +13,26 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+	"go.kenn.io/msgvault/internal/vector/personsearch"
 )
+
+type fakePersonSearchEngine struct {
+	results []personsearch.Result
+	err     error
+	queries []string
+	limits  []int
+}
+
+func (e *fakePersonSearchEngine) Search(
+	_ context.Context, query string, limit int,
+) ([]personsearch.Result, error) {
+	e.queries = append(e.queries, query)
+	e.limits = append(e.limits, limit)
+	return e.results, e.err
+}
 
 func TestPersonProfileHTTPPromoteListGetUpdateAndConflictingLink(t *testing.T) {
 	assert := assert.New(t)
@@ -116,6 +136,238 @@ func TestPersonPatchSchemaRequiresNullableDisplayName(t *testing.T) {
 		require.Contains(schema.Properties, "display_name")
 		assert.True(schema.Properties["display_name"].Nullable)
 	}
+}
+
+func TestSemanticPersonSearchReturnsRankedDurableRootsWithScores(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	firstName := "Synthetic Architect"
+	secondName := "Test Researcher"
+	engine := &fakePersonSearchEngine{results: []personsearch.Result{
+		{Person: store.Person{
+			ID: 22, VCardUID: "00000000-0000-4000-8000-000000000022",
+			DisplayName: &firstName, Revision: 4, ParticipantIDs: []int64{220},
+		}, Score: 0.91},
+		{Person: store.Person{
+			ID: 11, VCardUID: "00000000-0000-4000-8000-000000000011",
+			DisplayName: &secondName, Revision: 7, ParticipantIDs: []int64{110},
+		}, Score: 0.82},
+	}}
+	srv := newSemanticPersonSearchServer(t, engine, VectorStatusReady, "")
+
+	response := semanticPersonSearchRequest(t, srv,
+		[]byte(`{"query":"  synthetic product architect  "}`), "")
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	assert.Equal("no-store", response.Header().Get("Cache-Control"))
+	assert.Equal([]string{"synthetic product architect"}, engine.queries)
+	assert.Equal([]int{defaultPersonSearchLimit}, engine.limits)
+	var body PersonSearchResponse
+	require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+	require.Len(body.Results, 2)
+	assert.Equal(int64(22), body.Results[0].Person.ID)
+	assert.InDelta(0.91, body.Results[0].Score, 0.00001)
+	assert.Equal(int64(11), body.Results[1].Person.ID)
+	assert.InDelta(0.82, body.Results[1].Score, 0.00001)
+	assert.NotContains(response.Body.String(), "renderer_policy")
+	assert.NotContains(response.Body.String(), `"text"`)
+}
+
+func TestSemanticPersonSearchReturnsEmptyArrayAndPassesExplicitLimit(t *testing.T) {
+	engine := &fakePersonSearchEngine{results: []personsearch.Result{}}
+	srv := newSemanticPersonSearchServer(t, engine, VectorStatusReady, "")
+
+	response := semanticPersonSearchRequest(t, srv,
+		[]byte(`{"query":"no matching person","limit":3}`), "")
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	assert.Equal(t, []int{3}, engine.limits)
+	assert.JSONEq(t, `{"results":[]}`, response.Body.String())
+}
+
+func TestSemanticPersonSearchValidatesQueryAndLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "blank query", body: `{"query":"  "}`},
+		{name: "negative limit", body: `{"query":"synthetic","limit":-1}`},
+		{name: "limit above bound", body: `{"query":"synthetic","limit":101}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			engine := &fakePersonSearchEngine{}
+			srv := newSemanticPersonSearchServer(t, engine, VectorStatusReady, "")
+			response := semanticPersonSearchRequest(t, srv, []byte(test.body), "")
+			assert.Equal(t, http.StatusBadRequest, response.Code, response.Body.String())
+			assert.Empty(t, engine.queries)
+		})
+	}
+}
+
+func TestSemanticPersonSearchRequiresAuthenticationAndNeverCaches(t *testing.T) {
+	assert := assert.New(t)
+	const apiKey = "person-search-test-key"
+	engine := &fakePersonSearchEngine{results: []personsearch.Result{}}
+	srv := newSemanticPersonSearchServer(t, engine, VectorStatusReady, apiKey)
+
+	unauthorized := semanticPersonSearchRequest(t, srv,
+		[]byte(`{"query":"synthetic"}`), "")
+	assert.Equal(http.StatusUnauthorized, unauthorized.Code, unauthorized.Body.String())
+	assert.Equal("no-store", unauthorized.Header().Get("Cache-Control"))
+	assert.Empty(engine.queries)
+
+	authorized := semanticPersonSearchRequest(t, srv,
+		[]byte(`{"query":"synthetic"}`), apiKey)
+	assert.Equal(http.StatusOK, authorized.Code, authorized.Body.String())
+	assert.Equal("no-store", authorized.Header().Get("Cache-Control"))
+}
+
+func TestSemanticPersonSearchReportsEveryVectorStatusState(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    VectorStatus
+		statusErr string
+		wantCode  string
+	}{
+		{name: "disabled", status: VectorStatusDisabled, wantCode: "vector_not_enabled"},
+		{name: "initializing", status: VectorStatusInitializing, wantCode: "vector_initializing"},
+		{name: "failed", status: VectorStatusError, statusErr: "synthetic migration failure", wantCode: "vector_init_failed"},
+		{name: "stale", status: VectorStatusStale, statusErr: "synthetic stale index", wantCode: "index_stale"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			engine := &fakePersonSearchEngine{}
+			srv := newSemanticPersonSearchServer(t, engine, test.status, "")
+			if test.status == VectorStatusError {
+				srv.SetVectorInitError(errors.New(test.statusErr))
+			}
+			if test.status == VectorStatusStale {
+				srv.SetVectorStale(test.statusErr)
+			}
+			response := semanticPersonSearchRequest(t, srv,
+				[]byte(`{"query":"synthetic"}`), "")
+			require.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+			var body ErrorResponse
+			require.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+			assert.Equal(test.wantCode, body.Error)
+			assert.Empty(engine.queries)
+		})
+	}
+}
+
+func TestSemanticPersonSearchClearsCachedStaleStatusBeforeServing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cfg := vector.Config{}
+	backend := &resolvingVectorBackend{fingerprint: cfg.GenerationFingerprint()}
+	engine := &fakePersonSearchEngine{results: []personsearch.Result{}}
+	srv := NewServerWithOptions(ServerOptions{
+		Config:             &config.Config{},
+		Logger:             testLogger(),
+		Backend:            backend,
+		VectorCfg:          cfg,
+		VectorStatus:       VectorStatusStale,
+		PersonSearchEngine: engine,
+	})
+	srv.SetVectorStale("synthetic cached stale status")
+	status, _ := srv.VectorStatus()
+	require.Equal(VectorStatusStale, status, "precondition: stale is cached")
+
+	response := semanticPersonSearchRequest(t, srv,
+		[]byte(`{"query":"synthetic"}`), "")
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	assert.Equal([]string{"synthetic"}, engine.queries)
+	status, detail := srv.VectorStatus()
+	assert.Equal(VectorStatusReady, status)
+	assert.Empty(detail)
+}
+
+func TestSemanticPersonSearchMapsGenerationAndEmbeddingErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantCode    string
+		wantMessage string
+		wantDetail  string
+	}{
+		{name: "not enabled", err: vector.ErrNotEnabled, wantCode: "vector_not_enabled"},
+		{
+			name: "semantic people disabled", err: vector.ErrSemanticPersonEmbeddingsDisabled,
+			wantCode: "person_embeddings_disabled", wantMessage: "[vector.people] enabled = true",
+		},
+		{
+			name: "semantic people unconsented", err: vector.ErrSemanticPersonEmbeddingConsentRequired,
+			wantCode: "person_embedding_consent_required", wantMessage: "person provider consent --semantic-embeddings",
+		},
+		{
+			name: "semantic person policy unavailable",
+			err: fmt.Errorf("%w: read current policy: synthetic config source unavailable",
+				vector.ErrSemanticPersonEmbeddingPolicyUnavailable),
+			wantCode:    "person_embedding_policy_unavailable",
+			wantMessage: "cannot verify the current semantic person embedding policy",
+		},
+		{name: "stale", err: vector.ErrIndexStale, wantCode: "index_stale"},
+		{name: "building", err: vector.ErrIndexBuilding, wantCode: "index_building"},
+		{
+			name: "person coverage incomplete", err: personsearch.ErrPersonCoverageIncomplete,
+			wantCode: "index_building", wantMessage: "msgvault embeddings resume --backstop",
+		},
+		{
+			name: "person coverage terminal rejection",
+			err: &personsearch.CoverageIncompleteError{
+				Generation: 7, Rejected: 2,
+			},
+			wantCode:    "index_building",
+			wantMessage: "run `msgvault embeddings resume --backstop` first",
+			wantDetail:  "if terminal rejections remain",
+		},
+		{name: "embedding timeout", err: vector.ErrEmbeddingTimeout, wantCode: "embedding_timeout"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			engine := &fakePersonSearchEngine{err: test.err}
+			srv := newSemanticPersonSearchServer(t, engine, VectorStatusReady, "")
+			response := semanticPersonSearchRequest(t, srv,
+				[]byte(`{"query":"synthetic"}`), "")
+			requirements.Equal(http.StatusServiceUnavailable, response.Code, response.Body.String())
+			var body ErrorResponse
+			requirements.NoError(json.Unmarshal(response.Body.Bytes(), &body))
+			assertions.Equal(test.wantCode, body.Error)
+			if test.wantMessage != "" {
+				assertions.Contains(body.Message, test.wantMessage)
+			}
+			if test.wantDetail != "" {
+				assertions.Contains(body.Message, test.wantDetail)
+			}
+		})
+	}
+}
+
+func newSemanticPersonSearchServer(
+	t *testing.T, engine PersonSearchEngine, status VectorStatus, apiKey string,
+) *Server {
+	t.Helper()
+	return NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIKey: apiKey}},
+		Logger: testLogger(), VectorStatus: status, PersonSearchEngine: engine,
+	})
+}
+
+func semanticPersonSearchRequest(
+	t *testing.T, srv *Server, body []byte, apiKey string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, peoplePath+"/search", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		request.Header.Set("X-Api-Key", apiKey)
+	}
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, request)
+	return response
 }
 
 func personRequest(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -313,15 +313,16 @@ type Server struct {
 	// vectorMu guards the vector subsystem state: the daemon installs
 	// hybridEngine/backend/vectorCfg from a background init goroutine
 	// after the server is already handling requests.
-	vectorMu     sync.RWMutex
-	hybridEngine *hybrid.Engine
-	vectorCfg    vector.Config
-	backend      vector.Backend
-	visualSearch *visual.SearchService
-	visualBuild  func(context.Context) error
-	visualRun    func(context.Context) error
-	visualRetry  func(context.Context, int64, string) error
-	visualStatus func(context.Context, bool) (visual.Status, error)
+	vectorMu           sync.RWMutex
+	hybridEngine       *hybrid.Engine
+	vectorCfg          vector.Config
+	backend            vector.Backend
+	personSearchEngine PersonSearchEngine
+	visualSearch       *visual.SearchService
+	visualBuild        func(context.Context) error
+	visualRun          func(context.Context) error
+	visualRetry        func(context.Context, int64, string) error
+	visualStatus       func(context.Context, bool) (visual.Status, error)
 	// visualCoverageScan serializes the archive-wide coverage scan behind
 	// GET /multimodal/status?coverage=1.
 	visualCoverageScan sync.Mutex
@@ -438,6 +439,8 @@ type ServerOptions struct {
 	HybridEngine   *hybrid.Engine
 	VectorCfg      vector.Config
 	Backend        vector.Backend
+	// PersonSearchEngine is the optional semantic people service.
+	PersonSearchEngine PersonSearchEngine
 	// VectorStatus is the initial vector subsystem status. Zero value
 	// derives it: ready when Backend is non-nil, disabled otherwise. The
 	// serve daemon passes VectorStatusInitializing and installs the
@@ -517,6 +520,7 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		hybridEngine:             opts.HybridEngine,
 		vectorCfg:                opts.VectorCfg,
 		backend:                  opts.Backend,
+		personSearchEngine:       opts.PersonSearchEngine,
 		scheduler:                opts.Scheduler,
 		logger:                   opts.Logger,
 		requestTimeout:           timeout,

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -110,6 +110,13 @@ var settingsCatalog = []settingDefinition{
 	intSetting("vector.embeddings.max_retries", "search", func(c *config.Config) int { return c.Vector.Embeddings.MaxRetries }),
 	intSetting("vector.embeddings.max_input_chars", "search", func(c *config.Config) int { return c.Vector.Embeddings.MaxInputChars }),
 	intSetting("vector.embeddings.eta_window", "search", func(c *config.Config) int { return c.Vector.Embeddings.ETAWindow }),
+	boolSetting("vector.people.enabled", "search", func(c *config.Config) bool { return c.Vector.People.Enabled }),
+	stringSetting("vector.people.retention_posture", "search", nil, func(c *config.Config) string {
+		return c.Vector.People.RetentionPosture
+	}),
+	stringSetting("vector.people.training_posture", "search", nil, func(c *config.Config) string {
+		return c.Vector.People.TrainingPosture
+	}),
 	stringSetting("vector.embed.schedule.cron", "search", nil, func(c *config.Config) string { return c.Vector.Embed.Schedule.Cron }),
 	boolSetting("vector.embed.schedule.run_after_sync", "search", func(c *config.Config) bool { return c.Vector.Embed.Schedule.RunAfterSync }),
 	stringArraySetting("vector.embed.scope.message_types", "search", func(c *config.Config) []string { return c.Vector.Embed.Scope.MessageTypes }),

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -43,6 +43,11 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 	require.NotNil(byKey["vector.embeddings.api_format"].Value.String)
 	assert.Equal("openai", *byKey["vector.embeddings.api_format"].Value.String)
 	assert.Equal([]string{"openai", "voyage-contextual"}, byKey["vector.embeddings.api_format"].Options)
+	require.NotNil(byKey["vector.people.enabled"].Value)
+	require.NotNil(byKey["vector.people.enabled"].Value.Boolean)
+	assert.False(*byKey["vector.people.enabled"].Value.Boolean)
+	require.NotNil(byKey["vector.people.retention_posture"].Value)
+	require.NotNil(byKey["vector.people.training_posture"].Value)
 	require.NotNil(byKey["server.trusted_proxies"].Value)
 	assert.NotNil(byKey["server.trusted_proxies"].Value.Strings)
 	assert.NotContains(byKey, "unsupported.private_value")
@@ -56,6 +61,29 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 	assert.NotContains(resp.Body.String(), "test-api-key")
 	assert.NotContains(resp.Body.String(), "task-secret")
 	assert.NotContains(resp.Body.String(), "must-not-leak")
+}
+
+func TestPatchSettingsExposesCompleteSemanticPersonOptInPolicy(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	srv, path := newSettingsTestServer(t, "[vector]\n"+
+		"enabled = true\n"+
+		"[vector.embeddings]\n"+
+		"endpoint = \"https://embedding.example.test/v1\"\n"+
+		"model = \"synthetic-model\"\n"+
+		"dimension = 4\n")
+	response := patchSettings(t, srv, `{"updates":[
+		{"key":"vector.people.enabled","value":{"boolean":true}},
+		{"key":"vector.people.retention_posture","value":{"string":"zero_data_retention"}},
+		{"key":"vector.people.training_posture","value":{"string":"no_training"}}
+	]}`)
+	must.Equal(http.StatusOK, response.Code, response.Body.String())
+
+	got, err := os.ReadFile(path)
+	must.NoError(err)
+	check.Contains(string(got), "people.enabled = true")
+	check.Contains(string(got), `people.retention_posture = "zero_data_retention"`)
+	check.Contains(string(got), `people.training_posture = "no_training"`)
 }
 
 func TestPatchSettingsSelectsVoyageContextualEmbeddingFormat(t *testing.T) {

--- a/internal/api/vector_status.go
+++ b/internal/api/vector_status.go
@@ -30,13 +30,19 @@ const (
 	VectorStatusStale VectorStatus = "stale"
 )
 
-// SetVectorFeatures installs the vector components into a running server.
-// The serve daemon calls this from its background init goroutine once
-// migrations and the embed_gen backfill complete.
-func (s *Server) SetVectorFeatures(engine *hybrid.Engine, backend vector.Backend, cfg vector.Config) {
+// SetVectorFeatures atomically installs every vector search component before
+// publishing ready. The daemon uses this path so a request can never observe
+// ready vector status before semantic person search exists.
+func (s *Server) SetVectorFeatures(
+	engine *hybrid.Engine,
+	personEngine PersonSearchEngine,
+	backend vector.Backend,
+	cfg vector.Config,
+) {
 	s.vectorMu.Lock()
 	defer s.vectorMu.Unlock()
 	s.hybridEngine = engine
+	s.personSearchEngine = personEngine
 	s.backend = backend
 	s.vectorCfg = cfg
 	s.vectorStatus = VectorStatusReady
@@ -310,6 +316,12 @@ func (s *Server) vectorComponents() (*hybrid.Engine, vector.Backend, vector.Conf
 	s.vectorMu.RLock()
 	defer s.vectorMu.RUnlock()
 	return s.hybridEngine, s.backend, s.vectorCfg
+}
+
+func (s *Server) personSearchComponent() PersonSearchEngine {
+	s.vectorMu.RLock()
+	defer s.vectorMu.RUnlock()
+	return s.personSearchEngine
 }
 
 // writeVectorUnavailable reports why vector search cannot serve a request

--- a/internal/api/vector_status_test.go
+++ b/internal/api/vector_status_test.go
@@ -67,7 +67,7 @@ func TestSetVectorFeaturesTransitionsToReady(t *testing.T) {
 	srv := NewServerWithOptions(opts)
 
 	backend := &minimalVectorBackend{}
-	srv.SetVectorFeatures(nil, backend, vector.Config{})
+	srv.SetVectorFeatures(nil, nil, backend, vector.Config{})
 
 	status, errMsg := srv.VectorStatus()
 	assert.Equal(t, VectorStatusReady, status)
@@ -202,7 +202,7 @@ func TestHealthClearsStaleAfterReactivation(t *testing.T) {
 	opts := testServerOptions(t, backend)
 	opts.VectorStatus = VectorStatusInitializing
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 	srv.SetVectorStale("active=\"old:1\" configured=\"new:2\"")
 
 	// Sanity: status is stale before the health check re-validates.
@@ -235,7 +235,7 @@ func TestScopeDriftStaleSurvivesRefresh(t *testing.T) {
 	opts := testServerOptions(t, backend)
 	opts.VectorStatus = VectorStatusInitializing
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 	srv.SetVectorScopeDrift("configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/health", nil)
@@ -250,7 +250,7 @@ func TestScopeDriftStaleSurvivesRefresh(t *testing.T) {
 		"a matching startup fingerprint must not clear scope-drift stale")
 	assert.Contains(body.Vector.Error, "src-9")
 
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 	status, errMsg := srv.VectorStatus()
 	assert.Equal(VectorStatusReady, status, "reinit clears the latch")
 	assert.Empty(errMsg)
@@ -270,7 +270,7 @@ func TestVectorSearchEndpointsGateOnScopeDrift(t *testing.T) {
 		opts.VectorStatus = VectorStatusInitializing
 		opts.Store = &mockStore{}
 		srv := NewServerWithOptions(opts)
-		srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+		srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), nil, backend, cfg)
 		srv.SetVectorScopeDrift("configured embedding scope now resolves to \"src-9\" but vector search was initialized with \"src-7\"")
 		return srv
 	}
@@ -324,7 +324,7 @@ func TestVectorSearchPreflightDetectsScopeDrift(t *testing.T) {
 	opts.VectorStatus = VectorStatusInitializing
 	opts.Store = &mockStore{}
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), nil, backend, cfg)
 
 	checks := 0
 	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
@@ -365,7 +365,7 @@ func TestVectorSearchPreflightThrottlesScopeCheck(t *testing.T) {
 	opts.VectorStatus = VectorStatusInitializing
 	opts.Store = &mockStore{}
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), backend, cfg)
+	srv.SetVectorFeatures(hybrid.NewEngine(backend, nil, nil, hybrid.Config{}), nil, backend, cfg)
 
 	checks := 0
 	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
@@ -402,7 +402,7 @@ func TestHealthFlipsReadyToStaleAfterForeignActivation(t *testing.T) {
 	opts := testServerOptions(t, backend)
 	opts.VectorStatus = VectorStatusInitializing
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 
 	health := func() string {
 		rec := httptest.NewRecorder()
@@ -450,7 +450,7 @@ func TestHealthDetectsScopeDrift(t *testing.T) {
 	opts := testServerOptions(t, backend)
 	opts.VectorStatus = VectorStatusInitializing
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 	checks := 0
 	srv.SetVectorScopeCheck(func(context.Context) (string, error) {
 		checks++
@@ -482,7 +482,7 @@ func TestHealthKeepsStaleWhenStillMismatched(t *testing.T) {
 	opts := testServerOptions(t, backend)
 	opts.VectorStatus = VectorStatusInitializing
 	srv := NewServerWithOptions(opts)
-	srv.SetVectorFeatures(nil, backend, cfg)
+	srv.SetVectorFeatures(nil, nil, backend, cfg)
 	srv.SetVectorStale("active=\"still-old:1\" configured=\"new:2\"")
 
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
@@ -509,7 +509,7 @@ func TestSetVectorFeaturesConcurrentReads(t *testing.T) {
 			_, _ = srv.VectorStatus()
 		}
 	}()
-	srv.SetVectorFeatures(nil, &fakeVectorBackend{}, vector.Config{})
+	srv.SetVectorFeatures(nil, nil, &fakeVectorBackend{}, vector.Config{})
 	<-done
 
 	status, _ := srv.VectorStatus()

--- a/internal/scheduler/embed_job.go
+++ b/internal/scheduler/embed_job.go
@@ -29,20 +29,30 @@ type EmbedRunner interface {
 	ReclaimStale(ctx context.Context) (int, error)
 }
 
+type activePersonRunner interface {
+	RunPersonsOnce(ctx context.Context, gen vector.GenerationID) (embed.RunResult, error)
+}
+
 // ConvergenceResult is the complete activation gate for one generation.
-// Contextual modes require all three independent dimensions; legacy modes set
-// the journal and reconciliation dimensions complete by construction.
+// Every mode requires exact message and curated-person coverage. Contextual
+// modes additionally require the journal and reconciliation dimensions;
+// legacy modes set those dimensions complete by construction.
 type ConvergenceResult struct {
-	MessageCoverageComplete bool
-	MessageCoverageMissing  int64
-	LatestJournalSequence   int64
-	ConsumedJournalSequence int64
-	ReconciliationComplete  bool
+	MessageCoverageComplete  bool
+	MessageCoverageMissing   int64
+	PersonCoverageComplete   bool
+	PersonCoverageMismatched int64
+	PersonCoverageRejected   int64
+	LatestJournalSequence    int64
+	ConsumedJournalSequence  int64
+	ReconciliationComplete   bool
 }
 
 // Complete reports whether a generation is safe to activate.
 func (r ConvergenceResult) Complete() bool {
 	return r.MessageCoverageComplete &&
+		r.PersonCoverageComplete &&
+		r.PersonCoverageRejected == 0 &&
 		r.LatestJournalSequence == r.ConsumedJournalSequence &&
 		r.ReconciliationComplete
 }
@@ -225,6 +235,11 @@ func (j *EmbedJob) Run(ctx context.Context) {
 		log.Warn("embed reclaim failed", "error", err)
 	}
 
+	j.maintainActivePeopleDuringBuild(ctx, log)
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
+
 	target, isBuilding, ok := j.pickTarget(ctx, log)
 	if !ok {
 		return
@@ -236,6 +251,12 @@ func (j *EmbedJob) Run(ctx context.Context) {
 	// this operation boundary is authoritative.
 	if jobctx.YieldedToWaiter(ctx) {
 		return
+	}
+	if generationErr, ok := errors.AsType[*embed.GenerationRunError](err); ok {
+		if generationErr.Person != nil {
+			log.Warn("person embedding run failed", "gen", target, "error", generationErr.Person)
+		}
+		err = generationErr.Message
 	}
 	if err != nil {
 		log.Warn("embed run failed", "gen", target, "error", err)
@@ -315,6 +336,9 @@ func (j *EmbedJob) Run(ctx context.Context) {
 				"gen", target,
 				"message_coverage_complete", state.MessageCoverageComplete,
 				"message_coverage_missing", state.MessageCoverageMissing,
+				"person_coverage_complete", state.PersonCoverageComplete,
+				"person_coverage_mismatched", state.PersonCoverageMismatched,
+				"person_coverage_rejected", state.PersonCoverageRejected,
 				"latest_journal_sequence", state.LatestJournalSequence,
 				"consumed_journal_sequence", state.ConsumedJournalSequence,
 				"reconciliation_complete", state.ReconciliationComplete)
@@ -340,6 +364,43 @@ func (j *EmbedJob) Run(ctx context.Context) {
 		}
 	}
 	j.activateBuilding(ctx, target, contextualState, log)
+}
+
+func (j *EmbedJob) maintainActivePeopleDuringBuild(ctx context.Context, log *slog.Logger) {
+	runner, ok := j.Worker.(activePersonRunner)
+	if !ok || j.Fingerprint == "" {
+		return
+	}
+	building, err := j.Backend.BuildingGeneration(ctx)
+	if err != nil || building == nil || jobctx.YieldedToWaiter(ctx) {
+		return
+	}
+	active, err := j.Backend.ActiveGeneration(ctx)
+	if errors.Is(err, vector.ErrNoActiveGeneration) || jobctx.YieldedToWaiter(ctx) {
+		return
+	}
+	if err != nil {
+		log.Warn("active person embedding generation lookup failed", "error", err)
+		return
+	}
+	if active.Fingerprint != j.Fingerprint {
+		return
+	}
+	res, err := runner.RunPersonsOnce(ctx, active.ID)
+	if jobctx.YieldedToWaiter(ctx) {
+		return
+	}
+	if err != nil {
+		log.Warn("active person embedding run failed", "gen", active.ID, "error", err)
+		return
+	}
+	log.Info("active person embedding run complete",
+		"gen", active.ID,
+		"scanned", res.Claimed,
+		"succeeded", res.Succeeded,
+		"failed", res.Failed,
+		"truncated", res.Truncated,
+	)
 }
 
 func (j *EmbedJob) activateBuilding(
@@ -417,6 +478,12 @@ func (j *EmbedJob) maybeRunBackstop(ctx context.Context, gen vector.GenerationID
 	res, err := j.Worker.RunBackstop(ctx, gen)
 	if jobctx.YieldedToWaiter(ctx) {
 		return true
+	}
+	if generationErr, ok := errors.AsType[*embed.GenerationRunError](err); ok {
+		if generationErr.Person != nil {
+			log.Warn("person embedding backstop failed", "gen", gen, "error", generationErr.Person)
+		}
+		err = generationErr.Message
 	}
 	if err != nil {
 		log.Warn("embed backstop failed", "gen", gen, "error", err)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"maps"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -705,13 +706,29 @@ type fakeRunner struct {
 	backstopResult embed.RunResult
 	runDoneOnce    sync.Once
 	runDone        chan struct{} // optional: closed after first RunOnce
+	onRunOnce      func(vector.GenerationID)
 	yieldCancel    context.CancelCauseFunc
 	yieldBackstop  context.CancelCauseFunc
 	yieldReclaim   context.CancelCauseFunc
+	personErr      error
+	personCalls    []vector.GenerationID
+	onPerson       func(vector.GenerationID)
 	// onBackstop, if set, is invoked from RunBackstop (after recording the
 	// call) to let tests model a side effect of the backstop pass, e.g. a
 	// straggler becoming covered. Called while r.mu is held.
 	onBackstop func()
+}
+
+func (r *fakeRunner) RunPersonsOnce(
+	_ context.Context, gen vector.GenerationID,
+) (embed.RunResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.personCalls = append(r.personCalls, gen)
+	if r.onPerson != nil && r.personErr == nil {
+		r.onPerson(gen)
+	}
+	return embed.RunResult{}, r.personErr
 }
 
 func (r *fakeRunner) ReclaimStale(ctx context.Context) (int, error) {
@@ -730,6 +747,9 @@ func (r *fakeRunner) RunOnce(ctx context.Context, gen vector.GenerationID) (embe
 	r.mu.Lock()
 	r.runCalls++
 	r.lastRunGen = gen
+	if r.onRunOnce != nil && r.runErr == nil {
+		r.onRunOnce(gen)
+	}
 	ch := r.runDone
 	res := r.runOnceResult
 	err := r.runErr
@@ -770,6 +790,12 @@ func (r *fakeRunner) backstops() (n int, lastGen vector.GenerationID) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.backstopCalls, r.lastBackstop
+}
+
+func (r *fakeRunner) persons() []vector.GenerationID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]vector.GenerationID(nil), r.personCalls...)
 }
 
 // ---------- EmbedJob tests ----------
@@ -1011,6 +1037,25 @@ func TestEmbedJob_Run_ErrorWithoutYieldLogsFailure(t *testing.T) {
 	assert.NotContains(logs.String(), "embed run complete", "failed runs must not log completion")
 }
 
+func TestEmbedJob_Run_PersonFailureStillRunsMessageBackstop(t *testing.T) {
+	assert := assert.New(t)
+	backend := &fakeBackend{active: vector.Generation{ID: 5, State: vector.GenerationActive}}
+	runner := &fakeRunner{runErr: &embed.GenerationRunError{Person: errors.New("person provider failed")}}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker: runner, Backend: backend, BackstopInterval: time.Hour,
+		Log: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(t.Context())
+
+	n, gen := runner.backstops()
+	assert.Equal(1, n, "person-only failure must not starve message recovery")
+	assert.Equal(vector.GenerationID(5), gen)
+	assert.Contains(logs.String(), "person embedding run failed")
+	assert.NotContains(logs.String(), "embed run failed")
+}
+
 func TestEmbedJob_MaybeRunBackstop_YieldedCleanRunDoesNotRecordCompletion(t *testing.T) {
 	assert := assert.New(t)
 	ctx, cancel := context.WithCancelCause(context.Background())
@@ -1176,6 +1221,87 @@ func TestEmbedJob_Run_PrefersBuildingOverActive(t *testing.T) {
 	assert.Equal(t, vector.GenerationID(99), gen,
 		"RunOnce gen should be building (%d) — active (%d) would strand the rebuild",
 		building.ID, backend.active.ID)
+}
+
+// TestEmbedJobRunMaintainsActivePeopleThroughoutCompatibleBuild catches the
+// scheduler dropping active-generation person creations, edits, and deletions
+// whenever a compatible message rebuild is in flight.
+func TestEmbedJobRunMaintainsActivePeopleThroughoutCompatibleBuild(t *testing.T) {
+	check := assert.New(t)
+	active := vector.Generation{ID: 5, State: vector.GenerationActive, Fingerprint: "m:768"}
+	building := &vector.Generation{ID: 99, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{active: active, building: building}
+	desired := map[int64]string{1: "rev-one", 2: "rev-two"}
+	corpora := map[vector.GenerationID]map[int64]string{
+		active.ID:   {9: "deleted"},
+		building.ID: {9: "deleted"},
+	}
+	reconcile := func(gen vector.GenerationID) {
+		corpora[gen] = maps.Clone(desired)
+	}
+	runner := &fakeRunner{
+		onPerson:  reconcile,
+		onRunOnce: reconcile,
+	}
+	job := &EmbedJob{
+		Worker: runner, Backend: backend, Fingerprint: "m:768", BackstopInterval: -1,
+	}
+
+	job.Run(t.Context())
+	check.Equal(desired, corpora[active.ID], "active person additions and deletions")
+	check.Equal(desired, corpora[building.ID], "building person additions and deletions")
+
+	desired = map[int64]string{1: "rev-one-edited", 3: "rev-three"}
+	job.Run(t.Context())
+	check.Equal(desired, corpora[active.ID], "active person edits, additions, and deletions")
+	check.Equal(desired, corpora[building.ID], "building person edits, additions, and deletions")
+	check.Equal([]vector.GenerationID{active.ID, active.ID}, runner.persons())
+}
+
+// TestEmbedJobRunMaintainsCompatibleActivePeoplePastMismatchedBuild catches
+// the early mismatched-build return starving otherwise-compatible active
+// person upkeep.
+func TestEmbedJobRunMaintainsCompatibleActivePeoplePastMismatchedBuild(t *testing.T) {
+	active := vector.Generation{ID: 5, State: vector.GenerationActive, Fingerprint: "new:768"}
+	backend := &fakeBackend{
+		active: active,
+		building: &vector.Generation{
+			ID: 33, State: vector.GenerationBuilding, Fingerprint: "old:512",
+		},
+	}
+	runner := &fakeRunner{}
+	job := &EmbedJob{
+		Worker: runner, Backend: backend, Fingerprint: "new:768", BackstopInterval: -1,
+	}
+
+	job.Run(t.Context())
+
+	_, buildRuns, _ := runner.calls()
+	assert.Zero(t, buildRuns, "mismatched building message work remains declined")
+	assert.Equal(t, []vector.GenerationID{active.ID}, runner.persons(),
+		"compatible active person upkeep must still run")
+}
+
+// TestEmbedJobRunActivePersonFailureDoesNotStarveCompatibleBuild catches a
+// person-only active maintenance failure aborting valid building-generation
+// message and person work.
+func TestEmbedJobRunActivePersonFailureDoesNotStarveCompatibleBuild(t *testing.T) {
+	active := vector.Generation{ID: 5, State: vector.GenerationActive, Fingerprint: "m:768"}
+	building := &vector.Generation{ID: 99, State: vector.GenerationBuilding, Fingerprint: "m:768"}
+	backend := &fakeBackend{active: active, building: building}
+	runner := &fakeRunner{personErr: errors.New("synthetic active person failure")}
+	var logs bytes.Buffer
+	job := &EmbedJob{
+		Worker: runner, Backend: backend, Fingerprint: "m:768", BackstopInterval: -1,
+		Log: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	job.Run(t.Context())
+
+	_, buildRuns, buildGen := runner.calls()
+	assert.Equal(t, 1, buildRuns, "valid building pass must still run")
+	assert.Equal(t, building.ID, buildGen)
+	assert.Contains(t, logs.String(), "active person embedding run failed")
 }
 
 // TestEmbedJob_Run_ActivatesBuildingWhenDrained verifies the
@@ -1491,6 +1617,7 @@ func TestEmbedJob_Run_YieldedConvergenceStopsWithoutWarning(t *testing.T) {
 func TestEmbedJob_Run_ContextualActivationRequiresEveryConvergenceDimension(t *testing.T) {
 	complete := ConvergenceResult{
 		MessageCoverageComplete: true,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   12,
 		ConsumedJournalSequence: 12,
 		ReconciliationComplete:  true,
@@ -1502,6 +1629,7 @@ func TestEmbedJob_Run_ContextualActivationRequiresEveryConvergenceDimension(t *t
 	}{
 		{name: "complete", want: true},
 		{name: "message coverage incomplete", mutate: func(r *ConvergenceResult) { r.MessageCoverageComplete = false }},
+		{name: "person coverage incomplete", mutate: func(r *ConvergenceResult) { r.PersonCoverageComplete = false }},
 		{name: "journal not consumed", mutate: func(r *ConvergenceResult) { r.ConsumedJournalSequence-- }},
 		{name: "reconciliation incomplete", mutate: func(r *ConvergenceResult) { r.ReconciliationComplete = false }},
 	}
@@ -1535,6 +1663,7 @@ func TestEmbedJob_Run_ContextualConvergedBuildActivatesBeforeBackstop(t *testing
 		Worker: runner, Backend: backend, Fingerprint: "m:768",
 		Convergence: &fakeConvergenceChecker{result: ConvergenceResult{
 			MessageCoverageComplete: true,
+			PersonCoverageComplete:  true,
 			LatestJournalSequence:   12,
 			ConsumedJournalSequence: 12,
 			ReconciliationComplete:  true,
@@ -1556,6 +1685,7 @@ func TestEmbedJob_Run_ContextualIncompleteBuildUsesBackstopRecovery(t *testing.T
 	backend := &fakeBackend{building: &vector.Generation{ID: 7, Fingerprint: "m:768"}}
 	checker := &fakeConvergenceChecker{result: ConvergenceResult{
 		MessageCoverageComplete: false,
+		PersonCoverageComplete:  true,
 		LatestJournalSequence:   12,
 		ConsumedJournalSequence: 12,
 		ReconciliationComplete:  true,
@@ -1583,6 +1713,7 @@ func TestEmbedJob_Run_LegacyConvergenceUsesNormalActivation(t *testing.T) {
 		Worker: &fakeRunner{}, Backend: backend, Fingerprint: "m:768",
 		Convergence: &fakeConvergenceChecker{result: ConvergenceResult{
 			MessageCoverageComplete: true,
+			PersonCoverageComplete:  true,
 			ReconciliationComplete:  true,
 		}},
 		BackstopInterval: -1,

--- a/internal/store/attribute_seed.go
+++ b/internal/store/attribute_seed.go
@@ -386,6 +386,27 @@ func (s *Store) reconcileSeededDefinitionWith(
 	if !seededDefinitionDiffers(existing, validated) {
 		return nil
 	}
+	if existing.ValueType != validated.ValueType {
+		queryer, ok := execer.(interface {
+			QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+		})
+		if !ok {
+			return fmt.Errorf("count existing values for seeded attribute definition %s: query rows unsupported", seed.Slug)
+		}
+		var valueCount int64
+		err := queryer.QueryRowContext(ctx, `
+			SELECT
+				(SELECT COUNT(*) FROM person_attribute_values WHERE definition_id = ?) +
+				(SELECT COUNT(*) FROM organization_attribute_values WHERE definition_id = ?)
+		`, existing.ID, existing.ID).Scan(&valueCount)
+		if err != nil {
+			return fmt.Errorf("count existing values for seeded attribute definition %s: %w", seed.Slug, err)
+		}
+		if valueCount > 0 {
+			return fmt.Errorf("cannot reconcile seeded attribute definition %s value_type from %s to %s: definition has existing values",
+				seed.Slug, existing.ValueType, validated.ValueType)
+		}
+	}
 	options, err := marshalAttributeOptions(validated.Options)
 	if err != nil {
 		return err

--- a/internal/store/attribute_seed_test.go
+++ b/internal/store/attribute_seed_test.go
@@ -211,6 +211,38 @@ func TestReSeedingPreservesUserLabelChangesAndRepairsStructure(t *testing.T) {
 	assert.Len(all, 15)
 }
 
+func TestReSeedingRefusesValueTypeRepairWhenValuesExist(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := t.Context()
+	participantID, err := st.EnsureParticipantByIdentifier(
+		"email", "seed-type-guard@example.invalid", "Seed Type Guard")
+	require.NoError(err)
+	person, _, err := st.CreatePersonFromParticipant(participantID)
+	require.NoError(err)
+	value := "distributed systems"
+	_, err = st.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: person.ID, DefinitionSlug: store.AttributeSlugAskMeAbout,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: &value},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE attribute_definitions
+		SET value_type = 'record_reference', field_type = 'person', record_target = 'person'
+		WHERE universal_id = ?
+	`), store.AttributeUniversalIDAskMeAbout)
+	require.NoError(err)
+
+	err = st.EnsureSeededAttributeDefinitionsContext(ctx)
+	require.ErrorContains(err, "value_type")
+	require.ErrorContains(err, "has existing values")
+	drifted, getErr := st.GetAttributeDefinitionBySlugContext(
+		ctx, store.AttributeObjectPerson, store.AttributeSlugAskMeAbout)
+	require.NoError(getErr)
+	assert.Equal(t, store.AttributeValueRecordReference, drifted.ValueType)
+}
+
 func TestInitSchemaPreservesLegacySeedSlugCollision(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/store/person_semantic.go
+++ b/internal/store/person_semantic.go
@@ -1,0 +1,514 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"go.kenn.io/msgvault/internal/vector"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	// PersonSemanticRendererPolicy changes whenever the selected fields,
+	// labels, ordering, normalization, or cap changes.
+	PersonSemanticRendererPolicy = vector.SemanticPersonRendererPolicy
+
+	// MaxPersonSemanticDocumentBytes bounds the exact UTF-8 provider input.
+	// The cap is applied before Revision is calculated.
+	MaxPersonSemanticDocumentBytes = 32 * 1024
+)
+
+// PersonSemanticDocument is the canonical, privacy-bounded embedding source
+// for one durable person. Revision is the lowercase SHA-256 digest of the
+// renderer policy, a NUL separator, and Text's exact capped bytes.
+type PersonSemanticDocument struct {
+	PersonID       int64  `json:"person_id"`
+	RendererPolicy string `json:"renderer_policy"`
+	Revision       string `json:"revision"`
+	Text           string `json:"text"`
+}
+
+// PersonSemanticCandidate identifies one person ANN hit by the exact semantic
+// revision published with its vector.
+type PersonSemanticCandidate struct {
+	PersonID int64
+	Revision string
+}
+
+type personSemanticSnapshot struct {
+	person        Person
+	names         []PersonName
+	categories    []PersonCategory
+	addresses     []PersonAddress
+	attributes    []personSemanticAttribute
+	employments   []personSemanticEmployment
+	relationships []PersonRelationshipView
+}
+
+type personSemanticAttribute struct {
+	definition AttributeDefinition
+	value      PersonAttributeValue
+}
+
+type personSemanticEmployment struct {
+	employment             Employment
+	organization           Organization
+	organizationNames      []OrganizationName
+	organizationCategories []OrganizationCategory
+	organizationAddresses  []OrganizationAddress
+}
+
+// LoadPersonSemanticDocumentContext returns one extant person's canonical
+// semantic document from a single repeatable-read snapshot.
+func (s *Store) LoadPersonSemanticDocumentContext(
+	ctx context.Context, personID int64,
+) (*PersonSemanticDocument, error) {
+	var document *PersonSemanticDocument
+	err := s.withReadSnapshotContext(ctx, func(tx *loggedTx) error {
+		allowed, err := s.loadPersonSemanticAttributeDefinitionsTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		snapshot, err := s.loadPersonSemanticSnapshotTx(ctx, tx, personID, allowed)
+		if err != nil {
+			return err
+		}
+		document, err = renderPersonSemanticDocument(snapshot)
+		return err
+	})
+	return document, err
+}
+
+// ListPersonSemanticDocumentsContext returns every extant person's canonical
+// semantic document in durable-person-ID order from one repeatable-read
+// snapshot.
+func (s *Store) ListPersonSemanticDocumentsContext(
+	ctx context.Context,
+) ([]PersonSemanticDocument, error) {
+	documents := make([]PersonSemanticDocument, 0)
+	err := s.withReadSnapshotContext(ctx, func(tx *loggedTx) error {
+		allowed, err := s.loadPersonSemanticAttributeDefinitionsTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		rows, err := tx.QueryContext(ctx, `SELECT id FROM persons ORDER BY id`)
+		if err != nil {
+			return fmt.Errorf("list people for semantic projection: %w", err)
+		}
+		personIDs := make([]int64, 0)
+		for rows.Next() {
+			var personID int64
+			if err := rows.Scan(&personID); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("scan person for semantic projection: %w", err)
+			}
+			personIDs = append(personIDs, personID)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("iterate people for semantic projection: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("close people semantic projection rows: %w", err)
+		}
+
+		for _, personID := range personIDs {
+			snapshot, err := s.loadPersonSemanticSnapshotTx(ctx, tx, personID, allowed)
+			if err != nil {
+				return err
+			}
+			document, err := renderPersonSemanticDocument(snapshot)
+			if err != nil {
+				return err
+			}
+			documents = append(documents, *document)
+		}
+		return nil
+	})
+	return documents, err
+}
+
+// ResolvePersonSemanticCandidatesContext validates candidate revisions and
+// returns their durable roots in candidate order from one repeatable-read
+// snapshot. A stale or deleted candidate is omitted. Keeping render,
+// comparison, and root hydration inside this single snapshot prevents an edit
+// from pairing a score for an old semantic document with a newer person root.
+// Revisions intentionally include rendered organization and relationship
+// counterpart text. Editing either linked record therefore suppresses stale
+// hits for affected people until the scheduled person worker republishes them.
+func (s *Store) ResolvePersonSemanticCandidatesContext(
+	ctx context.Context, candidates []PersonSemanticCandidate,
+) ([]Person, error) {
+	people := make([]Person, 0, len(candidates))
+	err := s.withReadSnapshotContext(ctx, func(tx *loggedTx) error {
+		allowed, err := s.loadPersonSemanticAttributeDefinitionsTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		for _, candidate := range candidates {
+			snapshot, err := s.loadPersonSemanticSnapshotTx(ctx, tx, candidate.PersonID, allowed)
+			if errors.Is(err, ErrPersonNotFound) {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("load person %d semantic search candidate: %w", candidate.PersonID, err)
+			}
+			document, err := renderPersonSemanticDocument(snapshot)
+			if err != nil {
+				slog.Warn("skipping unrenderable person semantic search candidate",
+					"person_id", candidate.PersonID, "error", err)
+				continue
+			}
+			if document.Text == "" || document.Revision != candidate.Revision {
+				continue
+			}
+			people = append(people, snapshot.person)
+		}
+		return nil
+	})
+	return people, err
+}
+
+func (s *Store) loadPersonSemanticSnapshotTx(
+	ctx context.Context, tx *loggedTx, personID int64,
+	allowedAttributes map[string]AttributeDefinition,
+) (*personSemanticSnapshot, error) {
+	person, err := s.getPersonTx(ctx, tx, personID)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := &personSemanticSnapshot{person: *person}
+	if snapshot.names, err = s.listPersonNamesTx(ctx, tx, personID, true); err != nil {
+		return nil, fmt.Errorf("load current person names for semantic projection: %w", err)
+	}
+	if snapshot.categories, err = s.listPersonCategoriesTx(ctx, tx, personID, true); err != nil {
+		return nil, fmt.Errorf("load current person categories for semantic projection: %w", err)
+	}
+	if snapshot.addresses, err = s.listPersonAddressesTx(ctx, tx, personID, true); err != nil {
+		return nil, fmt.Errorf("load current person locations for semantic projection: %w", err)
+	}
+	if snapshot.attributes, err = s.loadPersonSemanticAttributesTx(
+		ctx, tx, personID, allowedAttributes,
+	); err != nil {
+		return nil, err
+	}
+	if snapshot.employments, err = s.loadPersonSemanticEmploymentsTx(ctx, tx, personID); err != nil {
+		return nil, err
+	}
+	if snapshot.relationships, err = s.listPersonRelationshipsContext(
+		ctx, tx, personID, PersonRelationshipListOptions{},
+	); err != nil {
+		return nil, fmt.Errorf("load active person relationships for semantic projection: %w", err)
+	}
+	return snapshot, nil
+}
+
+func (s *Store) loadPersonSemanticAttributeDefinitionsTx(
+	ctx context.Context, tx *loggedTx,
+) (map[string]AttributeDefinition, error) {
+	definitions, err := s.listAttributeDefinitionsContext(ctx, tx,
+		AttributeDefinitionFilter{ObjectType: AttributeObjectPerson})
+	if err != nil {
+		return nil, fmt.Errorf("load active person attribute definitions for semantic projection: %w", err)
+	}
+	allowed := make(map[string]AttributeDefinition, len(definitions))
+	for _, definition := range definitions {
+		if !definition.IsSearchable || definition.IsSensitive ||
+			definition.FieldType == AttributeFieldEmail ||
+			definition.FieldType == AttributeFieldPhone ||
+			definition.ValueType == AttributeValueDate ||
+			definition.ValueType == AttributeValueTimestamp {
+			continue
+		}
+		allowed[definition.Slug] = definition
+	}
+	return allowed, nil
+}
+
+func (s *Store) loadPersonSemanticAttributesTx(
+	ctx context.Context, tx *loggedTx, personID int64,
+	allowed map[string]AttributeDefinition,
+) ([]personSemanticAttribute, error) {
+	values, err := s.listPersonAttributeValuesContext(
+		ctx, tx, personID, PersonAttributeQuery{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load current person attributes for semantic projection: %w", err)
+	}
+	attributes := make([]personSemanticAttribute, 0, len(values))
+	for _, value := range values {
+		definition, ok := allowed[value.DefinitionSlug]
+		if !ok {
+			continue
+		}
+		attributes = append(attributes, personSemanticAttribute{
+			definition: definition,
+			value:      value,
+		})
+	}
+	return attributes, nil
+}
+
+func (s *Store) loadPersonSemanticEmploymentsTx(
+	ctx context.Context, tx *loggedTx, personID int64,
+) ([]personSemanticEmployment, error) {
+	employments, err := s.listAllEmploymentsContext(ctx, tx, EmploymentFilter{
+		PersonID: personID, CurrentOnly: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load current employments for semantic projection: %w", err)
+	}
+	result := make([]personSemanticEmployment, 0, len(employments))
+	for _, employment := range employments {
+		organization, err := getOrganizationTx(ctx, tx, employment.OrganizationID)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"load employment organization %d for semantic projection: %w",
+				employment.OrganizationID, err,
+			)
+		}
+		item := personSemanticEmployment{
+			employment: employment, organization: *organization,
+		}
+		if item.organizationNames, err = queryOrganizationRows(
+			ctx, tx, organizationNameSelect, organization.ID, false, scanOrganizationName,
+		); err != nil {
+			return nil, fmt.Errorf("load current organization names for semantic projection: %w", err)
+		}
+		if item.organizationCategories, err = queryOrganizationRows(
+			ctx, tx, organizationCategorySelect, organization.ID, false, scanOrganizationCategory,
+		); err != nil {
+			return nil, fmt.Errorf("load current organization categories for semantic projection: %w", err)
+		}
+		if item.organizationAddresses, err = queryOrganizationRows(
+			ctx, tx, organizationAddressSelect, organization.ID, false, scanOrganizationAddress,
+		); err != nil {
+			return nil, fmt.Errorf("load current organization locations for semantic projection: %w", err)
+		}
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+func renderPersonSemanticDocument(
+	snapshot *personSemanticSnapshot,
+) (*PersonSemanticDocument, error) {
+	sections := make([][]string, 10)
+	add := func(section int, label, value string) {
+		value = normalizePersonSemanticText(value)
+		if value != "" {
+			sections[section] = append(sections[section], label+": "+value)
+		}
+	}
+
+	if snapshot.person.DisplayName != nil {
+		add(0, "Display name", *snapshot.person.DisplayName)
+	}
+	displayName := normalizePersonSemanticText(derefString(snapshot.person.DisplayName))
+	for _, name := range snapshot.names {
+		value := renderPersonSemanticName(name)
+		if value != "" && value != displayName {
+			add(1, "Alternate name", value)
+		}
+	}
+	for _, category := range snapshot.categories {
+		add(2, "Category", category.OriginalValue)
+	}
+	for _, address := range snapshot.addresses {
+		add(3, "Location", renderPersonSemanticLocation(
+			address.Locality, address.Region, address.CountryName, address.CountryCode,
+		))
+	}
+	for _, attribute := range snapshot.attributes {
+		value, err := renderPersonSemanticAttribute(attribute.value.Value)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"render person %d attribute %s: %w",
+				snapshot.person.ID, attribute.definition.Slug, err,
+			)
+		}
+		add(4, fmt.Sprintf("Attribute %s [%s]",
+			attribute.definition.Label, attribute.definition.Slug), value)
+	}
+	for _, employment := range snapshot.employments {
+		add(5, "Current employment", renderPersonSemanticEmployment(employment))
+		add(6, "Organization", employment.organization.Name)
+		for _, name := range employment.organizationNames {
+			add(7, "Organization alternate name", name.Name)
+		}
+		for _, category := range employment.organizationCategories {
+			add(7, "Organization category", category.Category)
+		}
+		if employment.organization.Description != nil {
+			add(7, "Organization description", *employment.organization.Description)
+		}
+		if employment.organization.PrimaryDomain != nil {
+			add(7, "Organization domain", *employment.organization.PrimaryDomain)
+		}
+		add(7, "Organization kind", string(employment.organization.Kind))
+		for _, address := range employment.organizationAddresses {
+			add(8, "Organization location", renderPersonSemanticLocation(
+				address.Locality, address.Region, address.CountryName, address.CountryCode,
+			))
+		}
+	}
+	for _, relationship := range snapshot.relationships {
+		value := relationship.CounterpartLabel
+		if relationship.CounterpartDisplayName != nil {
+			counterpart := normalizePersonSemanticText(*relationship.CounterpartDisplayName)
+			if counterpart != "" {
+				value += " — " + counterpart
+			}
+		}
+		add(9, "Relationship", value)
+	}
+
+	lines := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, section := range sections {
+		slices.Sort(section)
+		for _, line := range section {
+			if _, exists := seen[line]; exists {
+				continue
+			}
+			seen[line] = struct{}{}
+			lines = append(lines, line)
+		}
+	}
+	text := capPersonSemanticUTF8(strings.Join(lines, "\n"))
+	digest := sha256.Sum256([]byte(PersonSemanticRendererPolicy + "\x00" + text))
+	return &PersonSemanticDocument{
+		PersonID:       snapshot.person.ID,
+		RendererPolicy: PersonSemanticRendererPolicy,
+		Revision:       hex.EncodeToString(digest[:]),
+		Text:           text,
+	}, nil
+}
+
+func renderPersonSemanticName(name PersonName) string {
+	if formatted := normalizePersonSemanticText(derefString(name.Formatted)); formatted != "" {
+		return formatted
+	}
+	parts := make([]string, 0, 7)
+	for _, value := range []*string{
+		name.HonorificPrefixes, name.GivenName, name.AdditionalNames,
+		name.FamilyName, name.SecondarySurname, name.HonorificSuffixes,
+		name.Generation,
+	} {
+		if normalized := normalizePersonSemanticText(derefString(value)); normalized != "" {
+			parts = append(parts, normalized)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, " ")
+	}
+	if sortAs := normalizePersonSemanticText(derefString(name.SortAs)); sortAs != "" {
+		return sortAs
+	}
+	return normalizePersonSemanticText(name.OriginalValue)
+}
+
+func renderPersonSemanticLocation(
+	locality, region, countryName, countryCode *string,
+) string {
+	parts := make([]string, 0, 3)
+	for _, value := range []*string{locality, region} {
+		if normalized := normalizePersonSemanticText(derefString(value)); normalized != "" {
+			parts = append(parts, normalized)
+		}
+	}
+	country := normalizePersonSemanticText(derefString(countryName))
+	if country == "" {
+		country = normalizePersonSemanticText(derefString(countryCode))
+	}
+	if country != "" {
+		parts = append(parts, country)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func renderPersonSemanticEmployment(item personSemanticEmployment) string {
+	parts := make([]string, 0, 5)
+	for _, value := range []*string{
+		item.employment.Title, item.employment.Role, item.employment.Department,
+		item.employment.Location, item.employment.Description,
+	} {
+		if normalized := normalizePersonSemanticText(derefString(value)); normalized != "" {
+			parts = append(parts, normalized)
+		}
+	}
+	organization := normalizePersonSemanticText(item.organization.Name)
+	if len(parts) == 0 {
+		return organization
+	}
+	if organization == "" {
+		return strings.Join(parts, "; ")
+	}
+	return strings.Join(parts, "; ") + " at " + organization
+}
+
+func renderPersonSemanticAttribute(value AttributeValue) (string, error) {
+	switch value.Type {
+	case AttributeValueJSON:
+		return canonicalPersonSemanticJSON(value.JSON)
+	case AttributeValueRecordReference:
+		if value.RecordType == nil || value.RecordID == nil {
+			return "", errors.New("incomplete record reference")
+		}
+		return fmt.Sprintf("%s:%d", normalizePersonSemanticText(*value.RecordType), *value.RecordID), nil
+	case AttributeValueDate, AttributeValueTimestamp:
+		return "", nil
+	default:
+		canonical, err := value.CanonicalString()
+		if err != nil {
+			return "", err
+		}
+		return normalizePersonSemanticText(canonical), nil
+	}
+}
+
+func canonicalPersonSemanticJSON(raw json.RawMessage) (string, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		if err == nil {
+			return "", errors.New("multiple JSON values")
+		}
+		return "", err
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(canonical), nil
+}
+
+func normalizePersonSemanticText(value string) string {
+	return strings.Join(strings.Fields(norm.NFC.String(value)), " ")
+}
+
+func capPersonSemanticUTF8(value string) string {
+	value = strings.ToValidUTF8(value, "\uFFFD")
+	if len(value) <= MaxPersonSemanticDocumentBytes {
+		return value
+	}
+	end := MaxPersonSemanticDocumentBytes
+	for end > 0 && !utf8.ValidString(value[:end]) {
+		end--
+	}
+	return value[:end]
+}

--- a/internal/store/person_semantic_consent.go
+++ b/internal/store/person_semantic_consent.go
@@ -1,0 +1,324 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// PersonSemanticEmbeddingConsent is one preserved semantic-person grant and
+// its optional revocation. It intentionally shares the established audit
+// shape without sharing the people-sweep authorization namespace.
+type PersonSemanticEmbeddingConsent = PersonInferenceConsent
+
+// PersonSemanticEmbeddingConsentStatus reports authority for one exact
+// semantic-person profile.
+type PersonSemanticEmbeddingConsentStatus = PersonInferenceConsentStatus
+
+const personSemanticEmbeddingConsentColumns = `
+	id, profile_fingerprint, granted_by, granted_at, revoked_by, revoked_at`
+
+func (s *Store) EnsurePersonSemanticEmbeddingProfile(
+	ctx context.Context,
+	profile vector.SemanticPersonEmbeddingProfile,
+) (bool, error) {
+	canonical, err := profile.Canonical()
+	if err != nil {
+		return false, err
+	}
+	disclosed, err := json.Marshal(canonical.DisclosedFieldClasses)
+	if err != nil {
+		return false, fmt.Errorf("encode semantic person disclosed fields: %w", err)
+	}
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO person_semantic_embedding_profiles
+			(fingerprint, purpose, destination, api_format, model, api_key_env,
+			 retention_posture, training_posture, renderer_policy,
+			 disclosed_field_classes, corpus_scope, policy_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, `+s.dialect.JSONBindExpr()+`, ?, `+s.dialect.JSONBindExpr()+`)
+		ON CONFLICT (fingerprint) DO NOTHING`,
+		canonical.Fingerprint, canonical.Purpose, canonical.Destination,
+		canonical.APIFormat, canonical.Model, canonical.APIKeyEnv,
+		canonical.RetentionPosture, canonical.TrainingPosture,
+		canonical.RendererPolicy, string(disclosed), canonical.CorpusScope,
+		string(canonical.PolicyJSON),
+	)
+	if err != nil {
+		return false, fmt.Errorf("insert semantic person embedding profile: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read semantic person embedding profile insert result: %w", err)
+	}
+	if err := s.verifyPersonSemanticEmbeddingProfile(ctx, canonical, disclosed); err != nil {
+		return false, err
+	}
+	return rows == 1, nil
+}
+
+func (s *Store) verifyPersonSemanticEmbeddingProfile(
+	ctx context.Context,
+	profile vector.SemanticPersonEmbeddingProfile,
+	disclosed []byte,
+) error {
+	var (
+		fingerprint, purpose, destination, apiFormat, model, apiKeyEnv string
+		retention, training, renderer, storedDisclosed, scope          string
+		storedPolicy                                                   string
+	)
+	err := s.db.QueryRowContext(ctx, `
+		SELECT fingerprint, purpose, destination, api_format, model,
+		       api_key_env, retention_posture, training_posture,
+		       renderer_policy, CAST(disclosed_field_classes AS TEXT),
+		       corpus_scope, CAST(policy_json AS TEXT)
+		FROM person_semantic_embedding_profiles WHERE fingerprint = ?`,
+		profile.Fingerprint,
+	).Scan(
+		&fingerprint, &purpose, &destination, &apiFormat, &model, &apiKeyEnv,
+		&retention, &training, &renderer, &storedDisclosed, &scope, &storedPolicy,
+	)
+	if err != nil {
+		return fmt.Errorf("read semantic person embedding profile: %w", err)
+	}
+	if fingerprint != profile.Fingerprint || purpose != profile.Purpose ||
+		destination != profile.Destination || apiFormat != string(profile.APIFormat) ||
+		model != profile.Model || apiKeyEnv != profile.APIKeyEnv ||
+		retention != profile.RetentionPosture || training != profile.TrainingPosture ||
+		renderer != profile.RendererPolicy || scope != profile.CorpusScope ||
+		!equalJSON([]byte(storedDisclosed), disclosed) ||
+		!equalJSON([]byte(storedPolicy), profile.PolicyJSON) {
+		return errors.New("semantic person embedding profile fingerprint already has different immutable policy")
+	}
+	return nil
+}
+
+func (s *Store) ListPersonSemanticEmbeddingProfiles(
+	ctx context.Context,
+) ([]vector.SemanticPersonEmbeddingProfile, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT fingerprint, purpose, destination, api_format, model,
+		       api_key_env, retention_posture, training_posture,
+		       renderer_policy, CAST(disclosed_field_classes AS TEXT),
+		       corpus_scope, CAST(policy_json AS TEXT)
+		FROM person_semantic_embedding_profiles
+		ORDER BY fingerprint`)
+	if err != nil {
+		return nil, fmt.Errorf("list semantic person embedding profiles: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	profiles := make([]vector.SemanticPersonEmbeddingProfile, 0)
+	for rows.Next() {
+		profile, scanErr := scanPersonSemanticEmbeddingProfile(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("read semantic person embedding profile: %w", scanErr)
+		}
+		profiles = append(profiles, profile)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list semantic person embedding profiles: %w", err)
+	}
+	return profiles, nil
+}
+
+func (s *Store) GrantPersonSemanticEmbeddingConsent(
+	ctx context.Context,
+	fingerprint, actor string,
+) (*PersonSemanticEmbeddingConsent, bool, error) {
+	actor, err := validatePersonSemanticEmbeddingConsentInput(fingerprint, actor)
+	if err != nil {
+		return nil, false, err
+	}
+	var profileExists bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM person_semantic_embedding_profiles WHERE fingerprint = ?)`,
+		fingerprint,
+	).Scan(&profileExists); err != nil {
+		return nil, false, fmt.Errorf("check semantic person embedding profile: %w", err)
+	}
+	if !profileExists {
+		return nil, false, errors.New("semantic person embedding consent profile does not exist")
+	}
+
+	for range 3 {
+		consent, insertErr := scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+			INSERT INTO person_semantic_embedding_consents
+				(profile_fingerprint, granted_by)
+			VALUES (?, ?)
+			ON CONFLICT DO NOTHING
+			RETURNING `+personSemanticEmbeddingConsentColumns,
+			fingerprint, actor,
+		))
+		if insertErr == nil {
+			return consent, true, nil
+		}
+		if !errors.Is(insertErr, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("grant semantic person embedding consent: %w", insertErr)
+		}
+		consent, readErr := s.activePersonSemanticEmbeddingConsent(ctx, fingerprint)
+		if readErr == nil {
+			return consent, false, nil
+		}
+		if !errors.Is(readErr, sql.ErrNoRows) {
+			return nil, false, fmt.Errorf("read active semantic person embedding consent: %w", readErr)
+		}
+	}
+	return nil, false, errors.New("semantic person embedding consent changed concurrently; retry")
+}
+
+func (s *Store) RevokePersonSemanticEmbeddingConsent(
+	ctx context.Context,
+	fingerprint, actor string,
+) (bool, error) {
+	actor, err := validatePersonSemanticEmbeddingConsentInput(fingerprint, actor)
+	if err != nil {
+		return false, err
+	}
+	var id int64
+	err = s.db.QueryRowContext(ctx, `
+		UPDATE person_semantic_embedding_consents
+		SET revoked_by = ?, revoked_at = CURRENT_TIMESTAMP
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL
+		RETURNING id`, actor, fingerprint).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("revoke semantic person embedding consent: %w", err)
+	}
+	return true, nil
+}
+
+func (s *Store) RevokeAllPersonSemanticEmbeddingConsents(
+	ctx context.Context,
+	actor string,
+) (int64, error) {
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return 0, errors.New("semantic person embedding consent actor is required")
+	}
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE person_semantic_embedding_consents
+		SET revoked_by = ?, revoked_at = CURRENT_TIMESTAMP
+		WHERE revoked_at IS NULL`, actor)
+	if err != nil {
+		return 0, fmt.Errorf("revoke all semantic person embedding consents: %w", err)
+	}
+	changed, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read revoked semantic person embedding consent count: %w", err)
+	}
+	return changed, nil
+}
+
+func (s *Store) HasActivePersonSemanticEmbeddingConsent(
+	ctx context.Context,
+	fingerprint string,
+) (bool, error) {
+	if !validLowerSHA256(fingerprint) {
+		return false, errors.New("semantic person embedding consent requires a lowercase SHA-256 fingerprint")
+	}
+	var active bool
+	err := s.db.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM person_semantic_embedding_consents
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL)`,
+		fingerprint,
+	).Scan(&active)
+	if err != nil {
+		return false, fmt.Errorf("check active semantic person embedding consent: %w", err)
+	}
+	return active, nil
+}
+
+func (s *Store) GetPersonSemanticEmbeddingConsentStatus(
+	ctx context.Context,
+	fingerprint string,
+) (*PersonSemanticEmbeddingConsentStatus, error) {
+	if !validLowerSHA256(fingerprint) {
+		return nil, errors.New("semantic person embedding consent requires a lowercase SHA-256 fingerprint")
+	}
+	status := &PersonSemanticEmbeddingConsentStatus{Fingerprint: fingerprint}
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM person_semantic_embedding_profiles WHERE fingerprint = ?)`,
+		fingerprint,
+	).Scan(&status.ProfileExists); err != nil {
+		return nil, fmt.Errorf("check semantic person embedding profile status: %w", err)
+	}
+	if !status.ProfileExists {
+		return status, nil
+	}
+	active, err := s.activePersonSemanticEmbeddingConsent(ctx, fingerprint)
+	if err == nil {
+		status.Active = true
+		status.Consent = active
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read active semantic person embedding consent status: %w", err)
+	}
+	lastRevoked, err := scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+		SELECT `+personSemanticEmbeddingConsentColumns+`
+		FROM person_semantic_embedding_consents
+		WHERE profile_fingerprint = ? AND revoked_at IS NOT NULL
+		ORDER BY revoked_at DESC, id DESC LIMIT 1`, fingerprint))
+	if err == nil {
+		status.LastRevoked = lastRevoked
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("read revoked semantic person embedding consent status: %w", err)
+	}
+	return status, nil
+}
+
+func (s *Store) activePersonSemanticEmbeddingConsent(
+	ctx context.Context,
+	fingerprint string,
+) (*PersonSemanticEmbeddingConsent, error) {
+	return scanPersonInferenceConsent(s.db.QueryRowContext(ctx, `
+		SELECT `+personSemanticEmbeddingConsentColumns+`
+		FROM person_semantic_embedding_consents
+		WHERE profile_fingerprint = ? AND revoked_at IS NULL
+		ORDER BY id DESC LIMIT 1`, fingerprint))
+}
+
+func scanPersonSemanticEmbeddingProfile(row scanner) (
+	vector.SemanticPersonEmbeddingProfile,
+	error,
+) {
+	var (
+		profile                      vector.SemanticPersonEmbeddingProfile
+		apiFormat, disclosed, policy string
+	)
+	if err := row.Scan(
+		&profile.Fingerprint, &profile.Purpose, &profile.Destination, &apiFormat,
+		&profile.Model, &profile.APIKeyEnv, &profile.RetentionPosture,
+		&profile.TrainingPosture, &profile.RendererPolicy, &disclosed,
+		&profile.CorpusScope, &policy,
+	); err != nil {
+		return vector.SemanticPersonEmbeddingProfile{}, err
+	}
+	profile.APIFormat = vector.EmbeddingAPIFormat(apiFormat)
+	if err := json.Unmarshal([]byte(disclosed), &profile.DisclosedFieldClasses); err != nil {
+		return vector.SemanticPersonEmbeddingProfile{}, fmt.Errorf("decode disclosed fields: %w", err)
+	}
+	profile.PolicyJSON = json.RawMessage(policy)
+	canonical, err := profile.Canonical()
+	if err != nil {
+		return vector.SemanticPersonEmbeddingProfile{}, fmt.Errorf(
+			"stored semantic person embedding profile does not match its immutable policy: %w", err)
+	}
+	return canonical, nil
+}
+
+func validatePersonSemanticEmbeddingConsentInput(fingerprint, actor string) (string, error) {
+	if !validLowerSHA256(fingerprint) {
+		return "", errors.New("semantic person embedding consent requires a lowercase SHA-256 fingerprint")
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		return "", errors.New("semantic person embedding consent actor is required")
+	}
+	return actor, nil
+}

--- a/internal/store/person_semantic_consent_test.go
+++ b/internal/store/person_semantic_consent_test.go
@@ -1,0 +1,125 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+func semanticPersonTestProfile(t *testing.T) vector.SemanticPersonEmbeddingProfile {
+	t.Helper()
+	config := vector.Config{
+		Enabled: true,
+		Backend: "sqlite-vec",
+		Embeddings: vector.EmbeddingsConfig{
+			APIFormat: vector.APIFormatOpenAI,
+			Endpoint:  "https://embedding.example.test/v1",
+			APIKeyEnv: "SEMANTIC_PERSON_TEST_KEY",
+			Model:     "synthetic-embedding-model",
+			Dimension: 4,
+			BatchSize: 8,
+		},
+		People: vector.PeopleConfig{
+			Enabled:          true,
+			RetentionPosture: "zero_data_retention",
+			TrainingPosture:  "no_training",
+		},
+	}
+	profile, err := config.SemanticPersonEmbeddingProfile()
+	require.NoError(t, err)
+	return profile
+}
+
+// TestPersonSemanticConsentLifecycle catches semantic grants being stored in
+// the people-sweep consent namespace or revocation failing to stop authority.
+func TestPersonSemanticConsentLifecycle(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	st := testutil.NewTestStore(t)
+	profile := semanticPersonTestProfile(t)
+
+	status, err := st.GetPersonSemanticEmbeddingConsentStatus(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.False(status.ProfileExists)
+	check.False(status.Active)
+
+	created, err := st.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+	must.NoError(err)
+	check.True(created)
+	created, err = st.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+	must.NoError(err)
+	check.False(created)
+
+	consent, created, err := st.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	must.NoError(err)
+	check.True(created)
+	check.Equal(profile.Fingerprint, consent.ProfileFingerprint)
+	active, err := st.HasActivePersonSemanticEmbeddingConsent(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.True(active)
+
+	changed, err := st.RevokePersonSemanticEmbeddingConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	must.NoError(err)
+	check.True(changed)
+	active, err = st.HasActivePersonSemanticEmbeddingConsent(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.False(active)
+
+	status, err = st.GetPersonSemanticEmbeddingConsentStatus(t.Context(), profile.Fingerprint)
+	must.NoError(err)
+	check.False(status.Active)
+	must.NotNil(status.LastRevoked)
+	check.Equal(consent.ID, status.LastRevoked.ID)
+
+	_, created, err = st.GrantPersonSemanticEmbeddingConsent(
+		t.Context(), profile.Fingerprint, "cli")
+	must.NoError(err)
+	check.True(created)
+}
+
+// TestPeopleSweepConsentCannotAuthorizeSemanticPersonEmbeddings catches a
+// purpose-confused lookup accepting a grant from the pre-existing subsystem.
+func TestPeopleSweepConsentCannotAuthorizeSemanticPersonEmbeddings(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	st := testutil.NewTestStore(t)
+	inference := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), inference)
+	must.NoError(err)
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), inference.Fingerprint, "cli")
+	must.NoError(err)
+
+	semantic := semanticPersonTestProfile(t)
+	active, err := st.HasActivePersonSemanticEmbeddingConsent(t.Context(), semantic.Fingerprint)
+	must.NoError(err)
+	check.False(active)
+}
+
+// TestPersonSemanticStoredProfileRejectsImmutablePolicyCorruption catches an
+// audit/list path trusting mutable columns or noncanonical policy JSON.
+func TestPersonSemanticStoredProfileRejectsImmutablePolicyCorruption(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	profile := semanticPersonTestProfile(t)
+	_, err := st.EnsurePersonSemanticEmbeddingProfile(t.Context(), profile)
+	require.NoError(t, err)
+
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_semantic_embedding_profiles
+		SET renderer_policy = ? WHERE fingerprint = ?`),
+		"person-semantic-corrupted", profile.Fingerprint)
+	require.NoError(t, err)
+
+	_, err = st.ListPersonSemanticEmbeddingProfiles(t.Context())
+	assert.ErrorContains(t, err, "immutable policy")
+}
+
+var _ interface {
+	HasActivePersonSemanticEmbeddingConsent(ctx context.Context, fingerprint string) (bool, error)
+} = (*store.Store)(nil)

--- a/internal/store/person_semantic_internal_test.go
+++ b/internal/store/person_semantic_internal_test.go
@@ -1,0 +1,39 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapPersonSemanticUTF8RepairsMalformedInputBeforeCapping(t *testing.T) {
+	input := string([]byte{0xff}) + strings.Repeat("x", MaxPersonSemanticDocumentBytes+100)
+
+	got := capPersonSemanticUTF8(input)
+
+	require.True(t, utf8.ValidString(got))
+	assert.Len(t, []byte(got), MaxPersonSemanticDocumentBytes)
+	assert.True(t, strings.HasSuffix(got, "x"), "valid suffix should survive malformed leading bytes")
+}
+
+func TestCapPersonSemanticUTF8BacksOffPartialRune(t *testing.T) {
+	input := strings.Repeat("x", MaxPersonSemanticDocumentBytes-1) + "雪"
+
+	got := capPersonSemanticUTF8(input)
+
+	require.True(t, utf8.ValidString(got))
+	assert.Greater(t, len(got), MaxPersonSemanticDocumentBytes-4)
+	assert.Less(t, len(got), MaxPersonSemanticDocumentBytes)
+}
+
+func TestRenderPersonSemanticNameFallsBackFromBlankOptionalValues(t *testing.T) {
+	assert.Equal(t, "Alice Example", renderPersonSemanticName(PersonName{
+		Formatted: new("  "), GivenName: new("Alice"), FamilyName: new("Example"),
+	}))
+	assert.Equal(t, "Original Name", renderPersonSemanticName(PersonName{
+		SortAs: new("\n"), OriginalValue: "Original Name",
+	}))
+}

--- a/internal/store/person_semantic_test.go
+++ b/internal/store/person_semantic_test.go
@@ -1,0 +1,488 @@
+package store_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestPersonSemanticDocumentRendersCuratedCurrentTextExactly(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	ctx := t.Context()
+	personID := mustPerson(t, f, "semantic-person@example.invalid", "Synthetic Person")
+	counterpartID := mustPerson(t, f, "semantic-counterpart@example.invalid", "Synthetic Counterpart")
+
+	currentName, err := f.Store.AddPersonNameContext(ctx, personID, store.PersonNameInput{
+		NameKind: store.PersonNameNickname, Formatted: new("  Alias\nPerson  "),
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	historicalName, err := f.Store.AddPersonNameContext(ctx, personID, store.PersonNameInput{
+		NameKind: store.PersonNameFormatted, Formatted: new("Historical Name"),
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	require.NoError(f.Store.SupersedePersonNameContext(ctx, personID, historicalName.Envelope.ID, nil))
+	_, err = f.Store.AddPersonCategoryContext(ctx, personID, store.PersonCategoryInput{
+		OriginalValue: " Collaborator ",
+		Envelope:      store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+
+	_, err = f.Store.AddPersonAddressContext(ctx, personID, store.PersonAddressInput{
+		AddressKind:   store.PersonAddressPostal,
+		StreetAddress: new("42 Private Street"), PostalCode: new("A1B 2C3"),
+		Locality: new("Harbor City"), Region: new("North Region"),
+		CountryName: new("Exampleland"),
+		Envelope:    store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = f.Store.AddPersonContactPointContext(ctx, personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressEmail, OriginalValue: "private@example.invalid",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = f.Store.AddPersonContactPointContext(ctx, personID, store.PersonContactPointInput{
+		AddressKind: store.ContactAddressPhone, OriginalValue: "+15550000001",
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = f.Store.AddPersonDateContext(ctx, personID, store.PersonDateInput{
+		DateKind: store.PersonDateBirthday, DateText: new("private-date"),
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = f.Store.AddPersonMediaContext(ctx, personID, store.PersonMediaInput{
+		MediaKind: store.PersonMediaPhoto, URI: new("https://media.example.invalid/private"),
+		Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+	})
+	require.NoError(err)
+	_, err = f.Store.RecordContactObservationContext(ctx,
+		f.EnsureParticipant("observed@example.invalid", "observed-secret", "example.invalid"),
+		store.ParticipantContactObservationInput{
+			AddressKind: store.ContactAddressUsername, ServiceSlug: new("x"),
+			OriginalValue: "observed-secret",
+			Envelope:      store.ValueEnvelopeInput{Source: store.ProvenanceArchiveObservation},
+		})
+	require.NoError(err)
+
+	createSemanticAttribute(t, f, "favorite_topics", "Favorite topics",
+		store.AttributeValueJSON, store.AttributeFieldJSON, true, false)
+	_, err = f.Store.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: personID, DefinitionSlug: "favorite_topics",
+		Value: store.AttributeValue{Type: store.AttributeValueJSON,
+			JSON: json.RawMessage(`{ "z": "distributed\nsystems", "a": [2, 1] }`)},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	createSemanticAttribute(t, f, "private_code", "Private code",
+		store.AttributeValueText, store.AttributeFieldText, true, true)
+	setSemanticTextAttribute(t, f, personID, "private_code", "sensitive-secret")
+	createSemanticAttribute(t, f, "internal_note", "Internal note",
+		store.AttributeValueText, store.AttributeFieldText, false, false)
+	setSemanticTextAttribute(t, f, personID, "internal_note", "non-searchable-secret")
+	createSemanticAttribute(t, f, "email_alias", "Email alias",
+		store.AttributeValueText, store.AttributeFieldEmail, true, false)
+	setSemanticTextAttribute(t, f, personID, "email_alias", "typed-private@example.invalid")
+	createSemanticAttribute(t, f, "important_date", "Important date",
+		store.AttributeValueDate, store.AttributeFieldDate, true, false)
+	_, err = f.Store.SetPersonAttributeValueContext(ctx, store.PersonAttributeValueInput{
+		PersonID: personID, DefinitionSlug: "important_date",
+		Value:  store.AttributeValue{Type: store.AttributeValueDate, Date: new("2026-08-20")},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+
+	organization, err := f.Store.CreateOrganizationContext(ctx, store.OrganizationInput{
+		Name: "Example Labs", Kind: store.OrganizationKindCompany,
+		PrimaryDomain: new("example.invalid"), Description: new("Synthetic organization"),
+	})
+	require.NoError(err)
+	organizationProfile, err := f.Store.ReplaceOrganizationProfileContext(
+		ctx, organization.ID, organization.Revision, store.OrganizationProfileInput{
+			Names: []store.OrganizationNameInput{{
+				Name: "Synthetic Research Lab", NameKind: store.OrganizationNameKindAlias,
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			}},
+			Addresses: []store.OrganizationAddressInput{{
+				AddressKind:   store.PersonAddressPostal,
+				StreetAddress: new("99 Hidden Avenue"), PostalCode: new("99999"),
+				Locality: new("Worktown"), Region: new("Work Region"), CountryName: new("Workland"),
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			}},
+			ContactPoints: []store.OrganizationContactPointInput{{
+				AddressKind: store.ContactAddressEmail, OriginalValue: "org-private@example.invalid",
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			}},
+			Media: []store.OrganizationMediaInput{{
+				MediaKind: store.PersonMediaLogo, URI: new("https://media.example.invalid/org-private"),
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			}},
+			Categories: []store.OrganizationCategoryInput{{
+				Category: "Research", Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			}},
+		})
+	require.NoError(err)
+	_, err = f.Store.AddEmploymentContext(ctx, store.EmploymentInput{
+		PersonID: personID, OrganizationID: organizationProfile.Organization.ID,
+		Title: new("Principal Engineer"), Role: new("Platform Lead"),
+		Department: new("Research"), Location: new("Remote"),
+		Description: new("Builds synthetic systems"), Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	past, err := f.Store.AddEmploymentContext(ctx, store.EmploymentInput{
+		PersonID: personID, OrganizationID: organizationProfile.Organization.ID,
+		Title: new("Historical Job"), IsCurrent: new(false), Source: store.ProvenanceUser,
+	})
+	require.NoError(err)
+	require.False(past.IsCurrent)
+
+	_, err = f.Store.AddPersonRelationshipContext(ctx, store.PersonRelationshipInput{
+		SourcePersonID: personID, TargetPersonID: counterpartID, TypeSlug: "parent",
+		Notes: new("relationship-private-note"), Source: store.ProvenanceUser, Actor: "synthetic-user",
+	})
+	require.NoError(err)
+	ended, err := f.Store.AddPersonRelationshipContext(ctx, store.PersonRelationshipInput{
+		SourcePersonID: personID, TargetPersonID: counterpartID, TypeSlug: "co-worker",
+		Source: store.ProvenanceUser, Actor: "synthetic-user",
+	})
+	require.NoError(err)
+	endDate, err := store.ParseRelationshipDate("2024")
+	require.NoError(err)
+	_, err = f.Store.EndPersonRelationshipContext(ctx, ended.ID, ended.Revision, endDate, "synthetic-user")
+	require.NoError(err)
+
+	document, err := f.Store.LoadPersonSemanticDocumentContext(ctx, personID)
+	require.NoError(err)
+	wantText := strings.Join([]string{
+		"Display name: Synthetic Person",
+		"Alternate name: Alias Person",
+		"Category: Collaborator",
+		"Location: Harbor City, North Region, Exampleland",
+		`Attribute Favorite topics [favorite_topics]: {"a":[2,1],"z":"distributed\nsystems"}`,
+		"Current employment: Principal Engineer; Platform Lead; Research; Remote; Builds synthetic systems at Example Labs",
+		"Organization: Example Labs",
+		"Organization alternate name: Synthetic Research Lab",
+		"Organization category: Research",
+		"Organization description: Synthetic organization",
+		"Organization domain: example.invalid",
+		"Organization kind: company",
+		"Organization location: Worktown, Work Region, Workland",
+		"Relationship: child — Synthetic Counterpart",
+	}, "\n")
+	assert.Equal(wantText, document.Text)
+	assert.Equal(personID, document.PersonID)
+	assert.Equal(store.PersonSemanticRendererPolicy, document.RendererPolicy)
+	assert.Equal(semanticDigest(wantText), document.Revision)
+	assert.NotEmpty(currentName.Envelope.Source, "fixture includes excluded provenance")
+	for _, excluded := range []string{
+		"private@example.invalid", "+15550000001", "42 Private Street", "A1B 2C3",
+		"private-date", "media.example.invalid", "observed-secret", "Historical Name",
+		"sensitive-secret", "non-searchable-secret", "typed-private@example.invalid",
+		"2026-08-20", "99 Hidden Avenue", "99999", "org-private@example.invalid",
+		"Historical Job", "relationship-private-note", "co-worker", "synthetic-user",
+	} {
+		assert.NotContains(document.Text, excluded)
+	}
+}
+
+func TestPersonSemanticDocumentIsStableAcrossInsertionOrderAndCanonicalJSON(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	firstID := mustPerson(t, f, "semantic-order-a@example.invalid", "Same Person")
+	secondID := mustPerson(t, f, "semantic-order-b@example.invalid", "Same Person")
+
+	createSemanticAttribute(t, f, "semantic_json", "Structured data",
+		store.AttributeValueJSON, store.AttributeFieldJSON, true, false)
+	for _, fixture := range []struct {
+		personID   int64
+		names      []string
+		categories []string
+		jsonValue  string
+	}{
+		{firstID, []string{"Zulu", "Alpha"}, []string{"Team Z", "Team A"}, `{"z":2,"a":{"y":1,"x":0}}`},
+		{secondID, []string{"Alpha", "Zulu"}, []string{"Team A", "Team Z"}, `{ "a": { "x": 0, "y": 1 }, "z": 2 }`},
+	} {
+		for _, name := range fixture.names {
+			_, err := f.Store.AddPersonNameContext(t.Context(), fixture.personID, store.PersonNameInput{
+				NameKind: store.PersonNameNickname, Formatted: &name,
+				Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser},
+			})
+			require.NoError(err)
+		}
+		for _, category := range fixture.categories {
+			_, err := f.Store.AddPersonCategoryContext(t.Context(), fixture.personID,
+				store.PersonCategoryInput{OriginalValue: category,
+					Envelope: store.ValueEnvelopeInput{Source: store.ProvenanceUser}})
+			require.NoError(err)
+		}
+		_, err := f.Store.SetPersonAttributeValueContext(t.Context(), store.PersonAttributeValueInput{
+			PersonID: fixture.personID, DefinitionSlug: "semantic_json",
+			Value: store.AttributeValue{Type: store.AttributeValueJSON,
+				JSON: json.RawMessage(fixture.jsonValue)},
+			Source: store.ProvenanceUser,
+		})
+		require.NoError(err)
+	}
+
+	first, err := f.Store.LoadPersonSemanticDocumentContext(t.Context(), firstID)
+	require.NoError(err)
+	second, err := f.Store.LoadPersonSemanticDocumentContext(t.Context(), secondID)
+	require.NoError(err)
+	assert.Equal(first.Text, second.Text)
+	assert.Equal(first.Revision, second.Revision)
+	assert.Equal(strings.Join([]string{
+		"Display name: Same Person",
+		"Alternate name: Alpha",
+		"Alternate name: Zulu",
+		"Category: Team A",
+		"Category: Team Z",
+		`Attribute Structured data [semantic_json]: {"a":{"x":0,"y":1},"z":2}`,
+	}, "\n"), first.Text)
+}
+
+func TestPersonSemanticDocumentIncludesEveryAllowedTypedAttributeKind(t *testing.T) {
+	f := storetest.New(t)
+	personID := mustPerson(t, f, "semantic-types@example.invalid", "Typed Person")
+	targetID := mustPerson(t, f, "semantic-types-target@example.invalid", "Target Person")
+
+	tests := []struct {
+		slug, label string
+		valueType   store.AttributeValueType
+		fieldType   store.AttributeFieldType
+		value       store.AttributeValue
+		want        string
+	}{
+		{"bool_value", "Boolean value", store.AttributeValueBoolean, store.AttributeFieldCheckbox,
+			store.AttributeValue{Type: store.AttributeValueBoolean, Boolean: new(true)}, "true"},
+		{"integer_value", "Integer value", store.AttributeValueInteger, store.AttributeFieldDuration,
+			store.AttributeValue{Type: store.AttributeValueInteger, Integer: new(int64(42))}, "42"},
+		{"real_value", "Real value", store.AttributeValueReal, store.AttributeFieldText,
+			store.AttributeValue{Type: store.AttributeValueReal, Real: new(2.5)}, "2.5"},
+		{"text_value", "Text value", store.AttributeValueText, store.AttributeFieldTextarea,
+			store.AttributeValue{Type: store.AttributeValueText, Text: new("multi\n line")}, "multi line"},
+		{"record_value", "Record value", store.AttributeValueRecordReference, store.AttributeFieldPerson,
+			store.AttributeValue{Type: store.AttributeValueRecordReference,
+				RecordType: new("person"), RecordID: &targetID}, fmt.Sprintf("person:%d", targetID)},
+	}
+	for _, tc := range tests {
+		createSemanticAttribute(t, f, tc.slug, tc.label, tc.valueType, tc.fieldType, true, false)
+		_, err := f.Store.SetPersonAttributeValueContext(t.Context(), store.PersonAttributeValueInput{
+			PersonID: personID, DefinitionSlug: tc.slug, Value: tc.value,
+			Source: store.ProvenanceUser,
+		})
+		require.NoError(t, err)
+	}
+
+	document, err := f.Store.LoadPersonSemanticDocumentContext(t.Context(), personID)
+	require.NoError(t, err)
+	for _, tc := range tests {
+		assert.Contains(t, document.Text,
+			fmt.Sprintf("Attribute %s [%s]: %s", tc.label, tc.slug, tc.want))
+	}
+}
+
+func TestPersonSemanticDocumentMutationListAndDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	ctx := t.Context()
+	emptyParticipant := f.EnsureParticipant(
+		"semantic-empty@example.invalid", "observed-only", "example.invalid")
+	emptyPerson, _, err := f.Store.CreatePersonFromParticipantContext(ctx, emptyParticipant)
+	require.NoError(err)
+	populatedID := mustPerson(t, f, "semantic-list@example.invalid", "Before Mutation")
+
+	empty, err := f.Store.LoadPersonSemanticDocumentContext(ctx, emptyPerson.ID)
+	require.NoError(err)
+	assert.Empty(empty.Text, "an extant person with no curated discoverability text is valid")
+	assert.Equal(semanticDigest(""), empty.Revision)
+
+	before, err := f.Store.LoadPersonSemanticDocumentContext(ctx, populatedID)
+	require.NoError(err)
+	person, err := f.Store.GetPersonContext(ctx, populatedID)
+	require.NoError(err)
+	_, err = f.Store.UpdatePersonDisplayNameContext(ctx, populatedID, person.Revision, new("After Mutation"))
+	require.NoError(err)
+	after, err := f.Store.LoadPersonSemanticDocumentContext(ctx, populatedID)
+	require.NoError(err)
+	assert.NotEqual(before.Revision, after.Revision)
+	assert.Equal("Display name: After Mutation", after.Text)
+
+	documents, err := f.Store.ListPersonSemanticDocumentsContext(ctx)
+	require.NoError(err)
+	require.Len(documents, 2)
+	assert.Less(documents[0].PersonID, documents[1].PersonID)
+
+	person, err = f.Store.GetPersonContext(ctx, populatedID)
+	require.NoError(err)
+	require.NoError(f.Store.DeletePersonContext(ctx, populatedID, person.Revision))
+	_, err = f.Store.LoadPersonSemanticDocumentContext(ctx, populatedID)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+	documents, err = f.Store.ListPersonSemanticDocumentsContext(ctx)
+	require.NoError(err)
+	require.Len(documents, 1)
+	assert.Equal(emptyPerson.ID, documents[0].PersonID)
+}
+
+func TestResolvePersonSemanticCandidatesReturnsOnlyCurrentRootsInCandidateOrder(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := storetest.New(t)
+	ctx := t.Context()
+	firstID := mustPerson(t, f, "semantic-candidate-first@example.invalid", "Synthetic First")
+	secondID := mustPerson(t, f, "semantic-candidate-second@example.invalid", "Synthetic Second")
+	deletedID := mustPerson(t, f, "semantic-candidate-deleted@example.invalid", "Synthetic Deleted")
+	lastID := mustPerson(t, f, "semantic-candidate-last@example.invalid", "Synthetic Last")
+	emptyParticipant := f.EnsureParticipant(
+		"semantic-candidate-empty@example.invalid", "observed-only", "example.invalid")
+	emptyPerson, _, err := f.Store.CreatePersonFromParticipantContext(ctx, emptyParticipant)
+	require.NoError(err)
+	require.Greater(lastID, secondID, "precondition: candidates will reverse durable ID order")
+	firstDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, firstID)
+	require.NoError(err)
+	secondDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, secondID)
+	require.NoError(err)
+	deletedDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, deletedID)
+	require.NoError(err)
+	lastDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, lastID)
+	require.NoError(err)
+	emptyDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, emptyPerson.ID)
+	require.NoError(err)
+	require.Empty(emptyDocument.Text)
+
+	first, err := f.Store.GetPersonContext(ctx, firstID)
+	require.NoError(err)
+	_, err = f.Store.UpdatePersonDisplayNameContext(
+		ctx, firstID, first.Revision, new("Synthetic First Updated"),
+	)
+	require.NoError(err)
+	deleted, err := f.Store.GetPersonContext(ctx, deletedID)
+	require.NoError(err)
+	require.NoError(f.Store.DeletePersonContext(ctx, deletedID, deleted.Revision))
+
+	people, err := f.Store.ResolvePersonSemanticCandidatesContext(ctx, []store.PersonSemanticCandidate{
+		{PersonID: emptyPerson.ID, Revision: emptyDocument.Revision},
+		{PersonID: lastID, Revision: lastDocument.Revision},
+		{PersonID: secondID, Revision: secondDocument.Revision},
+		{PersonID: firstID, Revision: firstDocument.Revision},
+		{PersonID: deletedID, Revision: deletedDocument.Revision},
+		{PersonID: 999999, Revision: "missing"},
+	})
+	require.NoError(err)
+	require.Len(people, 2)
+	assert.Equal([]int64{lastID, secondID}, []int64{people[0].ID, people[1].ID})
+	require.NotNil(people[0].DisplayName)
+	require.NotNil(people[1].DisplayName)
+	assert.Equal([]string{"Synthetic Last", "Synthetic Second"}, []string{
+		*people[0].DisplayName, *people[1].DisplayName,
+	})
+}
+
+func TestPersonSemanticScanFailsButResolverSkipsOneUnrenderablePerson(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	ctx := t.Context()
+	badID := mustPerson(t, f, "semantic-bad@example.invalid", "Broken Projection")
+	goodID := mustPerson(t, f, "semantic-good@example.invalid", "Healthy Projection")
+	setSemanticTextAttribute(t, f, badID, store.AttributeSlugAskMeAbout, "distributed systems")
+
+	goodDocument, err := f.Store.LoadPersonSemanticDocumentContext(ctx, goodID)
+	require.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE attribute_definitions
+		SET value_type = 'record_reference', field_type = 'person', record_target = 'person'
+		WHERE universal_id = ?
+	`), store.AttributeUniversalIDAskMeAbout)
+	require.NoError(err)
+
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	documents, err := f.Store.ListPersonSemanticDocumentsContext(ctx)
+	require.ErrorContains(err, "incomplete record reference")
+	assert.Empty(documents)
+
+	people, err := f.Store.ResolvePersonSemanticCandidatesContext(ctx, []store.PersonSemanticCandidate{
+		{PersonID: badID, Revision: "unrenderable"},
+		{PersonID: goodID, Revision: goodDocument.Revision},
+	})
+	require.NoError(err)
+	require.Len(people, 1)
+	assert.Equal(goodID, people[0].ID)
+	assert.Contains(logs.String(), "person_id="+strconv.FormatInt(badID, 10))
+}
+
+func TestPersonSemanticDocumentCapsExactHashedUTF8Bytes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	personID := mustPerson(t, f, "semantic-cap@example.invalid", "before cap")
+	person, err := f.Store.GetPersonContext(t.Context(), personID)
+	require.NoError(err)
+	longName := strings.Repeat("雪", store.MaxPersonSemanticDocumentBytes)
+	_, err = f.Store.UpdatePersonDisplayNameContext(
+		t.Context(), personID, person.Revision, &longName)
+	require.NoError(err)
+
+	document, err := f.Store.LoadPersonSemanticDocumentContext(t.Context(), personID)
+	require.NoError(err)
+	assert.Len([]byte(document.Text), store.MaxPersonSemanticDocumentBytes)
+	assert.True(utf8.ValidString(document.Text))
+	assert.Equal(semanticDigest(document.Text), document.Revision)
+}
+
+func createSemanticAttribute(
+	t *testing.T, f *storetest.Fixture, slug, label string,
+	valueType store.AttributeValueType, fieldType store.AttributeFieldType,
+	searchable, sensitive bool,
+) {
+	t.Helper()
+	input := personTextDefinition(slug)
+	input.UniversalID = "person-semantic-test-" + slug
+	input.Label = label
+	input.ValueType = valueType
+	input.FieldType = fieldType
+	input.IsSearchable = searchable
+	input.IsSensitive = sensitive
+	if valueType == store.AttributeValueRecordReference {
+		input.RecordTarget = new("person")
+	}
+	_, err := f.Store.CreateAttributeDefinitionContext(t.Context(), input)
+	require.NoError(t, err)
+}
+
+func setSemanticTextAttribute(
+	t *testing.T, f *storetest.Fixture, personID int64, slug, value string,
+) {
+	t.Helper()
+	_, err := f.Store.SetPersonAttributeValueContext(t.Context(), store.PersonAttributeValueInput{
+		PersonID: personID, DefinitionSlug: slug,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: &value},
+		Source: store.ProvenanceUser,
+	})
+	require.NoError(t, err)
+}
+
+func semanticDigest(text string) string {
+	digest := sha256.Sum256([]byte(store.PersonSemanticRendererPolicy + "\x00" + text))
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -214,6 +214,38 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_person_inference_consents_active
     ON person_inference_consents(profile_fingerprint)
     WHERE revoked_at IS NULL;
 
+-- Curated-person semantic embedding is a distinct outbound-data purpose from
+-- people-sweep inference. Separate profile and grant tables make cross-purpose
+-- authorization impossible even if two policies happened to hash alike.
+CREATE TABLE IF NOT EXISTS person_semantic_embedding_profiles (
+    fingerprint             TEXT PRIMARY KEY,
+    purpose                 TEXT NOT NULL,
+    destination             TEXT NOT NULL,
+    api_format              TEXT NOT NULL,
+    model                   TEXT NOT NULL,
+    api_key_env             TEXT NOT NULL,
+    retention_posture       TEXT NOT NULL,
+    training_posture        TEXT NOT NULL,
+    renderer_policy         TEXT NOT NULL,
+    disclosed_field_classes JSON NOT NULL,
+    corpus_scope            TEXT NOT NULL,
+    policy_json             JSON NOT NULL,
+    created_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS person_semantic_embedding_consents (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    profile_fingerprint TEXT NOT NULL REFERENCES person_semantic_embedding_profiles(fingerprint),
+    granted_by          TEXT NOT NULL,
+    granted_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_by          TEXT,
+    revoked_at          DATETIME,
+    CHECK ((revoked_by IS NULL) = (revoked_at IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_semantic_embedding_consents_active
+    ON person_semantic_embedding_consents(profile_fingerprint)
+    WHERE revoked_at IS NULL;
+
 -- Lossless native vCard resources. Typed profile tables remain the semantic
 -- source of truth; this table retains exact wire bodies and normalized
 -- occurrence metadata for future CardDAV layers.

--- a/internal/store/schema_pg.sql
+++ b/internal/store/schema_pg.sql
@@ -203,6 +203,35 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_person_inference_consents_active
     ON person_inference_consents(profile_fingerprint)
     WHERE revoked_at IS NULL;
 
+CREATE TABLE IF NOT EXISTS person_semantic_embedding_profiles (
+    fingerprint             TEXT PRIMARY KEY,
+    purpose                 TEXT NOT NULL,
+    destination             TEXT NOT NULL,
+    api_format              TEXT NOT NULL,
+    model                   TEXT NOT NULL,
+    api_key_env             TEXT NOT NULL,
+    retention_posture       TEXT NOT NULL,
+    training_posture        TEXT NOT NULL,
+    renderer_policy         TEXT NOT NULL,
+    disclosed_field_classes JSONB NOT NULL,
+    corpus_scope            TEXT NOT NULL,
+    policy_json             JSONB NOT NULL,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS person_semantic_embedding_consents (
+    id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    profile_fingerprint TEXT NOT NULL REFERENCES person_semantic_embedding_profiles(fingerprint),
+    granted_by          TEXT NOT NULL,
+    granted_at          TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_by          TEXT,
+    revoked_at          TIMESTAMPTZ,
+    CHECK ((revoked_by IS NULL) = (revoked_at IS NULL))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_person_semantic_embedding_consents_active
+    ON person_semantic_embedding_consents(profile_fingerprint)
+    WHERE revoked_at IS NULL;
+
 -- Lossless native vCard resources. Typed profile tables remain the semantic
 -- source of truth; this table retains exact wire bodies and normalized
 -- occurrence metadata for future CardDAV layers.

--- a/internal/store/subset_test.go
+++ b/internal/store/subset_test.go
@@ -271,9 +271,21 @@ func TestCopySubsetExcludesDocumentDerivativesAndHostedConsent(t *testing.T) {
 		        '["conversation_text"]', '2025-01-01', '{}');
 		INSERT INTO person_inference_consents
 			(profile_fingerprint, granted_by)
+		VALUES (?, 'cli');
+		INSERT INTO person_semantic_embedding_profiles
+			(fingerprint, purpose, destination, api_format, model, api_key_env,
+			 retention_posture, training_posture, renderer_policy,
+			 disclosed_field_classes, corpus_scope, policy_json)
+		VALUES (?, 'semantic_person_embeddings', 'https://embedding.example.test/v1/embeddings',
+		        'openai', 'synthetic-model', 'TEST_KEY', 'zero_data_retention',
+		        'no_training', 'person-semantic-v1', '["person_display_name"]',
+		        'all_durable_people', '{}');
+		INSERT INTO person_semantic_embedding_consents
+			(profile_fingerprint, granted_by)
 		VALUES (?, 'cli')`,
 		fingerprint, fingerprint, strings.Repeat("b", 64), strings.Repeat("c", 64), strings.Repeat("d", 64),
 		strings.Repeat("e", 64), strings.Repeat("e", 64),
+		strings.Repeat("f", 64), strings.Repeat("f", 64),
 	)
 	require.NoError(err)
 	require.NoError(db.Close())
@@ -289,6 +301,7 @@ func TestCopySubsetExcludesDocumentDerivativesAndHostedConsent(t *testing.T) {
 		"document_extraction_heads", "document_units", "document_chunks", "document_chunk_spans",
 		"document_occurrences", "document_extraction_claims",
 		"person_inference_profiles", "person_inference_consents",
+		"person_semantic_embedding_profiles", "person_semantic_embedding_consents",
 	} {
 		var count int
 		require.NoError(destination.QueryRow(`SELECT COUNT(*) FROM `+table).Scan(&count), table)

--- a/internal/vector/backend.go
+++ b/internal/vector/backend.go
@@ -247,6 +247,22 @@ type ChunkScoringBackend interface {
 	ScoreMessageChunks(ctx context.Context, gen GenerationID, messageID int64, queryVec []float32) ([]ChunkHit, error)
 }
 
+// PersonBackend is the separate person-owned vector capability. Person IDs
+// never enter the message-owned Backend methods or result types.
+type PersonBackend interface {
+	PersonCoverageCounter
+	UpsertPersons(ctx context.Context, gen GenerationID, persons []PersonEmbedding) error
+	ListPersonRevisions(ctx context.Context, gen GenerationID) (map[int64]string, error)
+	DeletePersonsNotIn(ctx context.Context, gen GenerationID, currentPersonIDs []int64) error
+	SearchPeople(ctx context.Context, gen GenerationID, queryVec []float32, k int) ([]PersonHit, error)
+}
+
+// PersonCoverageCounter reports terminal person publications that have no
+// searchable vector for a generation.
+type PersonCoverageCounter interface {
+	CountRejectedPersons(ctx context.Context, gen GenerationID) (int64, error)
+}
+
 // Stats reports the size of one generation (or 0 for totals).
 type Stats struct {
 	EmbeddingCount int64

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -84,6 +84,7 @@ type Config struct {
 	Search     SearchConfig     `toml:"search"`
 	Embed      EmbedConfig      `toml:"embed"`
 	Multimodal MultimodalConfig `toml:"multimodal"`
+	People     PeopleConfig     `toml:"people"`
 
 	// SkipExtensionCreate skips the `CREATE EXTENSION IF NOT EXISTS
 	// vector` step on the pgvector backend while still letting Migrate
@@ -403,6 +404,10 @@ func (e EmbeddingsConfig) Fingerprint() string {
 // so two cap values produce two different embedding layouts and must
 // not share one generation.
 //
+// Person renderer policy is deliberately excluded: it is part of every
+// person document revision, so changing it rebuilds only the bounded person
+// corpus instead of forcing a paid full-message generation rebuild.
+//
 // embed_policy (the embedPolicyVersion constant) covers worker-side
 // changes that shift the vector layout for the same Preprocess output
 // — most notably the switch from one-vector-per-message-with-truncation
@@ -411,7 +416,8 @@ func (e EmbeddingsConfig) Fingerprint() string {
 // would silently accept new chunked entries from an upgraded worker.
 func (c *Config) GenerationFingerprint() string {
 	fp := fmt.Sprintf("%s:%s:c%d:e%d",
-		c.Embeddings.Fingerprint(), c.Preprocess.Fingerprint(), c.Embeddings.MaxInputChars, embedPolicyVersion)
+		c.Embeddings.Fingerprint(), c.Preprocess.Fingerprint(), c.Embeddings.MaxInputChars,
+		embedPolicyVersion)
 	if c.Embeddings.EffectiveAPIFormat() == APIFormatVoyageContextual {
 		fp = fmt.Sprintf("%s:a%s:v%d", fp, APIFormatVoyageContextual, contextPolicyVersion)
 	}
@@ -510,6 +516,11 @@ func (c *Config) Validate() error {
 	}
 	if c.Embeddings.BatchSize <= 0 {
 		return fmt.Errorf("vector.embeddings.batch_size: must be positive, got %d", c.Embeddings.BatchSize)
+	}
+	if c.People.Enabled {
+		if _, err := c.SemanticPersonEmbeddingProfile(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/vector/embed/client.go
+++ b/internal/vector/embed/client.go
@@ -42,6 +42,9 @@ type Config struct {
 	// call. Defaults to 3 when zero. Only transient errors (5xx, network)
 	// are retried; 4xx responses fail immediately.
 	MaxRetries int
+	// BeforeRequest reauthorizes each concrete HTTP attempt. A returned error
+	// is propagated without retrying. Nil leaves the client ungated.
+	BeforeRequest BeforeRequestFunc
 }
 
 // Client calls an OpenAI-compatible /v1/embeddings endpoint.
@@ -58,7 +61,7 @@ func NewClient(cfg Config) *Client {
 	if cfg.MaxRetries == 0 {
 		cfg.MaxRetries = 3
 	}
-	return &Client{cfg: cfg, http: &http.Client{Timeout: cfg.Timeout}}
+	return &Client{cfg: cfg, http: newHTTPClient(cfg.Timeout, cfg.BeforeRequest)}
 }
 
 // embeddingRequest is the JSON body sent to the server.
@@ -192,10 +195,16 @@ func (c *Client) doOnce(ctx context.Context, body []byte, want int) ([][]float32
 	}
 	resp, err := c.http.Do(req)
 	if err != nil {
+		if authorizationErr := beforeRequestCause(err); authorizationErr != nil {
+			return nil, authorizationErr
+		}
 		return nil, &retryError{err: fmt.Errorf("http do: %w", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+		return nil, ErrEmbeddingProviderRedirect
+	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		// 429 is a transient rate-limit signal. Honor Retry-After
 		// when the server provides it so we don't thrash.

--- a/internal/vector/embed/client_test.go
+++ b/internal/vector/embed/client_test.go
@@ -11,7 +11,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
 )
+
+type requestConsentState struct{ active atomic.Bool }
+
+func (s *requestConsentState) HasActivePersonSemanticEmbeddingConsent(
+	context.Context, string,
+) (bool, error) {
+	return s.active.Load(), nil
+}
+
+func newSemanticRequestGate(endpoint string) (*requestConsentState, vector.SemanticPersonEmbeddingGate) {
+	consent := &requestConsentState{}
+	consent.active.Store(true)
+	config := vector.Config{
+		Enabled: true,
+		Embeddings: vector.EmbeddingsConfig{
+			Endpoint: endpoint, Model: "m", Dimension: 1,
+		},
+		People: vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		},
+	}
+	return consent, vector.NewExactSemanticPersonEmbeddingGate(
+		func() (vector.Config, error) { return config, nil }, consent,
+	)
+}
 
 // writeEmbeddings writes an OpenAI-compatible embeddings response using the
 // provided vectors. It panics on encoding failure; that never happens for
@@ -79,6 +105,184 @@ func TestClient_EmbedQueryUsesSingleInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, [][]string{{"find this"}}, *calls)
 	assert.Equal(t, []float32{1}, got)
+}
+
+// TestClientBeforeRequestFencesEveryRetryAttempt catches a consent check that
+// runs once around the logical embedding operation instead of immediately
+// before every real HTTP attempt. Query retries are included because curated
+// person search uses the same provider client surface as document embedding.
+func TestClientBeforeRequestFencesEveryRetryAttempt(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		run  func(context.Context, *Client) error
+	}{
+		{
+			name: "documents",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.EmbedDocuments(ctx, []DocumentInput{{Chunks: []string{"curated person"}}})
+				return err
+			},
+		},
+		{
+			name: "query",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.EmbedQuery(ctx, "curated person query")
+				return err
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var requests atomic.Int32
+			consent, gate := newSemanticRequestGate("https://embedding.example.test/v1")
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				consent.active.Store(false)
+				w.Header().Set("Retry-After", "0")
+				http.Error(w, "rate limited", http.StatusTooManyRequests)
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(Config{
+				Endpoint: server.URL, Model: "m", Dimension: 1, MaxRetries: 3,
+				BeforeRequest: gate.Check,
+			})
+
+			err := test.run(t.Context(), client)
+
+			require.ErrorIs(t, err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+			assert.Equal(t, int32(1), requests.Load(),
+				"revocation after the first 429 must fence the retry")
+		})
+	}
+}
+
+// TestClientBeforeRequestRejectsProviderRedirects catches gated person clients
+// that let net/http replay a document or query body to a provider-selected URL.
+func TestClientBeforeRequestRejectsProviderRedirects(t *testing.T) {
+	operations := []struct {
+		name string
+		run  func(context.Context, *Client) error
+	}{
+		{
+			name: "documents",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.EmbedDocuments(ctx, []DocumentInput{{Chunks: []string{"curated person"}}})
+				return err
+			},
+		},
+		{
+			name: "query",
+			run: func(ctx context.Context, client *Client) error {
+				_, err := client.EmbedQuery(ctx, "curated person query")
+				return err
+			},
+		},
+	}
+	statuses := []struct {
+		name string
+		code int
+	}{
+		{name: "307", code: http.StatusTemporaryRedirect},
+		{name: "308", code: http.StatusPermanentRedirect},
+	}
+	destinations := []struct {
+		name        string
+		crossOrigin bool
+	}{
+		{name: "same_origin"},
+		{name: "cross_origin", crossOrigin: true},
+	}
+
+	for _, operation := range operations {
+		for _, status := range statuses {
+			for _, destination := range destinations {
+				t.Run(operation.name+"/"+status.name+"/"+destination.name, func(t *testing.T) {
+					var originRequests atomic.Int32
+					var targetRequests atomic.Int32
+					redirectLocation := "/redirected"
+					if destination.crossOrigin {
+						target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							targetRequests.Add(1)
+							writeEmbeddings(t, w, [][]float32{{1}})
+						}))
+						t.Cleanup(target.Close)
+						redirectLocation = target.URL + "/redirected"
+					}
+					origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						switch r.URL.Path {
+						case "/embeddings":
+							originRequests.Add(1)
+							w.Header().Set("Location", redirectLocation)
+							w.WriteHeader(status.code)
+						case "/redirected":
+							targetRequests.Add(1)
+							writeEmbeddings(t, w, [][]float32{{1}})
+						default:
+							http.NotFound(w, r)
+						}
+					}))
+					t.Cleanup(origin.Close)
+					_, gate := newSemanticRequestGate("https://embedding.example.test/v1")
+					client := NewClient(Config{
+						Endpoint: origin.URL, Model: "m", Dimension: 1, MaxRetries: 3,
+						BeforeRequest: gate.Check,
+					})
+
+					err := operation.run(t.Context(), client)
+
+					assert := assert.New(t)
+					require.ErrorIs(t, err, ErrEmbeddingProviderRedirect)
+					assert.Equal("embedding provider redirects are not allowed", err.Error())
+					assert.Equal(int32(1), originRequests.Load(), "redirect responses must not be retried")
+					assert.Zero(targetRequests.Load(), "person text must not reach the redirect target")
+				})
+			}
+		}
+	}
+}
+
+// TestClientWithoutBeforeRequestFollowsProviderRedirects protects the message
+// client composition, which intentionally retains net/http's redirect behavior.
+func TestClientWithoutBeforeRequestFollowsProviderRedirects(t *testing.T) {
+	for _, status := range []struct {
+		name string
+		code int
+	}{
+		{name: "307", code: http.StatusTemporaryRedirect},
+		{name: "308", code: http.StatusPermanentRedirect},
+	} {
+		t.Run(status.name, func(t *testing.T) {
+			var originRequests atomic.Int32
+			var targetRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/embeddings":
+					originRequests.Add(1)
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(status.code)
+				case "/redirected":
+					targetRequests.Add(1)
+					request := decodeRequest(t, r)
+					assert.Equal(t, []string{"message text"}, request.Input)
+					writeEmbeddings(t, w, [][]float32{{1}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := NewClient(Config{
+				Endpoint: server.URL, Model: "m", Dimension: 1, MaxRetries: 1,
+			})
+
+			vector, err := client.EmbedQuery(t.Context(), "message text")
+
+			assert := assert.New(t)
+			require.NoError(t, err)
+			assert.Equal([]float32{1}, vector)
+			assert.Equal(int32(1), originRequests.Load())
+			assert.Equal(int32(1), targetRequests.Load())
+		})
+	}
 }
 
 func TestClient_Embed_Success(t *testing.T) {

--- a/internal/vector/embed/person_worker.go
+++ b/internal/vector/embed/person_worker.go
@@ -1,0 +1,423 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// PersonDocumentStore is the source-side surface required to reconcile the
+// small curated person corpus. *store.Store implements it.
+type PersonDocumentStore interface {
+	ListPersonSemanticDocumentsContext(ctx context.Context) ([]store.PersonSemanticDocument, error)
+	LoadPersonSemanticDocumentContext(ctx context.Context, personID int64) (*store.PersonSemanticDocument, error)
+}
+
+var _ PersonDocumentStore = (*store.Store)(nil)
+
+// PersonWorkerDeps bundles the source projection, person-owned vector
+// backend, and embedding client. BatchSize defaults to 32.
+type PersonWorkerDeps struct {
+	Store         PersonDocumentStore
+	Backend       vector.PersonBackend
+	Client        SemanticClient
+	Gate          vector.SemanticPersonEmbeddingGate
+	BatchSize     int
+	MaxInputChars int
+}
+
+// PersonWorker reconciles one generation to the complete current curated
+// person corpus. Every run is a stable full scan; exact revisions make the
+// unchanged path provider-free.
+type PersonWorker struct {
+	deps PersonWorkerDeps
+}
+
+type personBatchState struct {
+	endpointHealthy bool
+	rejected        []store.PersonSemanticDocument
+	rejectionErr    error
+}
+
+const personEndpointProbeText = "msgvault semantic person health check"
+
+// NewPersonWorker constructs a bounded full-scan person reconciler.
+func NewPersonWorker(deps PersonWorkerDeps) *PersonWorker {
+	if deps.BatchSize <= 0 {
+		deps.BatchSize = 32
+	}
+	if deps.MaxInputChars <= 0 {
+		deps.MaxInputChars = store.MaxPersonSemanticDocumentBytes
+	}
+	return &PersonWorker{deps: deps}
+}
+
+// RunOnce embeds missing or changed person documents, fences each provider
+// response against a fresh source read, and removes vectors whose source
+// person no longer exists.
+func (w *PersonWorker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResult, error) {
+	var result RunResult
+	if w == nil || w.deps.Store == nil || w.deps.Backend == nil ||
+		w.deps.Client == nil || w.deps.Gate == nil {
+		return result, errors.New("person worker: store, backend, client, and gate are required")
+	}
+	if err := w.deps.Gate.Check(ctx); err != nil {
+		if vector.SemanticPersonEmbeddingInactive(err) {
+			return result, nil
+		}
+		return result, fmt.Errorf("person worker gate: %w", err)
+	}
+
+	documents, err := w.deps.Store.ListPersonSemanticDocumentsContext(ctx)
+	if err != nil {
+		return result, fmt.Errorf("list person semantic documents: %w", err)
+	}
+	sort.Slice(documents, func(i, j int) bool { return documents[i].PersonID < documents[j].PersonID })
+	revisions, err := w.deps.Backend.ListPersonRevisions(ctx, gen)
+	if errors.Is(err, vector.ErrGenerationRetired) {
+		return result, nil
+	}
+	if err != nil {
+		return result, fmt.Errorf("list person vector revisions for generation %d: %w", gen, err)
+	}
+
+	changed := make([]store.PersonSemanticDocument, 0)
+	for i, document := range documents {
+		if i > 0 && document.PersonID == documents[i-1].PersonID {
+			return result, fmt.Errorf("duplicate person id %d in semantic document scan", document.PersonID)
+		}
+		if document.Text == "" {
+			continue
+		}
+		if revisions[document.PersonID] != document.Revision {
+			changed = append(changed, document)
+		}
+	}
+	var runErr error
+	for start := 0; start < len(changed); start += w.deps.BatchSize {
+		end := min(start+w.deps.BatchSize, len(changed))
+		batch := changed[start:end]
+		result.Claimed += len(batch)
+		for _, document := range batch {
+			if capPersonProviderInput(document.Text, w.deps.MaxInputChars) != document.Text {
+				result.Truncated++
+			}
+		}
+		var batchState personBatchState
+		if err := w.embedPersonBatch(ctx, gen, batch, &result, &batchState); err != nil {
+			if errors.Is(err, vector.ErrGenerationRetired) {
+				return result, nil
+			}
+			if vector.SemanticPersonEmbeddingInactive(err) {
+				return result, nil
+			}
+			runErr = errors.Join(runErr, err)
+		}
+		if len(batchState.rejected) > 0 {
+			if !batchState.endpointHealthy {
+				probeErr := w.probePersonEndpoint(ctx)
+				if vector.SemanticPersonEmbeddingInactive(probeErr) {
+					return result, nil
+				}
+				batchState.endpointHealthy = probeErr == nil
+			}
+			if batchState.endpointHealthy {
+				if err := w.recordRejectedPersons(ctx, gen, batchState.rejected); err != nil {
+					if errors.Is(err, vector.ErrGenerationRetired) {
+						return result, nil
+					}
+					runErr = errors.Join(runErr, err)
+				}
+			} else {
+				runErr = errors.Join(runErr, fmt.Errorf(
+					"embed person documents: endpoint health not established: %w", batchState.rejectionErr,
+				))
+			}
+		}
+	}
+
+	current := documents
+	if len(changed) > 0 {
+		current, err = w.deps.Store.ListPersonSemanticDocumentsContext(ctx)
+		if err != nil {
+			return result, fmt.Errorf("refresh person semantic documents before reconciliation: %w", err)
+		}
+	}
+	currentIDs := make([]int64, 0, len(current))
+	for _, document := range current {
+		if document.Text != "" {
+			currentIDs = append(currentIDs, document.PersonID)
+		}
+	}
+	if err := w.deps.Backend.DeletePersonsNotIn(ctx, gen, currentIDs); errors.Is(err, vector.ErrGenerationRetired) {
+		return result, nil
+	} else if err != nil {
+		return result, fmt.Errorf("reconcile deleted person vectors for generation %d: %w", gen, err)
+	}
+	return result, runErr
+}
+
+func (w *PersonWorker) probePersonEndpoint(ctx context.Context) error {
+	if err := w.deps.Gate.Check(ctx); err != nil {
+		return err
+	}
+	vectors, err := w.deps.Client.EmbedDocuments(ctx, []DocumentInput{{Chunks: []string{
+		personEndpointProbeText,
+	}}})
+	if err != nil {
+		return err
+	}
+	if len(vectors) != 1 || len(vectors[0]) != 1 {
+		return fmt.Errorf("person endpoint probe returned %d documents", len(vectors))
+	}
+	return nil
+}
+
+func (w *PersonWorker) embedPersonBatch(
+	ctx context.Context,
+	gen vector.GenerationID,
+	batch []store.PersonSemanticDocument,
+	result *RunResult,
+	state *personBatchState,
+) error {
+	if err := w.deps.Gate.Check(ctx); err != nil {
+		return err
+	}
+	inputs := make([]DocumentInput, len(batch))
+	for i, document := range batch {
+		inputs[i] = DocumentInput{Chunks: []string{
+			capPersonProviderInput(document.Text, w.deps.MaxInputChars),
+		}}
+	}
+	vectors, embedErr := w.deps.Client.EmbedDocuments(ctx, inputs)
+	permanent := errors.Is(embedErr, ErrPermanent4xx) || errors.Is(embedErr, ErrDocumentTooLarge)
+	if permanent && len(batch) > 1 {
+		var batchErr error
+		for i := range batch {
+			if err := w.embedPersonBatch(ctx, gen, batch[i:i+1], result, state); err != nil {
+				if errors.Is(err, vector.ErrGenerationRetired) {
+					return vector.ErrGenerationRetired
+				}
+				batchErr = errors.Join(batchErr, err)
+			}
+		}
+		return batchErr
+	}
+	if permanent && len(batch) == 1 && len(vectors) == 0 {
+		result.Failed++
+		if errors.Is(embedErr, ErrDocumentTooLarge) {
+			return w.recordRejectedPersons(ctx, gen, batch)
+		}
+		state.rejected = append(state.rejected, batch[0])
+		state.rejectionErr = errors.Join(state.rejectionErr, embedErr)
+		return nil
+	}
+	if len(vectors) > len(batch) || (embedErr == nil && len(vectors) != len(batch)) {
+		result.Failed += len(batch)
+		return fmt.Errorf("embed person documents: returned %d results for %d inputs", len(vectors), len(batch))
+	}
+	if len(vectors) > 0 {
+		state.endpointHealthy = true
+	}
+
+	publications := make([]vector.PersonEmbedding, 0, len(vectors))
+	for i, documentVectors := range vectors {
+		if len(documentVectors) != 1 {
+			result.Failed += len(batch)
+			return fmt.Errorf("embed person %d: expected one vector, got %d", batch[i].PersonID, len(documentVectors))
+		}
+		current, err := w.deps.Store.LoadPersonSemanticDocumentContext(ctx, batch[i].PersonID)
+		if errors.Is(err, store.ErrPersonNotFound) {
+			continue
+		}
+		if err != nil {
+			result.Failed += len(batch)
+			return fmt.Errorf("reload person %d after embedding: %w", batch[i].PersonID, err)
+		}
+		if current.Revision != batch[i].Revision || current.RendererPolicy != batch[i].RendererPolicy {
+			continue
+		}
+		publications = append(publications, vector.PersonEmbedding{
+			PersonID: batch[i].PersonID, Revision: batch[i].Revision, Vector: documentVectors[0],
+		})
+	}
+	if err := w.deps.Backend.UpsertPersons(ctx, gen, publications); errors.Is(err, vector.ErrGenerationRetired) {
+		return vector.ErrGenerationRetired
+	} else if err != nil {
+		result.Failed += len(batch)
+		return fmt.Errorf("upsert person vectors for generation %d: %w", gen, err)
+	}
+	result.Succeeded += len(publications)
+	result.Failed += len(vectors) - len(publications)
+	if embedErr != nil {
+		result.Failed += len(batch) - len(vectors)
+		return fmt.Errorf("embed person documents: %w", embedErr)
+	}
+	return nil
+}
+
+func (w *PersonWorker) recordRejectedPersons(
+	ctx context.Context,
+	gen vector.GenerationID,
+	documents []store.PersonSemanticDocument,
+) error {
+	publications := make([]vector.PersonEmbedding, 0, len(documents))
+	for _, document := range documents {
+		current, err := w.deps.Store.LoadPersonSemanticDocumentContext(ctx, document.PersonID)
+		if errors.Is(err, store.ErrPersonNotFound) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("reload rejected person %d: %w", document.PersonID, err)
+		}
+		if current.Revision != document.Revision || current.RendererPolicy != document.RendererPolicy {
+			continue
+		}
+		publications = append(publications, vector.PersonEmbedding{
+			PersonID: document.PersonID, Revision: document.Revision,
+		})
+	}
+	if err := w.deps.Backend.UpsertPersons(ctx, gen, publications); errors.Is(err, vector.ErrGenerationRetired) {
+		return vector.ErrGenerationRetired
+	} else if err != nil {
+		return fmt.Errorf("record rejected person revisions for generation %d: %w", gen, err)
+	}
+	return nil
+}
+
+func capPersonProviderInput(text string, maxRunes int) string {
+	runes := []rune(text)
+	if maxRunes <= 0 || len(runes) <= maxRunes {
+		return text
+	}
+	return string(runes[:maxRunes])
+}
+
+// GenerationRunner is the message-owned runner contract composed with person
+// reconciliation. It deliberately matches scheduler.EmbedRunner without an
+// embed-to-scheduler package cycle.
+type GenerationRunner interface {
+	RunOnce(ctx context.Context, gen vector.GenerationID) (RunResult, error)
+	RunBackstop(ctx context.Context, gen vector.GenerationID) (RunResult, error)
+	ReclaimStale(ctx context.Context) (int, error)
+}
+
+// GenerationWorker runs message and person maintenance inside one scheduler
+// job and one generation lifecycle.
+type GenerationWorker struct {
+	messages      GenerationRunner
+	persons       *PersonWorker
+	personScanned map[vector.GenerationID]bool
+}
+
+type personBuildingGenerationReader interface {
+	BuildingGeneration(ctx context.Context) (*vector.Generation, error)
+}
+
+// GenerationRunError preserves the message and person maintenance channels.
+// Schedulers may continue message recovery after a person-only failure while
+// direct callers still receive the underlying person error.
+type GenerationRunError struct {
+	Message error
+	Person  error
+}
+
+func (e *GenerationRunError) Error() string {
+	joined := errors.Join(e.Message, e.Person)
+	if joined == nil {
+		return ""
+	}
+	return joined.Error()
+}
+
+func (e *GenerationRunError) Unwrap() []error {
+	return []error{e.Message, e.Person}
+}
+
+// NewGenerationWorker composes the existing message runner with person
+// reconciliation.
+func NewGenerationWorker(messages GenerationRunner, persons *PersonWorker) *GenerationWorker {
+	return &GenerationWorker{
+		messages: messages, persons: persons, personScanned: make(map[vector.GenerationID]bool),
+	}
+}
+
+// ReclaimStale delegates message lease maintenance; the person worker is a
+// revisioned scan-and-fill reconciler and owns no leases.
+func (w *GenerationWorker) ReclaimStale(ctx context.Context) (int, error) {
+	if w == nil || w.messages == nil {
+		return 0, errors.New("generation worker: message runner is required")
+	}
+	return w.messages.ReclaimStale(ctx)
+}
+
+// RunOnce maintains both corpora even when one side returns an error, so a
+// transient message failure cannot indefinitely starve active-person upkeep.
+func (w *GenerationWorker) RunOnce(ctx context.Context, gen vector.GenerationID) (RunResult, error) {
+	if w == nil || w.messages == nil || w.persons == nil {
+		return RunResult{}, errors.New("generation worker: message and person workers are required")
+	}
+	messageResult, messageErr := w.messages.RunOnce(ctx, gen)
+	var personResult RunResult
+	var personErr error
+	if w.personScanned == nil {
+		w.personScanned = make(map[vector.GenerationID]bool)
+	}
+	// A contextual build can require many bounded message passes. Scan the
+	// person corpus on its first pass and final converged pass, not on every
+	// intermediate build pass. Active generations continue person maintenance
+	// on every scheduler tick, including ticks with message-side failures.
+	building := false
+	if reader, ok := w.persons.deps.Backend.(personBuildingGenerationReader); ok {
+		generation, readErr := reader.BuildingGeneration(ctx)
+		building = readErr == nil && generation != nil && generation.ID == gen
+	}
+	if !building || messageResult.Contextual == nil ||
+		messageResult.Contextual.Converged || !w.personScanned[gen] {
+		personResult, personErr = w.persons.RunOnce(ctx, gen)
+		w.personScanned[gen] = true
+	}
+	return mergeGenerationResults(messageResult, personResult), newGenerationRunError(messageErr, personErr)
+}
+
+// RunPersonsOnce performs only curated-person reconciliation. The scheduler
+// uses it to maintain the compatible active generation independently while a
+// message rebuild drains into another generation.
+func (w *GenerationWorker) RunPersonsOnce(
+	ctx context.Context, gen vector.GenerationID,
+) (RunResult, error) {
+	if w == nil || w.persons == nil {
+		return RunResult{}, errors.New("generation worker: person worker is required")
+	}
+	return w.persons.RunOnce(ctx, gen)
+}
+
+// RunBackstop preserves the message runner's watermark-ignoring behavior and
+// performs the same idempotent person full scan used by ordinary ticks.
+func (w *GenerationWorker) RunBackstop(ctx context.Context, gen vector.GenerationID) (RunResult, error) {
+	if w == nil || w.messages == nil || w.persons == nil {
+		return RunResult{}, errors.New("generation worker: message and person workers are required")
+	}
+	messageResult, messageErr := w.messages.RunBackstop(ctx, gen)
+	personResult, personErr := w.persons.RunOnce(ctx, gen)
+	return mergeGenerationResults(messageResult, personResult), newGenerationRunError(messageErr, personErr)
+}
+
+func newGenerationRunError(messageErr, personErr error) error {
+	if messageErr == nil && personErr == nil {
+		return nil
+	}
+	return &GenerationRunError{Message: messageErr, Person: personErr}
+}
+
+func mergeGenerationResults(message, person RunResult) RunResult {
+	message.Claimed += person.Claimed
+	message.Succeeded += person.Succeeded
+	message.Failed += person.Failed
+	message.Truncated += person.Truncated
+	return message
+}

--- a/internal/vector/embed/person_worker_test.go
+++ b/internal/vector/embed/person_worker_test.go
@@ -1,0 +1,985 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+type personWorkerSource struct {
+	mu   sync.Mutex
+	docs map[int64]store.PersonSemanticDocument
+}
+
+func newPersonWorkerSource(docs ...store.PersonSemanticDocument) *personWorkerSource {
+	source := &personWorkerSource{docs: make(map[int64]store.PersonSemanticDocument, len(docs))}
+	for _, document := range docs {
+		source.docs[document.PersonID] = document
+	}
+	return source
+}
+
+func (s *personWorkerSource) ListPersonSemanticDocumentsContext(context.Context) ([]store.PersonSemanticDocument, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	documents := make([]store.PersonSemanticDocument, 0, len(s.docs))
+	for _, document := range s.docs {
+		documents = append(documents, document)
+	}
+	// Return a deliberate reverse ordering so the worker's stable-order
+	// contract is exercised instead of being supplied by the fake.
+	sort.Slice(documents, func(i, j int) bool { return documents[i].PersonID > documents[j].PersonID })
+	return documents, nil
+}
+
+func (s *personWorkerSource) LoadPersonSemanticDocumentContext(
+	_ context.Context, personID int64,
+) (*store.PersonSemanticDocument, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	document, ok := s.docs[personID]
+	if !ok {
+		return nil, store.ErrPersonNotFound
+	}
+	return &document, nil
+}
+
+func (s *personWorkerSource) put(document store.PersonSemanticDocument) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docs[document.PersonID] = document
+}
+
+func (s *personWorkerSource) delete(personID int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.docs, personID)
+}
+
+type personWorkerBackend struct {
+	mu        sync.Mutex
+	revisions map[vector.GenerationID]map[int64]string
+	vectors   map[vector.GenerationID]map[int64][]float32
+	listErr   error
+	upsertErr error
+	deleteErr error
+	building  *vector.Generation
+}
+
+func (b *personWorkerBackend) BuildingGeneration(context.Context) (*vector.Generation, error) {
+	if b.building == nil {
+		return nil, nil //nolint:nilnil // matches the production optional building-generation contract
+	}
+	return b.building, nil
+}
+
+func newPersonWorkerBackend() *personWorkerBackend {
+	return &personWorkerBackend{
+		revisions: make(map[vector.GenerationID]map[int64]string),
+		vectors:   make(map[vector.GenerationID]map[int64][]float32),
+	}
+}
+
+func (b *personWorkerBackend) UpsertPersons(
+	_ context.Context, gen vector.GenerationID, persons []vector.PersonEmbedding,
+) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.upsertErr != nil {
+		return b.upsertErr
+	}
+	if b.revisions[gen] == nil {
+		b.revisions[gen] = make(map[int64]string)
+		b.vectors[gen] = make(map[int64][]float32)
+	}
+	for _, person := range persons {
+		b.revisions[gen][person.PersonID] = person.Revision
+		b.vectors[gen][person.PersonID] = slices.Clone(person.Vector)
+	}
+	return nil
+}
+
+func (b *personWorkerBackend) ListPersonRevisions(
+	_ context.Context, gen vector.GenerationID,
+) (map[int64]string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.listErr != nil {
+		return nil, b.listErr
+	}
+	return clonePersonRevisions(b.revisions[gen]), nil
+}
+
+func (b *personWorkerBackend) CountRejectedPersons(
+	_ context.Context, gen vector.GenerationID,
+) (int64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var count int64
+	for personID := range b.revisions[gen] {
+		if len(b.vectors[gen][personID]) == 0 {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (b *personWorkerBackend) DeletePersonsNotIn(
+	_ context.Context, gen vector.GenerationID, currentPersonIDs []int64,
+) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.deleteErr != nil {
+		return b.deleteErr
+	}
+	keep := make(map[int64]struct{}, len(currentPersonIDs))
+	for _, personID := range currentPersonIDs {
+		keep[personID] = struct{}{}
+	}
+	for personID := range b.revisions[gen] {
+		if _, ok := keep[personID]; !ok {
+			delete(b.revisions[gen], personID)
+			delete(b.vectors[gen], personID)
+		}
+	}
+	return nil
+}
+
+func (b *personWorkerBackend) SearchPeople(
+	context.Context, vector.GenerationID, []float32, int,
+) ([]vector.PersonHit, error) {
+	return nil, errors.New("not implemented")
+}
+
+func clonePersonRevisions(input map[int64]string) map[int64]string {
+	return maps.Clone(input)
+}
+
+type personWorkerClient struct {
+	mu              sync.Mutex
+	calls           [][][]string
+	failOnceAfter   int
+	failureReturned bool
+	malformed       bool
+	onEmbed         func()
+}
+
+type poisonPersonWorkerClient struct {
+	calls          int
+	rejectAll      bool
+	rejectFromCall int
+}
+
+func (c *poisonPersonWorkerClient) EmbedQuery(context.Context, string) ([]float32, error) {
+	return nil, errors.New("unexpected query embedding")
+}
+
+func (c *poisonPersonWorkerClient) EmbedDocuments(
+	_ context.Context, documents []DocumentInput,
+) ([][][]float32, error) {
+	c.calls++
+	for _, document := range documents {
+		if c.rejectAll || (c.rejectFromCall > 0 && c.calls >= c.rejectFromCall) ||
+			document.Chunks[0] == "Synthetic Reject" {
+			return nil, fmt.Errorf("synthetic rejection: %w", ErrPermanent4xx)
+		}
+	}
+	results := make([][][]float32, len(documents))
+	for i := range documents {
+		results[i] = [][]float32{{float32(i + 1), 1}}
+	}
+	return results, nil
+}
+
+func (c *personWorkerClient) EmbedQuery(context.Context, string) ([]float32, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *personWorkerClient) EmbedDocuments(
+	_ context.Context, documents []DocumentInput,
+) ([][][]float32, error) {
+	c.mu.Lock()
+	inputs := make([][]string, len(documents))
+	for i, document := range documents {
+		inputs[i] = slices.Clone(document.Chunks)
+	}
+	c.calls = append(c.calls, inputs)
+	onEmbed := c.onEmbed
+	failAfter := c.failOnceAfter
+	shouldFail := failAfter > 0 && !c.failureReturned
+	if shouldFail {
+		c.failureReturned = true
+	}
+	c.mu.Unlock()
+
+	if onEmbed != nil {
+		onEmbed()
+	}
+	if c.malformed {
+		return nil, nil
+	}
+	completed := len(documents)
+	if shouldFail {
+		completed = min(failAfter, len(documents))
+	}
+	results := make([][][]float32, completed)
+	for i := range completed {
+		requireDocumentShape := len(documents[i].Chunks) == 1
+		if !requireDocumentShape {
+			return nil, errors.New("person input must contain exactly one chunk")
+		}
+		results[i] = [][]float32{{float32(len(documents[i].Chunks[0])), float32(i + 1)}}
+	}
+	if shouldFail {
+		return results, errors.New("synthetic provider interruption")
+	}
+	return results, nil
+}
+
+func personDocument(id int64, revision, text string) store.PersonSemanticDocument {
+	return store.PersonSemanticDocument{
+		PersonID: id, RendererPolicy: store.PersonSemanticRendererPolicy,
+		Revision: revision, Text: text,
+	}
+}
+
+func newTestPersonWorker(
+	source PersonDocumentStore, backend vector.PersonBackend, client SemanticClient, batchSize int,
+) *PersonWorker {
+	return NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: batchSize,
+		Gate: allowSemanticPersonGate(),
+	})
+}
+
+func allowSemanticPersonGate() vector.SemanticPersonEmbeddingGate {
+	return vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return nil })
+}
+
+// TestPersonWorkerGateBlocksDisabledUnconsentedAndRevokedProviderCalls catches
+// the reconciler treating vector enablement as authority for curated egress.
+func TestPersonWorkerGateBlocksDisabledUnconsentedAndRevokedProviderCalls(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(1, "rev-one", "Synthetic One"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	gateErr := vector.ErrSemanticPersonEmbeddingsDisabled
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 1,
+		Gate: vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return gateErr }),
+	})
+
+	result, err := worker.RunOnce(t.Context(), 1)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Empty(client.calls)
+
+	gateErr = vector.ErrSemanticPersonEmbeddingConsentRequired
+	result, err = worker.RunOnce(t.Context(), 1)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Empty(client.calls)
+
+	gateErr = nil
+	_, err = worker.RunOnce(t.Context(), 1)
+	must.NoError(err)
+	must.Len(client.calls, 1)
+
+	source.put(personDocument(1, "rev-two", "Synthetic Two"))
+	gateErr = vector.ErrSemanticPersonEmbeddingConsentRequired
+	_, err = worker.RunOnce(t.Context(), 1)
+	must.NoError(err)
+	check.Len(client.calls, 1, "revoked consent must make zero later provider calls")
+}
+
+// TestPersonWorkerRechecksGateBeforeEveryProviderCall catches a mid-run
+// revocation being ignored for later batches or endpoint probes.
+func TestPersonWorkerRechecksGateBeforeEveryProviderCall(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	gateErr := error(nil)
+	client.onEmbed = func() { gateErr = vector.ErrSemanticPersonEmbeddingConsentRequired }
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 1,
+		Gate: vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return gateErr }),
+	})
+
+	_, err := worker.RunOnce(t.Context(), 2)
+	must.NoError(err)
+	check.Len(client.calls, 1)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 2)
+	must.NoError(err)
+	check.Equal(map[int64]string{1: "rev-one"}, revisions)
+}
+
+func TestPersonWorkerMissingGateFailsClosedBeforeProvider(t *testing.T) {
+	client := &personWorkerClient{}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store:   newPersonWorkerSource(personDocument(1, "rev-one", "Synthetic One")),
+		Backend: newPersonWorkerBackend(), Client: client,
+	})
+	_, err := worker.RunOnce(t.Context(), 1)
+	require.ErrorContains(t, err, "gate")
+	assert.Empty(t, client.calls)
+}
+
+// TestPersonWorkerEmbedsInitialAndChangedDocumentsInStableBatches catches a
+// worker that ignores revisions, embeds in unstable order, or fails to replace
+// a changed person's vector.
+func TestPersonWorkerEmbedsInitialAndChangedDocumentsInStableBatches(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(30, "rev-30-a", "Synthetic Thirty"),
+		personDocument(10, "rev-10-a", "Synthetic Ten"),
+		personDocument(20, "rev-20-a", "Synthetic Twenty"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 2)
+
+	result, err := worker.RunOnce(t.Context(), 7)
+	must.NoError(err)
+	check.Equal(3, result.Claimed)
+	check.Equal(3, result.Succeeded)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 7)
+	must.NoError(err)
+	check.Equal(map[int64]string{10: "rev-10-a", 20: "rev-20-a", 30: "rev-30-a"}, revisions)
+	must.Len(client.calls, 2)
+	check.Equal([][]string{{"Synthetic Ten"}, {"Synthetic Twenty"}}, client.calls[0])
+	check.Equal([][]string{{"Synthetic Thirty"}}, client.calls[1])
+
+	source.put(personDocument(20, "rev-20-b", "Synthetic Twenty Updated"))
+	result, err = worker.RunOnce(t.Context(), 7)
+	must.NoError(err)
+	check.Equal(1, result.Claimed)
+	check.Equal(1, result.Succeeded)
+	revisions, err = backend.ListPersonRevisions(t.Context(), 7)
+	must.NoError(err)
+	check.Equal("rev-20-b", revisions[20])
+	must.Len(client.calls, 3)
+	check.Equal([][]string{{"Synthetic Twenty Updated"}}, client.calls[2])
+}
+
+// TestPersonWorkerNoOpDoesNotCallProvider catches full rescans that re-embed
+// already-current person documents instead of comparing exact revisions.
+func TestPersonWorkerNoOpDoesNotCallProvider(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(1, "rev-1", "Synthetic One"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 8)
+	_, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	must.Len(client.calls, 1)
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Zero(result.Claimed)
+	check.Len(client.calls, 1, "unchanged person must not call the provider again")
+}
+
+// TestPersonWorkerSkipsEmptyCanonicalDocument catches a valid person with no
+// discoverability text being sent to the provider or blocking convergence.
+func TestPersonWorkerSkipsEmptyCanonicalDocument(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(2, "rev-empty", ""))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 8)
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Empty(client.calls, "empty semantic documents must not reach the provider")
+	revisions, err := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(err)
+	check.Empty(revisions)
+
+	result, err = worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Empty(client.calls, "unchanged empty document must remain provider-free")
+}
+
+func TestPersonWorkerCapsProviderInput(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(2, "rev-capped", "Synthetic Profile"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 8, MaxInputChars: 9,
+		Gate: allowSemanticPersonGate(),
+	})
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{Claimed: 1, Succeeded: 1, Truncated: 1}, result)
+	must.Len(client.calls, 1)
+	check.Equal([][]string{{"Synthetic"}}, client.calls[0])
+}
+
+func TestPersonWorkerRemovesVectorWhenDocumentBecomesEmpty(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(2, "rev-full", "Synthetic Profile"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 8)
+
+	_, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	must.Len(client.calls, 1)
+	source.put(personDocument(2, "rev-empty", ""))
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Len(client.calls, 1, "empty transition must not call the provider")
+	revisions, err := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(err)
+	check.Empty(revisions, "empty transition must remove the old searchable vector")
+}
+
+func TestPersonWorkerRecordsPoisonDocumentAndContinues(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-reject", "Synthetic Reject"),
+		personDocument(3, "rev-three", "Synthetic Three"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &poisonPersonWorkerClient{}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 3, MaxInputChars: 100,
+		Gate: allowSemanticPersonGate(),
+	})
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{Claimed: 3, Succeeded: 2, Failed: 1}, result)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(map[int64]string{1: "rev-one", 2: "rev-reject", 3: "rev-three"}, revisions)
+	check.NotEmpty(backend.vectors[8][1])
+	check.Empty(backend.vectors[8][2], "rejected revision must not own a searchable vector")
+	check.NotEmpty(backend.vectors[8][3])
+	check.Equal(4, client.calls, "rejected batch must downshift to single documents")
+
+	result, err = worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Equal(4, client.calls, "durable terminal revision must not be retried")
+}
+
+func TestPersonWorkerDoesNotHideEndpointWidePermanentFailure(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+		personDocument(3, "rev-three", "Synthetic Three"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &poisonPersonWorkerClient{rejectAll: true}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 3, MaxInputChars: 100,
+		Gate: allowSemanticPersonGate(),
+	})
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.ErrorIs(err, ErrPermanent4xx)
+	check.Equal(RunResult{Claimed: 3, Failed: 3}, result)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(listErr)
+	check.Empty(revisions, "an endpoint-wide failure must remain uncovered and retryable")
+	check.Equal(5, client.calls, "the failed batch and synthetic health probe must remain visible")
+}
+
+func TestPersonWorkerTerminatesLonePoisonRevisionAfterHealthyProbe(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(1, "rev-reject", "Synthetic Reject"))
+	backend := newPersonWorkerBackend()
+	client := &poisonPersonWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 1)
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{Claimed: 1, Failed: 1}, result)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{1: "rev-reject"}, revisions)
+	check.Empty(backend.vectors[8][1])
+	check.Equal(2, client.calls, "a synthetic probe must establish endpoint health")
+
+	result, err = worker.RunOnce(t.Context(), 8)
+	must.NoError(err)
+	check.Equal(RunResult{}, result)
+	check.Equal(2, client.calls, "the terminal revision must not be retried")
+}
+
+func TestPersonWorkerScopesEndpointHealthToFailingBatch(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+		personDocument(3, "rev-three", "Synthetic Three"),
+		personDocument(4, "rev-four", "Synthetic Four"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &poisonPersonWorkerClient{rejectFromCall: 2}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 2, MaxInputChars: 100,
+		Gate: allowSemanticPersonGate(),
+	})
+
+	result, err := worker.RunOnce(t.Context(), 8)
+	must.ErrorIs(err, ErrPermanent4xx)
+	check.Equal(RunResult{Claimed: 4, Succeeded: 2, Failed: 2}, result)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{1: "rev-one", 2: "rev-two"}, revisions,
+		"success in an earlier batch must not hide a later endpoint-wide failure")
+	check.Equal(5, client.calls)
+}
+
+func TestPersonWorkerPreservesVectorWhenSourceProjectionCannotRender(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	f := storetest.New(t)
+	var personID int64
+	err := f.Store.DB().QueryRow(f.Store.Rebind(`
+		INSERT INTO persons (vcard_uid, display_name) VALUES (?, ?)
+		RETURNING id`),
+		"urn:uuid:00000000-0000-4000-8000-000000000099", "Broken Projection").Scan(&personID)
+	must.NoError(err)
+	value := "distributed systems"
+	_, err = f.Store.SetPersonAttributeValueContext(t.Context(), store.PersonAttributeValueInput{
+		PersonID: personID, DefinitionSlug: store.AttributeSlugAskMeAbout,
+		Value:  store.AttributeValue{Type: store.AttributeValueText, Text: &value},
+		Source: store.ProvenanceUser,
+	})
+	must.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`
+		UPDATE attribute_definitions
+		SET value_type = 'record_reference', field_type = 'person', record_target = 'person'
+		WHERE universal_id = ?
+	`), store.AttributeUniversalIDAskMeAbout)
+	must.NoError(err)
+
+	backend := newPersonWorkerBackend()
+	must.NoError(backend.UpsertPersons(t.Context(), 8, []vector.PersonEmbedding{{
+		PersonID: personID, Revision: "last-good", Vector: []float32{1, 0},
+	}}))
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(f.Store, backend, client, 8)
+
+	_, err = worker.RunOnce(t.Context(), 8)
+	must.ErrorContains(err, "render person")
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 8)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{personID: "last-good"}, revisions)
+	check.Empty(client.calls)
+}
+
+func TestPersonWorkerStopsProviderCallsWhenGenerationRetiresMidRun(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+		personDocument(3, "rev-three", "Synthetic Three"),
+	)
+	backend := newPersonWorkerBackend()
+	backend.upsertErr = vector.ErrGenerationRetired
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 1)
+
+	_, err := worker.RunOnce(t.Context(), 9)
+	must.NoError(err)
+	check.Len(client.calls, 1, "retirement must stop later paid provider batches")
+}
+
+func TestPersonWorkerStopsDownshiftWhenGenerationRetires(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-reject", "Synthetic Reject"),
+	)
+	backend := newPersonWorkerBackend()
+	backend.upsertErr = vector.ErrGenerationRetired
+	client := &poisonPersonWorkerClient{}
+	worker := NewPersonWorker(PersonWorkerDeps{
+		Store: source, Backend: backend, Client: client, BatchSize: 2, MaxInputChars: 100,
+		Gate: allowSemanticPersonGate(),
+	})
+
+	_, err := worker.RunOnce(t.Context(), 9)
+	must.NoError(err)
+	check.Equal(2, client.calls,
+		"retirement on the first singleton upsert must stop the rest of the downshift")
+}
+
+func TestPersonWorkerTreatsRetiredGenerationAsBenign(t *testing.T) {
+	document := personDocument(1, "rev-one", "Synthetic One")
+	tests := []struct {
+		name    string
+		prepare func(*personWorkerBackend)
+	}{
+		{name: "list", prepare: func(backend *personWorkerBackend) { backend.listErr = vector.ErrGenerationRetired }},
+		{name: "upsert", prepare: func(backend *personWorkerBackend) { backend.upsertErr = vector.ErrGenerationRetired }},
+		{name: "reconcile", prepare: func(backend *personWorkerBackend) {
+			backend.revisions[9] = map[int64]string{1: document.Revision}
+			backend.deleteErr = vector.ErrGenerationRetired
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backend := newPersonWorkerBackend()
+			test.prepare(backend)
+			worker := newTestPersonWorker(
+				newPersonWorkerSource(document), backend, &personWorkerClient{}, 8,
+			)
+			_, err := worker.RunOnce(t.Context(), 9)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestPersonWorkerReconcilesDeletedPeople catches orphaned person vectors
+// surviving after their durable source person has been deleted.
+func TestPersonWorkerReconcilesDeletedPeople(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-1", "Synthetic One"),
+		personDocument(2, "rev-2", "Synthetic Two"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	worker := newTestPersonWorker(source, backend, client, 8)
+	_, err := worker.RunOnce(t.Context(), 9)
+	must.NoError(err)
+
+	source.delete(1)
+	result, err := worker.RunOnce(t.Context(), 9)
+	must.NoError(err)
+	check.Zero(result.Claimed)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 9)
+	must.NoError(err)
+	check.Equal(map[int64]string{2: "rev-2"}, revisions)
+	check.Len(client.calls, 1, "deletion reconciliation must not call the provider")
+}
+
+// TestPersonWorkerDiscardsPostEmbedMutation catches publication of a provider
+// response generated from a revision that changed during the request.
+func TestPersonWorkerDiscardsPostEmbedMutation(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(1, "rev-old", "Synthetic Before"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	client.onEmbed = func() {
+		source.put(personDocument(1, "rev-new", "Synthetic After"))
+		client.mu.Lock()
+		client.onEmbed = nil
+		client.mu.Unlock()
+	}
+	worker := newTestPersonWorker(source, backend, client, 8)
+
+	result, err := worker.RunOnce(t.Context(), 10)
+	must.NoError(err)
+	check.Equal(1, result.Claimed)
+	check.Zero(result.Succeeded)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 10)
+	must.NoError(err)
+	check.Empty(revisions, "stale provider response must not be published")
+
+	result, err = worker.RunOnce(t.Context(), 10)
+	must.NoError(err)
+	check.Equal(1, result.Succeeded)
+	revisions, err = backend.ListPersonRevisions(t.Context(), 10)
+	must.NoError(err)
+	check.Equal(map[int64]string{1: "rev-new"}, revisions)
+}
+
+// TestPersonWorkerPersistsPartialPrefixAndRetriesOnlyRemainder catches a
+// worker that drops successful provider-prefix results or re-embeds them on
+// retry after a later document fails.
+func TestPersonWorkerPersistsPartialPrefixAndRetriesOnlyRemainder(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-1", "Synthetic One"),
+		personDocument(2, "rev-2", "Synthetic Two"),
+		personDocument(3, "rev-3", "Synthetic Three"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{failOnceAfter: 2}
+	worker := newTestPersonWorker(source, backend, client, 3)
+
+	result, err := worker.RunOnce(t.Context(), 11)
+	must.ErrorContains(err, "synthetic provider interruption")
+	check.Equal(3, result.Claimed)
+	check.Equal(2, result.Succeeded)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 11)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{1: "rev-1", 2: "rev-2"}, revisions)
+
+	result, err = worker.RunOnce(t.Context(), 11)
+	must.NoError(err)
+	check.Equal(1, result.Claimed)
+	check.Equal(1, result.Succeeded)
+	must.Len(client.calls, 2)
+	check.Equal([][]string{{"Synthetic Three"}}, client.calls[1])
+	revisions, listErr = backend.ListPersonRevisions(t.Context(), 11)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{1: "rev-1", 2: "rev-2", 3: "rev-3"}, revisions)
+}
+
+// TestPersonWorkerPartialErrorCountsReturnedFencedDocuments catches result
+// accounting that drops provider responses rejected by the source fence.
+func TestPersonWorkerPartialErrorCountsReturnedFencedDocuments(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-old", "Synthetic Before"),
+		personDocument(2, "rev-2", "Synthetic Two"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{failOnceAfter: 2}
+	client.onEmbed = func() {
+		source.put(personDocument(1, "rev-new", "Synthetic After"))
+	}
+	worker := newTestPersonWorker(source, backend, client, 2)
+
+	result, err := worker.RunOnce(t.Context(), 12)
+	must.ErrorContains(err, "synthetic provider interruption")
+	check.Equal(2, result.Claimed)
+	check.Equal(1, result.Succeeded)
+	check.Equal(1, result.Failed)
+	check.Equal(result.Claimed, result.Succeeded+result.Failed)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 12)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{2: "rev-2"}, revisions)
+}
+
+func TestPersonWorkerAccountsMalformedProviderBatchAsFailed(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+	)
+	backend := newPersonWorkerBackend()
+	worker := newTestPersonWorker(source, backend, &personWorkerClient{malformed: true}, 2)
+
+	result, err := worker.RunOnce(t.Context(), 12)
+	must.ErrorContains(err, "returned 0 results for 2 inputs")
+	check.Equal(RunResult{Claimed: 2, Failed: 2}, result)
+}
+
+func TestPersonWorkerAccountsBackendWriteFailure(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-one", "Synthetic One"),
+		personDocument(2, "rev-two", "Synthetic Two"),
+	)
+	backend := newPersonWorkerBackend()
+	backend.upsertErr = errors.New("synthetic backend failure")
+	worker := newTestPersonWorker(source, backend, &personWorkerClient{}, 2)
+
+	result, err := worker.RunOnce(t.Context(), 12)
+	must.ErrorContains(err, "synthetic backend failure")
+	check.Equal(RunResult{Claimed: 2, Failed: 2}, result)
+}
+
+// TestPersonWorkerEarlyBatchErrorContinuesLaterBatches catches one failed
+// document starving unrelated later batches. The retry processes only the
+// unpublished document.
+func TestPersonWorkerEarlyBatchErrorContinuesLaterBatches(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(
+		personDocument(1, "rev-1", "Synthetic One"),
+		personDocument(2, "rev-2", "Synthetic Two"),
+		personDocument(3, "rev-3", "Synthetic Three"),
+		personDocument(4, "rev-4", "Synthetic Four"),
+	)
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{failOnceAfter: 1}
+	worker := newTestPersonWorker(source, backend, client, 2)
+
+	result, err := worker.RunOnce(t.Context(), 13)
+	must.ErrorContains(err, "synthetic provider interruption")
+	check.Equal(RunResult{Claimed: 4, Succeeded: 3, Failed: 1}, result)
+	check.Equal(result.Claimed, result.Succeeded+result.Failed)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 13)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{1: "rev-1", 3: "rev-3", 4: "rev-4"}, revisions)
+	must.Len(client.calls, 2)
+	check.Equal([][]string{{"Synthetic One"}, {"Synthetic Two"}}, client.calls[0])
+	check.Equal([][]string{{"Synthetic Three"}, {"Synthetic Four"}}, client.calls[1])
+
+	result, err = worker.RunOnce(t.Context(), 13)
+	must.NoError(err)
+	check.Equal(RunResult{Claimed: 1, Succeeded: 1}, result)
+	revisions, listErr = backend.ListPersonRevisions(t.Context(), 13)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{
+		1: "rev-1", 2: "rev-2", 3: "rev-3", 4: "rev-4",
+	}, revisions)
+	must.Len(client.calls, 3)
+	check.Equal([][]string{{"Synthetic Two"}}, client.calls[2])
+}
+
+type personWorkerMessageRunner struct {
+	runOnce        []vector.GenerationID
+	runBackstop    []vector.GenerationID
+	runOnceResult  *RunResult
+	runOnceErr     error
+	runBackstopErr error
+}
+
+func (r *personWorkerMessageRunner) RunOnce(
+	_ context.Context, gen vector.GenerationID,
+) (RunResult, error) {
+	r.runOnce = append(r.runOnce, gen)
+	if r.runOnceResult != nil {
+		return *r.runOnceResult, r.runOnceErr
+	}
+	return RunResult{Claimed: 2, Succeeded: 2}, r.runOnceErr
+}
+
+func (r *personWorkerMessageRunner) RunBackstop(_ context.Context, gen vector.GenerationID) (RunResult, error) {
+	r.runBackstop = append(r.runBackstop, gen)
+	return RunResult{}, r.runBackstopErr
+}
+
+func (r *personWorkerMessageRunner) ReclaimStale(context.Context) (int, error) { return 0, nil }
+
+// TestGenerationWorkerMaintainsPeopleForAnActiveGeneration catches runtime
+// composition that drains only message work when the scheduler targets an
+// already-active generation.
+func TestGenerationWorkerMaintainsPeopleForAnActiveGeneration(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(5, "rev-active", "Synthetic Active"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	messages := &personWorkerMessageRunner{}
+	worker := NewGenerationWorker(messages, newTestPersonWorker(source, backend, client, 8))
+
+	result, err := worker.RunOnce(t.Context(), 42)
+	must.NoError(err)
+	check.Equal([]vector.GenerationID{42}, messages.runOnce)
+	check.Equal(3, result.Claimed)
+	check.Equal(3, result.Succeeded)
+	revisions, err := backend.ListPersonRevisions(t.Context(), 42)
+	must.NoError(err)
+	check.Equal(map[int64]string{5: "rev-active"}, revisions)
+}
+
+// TestGenerationWorkerMaintainsPeopleWhenMessageRunFails catches an active
+// generation's person upkeep being skipped after a message-side error.
+func TestGenerationWorkerMaintainsPeopleWhenMessageRunFails(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	messageErr := errors.New("synthetic message failure")
+	source := newPersonWorkerSource(personDocument(6, "rev-active", "Synthetic Active"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	messages := &personWorkerMessageRunner{runOnceErr: messageErr}
+	worker := NewGenerationWorker(messages, newTestPersonWorker(source, backend, client, 8))
+
+	result, err := worker.RunOnce(t.Context(), 43)
+	must.ErrorIs(err, messageErr)
+	check.Equal([]vector.GenerationID{43}, messages.runOnce)
+	check.Equal(RunResult{Claimed: 3, Succeeded: 3}, result)
+	revisions, listErr := backend.ListPersonRevisions(t.Context(), 43)
+	must.NoError(listErr)
+	check.Equal(map[int64]string{6: "rev-active"}, revisions)
+}
+
+func TestGenerationWorkerScansPeopleOnlyAtContextualBuildBoundaries(t *testing.T) {
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(7, "rev-one", "Synthetic One"))
+	backend := newPersonWorkerBackend()
+	backend.building = &vector.Generation{ID: 44}
+	client := &personWorkerClient{}
+	messages := &personWorkerMessageRunner{runOnceResult: &RunResult{
+		Contextual: &ContextConvergence{Converged: false},
+	}}
+	worker := NewGenerationWorker(messages, newTestPersonWorker(source, backend, client, 8))
+
+	_, err := worker.RunOnce(t.Context(), 44)
+	must.NoError(err)
+	source.put(personDocument(7, "rev-two", "Synthetic Two"))
+	_, err = worker.RunOnce(t.Context(), 44)
+	must.NoError(err)
+	must.Len(client.calls, 1, "intermediate contextual pass must skip an unchanged corpus scan")
+
+	messages.runOnceResult.Contextual.Converged = true
+	_, err = worker.RunOnce(t.Context(), 44)
+	must.NoError(err)
+	must.Len(client.calls, 2, "final contextual pass must recheck the person corpus")
+}
+
+func TestGenerationWorkerMaintainsActivePeopleDuringContextualFailures(t *testing.T) {
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(7, "rev-one", "Synthetic One"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	messages := &personWorkerMessageRunner{runOnceResult: &RunResult{
+		Failed: 1, Contextual: &ContextConvergence{Converged: false},
+	}}
+	worker := NewGenerationWorker(messages, newTestPersonWorker(source, backend, client, 8))
+
+	_, err := worker.RunOnce(t.Context(), 45)
+	must.NoError(err)
+	source.put(personDocument(7, "rev-two", "Synthetic Two"))
+	_, err = worker.RunOnce(t.Context(), 45)
+	must.NoError(err)
+	must.Len(client.calls, 2, "active generations must reconcile people on every scheduler tick")
+}
+
+func TestGenerationWorkerBackstopMaintainsPeople(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	source := newPersonWorkerSource(personDocument(8, "rev-backstop", "Synthetic Backstop"))
+	backend := newPersonWorkerBackend()
+	client := &personWorkerClient{}
+	messages := &personWorkerMessageRunner{}
+	worker := NewGenerationWorker(messages, newTestPersonWorker(source, backend, client, 8))
+
+	result, err := worker.RunBackstop(t.Context(), 45)
+	must.NoError(err)
+	check.Equal([]vector.GenerationID{45}, messages.runBackstop)
+	check.Equal(RunResult{Claimed: 1, Succeeded: 1}, result)
+}

--- a/internal/vector/embed/request_gate.go
+++ b/internal/vector/embed/request_gate.go
@@ -1,0 +1,56 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// ErrEmbeddingProviderRedirect classifies redirects rejected by a gated
+// embeddings client. Redirect responses are permanent policy failures and are
+// never retried or followed.
+var ErrEmbeddingProviderRedirect = errors.New("embedding provider redirects are not allowed")
+
+// BeforeRequestFunc authorizes one concrete HTTP attempt. It runs from the
+// transport boundary, so retries and provider-specific request packing each
+// receive a fresh check. Clients with a BeforeRequestFunc reject redirects.
+type BeforeRequestFunc func(context.Context) error
+
+type beforeRequestTransport struct {
+	base   http.RoundTripper
+	before BeforeRequestFunc
+}
+
+type beforeRequestError struct{ err error }
+
+func (e *beforeRequestError) Error() string { return e.err.Error() }
+func (e *beforeRequestError) Unwrap() error { return e.err }
+
+func (t beforeRequestTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if err := t.before(request.Context()); err != nil {
+		return nil, &beforeRequestError{err: err}
+	}
+	return t.base.RoundTrip(request)
+}
+
+func newHTTPClient(timeout time.Duration, before BeforeRequestFunc) *http.Client {
+	client := &http.Client{Timeout: timeout}
+	if before != nil {
+		client.Transport = beforeRequestTransport{
+			base: http.DefaultTransport, before: before,
+		}
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+	return client
+}
+
+func beforeRequestCause(err error) error {
+	var requestErr *beforeRequestError
+	if !errors.As(err, &requestErr) {
+		return nil
+	}
+	return requestErr.err
+}

--- a/internal/vector/embed/voyage.go
+++ b/internal/vector/embed/voyage.go
@@ -21,6 +21,9 @@ type VoyageConfig struct {
 	Timeout    time.Duration
 	MaxRetries int
 	Limits     RequestLimits
+	// BeforeRequest reauthorizes each concrete HTTP attempt. A returned error
+	// is propagated without retrying. Nil leaves the client ungated.
+	BeforeRequest BeforeRequestFunc
 }
 
 // VoyageClient calls Voyage's nested contextualized embeddings endpoint.
@@ -47,7 +50,7 @@ func NewVoyageClient(cfg VoyageConfig) *VoyageClient {
 		cfg.Limits.MaxUTF8Bytes = defaultVoyageRequestLimits.MaxUTF8Bytes
 	}
 	cfg.Limits = capVoyageRequestLimits(cfg.Limits)
-	return &VoyageClient{cfg: cfg, http: &http.Client{Timeout: cfg.Timeout}}
+	return &VoyageClient{cfg: cfg, http: newHTTPClient(cfg.Timeout, cfg.BeforeRequest)}
 }
 
 type voyageRequest struct {
@@ -190,10 +193,16 @@ func (c *VoyageClient) doVoyageOnce(ctx context.Context, body []byte, inputs [][
 
 	resp, err := c.http.Do(req)
 	if err != nil {
+		if authorizationErr := beforeRequestCause(err); authorizationErr != nil {
+			return nil, authorizationErr
+		}
 		return nil, &retryError{err: fmt.Errorf("voyage HTTP request: %w", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+		return nil, ErrEmbeddingProviderRedirect
+	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		retryAfter, ok := parseRetryAfter(resp.Header.Get("Retry-After"))
 		return nil, &retryError{

--- a/internal/vector/embed/voyage_test.go
+++ b/internal/vector/embed/voyage_test.go
@@ -21,8 +21,35 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/embed"
 )
+
+type voyageRequestConsentState struct{ active atomic.Bool }
+
+func (s *voyageRequestConsentState) HasActivePersonSemanticEmbeddingConsent(
+	context.Context, string,
+) (bool, error) {
+	return s.active.Load(), nil
+}
+
+func newVoyageSemanticRequestGate() (*voyageRequestConsentState, vector.SemanticPersonEmbeddingGate) {
+	consent := &voyageRequestConsentState{}
+	consent.active.Store(true)
+	config := vector.Config{
+		Enabled: true,
+		Embeddings: vector.EmbeddingsConfig{
+			Endpoint: "https://embedding.example.test/v1", APIFormat: vector.APIFormatVoyageContextual,
+			Model: "voyage-context-4", Dimension: 4,
+		},
+		People: vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		},
+	}
+	return consent, vector.NewExactSemanticPersonEmbeddingGate(
+		func() (vector.Config, error) { return config, nil }, consent,
+	)
+}
 
 type capturedVoyageRequest struct {
 	Path               string     `json:"-"`
@@ -505,6 +532,171 @@ func TestVoyageClient_LaterPackedRequestReturnsSuccessfulPrefix(t *testing.T) {
 		"the caller needs the successful prefix to avoid repeating a billed request")
 }
 
+// TestVoyageClientBeforeRequestFencesLaterPackedRequest catches a gate that is
+// checked only once around EmbedDocuments. Voyage may split one logical call
+// into several provider requests, and each packed request needs fresh
+// authorization.
+func TestVoyageClientBeforeRequestFencesLaterPackedRequest(t *testing.T) {
+	var requests atomic.Int32
+	consent, gate := newVoyageSemanticRequestGate()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := decodeVoyageRequest(t, r)
+		requests.Add(1)
+		consent.active.Store(false)
+		writeVoyageResponse(t, w, sequentialVoyageResults(request.Inputs))
+	}))
+	t.Cleanup(server.Close)
+
+	got, err := newVoyageClient(server.URL, func(cfg *embed.VoyageConfig) {
+		cfg.MaxRetries = 1
+		cfg.Limits.MaxDocuments = 1
+		cfg.BeforeRequest = gate.Check
+	}).EmbedDocuments(t.Context(), []embed.DocumentInput{
+		{Chunks: []string{"first curated person"}},
+		{Chunks: []string{"second curated person"}},
+	})
+
+	require.ErrorIs(t, err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	assert.Equal(t, int32(1), requests.Load(),
+		"policy removal after the first packed request must fence the second")
+	assert.Equal(t, [][][]float32{{{1, 1, 1, 1}}}, got,
+		"the authorized successful prefix remains available to the caller")
+}
+
+// TestVoyageClientBeforeRequestRejectsProviderRedirects catches gated person
+// clients that let net/http replay nested document or query input to a
+// provider-selected URL.
+func TestVoyageClientBeforeRequestRejectsProviderRedirects(t *testing.T) {
+	operations := []struct {
+		name    string
+		wantErr string
+		run     func(context.Context, *embed.VoyageClient) error
+	}{
+		{
+			name:    "documents",
+			wantErr: "embedding provider redirects are not allowed",
+			run: func(ctx context.Context, client *embed.VoyageClient) error {
+				_, err := client.EmbedDocuments(ctx, []embed.DocumentInput{{Chunks: []string{"curated person"}}})
+				return err
+			},
+		},
+		{
+			name:    "query",
+			wantErr: "embed query: embedding provider redirects are not allowed",
+			run: func(ctx context.Context, client *embed.VoyageClient) error {
+				_, err := client.EmbedQuery(ctx, "curated person query")
+				return err
+			},
+		},
+	}
+	statuses := []struct {
+		name string
+		code int
+	}{
+		{name: "307", code: http.StatusTemporaryRedirect},
+		{name: "308", code: http.StatusPermanentRedirect},
+	}
+	destinations := []struct {
+		name        string
+		crossOrigin bool
+	}{
+		{name: "same_origin"},
+		{name: "cross_origin", crossOrigin: true},
+	}
+
+	for _, operation := range operations {
+		for _, status := range statuses {
+			for _, destination := range destinations {
+				t.Run(operation.name+"/"+status.name+"/"+destination.name, func(t *testing.T) {
+					var originRequests atomic.Int32
+					var targetRequests atomic.Int32
+					redirectLocation := "/redirected"
+					if destination.crossOrigin {
+						target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+							targetRequests.Add(1)
+							writeVoyageResponse(t, w, sequentialVoyageResults([][]string{{"redirected"}}))
+						}))
+						t.Cleanup(target.Close)
+						redirectLocation = target.URL + "/redirected"
+					}
+					origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						switch r.URL.Path {
+						case "/contextualizedembeddings":
+							originRequests.Add(1)
+							w.Header().Set("Location", redirectLocation)
+							w.WriteHeader(status.code)
+						case "/redirected":
+							targetRequests.Add(1)
+							writeVoyageResponse(t, w, sequentialVoyageResults([][]string{{"redirected"}}))
+						default:
+							http.NotFound(w, r)
+						}
+					}))
+					t.Cleanup(origin.Close)
+					_, gate := newVoyageSemanticRequestGate()
+					client := newVoyageClient(origin.URL, func(cfg *embed.VoyageConfig) {
+						cfg.MaxRetries = 3
+						cfg.BeforeRequest = gate.Check
+					})
+
+					err := operation.run(t.Context(), client)
+
+					assert := assert.New(t)
+					require.ErrorIs(t, err, embed.ErrEmbeddingProviderRedirect)
+					assert.Equal(operation.wantErr, err.Error())
+					assert.Equal(int32(1), originRequests.Load(), "redirect responses must not be retried")
+					assert.Zero(targetRequests.Load(), "person text must not reach the redirect target")
+				})
+			}
+		}
+	}
+}
+
+// TestVoyageClientWithoutBeforeRequestFollowsProviderRedirects protects the
+// message client composition, which intentionally retains default redirects.
+func TestVoyageClientWithoutBeforeRequestFollowsProviderRedirects(t *testing.T) {
+	for _, status := range []struct {
+		name string
+		code int
+	}{
+		{name: "307", code: http.StatusTemporaryRedirect},
+		{name: "308", code: http.StatusPermanentRedirect},
+	} {
+		t.Run(status.name, func(t *testing.T) {
+			var originRequests atomic.Int32
+			var targetRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/contextualizedembeddings":
+					originRequests.Add(1)
+					w.Header().Set("Location", "/redirected")
+					w.WriteHeader(status.code)
+				case "/redirected":
+					targetRequests.Add(1)
+					request := decodeVoyageRequest(t, r)
+					assert.Equal(t, "query", request.InputType)
+					assert.Equal(t, [][]string{{"message query"}}, request.Inputs)
+					writeVoyageResponse(t, w, sequentialVoyageResults(request.Inputs))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(server.Close)
+			client := newVoyageClient(server.URL, func(cfg *embed.VoyageConfig) {
+				cfg.MaxRetries = 1
+			})
+
+			vector, err := client.EmbedQuery(t.Context(), "message query")
+
+			assert := assert.New(t)
+			require.NoError(t, err)
+			assert.Equal([]float32{1, 1, 1, 1}, vector)
+			assert.Equal(int32(1), originRequests.Load())
+			assert.Equal(int32(1), targetRequests.Load())
+		})
+	}
+}
+
 // TestVoyageClient_EmbedQueryUsesQueryRole catches query calls that use the
 // document role or the flat /embeddings request shape.
 func TestVoyageClient_EmbedQueryUsesQueryRole(t *testing.T) {
@@ -762,6 +954,29 @@ func TestVoyageClient_RetriesTransientResponses(t *testing.T) {
 			assert.Equal(t, int32(2), attempts.Load())
 		})
 	}
+}
+
+// TestVoyageClientBeforeRequestFencesQueryRetry covers the query-role retry
+// path separately from packed document calls.
+func TestVoyageClientBeforeRequestFencesQueryRetry(t *testing.T) {
+	var requests atomic.Int32
+	consent, gate := newVoyageSemanticRequestGate()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		consent.active.Store(false)
+		w.Header().Set("Retry-After", "0")
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := newVoyageClient(server.URL, func(cfg *embed.VoyageConfig) {
+		cfg.MaxRetries = 3
+		cfg.BeforeRequest = gate.Check
+	}).EmbedQuery(t.Context(), "curated person query")
+
+	require.ErrorIs(t, err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	assert.Equal(t, int32(1), requests.Load(),
+		"revocation after the first 429 must fence the Voyage query retry")
 }
 
 func TestVoyageClient_ContextCancellationStopsRetryBackoff(t *testing.T) {

--- a/internal/vector/person.go
+++ b/internal/vector/person.go
@@ -1,0 +1,19 @@
+package vector
+
+// PersonEmbedding is one complete person document publication. Revision is
+// the exact digest of the curated text. An empty Vector records a terminal,
+// provider-rejected revision without making the person searchable.
+type PersonEmbedding struct {
+	PersonID int64
+	Revision string
+	Vector   []float32
+}
+
+// PersonHit is one person-owned ANN result. Revision lets callers revalidate
+// the hit against the current store projection before returning it.
+type PersonHit struct {
+	PersonID int64
+	Revision string
+	Score    float64
+	Rank     int
+}

--- a/internal/vector/person_gate.go
+++ b/internal/vector/person_gate.go
@@ -1,0 +1,150 @@
+package vector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrSemanticPersonEmbeddingsDisabled reports the explicit default-off
+	// configuration boundary before any curated text reaches a provider.
+	ErrSemanticPersonEmbeddingsDisabled = errors.New(
+		"semantic person embeddings require [vector.people] enabled = true",
+	)
+	// ErrSemanticPersonEmbeddingConsentRequired reports that the exact current
+	// outbound policy has no active grant.
+	ErrSemanticPersonEmbeddingConsentRequired = errors.New(
+		"semantic person embeddings require active exact consent; run `msgvault person provider consent --semantic-embeddings` to review the current policy",
+	)
+	// ErrSemanticPersonEmbeddingRuntimeStale prevents a newly-consented config
+	// from authorizing a provider client that was initialized under old routing
+	// or model settings.
+	ErrSemanticPersonEmbeddingRuntimeStale = fmt.Errorf(
+		"semantic person embedding provider settings changed; restart to reinitialize the provider client: %w",
+		ErrIndexStale,
+	)
+	// ErrSemanticPersonEmbeddingPolicyUnavailable reports that current
+	// authorization could not be established because the live policy or its
+	// consent source could not be read or validated. Person operations expose
+	// the wrapped cause while message-generation convergence treats person
+	// coverage as not currently required.
+	ErrSemanticPersonEmbeddingPolicyUnavailable = errors.New(
+		"semantic person embedding authorization policy is unavailable",
+	)
+)
+
+// SemanticPersonEmbeddingGate is rechecked immediately before every curated
+// person provider request and before each person search request.
+type SemanticPersonEmbeddingGate interface {
+	Check(ctx context.Context) error
+}
+
+// SemanticPersonEmbeddingGateFunc adapts focused callers and tests.
+type SemanticPersonEmbeddingGateFunc func(context.Context) error
+
+func (f SemanticPersonEmbeddingGateFunc) Check(ctx context.Context) error { return f(ctx) }
+
+// SemanticPersonEmbeddingConsentChecker is the narrow store authority used by
+// the policy gate. *store.Store implements it in a purpose-specific table.
+type SemanticPersonEmbeddingConsentChecker interface {
+	HasActivePersonSemanticEmbeddingConsent(ctx context.Context, fingerprint string) (bool, error)
+}
+
+// SemanticPersonEmbeddingConfigSource returns the current configuration. It
+// must not be a startup snapshot in long-running processes.
+type SemanticPersonEmbeddingConfigSource func() (Config, error)
+
+type exactSemanticPersonEmbeddingGate struct {
+	configSource SemanticPersonEmbeddingConfigSource
+	consents     SemanticPersonEmbeddingConsentChecker
+	initialized  *semanticPersonEmbeddingRuntimeIdentity
+}
+
+type semanticPersonEmbeddingRuntimeIdentity struct {
+	endpoint  string
+	apiFormat EmbeddingAPIFormat
+	model     string
+	apiKeyEnv string
+}
+
+func NewExactSemanticPersonEmbeddingGate(
+	configSource SemanticPersonEmbeddingConfigSource,
+	consents SemanticPersonEmbeddingConsentChecker,
+) SemanticPersonEmbeddingGate {
+	return &exactSemanticPersonEmbeddingGate{configSource: configSource, consents: consents}
+}
+
+// NewPinnedExactSemanticPersonEmbeddingGate additionally binds the live
+// provider client identity. Provider-routing drift fails closed until restart,
+// even if the operator has already granted the new policy.
+func NewPinnedExactSemanticPersonEmbeddingGate(
+	initialized Config,
+	configSource SemanticPersonEmbeddingConfigSource,
+	consents SemanticPersonEmbeddingConsentChecker,
+) SemanticPersonEmbeddingGate {
+	identity := semanticPersonEmbeddingRuntimeIdentityForConfig(initialized)
+	return &exactSemanticPersonEmbeddingGate{
+		configSource: configSource, consents: consents, initialized: &identity,
+	}
+}
+
+func (g *exactSemanticPersonEmbeddingGate) Check(ctx context.Context) error {
+	if g == nil || g.configSource == nil || g.consents == nil {
+		return errors.New("semantic person embedding gate is not configured")
+	}
+	config, err := g.configSource()
+	if err != nil {
+		return fmt.Errorf("%w: read current semantic person embedding policy: %w",
+			ErrSemanticPersonEmbeddingPolicyUnavailable, err)
+	}
+	if !config.Enabled || !config.People.Enabled {
+		return ErrSemanticPersonEmbeddingsDisabled
+	}
+	if g.initialized != nil && *g.initialized != semanticPersonEmbeddingRuntimeIdentityForConfig(config) {
+		return ErrSemanticPersonEmbeddingRuntimeStale
+	}
+	profile, err := config.SemanticPersonEmbeddingProfile()
+	if err != nil {
+		return fmt.Errorf("%w: validate current semantic person embedding policy: %w",
+			ErrSemanticPersonEmbeddingPolicyUnavailable, err)
+	}
+	active, err := g.consents.HasActivePersonSemanticEmbeddingConsent(ctx, profile.Fingerprint)
+	if err != nil {
+		return fmt.Errorf("%w: check semantic person embedding consent: %w",
+			ErrSemanticPersonEmbeddingPolicyUnavailable, err)
+	}
+	if !active {
+		return fmt.Errorf("%w (fingerprint %s)",
+			ErrSemanticPersonEmbeddingConsentRequired, profile.Fingerprint)
+	}
+	return nil
+}
+
+func semanticPersonEmbeddingRuntimeIdentityForConfig(
+	config Config,
+) semanticPersonEmbeddingRuntimeIdentity {
+	return semanticPersonEmbeddingRuntimeIdentity{
+		endpoint:  config.Embeddings.Endpoint,
+		apiFormat: config.Embeddings.EffectiveAPIFormat(),
+		model:     config.Embeddings.Model,
+		apiKeyEnv: config.Embeddings.APIKeyEnv,
+	}
+}
+
+// SemanticPersonEmbeddingInactive reports the expected default/administrative
+// states that should skip person maintenance without failing message work.
+func SemanticPersonEmbeddingInactive(err error) bool {
+	return errors.Is(err, ErrSemanticPersonEmbeddingsDisabled) ||
+		errors.Is(err, ErrSemanticPersonEmbeddingConsentRequired)
+}
+
+// SemanticPersonEmbeddingAuthorizationUnavailable reports every fail-closed
+// state in which current authorization cannot require person coverage from a
+// message generation. Person workers and searches still receive the original
+// error and make no provider request.
+func SemanticPersonEmbeddingAuthorizationUnavailable(err error) bool {
+	return SemanticPersonEmbeddingInactive(err) ||
+		errors.Is(err, ErrSemanticPersonEmbeddingRuntimeStale) ||
+		errors.Is(err, ErrSemanticPersonEmbeddingPolicyUnavailable)
+}

--- a/internal/vector/person_gate_test.go
+++ b/internal/vector/person_gate_test.go
@@ -1,0 +1,207 @@
+package vector
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type semanticPersonConsentSet map[string]bool
+
+func (s semanticPersonConsentSet) HasActivePersonSemanticEmbeddingConsent(
+	_ context.Context, fingerprint string,
+) (bool, error) {
+	return s[fingerprint], nil
+}
+
+// TestExactSemanticPersonGateRequiresOptInAndCurrentConsent catches either
+// half of the two-part privacy gate being treated as sufficient.
+func TestExactSemanticPersonGateRequiresOptInAndCurrentConsent(t *testing.T) {
+	must := require.New(t)
+	current := semanticPersonPolicyTestConfig()
+	current.People.Enabled = false
+	consents := semanticPersonConsentSet{}
+	gate := NewExactSemanticPersonEmbeddingGate(
+		func() (Config, error) { return current, nil }, consents,
+	)
+
+	err := gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingsDisabled)
+	must.ErrorContains(err, "[vector.people] enabled = true")
+
+	current.People.Enabled = true
+	err = gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingConsentRequired)
+
+	profile, err := current.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	consents[profile.Fingerprint] = true
+	must.NoError(gate.Check(t.Context()))
+
+	current.Enabled = false
+	must.ErrorIs(gate.Check(t.Context()), ErrSemanticPersonEmbeddingsDisabled,
+		"disabling the enclosing vector feature must revoke runtime authority")
+}
+
+// TestExactSemanticPersonGateRechecksRevocationAndPolicyDrift catches a
+// startup-only consent cache authorizing later requests under changed policy.
+func TestExactSemanticPersonGateRechecksRevocationAndPolicyDrift(t *testing.T) {
+	must := require.New(t)
+	current := semanticPersonPolicyTestConfig()
+	consents := semanticPersonConsentSet{}
+	profile, err := current.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	consents[profile.Fingerprint] = true
+	gate := NewExactSemanticPersonEmbeddingGate(
+		func() (Config, error) { return current, nil }, consents,
+	)
+	must.NoError(gate.Check(t.Context()))
+
+	current.Embeddings.Model = "policy-drifted-model"
+	err = gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingConsentRequired)
+
+	current.Embeddings.Model = profile.Model
+	consents[profile.Fingerprint] = false
+	err = gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingConsentRequired)
+}
+
+// TestExactSemanticPersonGateRejectsConsentForProfileWithoutQueryDisclosure
+// catches an active grant for the pre-query-disclosure policy authorizing the
+// expanded current egress policy.
+func TestExactSemanticPersonGateRejectsConsentForProfileWithoutQueryDisclosure(t *testing.T) {
+	must := require.New(t)
+	current := semanticPersonPolicyTestConfig()
+	historical := historicalSemanticPersonEmbeddingProfile(t)
+	currentProfile, err := current.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	must.NotEqual(historical.Fingerprint, currentProfile.Fingerprint)
+
+	consents := semanticPersonConsentSet{historical.Fingerprint: true}
+	gate := NewExactSemanticPersonEmbeddingGate(
+		func() (Config, error) { return current, nil }, consents,
+	)
+	err = gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingConsentRequired)
+	must.ErrorContains(err, currentProfile.Fingerprint)
+
+	consents[currentProfile.Fingerprint] = true
+	must.NoError(gate.Check(t.Context()))
+}
+
+// TestPinnedSemanticPersonGateRejectsProviderDriftEvenAfterNewConsent catches
+// a restarted-policy grant authorizing the still-running old provider client.
+func TestPinnedSemanticPersonGateRejectsProviderDriftEvenAfterNewConsent(t *testing.T) {
+	must := require.New(t)
+	initialized := semanticPersonPolicyTestConfig()
+	current := initialized
+	consents := semanticPersonConsentSet{}
+	initialProfile, err := initialized.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	consents[initialProfile.Fingerprint] = true
+	gate := NewPinnedExactSemanticPersonEmbeddingGate(
+		initialized, func() (Config, error) { return current, nil }, consents,
+	)
+	must.NoError(gate.Check(t.Context()))
+
+	current.Embeddings.Model = "newly-configured-model"
+	newProfile, err := current.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	consents[newProfile.Fingerprint] = true
+	err = gate.Check(t.Context())
+	must.ErrorIs(err, ErrSemanticPersonEmbeddingRuntimeStale)
+	must.ErrorIs(err, ErrIndexStale)
+}
+
+func TestExactSemanticPersonGateFailsClosedOnPolicySourceError(t *testing.T) {
+	gate := NewExactSemanticPersonEmbeddingGate(
+		func() (Config, error) { return Config{}, errors.New("synthetic config read") },
+		semanticPersonConsentSet{},
+	)
+	err := gate.Check(t.Context())
+	require.ErrorContains(t, err, "synthetic config read")
+	require.ErrorIs(t, err, ErrSemanticPersonEmbeddingPolicyUnavailable)
+	assert.True(t, SemanticPersonEmbeddingAuthorizationUnavailable(err))
+}
+
+type failingSemanticPersonConsentChecker struct{ err error }
+
+func (c failingSemanticPersonConsentChecker) HasActivePersonSemanticEmbeddingConsent(
+	context.Context, string,
+) (bool, error) {
+	return false, c.err
+}
+
+// TestSemanticPersonEmbeddingAuthorizationUnavailableClassifiesEveryPolicyState
+// defines the boundary used by convergence: message generations do not need
+// person coverage when current authorization cannot be established, while the
+// gate still returns the precise error to person workers and searches.
+func TestSemanticPersonEmbeddingAuthorizationUnavailableClassifiesEveryPolicyState(t *testing.T) {
+	valid := semanticPersonPolicyTestConfig()
+	profile, err := valid.SemanticPersonEmbeddingProfile()
+	require.NoError(t, err)
+	consented := semanticPersonConsentSet{profile.Fingerprint: true}
+
+	drifted := valid
+	drifted.Embeddings.Endpoint = "https://drifted.example.test/v1"
+	invalid := valid
+	invalid.Embeddings.Model = ""
+
+	tests := []struct {
+		name string
+		gate SemanticPersonEmbeddingGate
+	}{
+		{
+			name: "disabled",
+			gate: NewExactSemanticPersonEmbeddingGate(
+				func() (Config, error) { return Config{}, nil }, consented,
+			),
+		},
+		{
+			name: "unconsented",
+			gate: NewExactSemanticPersonEmbeddingGate(
+				func() (Config, error) { return valid, nil }, semanticPersonConsentSet{},
+			),
+		},
+		{
+			name: "runtime drift",
+			gate: NewPinnedExactSemanticPersonEmbeddingGate(
+				valid, func() (Config, error) { return drifted, nil }, consented,
+			),
+		},
+		{
+			name: "invalid live policy",
+			gate: NewExactSemanticPersonEmbeddingGate(
+				func() (Config, error) { return invalid, nil }, consented,
+			),
+		},
+		{
+			name: "config source unavailable",
+			gate: NewExactSemanticPersonEmbeddingGate(
+				func() (Config, error) { return Config{}, errors.New("synthetic source unavailable") }, consented,
+			),
+		},
+		{
+			name: "consent source unavailable",
+			gate: NewExactSemanticPersonEmbeddingGate(
+				func() (Config, error) { return valid, nil },
+				failingSemanticPersonConsentChecker{err: errors.New("synthetic consent store unavailable")},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.gate.Check(t.Context())
+			require.Error(t, err)
+			assert.True(t, SemanticPersonEmbeddingAuthorizationUnavailable(err), err.Error())
+		})
+	}
+	assert.False(t, SemanticPersonEmbeddingAuthorizationUnavailable(errors.New("unrelated failure")))
+}
+
+var _ SemanticPersonEmbeddingConsentChecker = semanticPersonConsentSet{}

--- a/internal/vector/person_policy.go
+++ b/internal/vector/person_policy.go
@@ -1,0 +1,305 @@
+package vector
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+const (
+	// SemanticPersonEmbeddingPurpose is deliberately distinct from the
+	// people-sweep inference purpose. Consent to either policy cannot authorize
+	// the other.
+	SemanticPersonEmbeddingPurpose = "semantic_person_embeddings"
+	// SemanticPersonCorpusAllDurablePeople records that message embedding scope
+	// is not applicable to curated people.
+	SemanticPersonCorpusAllDurablePeople = "all_durable_people"
+	// SemanticPersonRendererPolicy changes whenever the canonical curated
+	// person document changes.
+	SemanticPersonRendererPolicy = "person-semantic-v1"
+	// SemanticPersonSearchQueryDisclosedFieldClass records that caller-supplied
+	// free text is sent to the provider for semantic person search.
+	SemanticPersonSearchQueryDisclosedFieldClass = "caller_supplied_free_text_query_for_semantic_person_search"
+)
+
+var semanticPersonEnvironmentNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+var semanticPersonDisclosedFieldClasses = []string{
+	"active_relationship_counterpart_labels_and_display_names",
+	SemanticPersonSearchQueryDisclosedFieldClass,
+	"current_employment_title_role_department_location_description",
+	"current_organization_alternate_names_categories_description_domain_kind",
+	"current_organization_coarse_locations",
+	"current_organization_name",
+	"person_alternate_names",
+	"person_categories",
+	"person_coarse_locations",
+	"person_display_name",
+	"person_searchable_non_sensitive_custom_attributes_excluding_email_phone_date_timestamp",
+}
+
+// PeopleConfig is the separate, default-off policy switch for curated person
+// embeddings under [vector.people]. Provider posture assertions are part of
+// exact consent rather than operational embedding settings.
+type PeopleConfig struct {
+	Enabled          bool   `toml:"enabled"`
+	RetentionPosture string `toml:"retention_posture"`
+	TrainingPosture  string `toml:"training_posture"`
+}
+
+// SemanticPersonEmbeddingProfile is one immutable, canonical outbound-data
+// policy. PolicyJSON and Fingerprint never contain a credential value.
+type SemanticPersonEmbeddingProfile struct {
+	Fingerprint           string             `json:"fingerprint"`
+	Purpose               string             `json:"purpose"`
+	Destination           string             `json:"destination"`
+	APIFormat             EmbeddingAPIFormat `json:"api_format"`
+	Model                 string             `json:"model"`
+	APIKeyEnv             string             `json:"api_key_env"`
+	RetentionPosture      string             `json:"retention_posture"`
+	TrainingPosture       string             `json:"training_posture"`
+	RendererPolicy        string             `json:"renderer_policy"`
+	DisclosedFieldClasses []string           `json:"disclosed_field_classes"`
+	CorpusScope           string             `json:"corpus_scope"`
+	PolicyJSON            json.RawMessage    `json:"-"`
+}
+
+type semanticPersonEmbeddingPolicy struct {
+	Purpose               string             `json:"purpose"`
+	Destination           string             `json:"destination"`
+	APIFormat             EmbeddingAPIFormat `json:"api_format"`
+	Model                 string             `json:"model"`
+	APIKeyEnv             string             `json:"api_key_env"`
+	RetentionPosture      string             `json:"retention_posture"`
+	TrainingPosture       string             `json:"training_posture"`
+	RendererPolicy        string             `json:"renderer_policy"`
+	DisclosedFieldClasses []string           `json:"disclosed_field_classes"`
+	CorpusScope           string             `json:"corpus_scope"`
+}
+
+// SemanticPersonDisclosedFieldClasses returns the stable explicit outbound
+// data-class disclosure in canonical order.
+func SemanticPersonDisclosedFieldClasses() []string {
+	return slices.Clone(semanticPersonDisclosedFieldClasses)
+}
+
+// SemanticPersonEmbeddingProfile returns the exact current curated-person
+// egress policy. Enablement is checked separately by the runtime gate so a
+// disabled but still fully configured policy remains auditable and revocable.
+func (c *Config) SemanticPersonEmbeddingProfile() (SemanticPersonEmbeddingProfile, error) {
+	policy, err := semanticPersonEmbeddingPolicyForConfig(*c)
+	if err != nil {
+		return SemanticPersonEmbeddingProfile{}, err
+	}
+	return newSemanticPersonEmbeddingProfile(policy)
+}
+
+func semanticPersonEmbeddingPolicyForConfig(c Config) (semanticPersonEmbeddingPolicy, error) {
+	format := c.Embeddings.EffectiveAPIFormat()
+	endpoint := c.Embeddings.Endpoint
+	if endpoint != strings.TrimSpace(endpoint) {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding endpoint must not have surrounding whitespace",
+		)
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return semanticPersonEmbeddingPolicy{}, fmt.Errorf(
+			"vector.people: embedding destination must be an absolute HTTP(S) URL (got %q)",
+			c.Embeddings.Endpoint,
+		)
+	}
+	if parsed.User != nil {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding destination must not contain credentials",
+		)
+	}
+	if parsed.RawQuery != "" {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding endpoint must not contain a query",
+		)
+	}
+	if parsed.Fragment != "" {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding endpoint must not contain a fragment",
+		)
+	}
+	model := c.Embeddings.Model
+	if model != strings.TrimSpace(model) {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding model must not have surrounding whitespace",
+		)
+	}
+	apiKeyEnv := c.Embeddings.APIKeyEnv
+	if apiKeyEnv != strings.TrimSpace(apiKeyEnv) {
+		return semanticPersonEmbeddingPolicy{}, errors.New(
+			"vector.people: embedding api_key_env must not have surrounding whitespace",
+		)
+	}
+	destination := endpoint + "/embeddings"
+	if format == APIFormatVoyageContextual {
+		destination = strings.TrimRight(endpoint, "/") + "/contextualizedembeddings"
+	}
+	return semanticPersonEmbeddingPolicy{
+		Purpose:               SemanticPersonEmbeddingPurpose,
+		Destination:           destination,
+		APIFormat:             format,
+		Model:                 model,
+		APIKeyEnv:             apiKeyEnv,
+		RetentionPosture:      strings.TrimSpace(c.People.RetentionPosture),
+		TrainingPosture:       strings.TrimSpace(c.People.TrainingPosture),
+		RendererPolicy:        SemanticPersonRendererPolicy,
+		DisclosedFieldClasses: SemanticPersonDisclosedFieldClasses(),
+		CorpusScope:           SemanticPersonCorpusAllDurablePeople,
+	}, nil
+}
+
+func newSemanticPersonEmbeddingProfile(
+	policy semanticPersonEmbeddingPolicy,
+) (SemanticPersonEmbeddingProfile, error) {
+	policy.Purpose = strings.TrimSpace(policy.Purpose)
+	policy.Destination = strings.TrimSpace(policy.Destination)
+	policy.Model = strings.TrimSpace(policy.Model)
+	policy.APIKeyEnv = strings.TrimSpace(policy.APIKeyEnv)
+	policy.RetentionPosture = strings.TrimSpace(policy.RetentionPosture)
+	policy.TrainingPosture = strings.TrimSpace(policy.TrainingPosture)
+	policy.RendererPolicy = strings.TrimSpace(policy.RendererPolicy)
+	policy.CorpusScope = strings.TrimSpace(policy.CorpusScope)
+	policy.DisclosedFieldClasses = slices.Clone(policy.DisclosedFieldClasses)
+	slices.Sort(policy.DisclosedFieldClasses)
+	if err := validateSemanticPersonEmbeddingPolicy(policy); err != nil {
+		return SemanticPersonEmbeddingProfile{}, err
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return SemanticPersonEmbeddingProfile{}, fmt.Errorf(
+			"encode semantic person embedding policy: %w", err,
+		)
+	}
+	digest := sha256.Sum256(policyJSON)
+	return SemanticPersonEmbeddingProfile{
+		Fingerprint:           hex.EncodeToString(digest[:]),
+		Purpose:               policy.Purpose,
+		Destination:           policy.Destination,
+		APIFormat:             policy.APIFormat,
+		Model:                 policy.Model,
+		APIKeyEnv:             policy.APIKeyEnv,
+		RetentionPosture:      policy.RetentionPosture,
+		TrainingPosture:       policy.TrainingPosture,
+		RendererPolicy:        policy.RendererPolicy,
+		DisclosedFieldClasses: slices.Clone(policy.DisclosedFieldClasses),
+		CorpusScope:           policy.CorpusScope,
+		PolicyJSON:            policyJSON,
+	}, nil
+}
+
+func validateSemanticPersonEmbeddingPolicy(policy semanticPersonEmbeddingPolicy) error {
+	if policy.Purpose == "" {
+		return errors.New("vector.people: semantic embedding purpose is required")
+	}
+	parsed, err := url.Parse(policy.Destination)
+	if err != nil || parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return errors.New("vector.people: effective embedding destination is invalid")
+	}
+	if parsed.User != nil {
+		return errors.New("vector.people: effective embedding destination must not contain credentials")
+	}
+	if parsed.RawQuery != "" {
+		return errors.New("vector.people: effective embedding destination must not contain a query")
+	}
+	if parsed.Fragment != "" {
+		return errors.New("vector.people: effective embedding destination must not contain a fragment")
+	}
+	switch policy.APIFormat {
+	case APIFormatOpenAI, APIFormatVoyageContextual:
+	default:
+		return fmt.Errorf("vector.people: embedding API format %q is invalid", policy.APIFormat)
+	}
+	if policy.Model == "" {
+		return errors.New("vector.people: embedding model is required")
+	}
+	if policy.APIKeyEnv != "" && !semanticPersonEnvironmentNamePattern.MatchString(policy.APIKeyEnv) {
+		return fmt.Errorf("vector.people: embedding api_key_env %q is invalid", policy.APIKeyEnv)
+	}
+	if policy.RetentionPosture == "" || strings.EqualFold(policy.RetentionPosture, "unknown") {
+		return errors.New("vector.people: retention_posture must be explicit")
+	}
+	if policy.TrainingPosture == "" || strings.EqualFold(policy.TrainingPosture, "unknown") {
+		return errors.New("vector.people: training_posture must be explicit")
+	}
+	if policy.RendererPolicy == "" {
+		return errors.New("vector.people: renderer policy is required")
+	}
+	if len(policy.DisclosedFieldClasses) == 0 {
+		return errors.New("vector.people: disclosed field classes must not be empty")
+	}
+	for i, field := range policy.DisclosedFieldClasses {
+		if strings.TrimSpace(field) == "" || field != strings.TrimSpace(field) {
+			return errors.New("vector.people: disclosed field classes must be non-empty canonical strings")
+		}
+		if i > 0 && field == policy.DisclosedFieldClasses[i-1] {
+			return fmt.Errorf("vector.people: duplicate disclosed field class %q", field)
+		}
+	}
+	if policy.CorpusScope == "" {
+		return errors.New("vector.people: corpus scope is required")
+	}
+	return nil
+}
+
+// Validate proves that the public fields, canonical policy bytes, and
+// fingerprint still describe exactly one immutable policy.
+func (p SemanticPersonEmbeddingProfile) Validate() error {
+	_, err := p.Canonical()
+	return err
+}
+
+// Canonical validates a possibly database-normalized profile and returns its
+// canonical policy JSON. PostgreSQL JSONB is allowed to normalize whitespace
+// and key ordering, but never policy content.
+func (p SemanticPersonEmbeddingProfile) Canonical() (SemanticPersonEmbeddingProfile, error) {
+	want, err := newSemanticPersonEmbeddingProfile(semanticPersonEmbeddingPolicy{
+		Purpose: p.Purpose, Destination: p.Destination, APIFormat: p.APIFormat,
+		Model: p.Model, APIKeyEnv: p.APIKeyEnv,
+		RetentionPosture: p.RetentionPosture, TrainingPosture: p.TrainingPosture,
+		RendererPolicy:        p.RendererPolicy,
+		DisclosedFieldClasses: slices.Clone(p.DisclosedFieldClasses),
+		CorpusScope:           p.CorpusScope,
+	})
+	if err != nil {
+		return SemanticPersonEmbeddingProfile{}, err
+	}
+	if p.Fingerprint != want.Fingerprint {
+		return SemanticPersonEmbeddingProfile{}, errors.New("semantic person embedding profile fingerprint does not match policy")
+	}
+	if !semanticPersonJSONEqual(p.PolicyJSON, want.PolicyJSON) {
+		return SemanticPersonEmbeddingProfile{}, errors.New("semantic person embedding profile policy does not match immutable fields")
+	}
+	if p.Purpose != want.Purpose || p.Destination != want.Destination ||
+		p.APIFormat != want.APIFormat || p.Model != want.Model ||
+		p.APIKeyEnv != want.APIKeyEnv || p.RetentionPosture != want.RetentionPosture ||
+		p.TrainingPosture != want.TrainingPosture ||
+		p.RendererPolicy != want.RendererPolicy ||
+		!slices.Equal(p.DisclosedFieldClasses, want.DisclosedFieldClasses) ||
+		p.CorpusScope != want.CorpusScope {
+		return SemanticPersonEmbeddingProfile{}, errors.New("semantic person embedding profile fields are not canonical")
+	}
+	return want, nil
+}
+
+func semanticPersonJSONEqual(left, right []byte) bool {
+	var leftValue, rightValue any
+	if json.Unmarshal(left, &leftValue) != nil || json.Unmarshal(right, &rightValue) != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
+}

--- a/internal/vector/person_policy_test.go
+++ b/internal/vector/person_policy_test.go
@@ -1,0 +1,168 @@
+package vector
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const semanticPersonSearchQueryDisclosureToken = "caller_supplied_free_text_query_for_semantic_person_search"
+
+func semanticPersonPolicyTestConfig() Config {
+	return Config{
+		Enabled: true,
+		Backend: "sqlite-vec",
+		Embeddings: EmbeddingsConfig{
+			APIFormat: APIFormatOpenAI,
+			Endpoint:  "https://embedding.example.test/v1",
+			APIKeyEnv: "SEMANTIC_PERSON_TEST_KEY",
+			Model:     "synthetic-embedding-model",
+			Dimension: 4,
+			BatchSize: 8,
+		},
+		People: PeopleConfig{
+			Enabled:          true,
+			RetentionPosture: "zero_data_retention",
+			TrainingPosture:  "no_training",
+		},
+	}
+}
+
+func historicalSemanticPersonEmbeddingProfile(t *testing.T) SemanticPersonEmbeddingProfile {
+	t.Helper()
+	policy, err := semanticPersonEmbeddingPolicyForConfig(semanticPersonPolicyTestConfig())
+	require.NoError(t, err)
+	policy.DisclosedFieldClasses = slices.DeleteFunc(
+		policy.DisclosedFieldClasses,
+		func(field string) bool { return field == semanticPersonSearchQueryDisclosureToken },
+	)
+	profile, err := newSemanticPersonEmbeddingProfile(policy)
+	require.NoError(t, err)
+	return profile
+}
+
+// TestSemanticPersonEmbeddingsDefaultDisabled catches an upgrade silently
+// opting existing vector configurations into curated-person egress.
+func TestSemanticPersonEmbeddingsDefaultDisabled(t *testing.T) {
+	assert.False(t, (Config{}).People.Enabled)
+}
+
+// TestSemanticPersonEmbeddingProfileBindsEveryDisclosureDimension catches an
+// old exact consent authorizing any changed destination, wire format, model,
+// credential name, provider posture, renderer, field class, or corpus scope.
+func TestSemanticPersonEmbeddingProfileBindsEveryDisclosureDimension(t *testing.T) {
+	basePolicy, err := semanticPersonEmbeddingPolicyForConfig(semanticPersonPolicyTestConfig())
+	require.NoError(t, err)
+	base, err := newSemanticPersonEmbeddingProfile(basePolicy)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		mutate func(*semanticPersonEmbeddingPolicy)
+	}{
+		{name: "purpose", mutate: func(p *semanticPersonEmbeddingPolicy) { p.Purpose = "different_purpose" }},
+		{name: "destination", mutate: func(p *semanticPersonEmbeddingPolicy) { p.Destination = "https://elsewhere.example.test/v1/embeddings" }},
+		{name: "api format", mutate: func(p *semanticPersonEmbeddingPolicy) { p.APIFormat = APIFormatVoyageContextual }},
+		{name: "model", mutate: func(p *semanticPersonEmbeddingPolicy) { p.Model = "different-model" }},
+		{name: "credential env", mutate: func(p *semanticPersonEmbeddingPolicy) { p.APIKeyEnv = "DIFFERENT_KEY" }},
+		{name: "retention posture", mutate: func(p *semanticPersonEmbeddingPolicy) { p.RetentionPosture = "provider_retains_30_days" }},
+		{name: "training posture", mutate: func(p *semanticPersonEmbeddingPolicy) { p.TrainingPosture = "provider_may_train" }},
+		{name: "renderer", mutate: func(p *semanticPersonEmbeddingPolicy) { p.RendererPolicy = "person-semantic-v2" }},
+		{name: "disclosed fields", mutate: func(p *semanticPersonEmbeddingPolicy) {
+			p.DisclosedFieldClasses = append(slices.Clone(p.DisclosedFieldClasses), "new_curated_field")
+		}},
+		{name: "corpus scope", mutate: func(p *semanticPersonEmbeddingPolicy) { p.CorpusScope = "subset_of_people" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			changedPolicy := basePolicy
+			changedPolicy.DisclosedFieldClasses = slices.Clone(basePolicy.DisclosedFieldClasses)
+			test.mutate(&changedPolicy)
+			changed, err := newSemanticPersonEmbeddingProfile(changedPolicy)
+			require.NoError(t, err)
+			assert.NotEqual(t, base.Fingerprint, changed.Fingerprint)
+		})
+	}
+}
+
+func TestSemanticPersonEmbeddingProfileDisclosesGlobalCuratedCorpusWithoutCredentialValue(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	t.Setenv("SEMANTIC_PERSON_TEST_KEY", "credential-value-must-not-persist")
+	config := semanticPersonPolicyTestConfig()
+	profile, err := config.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+
+	check.Equal(SemanticPersonEmbeddingPurpose, profile.Purpose)
+	check.Equal(SemanticPersonCorpusAllDurablePeople, profile.CorpusScope)
+	check.Equal(SemanticPersonRendererPolicy, profile.RendererPolicy)
+	check.Equal(SemanticPersonDisclosedFieldClasses(), profile.DisclosedFieldClasses)
+	check.Contains(profile.DisclosedFieldClasses, semanticPersonSearchQueryDisclosureToken)
+	check.NotContains(string(profile.PolicyJSON), "credential-value-must-not-persist")
+	check.Contains(string(profile.PolicyJSON), "SEMANTIC_PERSON_TEST_KEY")
+	check.NoError(profile.Validate())
+}
+
+// TestHistoricalSemanticPersonEmbeddingProfileWithoutQueryDisclosureRemainsCanonical
+// catches a current-policy disclosure expansion making stored audit profiles
+// unreadable or silently rewriting their immutable fingerprint.
+func TestHistoricalSemanticPersonEmbeddingProfileWithoutQueryDisclosureRemainsCanonical(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	profile := historicalSemanticPersonEmbeddingProfile(t)
+
+	check.NotContains(profile.DisclosedFieldClasses, semanticPersonSearchQueryDisclosureToken)
+	must.NoError(profile.Validate())
+	canonical, err := profile.Canonical()
+	must.NoError(err)
+	check.Equal(profile.Fingerprint, canonical.Fingerprint)
+	check.JSONEq(string(profile.PolicyJSON), string(canonical.PolicyJSON))
+}
+
+func TestSemanticPersonEmbeddingValidationRequiresExplicitProviderPostures(t *testing.T) {
+	for _, field := range []string{"retention", "training"} {
+		t.Run(field, func(t *testing.T) {
+			config := semanticPersonPolicyTestConfig()
+			if field == "retention" {
+				config.People.RetentionPosture = "unknown"
+			} else {
+				config.People.TrainingPosture = ""
+			}
+			err := config.Validate()
+			assert.ErrorContains(t, err, field+"_posture must be explicit")
+		})
+	}
+}
+
+// TestSemanticPersonEmbeddingValidationRejectsAmbiguousRuntimeIdentity catches
+// canonical disclosure silently trimming or reinterpreting values that the
+// initialized provider client would send verbatim.
+func TestSemanticPersonEmbeddingValidationRejectsAmbiguousRuntimeIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		want   string
+	}{
+		{name: "endpoint query", mutate: func(c *Config) {
+			c.Embeddings.Endpoint += "?tenant=synthetic"
+		}, want: "query"},
+		{name: "endpoint fragment", mutate: func(c *Config) {
+			c.Embeddings.Endpoint += "#fragment"
+		}, want: "fragment"},
+		{name: "model whitespace", mutate: func(c *Config) {
+			c.Embeddings.Model = " " + c.Embeddings.Model
+		}, want: "model"},
+		{name: "credential environment whitespace", mutate: func(c *Config) {
+			c.Embeddings.APIKeyEnv += " "
+		}, want: "api_key_env"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := semanticPersonPolicyTestConfig()
+			test.mutate(&config)
+			assert.ErrorContains(t, config.Validate(), test.want)
+		})
+	}
+}

--- a/internal/vector/personsearch/engine.go
+++ b/internal/vector/personsearch/engine.go
@@ -1,0 +1,283 @@
+// Package personsearch resolves semantic queries against the person-owned
+// vector corpus and returns current durable person roots.
+package personsearch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// ErrPersonCoverageIncomplete reports that the active generation exists but
+// does not yet cover the current curated person corpus. It retains
+// ErrIndexBuilding compatibility for existing API and CLI error handling.
+var ErrPersonCoverageIncomplete = fmt.Errorf(
+	"person corpus coverage incomplete: %w", vector.ErrIndexBuilding,
+)
+
+// Coverage is exact person-corpus coverage for one vector generation.
+type Coverage struct {
+	Mismatched int64
+	Rejected   int64
+}
+
+// Complete reports whether every current semantic person document has the
+// exact revision in the generation and no terminal rejection remains.
+func (c Coverage) Complete() bool {
+	return c.Mismatched == 0 && c.Rejected == 0
+}
+
+// CoverageChecker reads person-only coverage without scanning message or
+// contextual-document convergence state.
+type CoverageChecker interface {
+	CheckPersonCoverage(ctx context.Context, generation vector.GenerationID) (Coverage, error)
+}
+
+// CoverageIncompleteError preserves the reason an active generation cannot
+// yet serve semantic person search so callers can give correct recovery help.
+type CoverageIncompleteError struct {
+	Generation vector.GenerationID
+	Mismatched int64
+	Rejected   int64
+}
+
+func (e *CoverageIncompleteError) Error() string {
+	return fmt.Sprintf(
+		"person corpus coverage incomplete for generation %d (mismatched=%d, rejected=%d): %v",
+		e.Generation, e.Mismatched, e.Rejected, ErrPersonCoverageIncomplete,
+	)
+}
+
+// Unwrap retains errors.Is compatibility with ErrPersonCoverageIncomplete
+// and, through it, vector.ErrIndexBuilding.
+func (e *CoverageIncompleteError) Unwrap() error { return ErrPersonCoverageIncomplete }
+
+// Backend combines generation lifecycle reads with the separate person-owned
+// ANN capability. Search never calls the message-owned Search method.
+type Backend interface {
+	vector.Backend
+	vector.PersonBackend
+}
+
+// Store supplies the current semantic revision and durable roots used to
+// revalidate and hydrate ANN hits.
+type Store interface {
+	ResolvePersonSemanticCandidatesContext(
+		ctx context.Context, candidates []store.PersonSemanticCandidate,
+	) ([]store.Person, error)
+}
+
+// QueryEmbedder embeds one free-text query.
+type QueryEmbedder interface {
+	EmbedQuery(ctx context.Context, text string) ([]float32, error)
+}
+
+// Config controls generation compatibility.
+type Config struct {
+	ExpectedFingerprint string
+	// Gate rechecks default-off enablement and exact current consent before
+	// generation lookup or query embedding.
+	Gate vector.SemanticPersonEmbeddingGate
+	// PersonCoverage reports exact active-generation coverage for the current
+	// curated person corpus without consulting unrelated message coverage.
+	// Nil preserves the standalone engine contract for callers that do not own
+	// embedding maintenance.
+	PersonCoverage func(context.Context, vector.GenerationID) (Coverage, error)
+}
+
+// Result is one ranked, durable person match. Semantic projection text and
+// revision details never leave the engine.
+type Result struct {
+	Person store.Person
+	Score  float64
+}
+
+// Engine searches the person-owned corpus and fences results against current
+// source revisions before returning durable roots.
+type Engine struct {
+	backend  Backend
+	store    Store
+	embedder QueryEmbedder
+	config   Config
+}
+
+// NewEngine constructs a semantic person search engine.
+func NewEngine(backend Backend, data Store, embedder QueryEmbedder, config Config) *Engine {
+	return &Engine{backend: backend, store: data, embedder: embedder, config: config}
+}
+
+// Search embeds query once, searches only the person corpus, drops stale or
+// deleted hits, and returns durable person roots in ANN rank order.
+func (e *Engine) Search(ctx context.Context, query string, limit int) ([]Result, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, errors.New("empty person search query")
+	}
+	if limit <= 0 {
+		return nil, errors.New("person search limit must be positive")
+	}
+	if e.config.Gate == nil {
+		return nil, errors.New("semantic person search gate is not configured")
+	}
+	if err := e.config.Gate.Check(ctx); err != nil {
+		return nil, err
+	}
+
+	active, err := vector.ResolveActiveForFingerprint(
+		ctx, e.backend, e.config.ExpectedFingerprint,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if e.config.PersonCoverage != nil {
+		coverage, err := e.config.PersonCoverage(ctx, active.ID)
+		if err != nil {
+			return nil, fmt.Errorf("check person corpus coverage: %w", err)
+		}
+		if !coverage.Complete() {
+			return nil, &CoverageIncompleteError{
+				Generation: active.ID,
+				Mismatched: coverage.Mismatched,
+				Rejected:   coverage.Rejected,
+			}
+		}
+	}
+	queryVector, err := e.embedder.EmbedQuery(ctx, query)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("embed person query: %w: %w", vector.ErrEmbeddingTimeout, err)
+		}
+		return nil, fmt.Errorf("embed person query: %w", err)
+	}
+	searchLimit := limit
+	seen := make(map[store.PersonSemanticCandidate]struct{})
+	valid := make(map[store.PersonSemanticCandidate]struct{})
+	for {
+		hits, err := e.backend.SearchPeople(ctx, active.ID, queryVector, searchLimit)
+		if err != nil {
+			return nil, fmt.Errorf("search person corpus: %w", err)
+		}
+
+		newCandidates := make([]store.PersonSemanticCandidate, 0, len(hits))
+		for _, hit := range hits {
+			candidate := store.PersonSemanticCandidate{
+				PersonID: hit.PersonID,
+				Revision: hit.Revision,
+			}
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			newCandidates = append(newCandidates, candidate)
+		}
+		exhausted := len(hits) < searchLimit
+		if exhausted {
+			newSet := make(map[store.PersonSemanticCandidate]struct{}, len(newCandidates))
+			for _, candidate := range newCandidates {
+				newSet[candidate] = struct{}{}
+			}
+			finalCandidates := make([]store.PersonSemanticCandidate, 0, len(valid)+len(newCandidates))
+			for _, hit := range hits {
+				candidate := store.PersonSemanticCandidate{PersonID: hit.PersonID, Revision: hit.Revision}
+				_, wasValid := valid[candidate]
+				_, isNew := newSet[candidate]
+				if wasValid || isNew {
+					finalCandidates = append(finalCandidates, candidate)
+				}
+			}
+			people, err := e.store.ResolvePersonSemanticCandidatesContext(ctx, finalCandidates)
+			if err != nil {
+				return nil, fmt.Errorf("resolve final person search hits: %w", err)
+			}
+			return personResultsInHitOrder(hits, people, limit), nil
+		}
+		hadValidCandidates := len(valid) > 0
+		var newlyResolved []store.Person
+		if len(newCandidates) > 0 {
+			people, err := e.store.ResolvePersonSemanticCandidatesContext(ctx, newCandidates)
+			if err != nil {
+				return nil, fmt.Errorf("resolve current person search hits: %w", err)
+			}
+			candidateByID := make(map[int64]store.PersonSemanticCandidate, len(newCandidates))
+			for _, candidate := range newCandidates {
+				candidateByID[candidate.PersonID] = candidate
+			}
+			for _, person := range people {
+				if candidate, ok := candidateByID[person.ID]; ok {
+					valid[candidate] = struct{}{}
+				}
+			}
+			newlyResolved = people
+		}
+
+		currentCandidates := make([]store.PersonSemanticCandidate, 0, min(limit, len(valid)))
+		for _, hit := range hits {
+			candidate := store.PersonSemanticCandidate{PersonID: hit.PersonID, Revision: hit.Revision}
+			if _, ok := valid[candidate]; ok {
+				currentCandidates = append(currentCandidates, candidate)
+			}
+		}
+		if len(currentCandidates) >= limit {
+			if !hadValidCandidates {
+				return personResultsInHitOrder(hits, newlyResolved, limit), nil
+			}
+			people, err := e.store.ResolvePersonSemanticCandidatesContext(ctx, currentCandidates)
+			if err != nil {
+				return nil, fmt.Errorf("revalidate final person search hits: %w", err)
+			}
+			results := personResultsInHitOrder(hits, people, limit)
+			if len(results) == limit {
+				return results, nil
+			}
+			peopleByID := make(map[int64]struct{}, len(people))
+			for _, person := range people {
+				peopleByID[person.ID] = struct{}{}
+			}
+			valid = make(map[store.PersonSemanticCandidate]struct{}, len(people))
+			for _, candidate := range currentCandidates {
+				if _, ok := peopleByID[candidate.PersonID]; ok {
+					valid[candidate] = struct{}{}
+				}
+			}
+		}
+		next, ok := widenSearchLimit(searchLimit)
+		if !ok {
+			return nil, nil
+		}
+		searchLimit = next
+	}
+}
+
+func personResultsInHitOrder(hits []vector.PersonHit, people []store.Person, limit int) []Result {
+	peopleByID := make(map[int64]store.Person, len(people))
+	for _, person := range people {
+		peopleByID[person.ID] = person
+	}
+	results := make([]Result, 0, min(limit, len(people)))
+	for _, hit := range hits {
+		person, ok := peopleByID[hit.PersonID]
+		if !ok {
+			continue
+		}
+		results = append(results, Result{Person: person, Score: hit.Score})
+		if len(results) == limit {
+			break
+		}
+	}
+	return results
+}
+
+func widenSearchLimit(current int) (int, bool) {
+	maxInt := int(^uint(0) >> 1)
+	if current >= maxInt {
+		return current, false
+	}
+	if current > maxInt/2 {
+		return maxInt, true
+	}
+	return current * 2, true
+}

--- a/internal/vector/personsearch/engine_test.go
+++ b/internal/vector/personsearch/engine_test.go
@@ -1,0 +1,602 @@
+package personsearch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+type testBackend struct {
+	vector.Backend
+	vector.PersonBackend
+
+	active             *vector.Generation
+	building           *vector.Generation
+	personHits         []vector.PersonHit
+	personSearchErr    error
+	personSearchGen    vector.GenerationID
+	personSearchLimit  int
+	personSearchLimits []int
+	personSearchVector []float32
+}
+
+func (b *testBackend) ActiveGeneration(context.Context) (vector.Generation, error) {
+	if b.active == nil {
+		return vector.Generation{}, vector.ErrNoActiveGeneration
+	}
+	return *b.active, nil
+}
+
+func (b *testBackend) BuildingGeneration(context.Context) (*vector.Generation, error) {
+	return b.building, nil
+}
+
+func (b *testBackend) Search(context.Context, vector.GenerationID, []float32, int, vector.Filter) ([]vector.Hit, error) {
+	panic("person search must not call the message corpus")
+}
+
+func (b *testBackend) SearchPeople(
+	_ context.Context, generation vector.GenerationID, queryVector []float32, limit int,
+) ([]vector.PersonHit, error) {
+	b.personSearchGen = generation
+	b.personSearchLimit = limit
+	b.personSearchLimits = append(b.personSearchLimits, limit)
+	b.personSearchVector = append([]float32(nil), queryVector...)
+	return b.personHits[:min(limit, len(b.personHits))], b.personSearchErr
+}
+
+type testEmbedder struct {
+	calls []string
+	vec   []float32
+	err   error
+}
+
+type testSemanticPersonConsentSet map[string]bool
+
+func (s testSemanticPersonConsentSet) HasActivePersonSemanticEmbeddingConsent(
+	_ context.Context, fingerprint string,
+) (bool, error) {
+	return s[fingerprint], nil
+}
+
+func (e *testEmbedder) EmbedQuery(_ context.Context, query string) ([]float32, error) {
+	e.calls = append(e.calls, query)
+	return append([]float32(nil), e.vec...), e.err
+}
+
+type testStore struct {
+	documents          map[int64]*store.PersonSemanticDocument
+	people             map[int64]store.Person
+	afterDocumentLoad  func(personID int64)
+	resolvedCandidates int
+	resolveErr         error
+}
+
+func (s *testStore) ResolvePersonSemanticCandidatesContext(
+	_ context.Context, candidates []store.PersonSemanticCandidate,
+) ([]store.Person, error) {
+	if s.resolveErr != nil {
+		return nil, s.resolveErr
+	}
+	s.resolvedCandidates += len(candidates)
+	people := make([]store.Person, 0, len(candidates))
+	for _, candidate := range candidates {
+		document, documentOK := s.documents[candidate.PersonID]
+		person, personOK := s.people[candidate.PersonID]
+		if s.afterDocumentLoad != nil {
+			s.afterDocumentLoad(candidate.PersonID)
+		}
+		if documentOK && personOK && document.Revision == candidate.Revision {
+			people = append(people, person)
+		}
+	}
+	return people, nil
+}
+
+func newTestEngine(
+	backend *testBackend, data *testStore, embedder *testEmbedder,
+) *Engine {
+	return NewEngine(backend, data, embedder, Config{
+		ExpectedFingerprint: "test:3:rperson-semantic-v1",
+		Gate:                vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return nil }),
+	})
+}
+
+// TestEngineSearchGateBlocksDisabledUnconsentedAndRevokedQueryCalls catches
+// query text reaching the provider without both current opt-in and consent.
+func TestEngineSearchGateBlocksDisabledUnconsentedAndRevokedQueryCalls(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{active: &vector.Generation{
+		ID: 1, Fingerprint: "test:3:rperson-semantic-v1",
+	}}
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	gateErr := vector.ErrSemanticPersonEmbeddingsDisabled
+	engine := NewEngine(backend, &testStore{}, embedder, Config{
+		ExpectedFingerprint: "test:3:rperson-semantic-v1",
+		Gate:                vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return gateErr }),
+	})
+
+	_, err := engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, vector.ErrSemanticPersonEmbeddingsDisabled)
+	check.Empty(embedder.calls)
+
+	gateErr = vector.ErrSemanticPersonEmbeddingConsentRequired
+	_, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	check.Empty(embedder.calls)
+
+	gateErr = nil
+	_, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.NoError(err)
+	must.Len(embedder.calls, 1)
+
+	gateErr = vector.ErrSemanticPersonEmbeddingConsentRequired
+	_, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	check.Len(embedder.calls, 1, "revocation must apply without an engine restart")
+}
+
+// TestEngineSearchRejectsConsentThatPredatesQueryEgressDisclosure catches a
+// pre-expansion grant authorizing caller free text on the real query path.
+func TestEngineSearchRejectsConsentThatPredatesQueryEgressDisclosure(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	config := vector.Config{
+		Enabled: true,
+		Backend: "sqlite-vec",
+		Embeddings: vector.EmbeddingsConfig{
+			Endpoint: "https://embedding.example.test/v1", APIFormat: vector.APIFormatOpenAI,
+			Model: "semantic-person-model", APIKeyEnv: "SEMANTIC_PERSON_KEY",
+			Dimension: 4, BatchSize: 8,
+		},
+		People: vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		},
+	}
+	currentProfile, err := config.SemanticPersonEmbeddingProfile()
+	must.NoError(err)
+	const historicalFingerprint = "f002512c98b050443ebd3c113fc18199c48ed6ef2d27d70b62328c6bbac3d250"
+	must.NotEqual(historicalFingerprint, currentProfile.Fingerprint)
+
+	consents := testSemanticPersonConsentSet{historicalFingerprint: true}
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	engine := NewEngine(
+		&testBackend{active: &vector.Generation{
+			ID: 7, Fingerprint: "test:3:rperson-semantic-v1",
+		}},
+		&testStore{}, embedder,
+		Config{
+			ExpectedFingerprint: "test:3:rperson-semantic-v1",
+			Gate: vector.NewExactSemanticPersonEmbeddingGate(
+				func() (vector.Config, error) { return config, nil }, consents,
+			),
+		},
+	)
+
+	_, err = engine.Search(t.Context(), "caller supplied search text", 5)
+	must.ErrorIs(err, vector.ErrSemanticPersonEmbeddingConsentRequired)
+	check.Empty(embedder.calls)
+
+	consents[currentProfile.Fingerprint] = true
+	results, err := engine.Search(t.Context(), "caller supplied search text", 5)
+	must.NoError(err)
+	check.Empty(results)
+	check.Equal([]string{"caller supplied search text"}, embedder.calls)
+}
+
+func TestEngineSearchEmbedsOnceAndHydratesPersonHitsInRankOrder(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{
+			ID: 7, Fingerprint: "test:3:rperson-semantic-v1",
+		},
+		personHits: []vector.PersonHit{
+			{PersonID: 22, Revision: "rev-22", Score: 0.91, Rank: 1},
+			{PersonID: 11, Revision: "rev-11", Score: 0.82, Rank: 2},
+		},
+	}
+	data := &testStore{
+		documents: map[int64]*store.PersonSemanticDocument{
+			22: {PersonID: 22, Revision: "rev-22"},
+			11: {PersonID: 11, Revision: "rev-11"},
+		},
+		people: map[int64]store.Person{
+			22: {ID: 22, VCardUID: "00000000-0000-4000-8000-000000000022"},
+			11: {ID: 11, VCardUID: "00000000-0000-4000-8000-000000000011"},
+		},
+	}
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	engine := newTestEngine(backend, data, embedder)
+
+	results, err := engine.Search(t.Context(), "  synthetic architect  ", 8)
+	require.NoError(err)
+	require.Len(results, 2)
+	assert.Equal([]string{"synthetic architect"}, embedder.calls)
+	assert.Equal([]float32{1, 0, 0}, backend.personSearchVector)
+	assert.Equal(vector.GenerationID(7), backend.personSearchGen)
+	assert.Equal(8, backend.personSearchLimit)
+	assert.Equal(int64(22), results[0].Person.ID)
+	assert.InDelta(0.91, results[0].Score, 0.00001)
+	assert.Equal(int64(11), results[1].Person.ID)
+	assert.InDelta(0.82, results[1].Score, 0.00001)
+}
+
+func TestEngineSearchStopsAtLimitWithoutDuplicateResolution(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{ID: 7, Fingerprint: "test:3:rperson-semantic-v1"},
+	}
+	data := &testStore{
+		documents: make(map[int64]*store.PersonSemanticDocument),
+		people:    make(map[int64]store.Person),
+	}
+	for i := int64(1); i <= 5; i++ {
+		revision := fmt.Sprintf("rev-%d", i)
+		backend.personHits = append(backend.personHits, vector.PersonHit{
+			PersonID: i, Revision: revision, Score: 1 - float64(i)/10, Rank: int(i),
+		})
+		data.documents[i] = &store.PersonSemanticDocument{PersonID: i, Revision: revision}
+		data.people[i] = store.Person{ID: i}
+	}
+	engine := newTestEngine(backend, data, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic", 2)
+	must.NoError(err)
+	must.Len(results, 2)
+	check.Equal([]int64{1, 2}, []int64{results[0].Person.ID, results[1].Person.ID})
+	check.Equal(2, data.resolvedCandidates,
+		"the first valid page must be resolved and hydrated in one snapshot")
+}
+
+func TestEngineSearchDoesNotPairOldScoreWithPostValidationRootMutation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	originalName := "Synthetic Original"
+	updatedName := "Synthetic Updated"
+	backend := &testBackend{
+		active: &vector.Generation{
+			ID: 8, Fingerprint: "test:3:rperson-semantic-v1",
+		},
+		personHits: []vector.PersonHit{
+			{PersonID: 44, Revision: "rev-44", Score: 0.88, Rank: 1},
+		},
+	}
+	data := &testStore{
+		documents: map[int64]*store.PersonSemanticDocument{
+			44: {PersonID: 44, Revision: "rev-44"},
+		},
+		people: map[int64]store.Person{
+			44: {ID: 44, DisplayName: &originalName},
+		},
+	}
+	data.afterDocumentLoad = func(personID int64) {
+		data.people[personID] = store.Person{ID: personID, DisplayName: &updatedName}
+	}
+	engine := newTestEngine(backend, data, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic query", 5)
+	require.NoError(err)
+	require.Len(results, 1)
+	require.NotNil(results[0].Person.DisplayName)
+	assert.Equal(originalName, *results[0].Person.DisplayName,
+		"the root must come from the same snapshot that validated the old score")
+}
+
+func TestEngineSearchDropsStaleDeletedAndPostValidationDeletedHits(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{
+			ID: 9, Fingerprint: "test:3:rperson-semantic-v1",
+		},
+		personHits: []vector.PersonHit{
+			{PersonID: 10, Revision: "old-revision", Score: 0.99, Rank: 1},
+			{PersonID: 20, Revision: "deleted-revision", Score: 0.90, Rank: 2},
+			{PersonID: 30, Revision: "rev-30", Score: 0.80, Rank: 3},
+			{PersonID: 40, Revision: "rev-40", Score: 0.70, Rank: 4},
+		},
+	}
+	data := &testStore{
+		documents: map[int64]*store.PersonSemanticDocument{
+			10: {PersonID: 10, Revision: "current-revision"},
+			30: {PersonID: 30, Revision: "rev-30"},
+			40: {PersonID: 40, Revision: "rev-40"},
+		},
+		people: map[int64]store.Person{
+			30: {ID: 30, VCardUID: "00000000-0000-4000-8000-000000000030"},
+			// Person 40 disappears after document validation and before root
+			// hydration. It must not leak as a zero-value result.
+		},
+	}
+	engine := newTestEngine(backend, data, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic query", 10)
+	require.NoError(err)
+	require.Len(results, 1)
+	assert.Equal(int64(30), results[0].Person.ID)
+	assert.InDelta(0.80, results[0].Score, 0.00001)
+}
+
+// TestEngineSearchWidensPastInvalidTopHits catches a fenced top result
+// underfilling a page even though the person corpus has a valid lower-ranked
+// replacement. Widening must reuse the one query embedding.
+func TestEngineSearchWidensPastInvalidTopHits(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{
+			ID: 10, Fingerprint: "test:3:rperson-semantic-v1",
+		},
+		personHits: []vector.PersonHit{
+			{PersonID: 10, Revision: "stale-revision", Score: 0.99, Rank: 1},
+			{PersonID: 20, Revision: "rev-20", Score: 0.90, Rank: 2},
+		},
+	}
+	data := &testStore{
+		documents: map[int64]*store.PersonSemanticDocument{
+			10: {PersonID: 10, Revision: "current-revision"},
+			20: {PersonID: 20, Revision: "rev-20"},
+		},
+		people: map[int64]store.Person{
+			20: {ID: 20, VCardUID: "00000000-0000-4000-8000-000000000020"},
+		},
+	}
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	engine := newTestEngine(backend, data, embedder)
+
+	results, err := engine.Search(t.Context(), "synthetic query", 1)
+	must.NoError(err)
+	must.Len(results, 1)
+	check.Equal(int64(20), results[0].Person.ID)
+	check.InDelta(0.90, results[0].Score, 0.00001)
+	check.Equal([]int{1, 2}, backend.personSearchLimits)
+	check.Equal([]string{"synthetic query"}, embedder.calls)
+}
+
+// TestEngineSearchContinuesAfterWidenedRevalidationUnderfills catches the
+// widening loop returning early or losing still-current candidates when a
+// previously valid higher-ranked person changes before final revalidation.
+func TestEngineSearchContinuesAfterWidenedRevalidationUnderfills(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{ID: 16, Fingerprint: "test:3:rperson-semantic-v1"},
+		personHits: []vector.PersonHit{
+			{PersonID: 1, Revision: "rev-1", Score: 0.99, Rank: 1},
+			{PersonID: 2, Revision: "stale-2", Score: 0.92, Rank: 2},
+			{PersonID: 3, Revision: "rev-3", Score: 0.85, Rank: 3},
+			{PersonID: 4, Revision: "stale-4", Score: 0.78, Rank: 4},
+			{PersonID: 5, Revision: "rev-5", Score: 0.71, Rank: 5},
+			{PersonID: 6, Revision: "stale-6", Score: 0.64, Rank: 6},
+			{PersonID: 7, Revision: "stale-7", Score: 0.57, Rank: 7},
+			{PersonID: 8, Revision: "stale-8", Score: 0.50, Rank: 8},
+		},
+	}
+	data := &testStore{
+		documents: map[int64]*store.PersonSemanticDocument{
+			1: {PersonID: 1, Revision: "rev-1"},
+			3: {PersonID: 3, Revision: "rev-3"},
+			5: {PersonID: 5, Revision: "rev-5"},
+		},
+		people: map[int64]store.Person{
+			1: {ID: 1},
+			3: {ID: 3},
+			5: {ID: 5},
+		},
+	}
+	data.afterDocumentLoad = func(personID int64) {
+		if personID == 3 {
+			delete(data.documents, 1)
+			delete(data.people, 1)
+		}
+	}
+	engine := newTestEngine(backend, data, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic", 2)
+	must.NoError(err)
+	must.Len(results, 2)
+	check.Equal([]int64{3, 5}, []int64{results[0].Person.ID, results[1].Person.ID})
+	check.Equal([]int{2, 4, 8}, backend.personSearchLimits,
+		"revalidation underfill must widen finitely and stop once the page refills")
+}
+
+func TestEngineSearchDoesNotRevalidateRejectedPrefixes(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{
+		active: &vector.Generation{ID: 13, Fingerprint: "test:3:rperson-semantic-v1"},
+	}
+	data := &testStore{documents: make(map[int64]*store.PersonSemanticDocument), people: make(map[int64]store.Person)}
+	for i := 1; i <= 8; i++ {
+		revision := "stale"
+		if i > 6 {
+			revision = "current"
+			data.documents[int64(i)] = &store.PersonSemanticDocument{PersonID: int64(i), Revision: revision}
+			data.people[int64(i)] = store.Person{ID: int64(i)}
+		}
+		backend.personHits = append(backend.personHits, vector.PersonHit{
+			PersonID: int64(i), Revision: revision, Score: 1 - float64(i)/10, Rank: i,
+		})
+	}
+	engine := newTestEngine(backend, data, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic", 2)
+	must.NoError(err)
+	must.Len(results, 2)
+	check.Equal([]int64{7, 8}, []int64{results[0].Person.ID, results[1].Person.ID})
+	check.LessOrEqual(data.resolvedCandidates, 10,
+		"each rejected candidate should be rendered only once across widening rounds")
+}
+
+func TestEngineSearchUsesPersonCorpusWithoutMessageFallback(t *testing.T) {
+	backend := &testBackend{
+		active: &vector.Generation{
+			ID: 11, Fingerprint: "test:3:rperson-semantic-v1",
+		},
+		personHits: nil,
+	}
+	engine := newTestEngine(backend, &testStore{}, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "no person match", 5)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestEngineSearchRevalidatesMutablePersonCoverageBeforeProviderCall(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	backend := &testBackend{active: &vector.Generation{
+		ID: 17, Fingerprint: "test:3:rperson-semantic-v1",
+	}}
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	checkedGeneration := vector.GenerationID(0)
+	coverageReady := false
+	coverageChecks := 0
+	engine := NewEngine(backend, &testStore{}, embedder, Config{
+		ExpectedFingerprint: "test:3:rperson-semantic-v1",
+		Gate:                vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return nil }),
+		PersonCoverage: func(_ context.Context, generation vector.GenerationID) (Coverage, error) {
+			coverageChecks++
+			checkedGeneration = generation
+			if coverageReady {
+				return Coverage{}, nil
+			}
+			return Coverage{Mismatched: 1}, nil
+		},
+	})
+
+	results, err := engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, ErrPersonCoverageIncomplete)
+	must.ErrorIs(err, vector.ErrIndexBuilding)
+	check.Nil(results)
+	check.Equal(vector.GenerationID(17), checkedGeneration)
+	check.Empty(embedder.calls, "an incomplete corpus must not incur a provider call")
+	check.Empty(backend.personSearchLimits)
+
+	coverageReady = true
+	results, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.NoError(err)
+	check.Empty(results)
+	coverageReady = false
+	results, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, ErrPersonCoverageIncomplete)
+	check.Nil(results)
+	check.Equal(3, coverageChecks,
+		"a successful check must not hide later corpus mutations or terminal rejections")
+	check.Equal([]string{"synthetic query"}, embedder.calls)
+
+	backend.active = &vector.Generation{ID: 18, Fingerprint: "test:3:rperson-semantic-v1"}
+	coverageReady = false
+	results, err = engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, ErrPersonCoverageIncomplete)
+	check.Nil(results)
+	check.Equal(4, coverageChecks, "a newly active generation needs its own coverage proof")
+	check.Equal([]string{"synthetic query"}, embedder.calls)
+}
+
+func TestEngineSearchPropagatesPersonCoverageError(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	wantErr := errors.New("person coverage unavailable")
+	embedder := &testEmbedder{vec: []float32{1, 0, 0}}
+	engine := NewEngine(
+		&testBackend{active: &vector.Generation{
+			ID: 19, Fingerprint: "test:3:rperson-semantic-v1",
+		}},
+		&testStore{}, embedder,
+		Config{
+			ExpectedFingerprint: "test:3:rperson-semantic-v1",
+			Gate:                vector.SemanticPersonEmbeddingGateFunc(func(context.Context) error { return nil }),
+			PersonCoverage: func(context.Context, vector.GenerationID) (Coverage, error) {
+				return Coverage{}, wantErr
+			},
+		},
+	)
+
+	results, err := engine.Search(t.Context(), "synthetic query", 5)
+	must.ErrorIs(err, wantErr)
+	must.ErrorContains(err, "check person corpus coverage")
+	check.Nil(results)
+	check.Empty(embedder.calls)
+}
+
+func TestEngineSearchReusesVectorGenerationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend *testBackend
+		wantErr error
+	}{
+		{
+			name:    "disabled",
+			backend: &testBackend{},
+			wantErr: vector.ErrNotEnabled,
+		},
+		{
+			name:    "building",
+			backend: &testBackend{building: &vector.Generation{ID: 2}},
+			wantErr: vector.ErrIndexBuilding,
+		},
+		{
+			name:    "stale",
+			backend: &testBackend{active: &vector.Generation{ID: 3, Fingerprint: "old:3"}},
+			wantErr: vector.ErrIndexStale,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			engine := newTestEngine(test.backend, &testStore{}, &testEmbedder{vec: []float32{1, 0, 0}})
+			_, err := engine.Search(t.Context(), "synthetic query", 5)
+			require.ErrorIs(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestEngineSearchMapsEmbeddingDeadline(t *testing.T) {
+	backend := &testBackend{active: &vector.Generation{
+		ID: 12, Fingerprint: "test:3:rperson-semantic-v1",
+	}}
+	engine := newTestEngine(backend, &testStore{}, &testEmbedder{err: context.DeadlineExceeded})
+
+	_, err := engine.Search(t.Context(), "synthetic query", 5)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, vector.ErrEmbeddingTimeout)
+}
+
+func TestEngineSearchPropagatesPersonBackendError(t *testing.T) {
+	wantErr := errors.New("person backend unavailable")
+	backend := &testBackend{
+		active:          &vector.Generation{ID: 14, Fingerprint: "test:3:rperson-semantic-v1"},
+		personSearchErr: wantErr,
+	}
+	engine := newTestEngine(backend, &testStore{}, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic query", 5)
+	require.ErrorIs(t, err, wantErr)
+	require.ErrorContains(t, err, "search person corpus")
+	assert.Nil(t, results)
+}
+
+func TestEngineSearchPropagatesPersonStoreError(t *testing.T) {
+	wantErr := errors.New("person store unavailable")
+	backend := &testBackend{
+		active: &vector.Generation{ID: 15, Fingerprint: "test:3:rperson-semantic-v1"},
+		personHits: []vector.PersonHit{{
+			PersonID: 1, Revision: "rev-1", Score: 0.9, Rank: 1,
+		}},
+	}
+	engine := newTestEngine(backend, &testStore{resolveErr: wantErr}, &testEmbedder{vec: []float32{1, 0, 0}})
+
+	results, err := engine.Search(t.Context(), "synthetic query", 5)
+	require.ErrorIs(t, err, wantErr)
+	require.ErrorContains(t, err, "resolve final person search hits")
+	assert.Nil(t, results)
+}

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -173,6 +173,9 @@ func (b *Backend) CreateGeneration(ctx context.Context, model string, dim int, f
 	if err := EnsureVectorIndex(ctx, b.db, dim); err != nil {
 		return 0, err
 	}
+	if err := EnsurePersonVectorIndex(ctx, b.db, dim); err != nil {
+		return 0, err
+	}
 	fp := fingerprint
 	if fp == "" {
 		fp = fmt.Sprintf("%s:%d", model, dim)
@@ -437,6 +440,10 @@ func (b *Backend) activateGeneration(
 			`DELETE FROM embeddings WHERE generation_id = $1`, demoted.Int64); err != nil {
 			return fmt.Errorf("delete retired generation %d embeddings: %w", demoted.Int64, err)
 		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM person_embeddings WHERE generation_id = $1`, demoted.Int64); err != nil {
+			return fmt.Errorf("delete retired generation %d person embeddings: %w", demoted.Int64, err)
+		}
 	}
 	// The promote re-checks the coverage gate IN the same tx as the flip
 	// (unless force): refuse to activate while any live message still needs
@@ -586,6 +593,10 @@ func (b *Backend) RetireGeneration(ctx context.Context, gen vector.GenerationID,
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM embeddings WHERE generation_id = $1`, int64(gen)); err != nil {
 		return fmt.Errorf("delete retired generation %d embeddings: %w", gen, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM person_embeddings WHERE generation_id = $1`, int64(gen)); err != nil {
+		return fmt.Errorf("delete retired generation %d person embeddings: %w", gen, err)
 	}
 	// Scan-and-fill has no per-generation queue to reap.
 	if err := tx.Commit(); err != nil {

--- a/internal/vector/pgvector/migrate.go
+++ b/internal/vector/pgvector/migrate.go
@@ -125,6 +125,9 @@ func Migrate(ctx context.Context, db migrateExecer, defaultDim int, skipExtensio
 		if err := EnsureVectorIndex(ctx, db, defaultDim); err != nil {
 			return err
 		}
+		if err := EnsurePersonVectorIndex(ctx, db, defaultDim); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -149,7 +152,6 @@ func EnsureVectorIndex(ctx context.Context, db migrateExecer, dim int) error {
 		   WHERE dimension = %d`,
 		dim, dim, dim,
 	)
-
 	// Wrap the CREATE INDEX in a transaction that disables the pool-wide 30s
 	// statement_timeout: EnsureVectorIndex is also called lazily from
 	// CreateGeneration over a possibly-populated embeddings table, and HNSW

--- a/internal/vector/pgvector/person.go
+++ b/internal/vector/pgvector/person.go
@@ -1,0 +1,250 @@
+//go:build pgvector
+
+package pgvector
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+var _ vector.PersonBackend = (*Backend)(nil)
+
+// EnsurePersonVectorIndex creates the dimension-partial person-owned HNSW
+// compatibility index. SearchPeople ranks its capped curated corpus exactly,
+// but retaining this lifecycle keeps a future ANN path migration-free.
+func EnsurePersonVectorIndex(ctx context.Context, db migrateExecer, dim int) error {
+	if dim <= 0 {
+		return fmt.Errorf("invalid dimension %d", dim)
+	}
+	stmt := fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s
+		ON person_embeddings
+		USING hnsw ((embedding::vector(%d)) vector_cosine_ops)
+		WHERE dimension = %d AND embedding IS NOT NULL`, PersonVectorIndexName(dim), dim, dim)
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person hnsw index tx for dim %d: %w", dim, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = 0"); err != nil {
+		return fmt.Errorf("disable statement_timeout for person hnsw index: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("create person hnsw index for dim %d: %w", dim, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person hnsw index for dim %d: %w", dim, err)
+	}
+	return nil
+}
+
+// PersonVectorIndexName returns the dimension-specific person HNSW index.
+func PersonVectorIndexName(dim int) string {
+	return fmt.Sprintf("idx_person_embeddings_hnsw_d%d", dim)
+}
+
+// UpsertPersons atomically replaces each supplied person's published
+// revision and vector without touching message-owned embeddings.
+func (b *Backend) UpsertPersons(ctx context.Context, gen vector.GenerationID, persons []vector.PersonEmbedding) error {
+	if len(persons) == 0 {
+		return nil
+	}
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person upsert tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	dim, err := personGeneration(ctx, tx, gen, true)
+	if err != nil {
+		return err
+	}
+	seen := make(map[int64]struct{}, len(persons))
+	for _, person := range persons {
+		if len(person.Vector) != 0 && len(person.Vector) != dim {
+			return fmt.Errorf("%w: person %d has %d dims, gen has %d",
+				vector.ErrDimensionMismatch, person.PersonID, len(person.Vector), dim)
+		}
+		if _, duplicate := seen[person.PersonID]; duplicate {
+			return fmt.Errorf("duplicate person id %d in upsert batch", person.PersonID)
+		}
+		seen[person.PersonID] = struct{}{}
+	}
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO person_embeddings
+			(generation_id, person_id, published_revision, dimension, embedded_at, embedding)
+		VALUES ($1, $2, $3, $4, $5, $6::vector)
+		ON CONFLICT (generation_id, person_id) DO UPDATE SET
+			published_revision = excluded.published_revision,
+			dimension = excluded.dimension,
+			embedded_at = excluded.embedded_at,
+			embedding = excluded.embedding`)
+	if err != nil {
+		return fmt.Errorf("prepare person upsert: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+	now := time.Now().Unix()
+	for _, person := range persons {
+		var embedding any
+		if len(person.Vector) > 0 {
+			embedding = vectorLiteral(person.Vector)
+		}
+		if _, err := stmt.ExecContext(ctx, int64(gen), person.PersonID, person.Revision,
+			dim, now, embedding); err != nil {
+			return fmt.Errorf("upsert person %d: %w", person.PersonID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person upsert for generation %d: %w", gen, err)
+	}
+	return nil
+}
+
+// ListPersonRevisions returns the exact published revision owned by every
+// current person vector in gen.
+func (b *Backend) ListPersonRevisions(ctx context.Context, gen vector.GenerationID) (map[int64]string, error) {
+	if _, err := personGeneration(ctx, b.db, gen, false); err != nil {
+		return nil, err
+	}
+	rows, err := b.db.QueryContext(ctx, `
+		SELECT person_id, published_revision
+		  FROM person_embeddings
+		 WHERE generation_id = $1
+		 ORDER BY person_id`, int64(gen))
+	if err != nil {
+		return nil, fmt.Errorf("list person revisions for generation %d: %w", gen, err)
+	}
+	defer func() { _ = rows.Close() }()
+	revisions := make(map[int64]string)
+	for rows.Next() {
+		var id int64
+		var revision string
+		if err := rows.Scan(&id, &revision); err != nil {
+			return nil, fmt.Errorf("scan person revision: %w", err)
+		}
+		revisions[id] = revision
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person revisions: %w", err)
+	}
+	return revisions, nil
+}
+
+// CountRejectedPersons reports terminal person revisions that have no
+// searchable vector for the requested generation.
+func (b *Backend) CountRejectedPersons(ctx context.Context, gen vector.GenerationID) (int64, error) {
+	if _, err := personGeneration(ctx, b.db, gen, false); err != nil {
+		return 0, err
+	}
+	var count int64
+	if err := b.db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		  FROM person_embeddings
+		 WHERE generation_id = $1
+		   AND embedding IS NULL`, int64(gen)).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count rejected persons for generation %d: %w", gen, err)
+	}
+	return count, nil
+}
+
+// DeletePersonsNotIn reconciles gen to the exact current source person IDs.
+func (b *Backend) DeletePersonsNotIn(ctx context.Context, gen vector.GenerationID, currentPersonIDs []int64) error {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person reconcile tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := personGeneration(ctx, tx, gen, true); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM person_embeddings
+		 WHERE generation_id = $1
+		   AND person_id <> ALL($2::bigint[])`, int64(gen), int64Array(currentPersonIDs)); err != nil {
+		return fmt.Errorf("reconcile person embeddings for generation %d: %w", gen, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person reconcile for generation %d: %w", gen, err)
+	}
+	return nil
+}
+
+// SearchPeople searches only person-owned vectors and returns their published
+// revisions for read-time source revalidation.
+func (b *Backend) SearchPeople(ctx context.Context, gen vector.GenerationID, queryVec []float32, k int) ([]vector.PersonHit, error) {
+	if len(queryVec) == 0 {
+		return nil, errors.New("person search: empty query vector")
+	}
+	dim, err := personGeneration(ctx, b.db, gen, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(queryVec) != dim {
+		return nil, fmt.Errorf("%w: query has %d dims, gen has %d",
+			vector.ErrDimensionMismatch, len(queryVec), dim)
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+	// Materialize the requested generation before ranking so the bounded
+	// curated corpus is ranked exactly. The person HNSW compatibility index is
+	// retained for a future ANN path, but correctness does not rely on it.
+	q := fmt.Sprintf(`
+		WITH generation_candidates AS MATERIALIZED (
+			SELECT person_id, published_revision, embedding
+			  FROM person_embeddings
+			 WHERE generation_id = $2
+			   AND dimension = %[1]d
+			   AND embedding IS NOT NULL
+		)
+		SELECT person_id, published_revision,
+		       (embedding::vector(%[1]d)) <=> $1::vector AS distance
+		  FROM generation_candidates
+		 ORDER BY distance, person_id
+		 LIMIT $3`, dim)
+	rows, err := b.db.QueryContext(ctx, q, vectorLiteral(queryVec), int64(gen), k)
+	if err != nil {
+		return nil, fmt.Errorf("search person vectors: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	hits := make([]vector.PersonHit, 0, k)
+	for rows.Next() {
+		var hit vector.PersonHit
+		var distance float64
+		if err := rows.Scan(&hit.PersonID, &hit.Revision, &distance); err != nil {
+			return nil, fmt.Errorf("scan person hit: %w", err)
+		}
+		hit.Score = 1 - distance
+		hit.Rank = len(hits) + 1
+		hits = append(hits, hit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person hits: %w", err)
+	}
+	return hits, nil
+}
+
+func personGeneration(
+	ctx context.Context, q rowQueryer, gen vector.GenerationID, lock bool,
+) (int, error) {
+	query := `SELECT dimension, state FROM index_generations WHERE id = $1`
+	if lock {
+		query += ` FOR UPDATE`
+	}
+	var dim int
+	var state vector.GenerationState
+	err := q.QueryRowContext(ctx, query, int64(gen)).Scan(&dim, &state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("lookup generation %d: %w", gen, err)
+	}
+	if state == vector.GenerationRetired {
+		return 0, fmt.Errorf("%w: %d", vector.ErrGenerationRetired, gen)
+	}
+	return dim, nil
+}

--- a/internal/vector/pgvector/person_test.go
+++ b/internal/vector/pgvector/person_test.go
@@ -1,0 +1,337 @@
+//go:build pgvector
+
+package pgvector
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// TestPersonMigration_UpgradesAndIsIdempotent catches an upgrade that only
+// creates person storage for fresh databases, or a migration that fails when
+// startup applies it a second time.
+func TestPersonMigration_UpgradesAndIsIdempotent(t *testing.T) {
+	db := openPGTestDB(t)
+	ctx := context.Background()
+	seedLegacyPersonlessVectorSchema(t, db)
+
+	var before sql.NullString
+	require.NoError(t, db.QueryRow(`SELECT to_regclass('person_embeddings')::text`).Scan(&before))
+	require.False(t, before.Valid, "legacy schema must predate person vector storage")
+
+	require.NoError(t, Migrate(ctx, db, 4, false))
+	require.NoError(t, Migrate(ctx, db, 4, false))
+
+	var tableName string
+	require.NoError(t, db.QueryRow(`SELECT to_regclass('person_embeddings')::text`).Scan(&tableName))
+	assert.Equal(t, "person_embeddings", tableName)
+	var deadDimensionIndex sql.NullString
+	require.NoError(t, db.QueryRow(
+		`SELECT to_regclass('idx_person_embeddings_dim')::text`).Scan(&deadDimensionIndex))
+	assert.False(t, deadDimensionIndex.Valid, "exact person ranking must not retain a dead dimension index")
+	var personHNSWIndex string
+	require.NoError(t, db.QueryRow(
+		`SELECT to_regclass($1)::text`, PersonVectorIndexName(4)).Scan(&personHNSWIndex))
+	assert.Equal(t, PersonVectorIndexName(4), personHNSWIndex,
+		"migration must retain the approved per-dimension person HNSW compatibility object")
+	var personHNSWPredicate string
+	require.NoError(t, db.QueryRow(`
+		SELECT pg_get_expr(i.indpred, i.indrelid)
+		  FROM pg_index AS i
+		  JOIN pg_class AS c ON c.oid = i.indexrelid
+		 WHERE c.relname = $1`, PersonVectorIndexName(4)).Scan(&personHNSWPredicate))
+	assert.Contains(t, personHNSWPredicate, "dimension = 4")
+	assert.Contains(t, personHNSWPredicate, "embedding IS NOT NULL")
+	var legacyRows int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM embeddings WHERE message_id = 1`).Scan(&legacyRows))
+	assert.Equal(t, 1, legacyRows, "upgrade must preserve legacy message vectors")
+}
+
+// TestPersonBackend_CreateGenerationSupportsNonDefaultDimension catches an
+// exact person-ranking path accidentally tied to the configured default.
+func TestPersonBackend_CreateGenerationSupportsNonDefaultDimension(t *testing.T) {
+	b, ctx, db := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 7, "")
+	require.NoError(t, err)
+	var personHNSWIndex string
+	require.NoError(t, db.QueryRow(
+		`SELECT to_regclass($1)::text`, PersonVectorIndexName(7)).Scan(&personHNSWIndex))
+	assert.Equal(t, PersonVectorIndexName(7), personHNSWIndex,
+		"new dimensions must lazily receive their person HNSW compatibility object")
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 70, Revision: "rev-7", Vector: unitVec(7, 6),
+	}}))
+	hits, err := b.SearchPeople(ctx, gen, unitVec(7, 6), 1)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(70), hits[0].PersonID)
+}
+
+// TestPersonBackend_PublishSearchReplaceReconcile catches wrong cosine ordering,
+// stale revision/vector rows after replacement, and reconciliation that keeps
+// people absent from the exact current-ID set.
+func TestPersonBackend_PublishSearchReplaceReconcile(t *testing.T) {
+	b, ctx, _ := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 10, Revision: "rev-a", Vector: unitVec(4, 0)},
+		{PersonID: 20, Revision: "rev-b", Vector: unitVec(4, 1)},
+	}))
+	revisions, err := b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{10: "rev-a", 20: "rev-b"}, revisions)
+
+	hits, err := b.SearchPeople(ctx, gen, unitVec(4, 0), 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, int64(10), hits[0].PersonID)
+	assert.Equal(t, "rev-a", hits[0].Revision)
+	assert.Equal(t, 1, hits[0].Rank)
+	assert.Equal(t, int64(20), hits[1].PersonID)
+	assert.Equal(t, 2, hits[1].Rank)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 10, Revision: "rev-c", Vector: unitVec(4, 2)},
+	}))
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, int64(10), hits[0].PersonID)
+	assert.Equal(t, "rev-c", hits[0].Revision)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, []int64{20}))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{20: "rev-b"}, revisions)
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(20), hits[0].PersonID)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, nil))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Empty(t, revisions)
+}
+
+// TestPersonBackend_SearchCompletenessIsGenerationBounded catches exact
+// ranking leaking rows from a concurrent generation or underfilling the
+// requested generation's bounded corpus.
+func TestPersonBackend_SearchCompletenessIsGenerationBounded(t *testing.T) {
+	b, ctx, db := newPersonBackendForTest(t)
+	db.SetMaxOpenConns(1)
+
+	serving, err := b.CreateGeneration(ctx, "m", 4, "serving")
+	require.NoError(t, err)
+	servingPeople := make([]vector.PersonEmbedding, 5)
+	for i := range servingPeople {
+		servingPeople[i] = vector.PersonEmbedding{
+			PersonID: int64(101 + i), Revision: "serving", Vector: unitVec(4, 1),
+		}
+	}
+	require.NoError(t, b.UpsertPersons(ctx, serving, servingPeople))
+	require.NoError(t, b.ActivateGeneration(ctx, serving, true))
+
+	building, err := b.CreateGeneration(ctx, "m", 4, "building")
+	require.NoError(t, err)
+	buildingPeople := make([]vector.PersonEmbedding, 256)
+	for i := range buildingPeople {
+		buildingPeople[i] = vector.PersonEmbedding{
+			PersonID: int64(1000 + i), Revision: "building", Vector: unitVec(4, 0),
+		}
+	}
+	require.NoError(t, b.UpsertPersons(ctx, building, buildingPeople))
+
+	hits, err := b.SearchPeople(ctx, serving, unitVec(4, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, hits, 5)
+	assert.Equal(t, []int64{101, 102, 103, 104, 105}, []int64{
+		hits[0].PersonID, hits[1].PersonID, hits[2].PersonID, hits[3].PersonID, hits[4].PersonID,
+	})
+}
+
+func TestPersonBackend_TerminalRevisionIsCoveredButNotSearchable(t *testing.T) {
+	b, ctx, _ := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 1, Revision: "searchable", Vector: unitVec(4, 0)},
+		{PersonID: 2, Revision: "terminal"},
+	}))
+	revisions, err := b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{1: "searchable", 2: "terminal"}, revisions)
+	rejected, err := b.CountRejectedPersons(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rejected)
+	hits, err := b.SearchPeople(ctx, gen, unitVec(4, 0), 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(1), hits[0].PersonID)
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 1, Revision: "now-terminal"},
+	}))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{1: "now-terminal", 2: "terminal"}, revisions)
+	rejected, err = b.CountRejectedPersons(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), rejected)
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 0), 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits, "terminal replacement must remove the old searchable vector")
+}
+
+// TestPersonBackend_ErrorsAndRetirement catches writes/searches against an
+// unknown or retired generation and accepts neither vectors nor queries whose
+// dimensions disagree with the generation.
+func TestPersonBackend_ErrorsAndRetirement(t *testing.T) {
+	b, ctx, _ := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+
+	err = b.UpsertPersons(ctx, vector.GenerationID(999), []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(4, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrUnknownGeneration)
+	err = b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(3, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrDimensionMismatch)
+	_, err = b.SearchPeople(ctx, gen, unitVec(3, 0), 1)
+	require.ErrorIs(t, err, vector.ErrDimensionMismatch)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(4, 0),
+	}}))
+	require.NoError(t, b.RetireGeneration(ctx, gen, false))
+	err = b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 2, Revision: "rev", Vector: unitVec(4, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+	_, err = b.SearchPeople(ctx, gen, unitVec(4, 0), 1)
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+	_, err = b.ListPersonRevisions(ctx, gen)
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+
+	var count int
+	require.NoError(t, b.db.QueryRow(`SELECT COUNT(*) FROM person_embeddings WHERE generation_id = $1`, int64(gen)).Scan(&count))
+	assert.Zero(t, count, "pgvector retirement should remove rows from its shared ANN graph")
+}
+
+// TestPersonBackend_AutomaticRetirementDeletesPersonRows catches the distinct
+// activation path forgetting to remove the demoted generation's person rows
+// from pgvector's dimension-shared HNSW graph.
+func TestPersonBackend_AutomaticRetirementDeletesPersonRows(t *testing.T) {
+	b, ctx, db := newPersonBackendForTest(t)
+	serving, err := b.CreateGeneration(ctx, "m", 4, "serving")
+	require.NoError(t, err)
+	require.NoError(t, b.UpsertPersons(ctx, serving, []vector.PersonEmbedding{{
+		PersonID: 10, Revision: "serving-rev", Vector: unitVec(4, 0),
+	}}))
+	require.NoError(t, b.ActivateGeneration(ctx, serving, true))
+
+	replacement, err := b.CreateGeneration(ctx, "m", 4, "replacement")
+	require.NoError(t, err)
+	require.NoError(t, b.UpsertPersons(ctx, replacement, []vector.PersonEmbedding{{
+		PersonID: 20, Revision: "replacement-rev", Vector: unitVec(4, 1),
+	}}))
+	require.NoError(t, b.ActivateGeneration(ctx, replacement, true))
+
+	var retiredCount, replacementCount int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM person_embeddings WHERE generation_id = $1`, int64(serving)).Scan(&retiredCount))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM person_embeddings WHERE generation_id = $1`, int64(replacement)).Scan(&replacementCount))
+	assert.Zero(t, retiredCount, "automatic retirement must clean the demoted person corpus")
+	assert.Equal(t, 1, replacementCount, "activation must preserve the promoted person corpus")
+}
+
+// TestPersonBackend_MessageIDCollisionIsIsolated catches any implementation
+// that stores a person ID in message-owned embeddings or deletes one corpus
+// while replacing/reconciling the other.
+func TestPersonBackend_MessageIDCollisionIsIsolated(t *testing.T) {
+	b, ctx, db := newPersonBackendForTest(t)
+	gen := seedAndEmbed(t, b, db, map[int64][]float32{1: unitVec(4, 0)})
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "person-rev", Vector: unitVec(4, 1),
+	}}))
+	messageHits, err := b.Search(ctx, gen, unitVec(4, 0), 1, vector.Filter{})
+	require.NoError(t, err)
+	require.Len(t, messageHits, 1)
+	assert.Equal(t, int64(1), messageHits[0].MessageID)
+	personHits, err := b.SearchPeople(ctx, gen, unitVec(4, 1), 1)
+	require.NoError(t, err)
+	require.Len(t, personHits, 1)
+	assert.Equal(t, int64(1), personHits[0].PersonID)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, nil))
+	messageHits, err = b.Search(ctx, gen, unitVec(4, 0), 1, vector.Filter{})
+	require.NoError(t, err)
+	require.Len(t, messageHits, 1)
+	assert.Equal(t, int64(1), messageHits[0].MessageID)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "person-rev-2", Vector: unitVec(4, 2),
+	}}))
+	require.NoError(t, b.Delete(ctx, gen, []int64{1}))
+	personHits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 1)
+	require.NoError(t, err)
+	require.Len(t, personHits, 1)
+	assert.Equal(t, "person-rev-2", personHits[0].Revision)
+}
+
+func newPersonBackendForTest(t *testing.T) (*Backend, context.Context, *sql.DB) {
+	t.Helper()
+	return newBackendForTest(t)
+}
+
+// seedLegacyPersonlessVectorSchema installs the last vector schema shape that
+// existed before person_embeddings. Migrate then has to upgrade real existing
+// generation/message-vector tables rather than initialize an empty schema.
+func seedLegacyPersonlessVectorSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`
+		CREATE EXTENSION IF NOT EXISTS vector;
+		CREATE TABLE index_generations (
+			id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			model TEXT NOT NULL,
+			dimension INTEGER NOT NULL,
+			fingerprint TEXT NOT NULL,
+			started_at BIGINT NOT NULL,
+			seeded_at BIGINT,
+			completed_at BIGINT,
+			activated_at BIGINT,
+			state TEXT NOT NULL,
+			message_count BIGINT NOT NULL DEFAULT 0
+		);
+		CREATE TABLE embeddings (
+			generation_id BIGINT NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+			message_id BIGINT NOT NULL,
+			chunk_index INTEGER NOT NULL DEFAULT 0,
+			embedded_at BIGINT NOT NULL,
+			source_char_len INTEGER NOT NULL,
+			chunk_char_start INTEGER NOT NULL DEFAULT 0,
+			chunk_char_end INTEGER NOT NULL DEFAULT 0,
+			source_basis SMALLINT NOT NULL DEFAULT 0,
+			truncated BOOLEAN NOT NULL DEFAULT FALSE,
+			dimension INTEGER NOT NULL,
+			embedding vector NOT NULL,
+			PRIMARY KEY (generation_id, message_id, chunk_index)
+		);
+		INSERT INTO index_generations
+			(model, dimension, fingerprint, started_at, seeded_at, state, message_count)
+		VALUES ('legacy-model', 4, 'legacy:4', 1, 1, 'active', 1);
+		INSERT INTO embeddings
+			(generation_id, message_id, chunk_index, embedded_at, source_char_len,
+			 chunk_char_start, chunk_char_end, source_basis, truncated, dimension, embedding)
+		VALUES (1, 1, 0, 1, 1, 0, 1, 0, FALSE, 4, '[1,0,0,0]');
+	`)
+	require.NoError(t, err, "seed pre-person vector schema")
+}

--- a/internal/vector/pgvector/schema.sql
+++ b/internal/vector/pgvector/schema.sql
@@ -64,6 +64,22 @@ CREATE TABLE IF NOT EXISTS embeddings (
 CREATE INDEX IF NOT EXISTS idx_embeddings_msg ON embeddings(message_id);
 CREATE INDEX IF NOT EXISTS idx_embeddings_dim ON embeddings(dimension);
 
+-- Person embeddings are a separate corpus and never share message IDs or the
+-- message HNSW graph. Migrate creates a dimension-partial person HNSW
+-- compatibility index for the configured dimension; CreateGeneration adds
+-- one for each later generation dimension. Current person search ranks the
+-- capped curated corpus exactly instead.
+CREATE TABLE IF NOT EXISTS person_embeddings (
+    generation_id      BIGINT NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+    person_id          BIGINT NOT NULL,
+    published_revision TEXT NOT NULL,
+    dimension          INTEGER NOT NULL,
+    embedded_at        BIGINT NOT NULL,
+    embedding          vector,
+    PRIMARY KEY (generation_id, person_id)
+);
+DROP INDEX IF EXISTS idx_person_embeddings_dim;
+
 CREATE TABLE IF NOT EXISTS embed_runs (
     id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     generation_id BIGINT NOT NULL REFERENCES index_generations(id),

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -156,6 +156,9 @@ func (b *Backend) CreateGeneration(ctx context.Context, model string, dim int, f
 	if err := EnsureVectorTable(ctx, b.db, dim); err != nil {
 		return 0, err
 	}
+	if err := EnsurePersonVectorTable(ctx, b.db, dim); err != nil {
+		return 0, err
+	}
 	fp := fingerprint
 	if fp == "" {
 		// Defensive default: a missing fingerprint loses the staleness

--- a/internal/vector/sqlitevec/migrate.go
+++ b/internal/vector/sqlitevec/migrate.go
@@ -36,6 +36,9 @@ func Migrate(ctx context.Context, db *sql.DB, defaultDim int) error {
 	if err := migrateDocumentLedger(ctx, db); err != nil {
 		return fmt.Errorf("migrate document ledger: %w", err)
 	}
+	if err := migratePersonEmbeddings(ctx, db); err != nil {
+		return fmt.Errorf("migrate person embeddings: %w", err)
+	}
 	if _, err := db.ExecContext(ctx, schemaSQL); err != nil {
 		return fmt.Errorf("apply schema: %w", err)
 	}
@@ -74,12 +77,15 @@ func Migrate(ctx context.Context, db *sql.DB, defaultDim int) error {
 		return fmt.Errorf("migrate vec tables to chunked layout: %w", err)
 	}
 	// defaultDim is informational, mirroring pgvector: a multimodal-only
-	// configuration has no text embedding dimension, and text generations
-	// create their dimension-specific table in CreateGeneration anyway.
+	// configuration has no text/person embedding dimension, and text
+	// generations create their dimension-specific table in CreateGeneration.
 	if defaultDim <= 0 {
 		return nil
 	}
-	return EnsureVectorTable(ctx, db, defaultDim)
+	if err := EnsureVectorTable(ctx, db, defaultDim); err != nil {
+		return err
+	}
+	return EnsurePersonVectorTable(ctx, db, defaultDim)
 }
 
 // migrateEmbeddingsToChunked detects the pre-chunking schema (no

--- a/internal/vector/sqlitevec/person.go
+++ b/internal/vector/sqlitevec/person.go
@@ -1,0 +1,404 @@
+//go:build sqlite_vec
+
+package sqlitevec
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+var _ vector.PersonBackend = (*Backend)(nil)
+
+const personEmbeddingsSchema = `
+CREATE TABLE IF NOT EXISTS person_embeddings (
+	embedding_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+	generation_id      INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+	person_id          INTEGER NOT NULL,
+	published_revision TEXT NOT NULL,
+	dimension          INTEGER NOT NULL,
+	embedded_at        INTEGER NOT NULL,
+	UNIQUE (generation_id, person_id)
+);
+`
+
+// migratePersonEmbeddings is the explicit upgrade path for vector databases
+// created before the person corpus existed. Fresh databases receive the same
+// definition from schema.sql.
+func migratePersonEmbeddings(ctx context.Context, db *sql.DB) error {
+	exists, err := tableExists(ctx, db, "index_generations")
+	if err != nil || !exists {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, personEmbeddingsSchema); err != nil {
+		return fmt.Errorf("create person embeddings metadata: %w", err)
+	}
+	return migratePersonVectorMetrics(ctx, db)
+}
+
+// migratePersonVectorMetrics replaces person vec0 tables created before the
+// corpus standardized on cosine distance. Their metadata is discarded with
+// the incompatible vectors so the next worker pass re-embeds those people.
+func migratePersonVectorMetrics(ctx context.Context, db *sql.DB) error {
+	rows, err := db.QueryContext(ctx, `
+		SELECT name, sql
+		  FROM sqlite_master
+		 WHERE type = 'table'
+		   AND name LIKE 'person_vectors_vec_d%'
+		   AND sql LIKE '%USING vec0%'`)
+	if err != nil {
+		return fmt.Errorf("list person vector tables: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type legacyTable struct {
+		name      string
+		dimension int
+	}
+	legacy := make([]legacyTable, 0)
+	for rows.Next() {
+		var name, ddl string
+		if err := rows.Scan(&name, &ddl); err != nil {
+			return fmt.Errorf("scan person vector table: %w", err)
+		}
+		normalizedDDL := strings.NewReplacer(" ", "", "\n", "", "\r", "", "\t", "").Replace(strings.ToLower(ddl))
+		if strings.Contains(normalizedDDL, "distance_metric=cosine") {
+			continue
+		}
+		dimension, err := strconv.Atoi(strings.TrimPrefix(name, "person_vectors_vec_d"))
+		if err != nil || dimension <= 0 || PersonVectorTableName(dimension) != name {
+			return fmt.Errorf("invalid person vector table name %q", name)
+		}
+		legacy = append(legacy, legacyTable{name: name, dimension: dimension})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate person vector tables: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close person vector tables: %w", err)
+	}
+	if len(legacy) == 0 {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person vector metric migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, table := range legacy {
+		if _, err := tx.ExecContext(ctx, `DROP TABLE `+table.name); err != nil {
+			return fmt.Errorf("drop legacy person vector table %s: %w", table.name, err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM person_embeddings WHERE dimension = ?`, table.dimension); err != nil {
+			return fmt.Errorf("clear legacy person vector metadata for dimension %d: %w", table.dimension, err)
+		}
+		if _, err := tx.ExecContext(ctx, personVectorTableDDL(table.dimension)); err != nil {
+			return fmt.Errorf("recreate cosine person vector table %s: %w", table.name, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person vector metric migration: %w", err)
+	}
+	return nil
+}
+
+// EnsurePersonVectorTable creates the person-owned vec0 table for dim. Its
+// synthetic embedding_id key permits the same person to coexist in multiple
+// generations without colliding in vec0's global rowid namespace.
+func EnsurePersonVectorTable(ctx context.Context, db *sql.DB, dim int) error {
+	if dim <= 0 {
+		return fmt.Errorf("invalid dimension %d", dim)
+	}
+	name := PersonVectorTableName(dim)
+	if _, err := db.ExecContext(ctx, personVectorTableDDL(dim)); err != nil {
+		return fmt.Errorf("create %s: %w", name, err)
+	}
+	return nil
+}
+
+func personVectorTableDDL(dim int) string {
+	return fmt.Sprintf(`CREATE VIRTUAL TABLE IF NOT EXISTS %s USING vec0(
+		generation_id INTEGER PARTITION KEY,
+		embedding_id  INTEGER PRIMARY KEY,
+		embedding     FLOAT[%d] distance_metric=cosine
+	)`, PersonVectorTableName(dim), dim)
+}
+
+// PersonVectorTableName returns the dimension-specific person vec0 table.
+func PersonVectorTableName(dim int) string {
+	return fmt.Sprintf("person_vectors_vec_d%d", dim)
+}
+
+// UpsertPersons atomically replaces each supplied person's published
+// revision and vector without touching message-owned embeddings.
+func (b *Backend) UpsertPersons(ctx context.Context, gen vector.GenerationID, persons []vector.PersonEmbedding) error {
+	if len(persons) == 0 {
+		return nil
+	}
+	dim, err := personGeneration(ctx, b.db, gen)
+	if err != nil {
+		return err
+	}
+	if err := EnsurePersonVectorTable(ctx, b.db, dim); err != nil {
+		return err
+	}
+
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person upsert tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	dim, err = personGeneration(ctx, tx, gen)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]int64, 0, len(persons))
+	seen := make(map[int64]struct{}, len(persons))
+	for _, person := range persons {
+		if len(person.Vector) != 0 && len(person.Vector) != dim {
+			return fmt.Errorf("%w: person %d has %d dims, gen has %d",
+				vector.ErrDimensionMismatch, person.PersonID, len(person.Vector), dim)
+		}
+		if _, duplicate := seen[person.PersonID]; duplicate {
+			return fmt.Errorf("duplicate person id %d in upsert batch", person.PersonID)
+		}
+		seen[person.PersonID] = struct{}{}
+		ids = append(ids, person.PersonID)
+	}
+
+	if err := deleteSQLitePersons(ctx, tx, PersonVectorTableName(dim), gen, ids, false); err != nil {
+		return err
+	}
+	metadata, err := tx.PrepareContext(ctx, `
+		INSERT INTO person_embeddings
+			(generation_id, person_id, published_revision, dimension, embedded_at)
+		VALUES (?, ?, ?, ?, ?)
+		RETURNING embedding_id`)
+	if err != nil {
+		return fmt.Errorf("prepare person metadata insert: %w", err)
+	}
+	defer func() { _ = metadata.Close() }()
+	vecTable := PersonVectorTableName(dim)
+	vecInsert, err := tx.PrepareContext(ctx, fmt.Sprintf(
+		`INSERT INTO %s (generation_id, embedding_id, embedding) VALUES (?, ?, ?)`, vecTable))
+	if err != nil {
+		return fmt.Errorf("prepare person vector insert: %w", err)
+	}
+	defer func() { _ = vecInsert.Close() }()
+
+	now := time.Now().Unix()
+	for _, person := range persons {
+		var embeddingID int64
+		if err := metadata.QueryRowContext(ctx, int64(gen), person.PersonID, person.Revision, dim, now).Scan(&embeddingID); err != nil {
+			return fmt.Errorf("insert person %d metadata: %w", person.PersonID, err)
+		}
+		if len(person.Vector) == 0 {
+			continue
+		}
+		if _, err := vecInsert.ExecContext(ctx, int64(gen), embeddingID, float32SliceBlob(person.Vector)); err != nil {
+			return fmt.Errorf("insert person %d vector: %w", person.PersonID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person upsert for generation %d: %w", gen, err)
+	}
+	return nil
+}
+
+// ListPersonRevisions returns the exact published revision owned by every
+// current person vector in gen.
+func (b *Backend) ListPersonRevisions(ctx context.Context, gen vector.GenerationID) (map[int64]string, error) {
+	if _, err := personGeneration(ctx, b.db, gen); err != nil {
+		return nil, err
+	}
+	rows, err := b.db.QueryContext(ctx, `
+		SELECT person_id, published_revision
+		  FROM person_embeddings
+		 WHERE generation_id = ?
+		 ORDER BY person_id`, int64(gen))
+	if err != nil {
+		return nil, fmt.Errorf("list person revisions for generation %d: %w", gen, err)
+	}
+	defer func() { _ = rows.Close() }()
+	revisions := make(map[int64]string)
+	for rows.Next() {
+		var id int64
+		var revision string
+		if err := rows.Scan(&id, &revision); err != nil {
+			return nil, fmt.Errorf("scan person revision: %w", err)
+		}
+		revisions[id] = revision
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person revisions: %w", err)
+	}
+	return revisions, nil
+}
+
+// CountRejectedPersons reports terminal person revisions that have metadata
+// but no searchable vector for the requested generation.
+func (b *Backend) CountRejectedPersons(ctx context.Context, gen vector.GenerationID) (int64, error) {
+	dim, err := personGeneration(ctx, b.db, gen)
+	if err != nil {
+		return 0, err
+	}
+	if err := EnsurePersonVectorTable(ctx, b.db, dim); err != nil {
+		return 0, err
+	}
+	query := fmt.Sprintf(`
+		SELECT COUNT(*)
+		  FROM person_embeddings AS p
+		  LEFT JOIN %s AS v
+		    ON v.generation_id = p.generation_id
+		   AND v.embedding_id = p.embedding_id
+		 WHERE p.generation_id = ?
+		   AND v.embedding_id IS NULL`, PersonVectorTableName(dim))
+	var count int64
+	if err := b.db.QueryRowContext(ctx, query, int64(gen)).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count rejected persons for generation %d: %w", gen, err)
+	}
+	return count, nil
+}
+
+// DeletePersonsNotIn reconciles gen to the exact current source person IDs.
+func (b *Backend) DeletePersonsNotIn(ctx context.Context, gen vector.GenerationID, currentPersonIDs []int64) error {
+	dim, err := personGeneration(ctx, b.db, gen)
+	if err != nil {
+		return err
+	}
+	if err := EnsurePersonVectorTable(ctx, b.db, dim); err != nil {
+		return err
+	}
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin person reconcile tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := personGeneration(ctx, tx, gen); err != nil {
+		return err
+	}
+	if err := deleteSQLitePersons(ctx, tx, PersonVectorTableName(dim), gen, currentPersonIDs, true); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit person reconcile for generation %d: %w", gen, err)
+	}
+	return nil
+}
+
+// SearchPeople searches only person-owned vectors and returns their published
+// revisions for read-time source revalidation.
+func (b *Backend) SearchPeople(ctx context.Context, gen vector.GenerationID, queryVec []float32, k int) ([]vector.PersonHit, error) {
+	if len(queryVec) == 0 {
+		return nil, errors.New("person search: empty query vector")
+	}
+	dim, err := personGeneration(ctx, b.db, gen)
+	if err != nil {
+		return nil, err
+	}
+	if len(queryVec) != dim {
+		return nil, fmt.Errorf("%w: query has %d dims, gen has %d",
+			vector.ErrDimensionMismatch, len(queryVec), dim)
+	}
+	if k <= 0 {
+		return nil, nil
+	}
+	var count int
+	if err := b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM person_embeddings WHERE generation_id = ?`, int64(gen)).Scan(&count); err != nil {
+		return nil, fmt.Errorf("count person embeddings: %w", err)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	q := fmt.Sprintf(`
+		SELECT p.person_id, p.published_revision, v.distance
+		  FROM %s v
+		  JOIN person_embeddings p ON p.embedding_id = v.embedding_id
+		 WHERE v.generation_id = ?
+		   AND v.embedding MATCH ?
+		   AND k = ?
+		 ORDER BY v.distance, p.person_id`, PersonVectorTableName(dim))
+	rows, err := b.db.QueryContext(ctx, q, int64(gen), float32SliceBlob(queryVec), min(k, count))
+	if err != nil {
+		return nil, fmt.Errorf("search person vectors: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	hits := make([]vector.PersonHit, 0, min(k, count))
+	for rows.Next() {
+		var hit vector.PersonHit
+		var distance float64
+		if err := rows.Scan(&hit.PersonID, &hit.Revision, &distance); err != nil {
+			return nil, fmt.Errorf("scan person hit: %w", err)
+		}
+		hit.Score = 1 - distance
+		hit.Rank = len(hits) + 1
+		hits = append(hits, hit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person hits: %w", err)
+	}
+	return hits, nil
+}
+
+type personGenerationQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func personGeneration(ctx context.Context, q personGenerationQueryer, gen vector.GenerationID) (int, error) {
+	var dim int
+	var state vector.GenerationState
+	err := q.QueryRowContext(ctx,
+		`SELECT dimension, state FROM index_generations WHERE id = ?`, int64(gen)).Scan(&dim, &state)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("%w: %d", vector.ErrUnknownGeneration, gen)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("lookup generation %d: %w", gen, err)
+	}
+	if state == vector.GenerationRetired {
+		return 0, fmt.Errorf("%w: %d", vector.ErrGenerationRetired, gen)
+	}
+	return dim, nil
+}
+
+func deleteSQLitePersons(ctx context.Context, tx *sql.Tx, vecTable string, gen vector.GenerationID, ids []int64, invert bool) error {
+	if ids == nil {
+		ids = []int64{}
+	}
+	encoded, err := json.Marshal(ids)
+	if err != nil {
+		return fmt.Errorf("encode person ids: %w", err)
+	}
+	comparison := "IN"
+	if invert {
+		comparison = "NOT IN"
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM %s
+		 WHERE generation_id = ?
+		   AND embedding_id IN (
+			SELECT embedding_id FROM person_embeddings
+			 WHERE generation_id = ?
+			   AND person_id %s (SELECT value FROM json_each(?))
+		   )`, vecTable, comparison), int64(gen), int64(gen), string(encoded)); err != nil {
+		return fmt.Errorf("delete person vectors: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+		DELETE FROM person_embeddings
+		 WHERE generation_id = ?
+		   AND person_id %s (SELECT value FROM json_each(?))`, comparison),
+		int64(gen), string(encoded)); err != nil {
+		return fmt.Errorf("delete person metadata: %w", err)
+	}
+	return nil
+}

--- a/internal/vector/sqlitevec/person_test.go
+++ b/internal/vector/sqlitevec/person_test.go
@@ -1,0 +1,364 @@
+//go:build sqlite_vec
+
+package sqlitevec
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+// TestPersonMigration_UpgradesAndIsIdempotent catches an upgrade that only
+// creates person storage for fresh databases, or a migration that fails when
+// startup applies it a second time.
+func TestPersonMigration_UpgradesAndIsIdempotent(t *testing.T) {
+	require.NoError(t, RegisterExtension())
+	db, err := sql.Open(DriverName(), filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE index_generations (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		model TEXT NOT NULL,
+		dimension INTEGER NOT NULL,
+		fingerprint TEXT NOT NULL,
+		started_at INTEGER NOT NULL,
+		completed_at INTEGER,
+		activated_at INTEGER,
+		state TEXT NOT NULL,
+		message_count INTEGER NOT NULL DEFAULT 0
+	)`)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, Migrate(ctx, db, 4))
+	require.NoError(t, Migrate(ctx, db, 4))
+
+	for _, table := range []string{"person_embeddings", PersonVectorTableName(4)} {
+		exists, err := tableExists(ctx, db, table)
+		require.NoError(t, err)
+		assert.Truef(t, exists, "table %s should exist after upgrade", table)
+	}
+}
+
+func TestPersonMigration_RebuildsLegacyL2TableForCosine(t *testing.T) {
+	require.NoError(t, RegisterExtension())
+	db, err := sql.Open(DriverName(), filepath.Join(t.TempDir(), "vectors.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := t.Context()
+	require.NoError(t, Migrate(ctx, db, 4))
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO index_generations
+			(id, model, dimension, fingerprint, started_at, state)
+		VALUES (1, 'm', 4, 'legacy-l2', 1, 'active')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `DROP TABLE person_vectors_vec_d4`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `CREATE VIRTUAL TABLE person_vectors_vec_d4 USING vec0(
+		generation_id INTEGER PARTITION KEY,
+		embedding_id INTEGER PRIMARY KEY,
+		embedding FLOAT[4]
+	)`)
+	require.NoError(t, err)
+	var embeddingID int64
+	err = db.QueryRowContext(ctx, `
+		INSERT INTO person_embeddings
+			(generation_id, person_id, published_revision, dimension, embedded_at)
+		VALUES (1, 10, 'legacy', 4, 1)
+		RETURNING embedding_id`).Scan(&embeddingID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO person_vectors_vec_d4 (generation_id, embedding_id, embedding)
+		VALUES (?, ?, ?)`, 1, embeddingID, float32SliceBlob([]float32{2, 0, 0, 0}))
+	require.NoError(t, err)
+
+	require.NoError(t, Migrate(ctx, db, 7))
+	var ddl string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE name = ?`, PersonVectorTableName(4)).Scan(&ddl))
+	assert.Contains(t, ddl, "distance_metric=cosine")
+	var metadataRows int
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM person_embeddings WHERE dimension = 4`).Scan(&metadataRows))
+	assert.Zero(t, metadataRows, "discarded L2 vectors must be marked for re-embedding")
+	require.NoError(t, Migrate(ctx, db, 7), "cosine migration must be idempotent")
+}
+
+// TestPersonBackend_CreateGenerationCreatesNonDefaultDimensionANN catches a
+// generation path that creates only the configured default-dimension person
+// vec0 table and leaves a later generation's distinct dimension unavailable.
+func TestPersonBackend_CreateGenerationCreatesNonDefaultDimensionANN(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+
+	exists, err := tableExists(ctx, b.db, "person_vectors_vec_d7")
+	require.NoError(t, err)
+	require.False(t, exists, "dimension 7 table must be created lazily")
+
+	gen, err := b.CreateGeneration(ctx, "m", 7, "")
+	require.NoError(t, err)
+	exists, err = tableExists(ctx, b.db, "person_vectors_vec_d7")
+	require.NoError(t, err)
+	assert.True(t, exists, "generation dimension must own a person vec0 table")
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 70, Revision: "rev-7", Vector: unitVec(7, 6),
+	}}))
+	hits, err := b.SearchPeople(ctx, gen, unitVec(7, 6), 1)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(70), hits[0].PersonID)
+}
+
+// TestPersonBackend_PublishSearchReplaceReconcile catches wrong ANN ordering,
+// stale revision/vector rows after replacement, and reconciliation that keeps
+// people absent from the exact current-ID set.
+func TestPersonBackend_PublishSearchReplaceReconcile(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 10, Revision: "rev-a", Vector: unitVec(4, 0)},
+		{PersonID: 20, Revision: "rev-b", Vector: unitVec(4, 1)},
+	}))
+
+	revisions, err := b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{10: "rev-a", 20: "rev-b"}, revisions)
+
+	hits, err := b.SearchPeople(ctx, gen, unitVec(4, 0), 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, int64(10), hits[0].PersonID)
+	assert.Equal(t, "rev-a", hits[0].Revision)
+	assert.Equal(t, 1, hits[0].Rank)
+	assert.Equal(t, int64(20), hits[1].PersonID)
+	assert.Equal(t, 2, hits[1].Rank)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 10, Revision: "rev-c", Vector: unitVec(4, 2)},
+	}))
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, int64(10), hits[0].PersonID)
+	assert.Equal(t, "rev-c", hits[0].Revision)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, []int64{20}))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{20: "rev-b"}, revisions)
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(20), hits[0].PersonID)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, nil))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Empty(t, revisions)
+}
+
+func TestPersonBackend_SearchUsesCosineScores(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 10, Revision: "scaled", Vector: []float32{2, 0, 0, 0}},
+		{PersonID: 20, Revision: "orthogonal", Vector: []float32{0, 1, 0, 0}},
+	}))
+	hits, err := b.SearchPeople(ctx, gen, []float32{1, 0, 0, 0}, 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 2)
+	assert.Equal(t, int64(10), hits[0].PersonID)
+	assert.InDelta(t, 1, hits[0].Score, 1e-6)
+	assert.Equal(t, int64(20), hits[1].PersonID)
+	assert.InDelta(t, 0, hits[1].Score, 1e-6)
+}
+
+func TestPersonBackend_TerminalRevisionIsCoveredButNotSearchable(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 1, Revision: "searchable", Vector: unitVec(4, 0)},
+		{PersonID: 2, Revision: "terminal"},
+	}))
+	revisions, err := b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{1: "searchable", 2: "terminal"}, revisions)
+	rejected, err := b.CountRejectedPersons(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rejected)
+	hits, err := b.SearchPeople(ctx, gen, unitVec(4, 0), 10)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	assert.Equal(t, int64(1), hits[0].PersonID)
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{
+		{PersonID: 1, Revision: "now-terminal"},
+	}))
+	revisions, err = b.ListPersonRevisions(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]string{1: "now-terminal", 2: "terminal"}, revisions)
+	rejected, err = b.CountRejectedPersons(ctx, gen)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), rejected)
+	hits, err = b.SearchPeople(ctx, gen, unitVec(4, 0), 10)
+	require.NoError(t, err)
+	assert.Empty(t, hits, "terminal replacement must remove the old searchable vector")
+}
+
+func TestPersonBackend_CoverageAndReconcileRestoreMissingDimensionTable(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *Backend, vector.GenerationID) error
+	}{
+		{name: "coverage", run: func(ctx context.Context, backend *Backend, gen vector.GenerationID) error {
+			count, err := backend.CountRejectedPersons(ctx, gen)
+			assert.Zero(t, count)
+			return err
+		}},
+		{name: "reconcile", run: func(ctx context.Context, backend *Backend, gen vector.GenerationID) error {
+			return backend.DeletePersonsNotIn(ctx, gen, nil)
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backend, ctx := newPersonBackendForTest(t)
+			gen, err := backend.CreateGeneration(ctx, "m", 7, test.name)
+			require.NoError(t, err)
+			_, err = backend.db.ExecContext(ctx, `DROP TABLE `+PersonVectorTableName(7))
+			require.NoError(t, err)
+
+			require.NoError(t, test.run(ctx, backend, gen))
+			exists, err := tableExists(ctx, backend.db, PersonVectorTableName(7))
+			require.NoError(t, err)
+			assert.True(t, exists)
+		})
+	}
+}
+
+func TestPersonBackend_SearchCompletenessIsGenerationBounded(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	serving, err := b.CreateGeneration(ctx, "m", 4, "serving")
+	require.NoError(t, err)
+	servingPeople := make([]vector.PersonEmbedding, 5)
+	for i := range servingPeople {
+		servingPeople[i] = vector.PersonEmbedding{
+			PersonID: int64(101 + i), Revision: "serving", Vector: unitVec(4, 1),
+		}
+	}
+	require.NoError(t, b.UpsertPersons(ctx, serving, servingPeople))
+	require.NoError(t, b.ActivateGeneration(ctx, serving, true))
+
+	building, err := b.CreateGeneration(ctx, "m", 4, "building")
+	require.NoError(t, err)
+	buildingPeople := make([]vector.PersonEmbedding, 256)
+	for i := range buildingPeople {
+		buildingPeople[i] = vector.PersonEmbedding{
+			PersonID: int64(1000 + i), Revision: "building", Vector: unitVec(4, 0),
+		}
+	}
+	require.NoError(t, b.UpsertPersons(ctx, building, buildingPeople))
+
+	hits, err := b.SearchPeople(ctx, serving, unitVec(4, 0), 5)
+	require.NoError(t, err)
+	require.Len(t, hits, 5)
+	assert.Equal(t, []int64{101, 102, 103, 104, 105}, []int64{
+		hits[0].PersonID, hits[1].PersonID, hits[2].PersonID, hits[3].PersonID, hits[4].PersonID,
+	})
+}
+
+// TestPersonBackend_ErrorsAndRetirement catches writes/searches against an
+// unknown or retired generation and accepts neither vectors nor queries whose
+// dimensions disagree with the generation.
+func TestPersonBackend_ErrorsAndRetirement(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	gen, err := b.CreateGeneration(ctx, "m", 4, "")
+	require.NoError(t, err)
+
+	err = b.UpsertPersons(ctx, vector.GenerationID(999), []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(4, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrUnknownGeneration)
+	err = b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(3, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrDimensionMismatch)
+	_, err = b.SearchPeople(ctx, gen, unitVec(3, 0), 1)
+	require.ErrorIs(t, err, vector.ErrDimensionMismatch)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "rev", Vector: unitVec(4, 0),
+	}}))
+	require.NoError(t, b.RetireGeneration(ctx, gen, false))
+	var retained int
+	require.NoError(t, b.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM person_embeddings WHERE generation_id = ?`, int64(gen)).Scan(&retained))
+	assert.Equal(t, 1, retained, "retired SQLite generations retain partitioned person rows")
+	err = b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 2, Revision: "rev", Vector: unitVec(4, 0),
+	}})
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+	_, err = b.SearchPeople(ctx, gen, unitVec(4, 0), 1)
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+	_, err = b.ListPersonRevisions(ctx, gen)
+	require.ErrorIs(t, err, vector.ErrGenerationRetired)
+}
+
+// TestPersonBackend_MessageIDCollisionIsIsolated catches any implementation
+// that stores a person ID in message-owned embeddings or deletes one corpus
+// while replacing/reconciling the other.
+func TestPersonBackend_MessageIDCollisionIsIsolated(t *testing.T) {
+	b, ctx := newPersonBackendForTest(t)
+	gen := seedAndEmbed(t, b, map[int64][]float32{1: unitVec(4, 0)})
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "person-rev", Vector: unitVec(4, 1),
+	}}))
+	messageHits, err := b.Search(ctx, gen, unitVec(4, 0), 1, vector.Filter{})
+	require.NoError(t, err)
+	require.Len(t, messageHits, 1)
+	assert.Equal(t, int64(1), messageHits[0].MessageID)
+	personHits, err := b.SearchPeople(ctx, gen, unitVec(4, 1), 1)
+	require.NoError(t, err)
+	require.Len(t, personHits, 1)
+	assert.Equal(t, int64(1), personHits[0].PersonID)
+
+	require.NoError(t, b.DeletePersonsNotIn(ctx, gen, nil))
+	messageHits, err = b.Search(ctx, gen, unitVec(4, 0), 1, vector.Filter{})
+	require.NoError(t, err)
+	require.Len(t, messageHits, 1)
+	assert.Equal(t, int64(1), messageHits[0].MessageID)
+
+	require.NoError(t, b.UpsertPersons(ctx, gen, []vector.PersonEmbedding{{
+		PersonID: 1, Revision: "person-rev-2", Vector: unitVec(4, 2),
+	}}))
+	require.NoError(t, b.Delete(ctx, gen, []int64{1}))
+	personHits, err = b.SearchPeople(ctx, gen, unitVec(4, 2), 1)
+	require.NoError(t, err)
+	require.Len(t, personHits, 1)
+	assert.Equal(t, "person-rev-2", personHits[0].Revision)
+}
+
+func newPersonBackendForTest(t *testing.T) (*Backend, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	mainDB := openMainDBWithOneMessage(t)
+	b, err := Open(ctx, Options{
+		Path:      filepath.Join(t.TempDir(), "vectors.db"),
+		Dimension: 4,
+		MainDB:    mainDB,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.Close() })
+	return b, ctx
+}

--- a/internal/vector/sqlitevec/schema.sql
+++ b/internal/vector/sqlitevec/schema.sql
@@ -55,6 +55,17 @@ CREATE TABLE IF NOT EXISTS embeddings (
 CREATE INDEX IF NOT EXISTS idx_embeddings_msg ON embeddings(message_id);
 CREATE INDEX IF NOT EXISTS idx_embeddings_gen_msg ON embeddings(generation_id, message_id);
 
+-- Person embeddings are a separate corpus. The synthetic embedding_id joins
+-- to person_vectors_vec_dN without ever entering message-owned tables.
+CREATE TABLE IF NOT EXISTS person_embeddings (
+    embedding_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    generation_id      INTEGER NOT NULL REFERENCES index_generations(id) ON DELETE CASCADE,
+    person_id          INTEGER NOT NULL,
+    published_revision TEXT NOT NULL,
+    dimension          INTEGER NOT NULL,
+    embedded_at        INTEGER NOT NULL,
+    UNIQUE (generation_id, person_id)
+);
 CREATE TABLE IF NOT EXISTS embed_runs (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     generation_id INTEGER NOT NULL REFERENCES index_generations(id),

--- a/internal/vector/stats.go
+++ b/internal/vector/stats.go
@@ -34,6 +34,10 @@ type StatsView struct {
 	// generations contribute zero. Replaces the former pending-embeddings queue
 	// total under the scan-and-fill design.
 	MissingEmbeddingsTotal int64 `json:"missing_embeddings_total"`
+
+	// PersonCoverageRejected is the number of current terminal person
+	// publications that could not produce a searchable vector.
+	PersonCoverageRejected int64 `json:"person_coverage_rejected"`
 }
 
 // GenerationSummary reports the serving state for the active index
@@ -89,10 +93,15 @@ func CollectStats(ctx context.Context, b Backend) (*StatsView, error) {
 	var buildingExists bool
 	var activePending int64
 	var activeStatsOK bool
+	var activeID GenerationID
+	var activeExists bool
+	var personTarget GenerationID
 
 	active, err := b.ActiveGeneration(ctx)
 	switch {
 	case err == nil:
+		activeID = active.ID
+		activeExists = true
 		s, sErr := b.Stats(ctx, active.ID)
 		if sErr != nil {
 			errs = append(errs, fmt.Errorf("stats for active generation %d: %w", active.ID, sErr))
@@ -120,6 +129,7 @@ func CollectStats(ctx context.Context, b Backend) (*StatsView, error) {
 		errs = append(errs, fmt.Errorf("building generation: %w", err))
 	} else if building != nil {
 		buildingExists = true
+		personTarget = building.ID
 		s, sErr := b.Stats(ctx, building.ID)
 		if sErr != nil {
 			errs = append(errs, fmt.Errorf("stats for building generation %d: %w", building.ID, sErr))
@@ -139,6 +149,19 @@ func CollectStats(ctx context.Context, b Backend) (*StatsView, error) {
 	}
 	if !buildingExists && activeStatsOK {
 		out.MissingEmbeddingsTotal = activePending
+	}
+	if !buildingExists && activeExists {
+		personTarget = activeID
+	}
+	if personTarget != 0 {
+		if counter, ok := b.(PersonCoverageCounter); ok {
+			count, countErr := counter.CountRejectedPersons(ctx, personTarget)
+			if countErr != nil {
+				errs = append(errs, fmt.Errorf("rejected person coverage for generation %d: %w", personTarget, countErr))
+			} else {
+				out.PersonCoverageRejected = count
+			}
+		}
 	}
 	return out, errors.Join(errs...)
 }

--- a/internal/vector/stats_test.go
+++ b/internal/vector/stats_test.go
@@ -21,6 +21,7 @@ type statsFakeBackend struct {
 	buildErr   error
 	statsByGen map[GenerationID]Stats
 	statsErr   map[GenerationID]error
+	rejected   map[GenerationID]int64
 }
 
 func (f *statsFakeBackend) ActiveGeneration(context.Context) (Generation, error) {
@@ -45,6 +46,10 @@ func (f *statsFakeBackend) Stats(_ context.Context, gen GenerationID) (Stats, er
 		return Stats{}, err
 	}
 	return f.statsByGen[gen], nil
+}
+
+func (f *statsFakeBackend) CountRejectedPersons(_ context.Context, gen GenerationID) (int64, error) {
+	return f.rejected[gen], nil
 }
 
 func (f *statsFakeBackend) CreateGeneration(context.Context, string, int, string) (GenerationID, error) {
@@ -109,12 +114,14 @@ func TestCollectStats_ActiveOnly(t *testing.T) {
 		statsByGen: map[GenerationID]Stats{
 			5: {EmbeddingCount: 100, PendingCount: 7},
 		},
+		rejected: map[GenerationID]int64{5: 2},
 	}
 
 	sv, err := CollectStats(context.Background(), b)
 	require.NoError(err, "CollectStats")
 	require.NotNil(sv, "CollectStats returned nil StatsView")
 	assert.True(sv.Enabled)
+	assert.Equal(int64(2), sv.PersonCoverageRejected)
 	require.NotNil(sv.ActiveGeneration, "ActiveGeneration is nil")
 	ag := sv.ActiveGeneration
 	assert.Equal(GenerationID(5), ag.ID)

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -551,6 +551,10 @@ type ClientInterface interface {
 	CreatePerson(ctx context.Context, options *CreatePersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreatePersonResponseJSON, error)
 	CreatePersonWithResponse(ctx context.Context, options *CreatePersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreatePersonResp, error)
 
+	// SearchPeople Search durable people semantically
+	SearchPeople(ctx context.Context, options *SearchPeopleRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPeopleResponse, error)
+	SearchPeopleWithResponse(ctx context.Context, options *SearchPeopleRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPeopleResp, error)
+
 	// DeletePerson Delete a durable person profile
 	DeletePerson(ctx context.Context, options *DeletePersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*struct{}, error)
 	DeletePersonWithResponse(ctx context.Context, options *DeletePersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeletePersonResp, error)
@@ -8727,6 +8731,70 @@ func (c *Client) CreatePerson(ctx context.Context, options *CreatePersonRequestO
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SearchPeople Search durable people semantically
+func (c *Client) SearchPeople(ctx context.Context, options *SearchPeopleRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPeopleResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/people/search",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SearchPeopleResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SearchPeopleErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SearchPeopleErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SearchPeopleResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SearchPeopleResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people/search")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -5320,6 +5320,50 @@ func (o *CreatePersonRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// SearchPeopleRequestOptions is the options needed to make a request to SearchPeople.
+type SearchPeopleRequestOptions struct {
+	Body *SearchPeopleBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SearchPeopleRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SearchPeopleRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *SearchPeopleRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SearchPeopleRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SearchPeopleRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // DeletePersonRequestOptions is the options needed to make a request to DeletePerson.
 type DeletePersonRequestOptions struct {
 	PathParams *DeletePersonPath

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -10620,6 +10620,70 @@ func (c *Client) CreatePersonWithResponse(ctx context.Context, options *CreatePe
 	}
 }
 
+// SearchPeople Search durable people semantically
+func (c *Client) SearchPeopleWithResponse(ctx context.Context, options *SearchPeopleRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPeopleResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/people/search",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people/search")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SearchPeopleResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SearchPeopleResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPeopleResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 503:
+		out.JSON503 = new(SearchPeopleErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPeopleErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // DeletePerson Delete a durable person profile
 func (c *Client) DeletePersonWithResponse(ctx context.Context, options *DeletePersonRequestOptions, reqEditors ...runtime.RequestEditorFn) (*DeletePersonResp, error) {
 	var err error

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -114,6 +114,8 @@ type GetParticipantTimelineBody = ExploreHTTPRequest
 
 type CreatePersonBody = CreatePersonRequest
 
+type SearchPeopleBody = PersonSearchRequest
+
 type PatchPersonBody = PatchPersonRequest
 
 type SetPersonAttributeBody = SetPersonAttributeRequest

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -1563,6 +1563,10 @@ type CreatePersonErrorResponse = ErrorResponse
 
 type CreatePersonErrorResponseJSON = ErrorResponse
 
+type SearchPeopleResponse = PersonSearchResponse
+
+type SearchPeopleErrorResponse = ErrorResponse
+
 type DeletePersonErrorResponse = ErrorResponse
 
 type DeletePersonErrorResponseJSON = ErrorResponse
@@ -3427,6 +3431,14 @@ type CreatePersonResp struct {
 	Headers201   *CreatePersonResp201Headers
 	JSON409      *CreatePersonErrorResponse
 	JSON503      *CreatePersonErrorResponseJSON
+}
+
+type SearchPeopleResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SearchPeopleResponse
+	JSON503      *SearchPeopleErrorResponse
 }
 
 type DeletePersonResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -6188,6 +6188,52 @@ func (p PersonRelationshipsResponse) Validate() error {
 	return errors
 }
 
+type PersonSearchRequest struct {
+	Limit *int64 `json:"limit,omitempty" validate:"omitempty,gte=0,lte=100"`
+	Query string `json:"query" validate:"required,min=1"`
+}
+
+func (p PersonSearchRequest) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(p))
+}
+
+type PersonSearchResponse struct {
+	Results []PersonSearchResult `json:"results" validate:"required"`
+}
+
+func (p PersonSearchResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range p.Results {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Results[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type PersonSearchResult struct {
+	Person Person  `json:"person"`
+	Score  float64 `json:"score"`
+}
+
+func (p PersonSearchResult) Validate() error {
+	var errors runtime.ValidationErrors
+	if v, ok := any(p.Person).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Person", err)
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type PersonSummary struct {
 	ActivityCount int64              `json:"activity_count"`
 	CacheRevision string             `json:"cache_revision" validate:"required"`
@@ -7555,6 +7601,7 @@ type StatsView struct {
 	BuildingGeneration     *BuildingSummary  `json:"building_generation,omitempty"`
 	Enabled                bool              `json:"enabled"`
 	MissingEmbeddingsTotal int64             `json:"missing_embeddings_total"`
+	PersonCoverageRejected int64             `json:"person_coverage_rejected"`
 }
 
 func (s StatsView) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -6600,6 +6600,41 @@ components:
       required:
         - relationships
       type: object
+    PersonSearchRequest:
+      additionalProperties: false
+      properties:
+        limit:
+          default: 20
+          format: int64
+          maximum: 100
+          minimum: 0
+          type: integer
+        query:
+          minLength: 1
+          type: string
+      required:
+        - query
+      type: object
+    PersonSearchResponse:
+      properties:
+        results:
+          items:
+            $ref: "#/components/schemas/PersonSearchResult"
+          type: array
+      required:
+        - results
+      type: object
+    PersonSearchResult:
+      properties:
+        person:
+          $ref: "#/components/schemas/Person"
+        score:
+          format: double
+          type: number
+      required:
+        - person
+        - score
+      type: object
     PersonSummary:
       properties:
         activity_count:
@@ -7947,10 +7982,14 @@ components:
         missing_embeddings_total:
           format: int64
           type: integer
+        person_coverage_rejected:
+          format: int64
+          type: integer
       required:
         - enabled
         - active_generation
         - missing_embeddings_total
+        - person_coverage_rejected
       type: object
     Status:
       properties:
@@ -8807,7 +8846,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.5.0
+  version: 2.6.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -15026,6 +15065,40 @@ paths:
       security:
         - apiKey: []
       summary: Promote a participant cluster to a durable person
+      tags:
+        - API
+  /api/v1/people/search:
+    post:
+      description: Searches only the curated person vector corpus and returns durable person roots in relevance order.
+      operationId: searchPeople
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersonSearchRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonSearchResponse"
+          description: OK
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search durable people semantically
       tags:
         - API
   /api/v1/people/{id}:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -1905,6 +1905,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/people/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Search durable people semantically
+         * @description Searches only the curated person vector corpus and returns durable person roots in relevance order.
+         */
+        post: operations["searchPeople"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/people/{id}": {
         parameters: {
             query?: never;
@@ -5594,6 +5614,26 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        PersonSearchRequest: {
+            /**
+             * Format: int64
+             * @default 20
+             */
+            limit: number;
+            query: string;
+        };
+        PersonSearchResponse: {
+            results: components["schemas"]["PersonSearchResult"][];
+        } & {
+            [key: string]: unknown;
+        };
+        PersonSearchResult: {
+            person: components["schemas"]["Person"];
+            /** Format: double */
+            score: number;
+        } & {
+            [key: string]: unknown;
+        };
         PersonSummary: {
             /** Format: int64 */
             activity_count: number;
@@ -6195,6 +6235,8 @@ export interface components {
             enabled: boolean;
             /** Format: int64 */
             missing_embeddings_total: number;
+            /** Format: int64 */
+            person_coverage_rejected: number;
         } & {
             [key: string]: unknown;
         };
@@ -13624,6 +13666,48 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    searchPeople: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PersonSearchRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonSearchResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/lib/settings/catalog.test.ts
+++ b/web/src/lib/settings/catalog.test.ts
@@ -19,6 +19,9 @@ describe('settings catalog', () => {
     expect(settingsCatalog['vector.embed.scope.accounts'].group).toBe('search');
     expect(settingsCatalog['vector.multimodal.enabled'].group).toBe('search');
     expect(settingsCatalog['vector.multimodal.provider'].options).toEqual(['voyage']);
+    expect(settingsCatalog['vector.people.enabled'].description).toContain('every durable person');
+    expect(settingsCatalog['vector.people.retention_posture'].group).toBe('search');
+    expect(settingsCatalog['vector.people.training_posture'].group).toBe('search');
     expect(settingsCatalog['beeper.schedule'].group).toBe('sources');
     expect(settingsCatalog['integrations.tasks.api_key'].secret).toBe(true);
   });

--- a/web/src/lib/settings/catalog.ts
+++ b/web/src/lib/settings/catalog.ts
@@ -77,6 +77,21 @@ export const settingsCatalog: Record<string, CatalogEntry> = {
   'vector.embeddings.max_retries': entry('search', 'Embedding retries', 'Maximum transient request retries.'),
   'vector.embeddings.max_input_chars': entry('search', 'Maximum input characters', 'Per-chunk text limit.'),
   'vector.embeddings.eta_window': entry('search', 'ETA window', 'Recent samples used for ETA smoothing.'),
+  'vector.people.enabled': entry(
+    'search',
+    'Semantic person embeddings',
+    'Allow exact-consented curated fields for every durable person to use the embedding provider.'
+  ),
+  'vector.people.retention_posture': entry(
+    'search',
+    'Person embedding retention assertion',
+    'Operator assertion describing provider retention for curated person embeddings.'
+  ),
+  'vector.people.training_posture': entry(
+    'search',
+    'Person embedding training assertion',
+    'Operator assertion describing provider training use for curated person embeddings.'
+  ),
   'vector.embed.schedule.cron': entry('search', 'Embedding schedule', 'Cron schedule for background embedding.'),
   'vector.embed.schedule.run_after_sync': entry('search', 'Embed after sync', 'Run embedding after a successful source sync.'),
   'vector.embed.scope.message_types': entry('search', 'Embedded message types', 'Optional message-type scope.'),


### PR DESCRIPTION
## What changed

- Build one deterministic, privacy-bounded semantic document for each curated person and maintain it in a person-owned vector corpus, separate from message embeddings.
- Keep curated-person embedding off by default and require a separate exact consent bound to the provider destination, API format, model, credential variable, retention/training posture, renderer, disclosed profile fields, caller-supplied search-query text, and global durable-person scope.
- Keep SQLite and PostgreSQL behavior aligned for publication, reconciliation, cosine ranking, generation lifecycle, and read-time revision fencing.
- Add authenticated `POST /api/v1/people/search` and `msgvault person search`, returning current durable profiles in semantic rank order without exposing projection text.
- Keep a compatible active person corpus current while another generation builds, and keep disabled, unconsented, revoked, or stale person policy from blocking message embedding and activation.

## Why

Durable person profiles can be found by exact fields today, but not by intent such as “a finance expert in New York.” Operators need that query to return the person directly without routing person IDs through the message index, exposing projection text, or silently sending additional profile data under an older message-embedding configuration.

## Usage

Configure the separate people policy, inspect its exact disclosure, and consent:

```toml
[vector.people]
enabled = true
retention_posture = "zdr"
training_posture = "opted-out"
```

```sh
msgvault person provider status --semantic-embeddings
msgvault person provider consent --semantic-embeddings --yes
msgvault embeddings resume --backstop
```

Then search through the daemon:

```sh
msgvault person search "finance expert in New York"
msgvault person search --limit 10 --json "finance expert in New York"
```

The default limit is 20; `--limit` accepts 1–100. Each search query is embedded by the disclosed provider. Changing any fingerprinted provider policy requires new consent. `[vector.embed.scope]` remains message-only; semantic person consent explicitly covers all durable curated people.

Refs #534
