### PR TITLE
fix(teams): use exclusive cursor for incremental chat sync

### DIFF
--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -228,7 +228,12 @@ func (c *Client) ListChannels(ctx context.Context, teamID string) ([]Channel, er
 func (c *Client) ListChatMessages(ctx context.Context, chatID, sinceISO string, limit int) ([]ChatMessage, bool, error) {
 	url := "/me/chats/" + chatID + "/messages?$top=50"
 	if sinceISO != "" {
-		url += "&$filter=lastModifiedDateTime%20ge%20" + sinceISO + "&$orderby=lastModifiedDateTime%20desc"
+		// Graph rejects "ge" on lastModifiedDateTime for /chats/{id}/messages
+		// with BadRequest ("operationKind 'GreaterThanOrEqual' is not allowed
+		// in $filter"); only gt/lt are accepted. The cursor is the newest
+		// lastModifiedDateTime already ingested, so gt is also the correct
+		// boundary.
+		url += "&$filter=lastModifiedDateTime%20gt%20" + sinceISO + "&$orderby=lastModifiedDateTime%20desc"
 	}
 	var out []ChatMessage
 	_, truncated, err := pageThroughLimit[ChatMessage](ctx, c, url, limit, func(p []ChatMessage) { out = append(out, p...) })

--- a/internal/teams/client_test.go
+++ b/internal/teams/client_test.go
@@ -170,7 +170,11 @@ func TestListChatsAndMessages(t *testing.T) {
 	assert.Equal("m1", msgs[0].ID)
 }
 
-func TestListChatMessagesUsesInclusiveCursor(t *testing.T) {
+// Graph rejects "ge" on lastModifiedDateTime for /chats/{id}/messages with
+// BadRequest, so the cursor is necessarily exclusive. A message whose
+// lastModifiedDateTime exactly equals the stored cursor is therefore skipped;
+// the cursor carries nanosecond precision, so exact ties are vanishingly rare.
+func TestListChatMessagesUsesExclusiveCursor(t *testing.T) {
 	assert := assert.New(t)
 	var filter string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -183,5 +187,5 @@ func TestListChatMessagesUsesInclusiveCursor(t *testing.T) {
 	_, _, err := c.ListChatMessages(context.Background(), "19:x@thread.v2", "2025-01-01T00:00:00Z", 0)
 	require.NoError(t, err)
 
-	assert.Equal("lastModifiedDateTime ge 2025-01-01T00:00:00Z", filter)
+	assert.Equal("lastModifiedDateTime gt 2025-01-01T00:00:00Z", filter)
 }

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -158,6 +158,31 @@ func (imp *Importer) BackfillInlineMedia(ctx context.Context, opts ImportOptions
 	return sum, err
 }
 
+// chatCursorOverlap widens the incremental chat window backwards before
+// querying. Graph only accepts an exclusive "gt" filter on
+// lastModifiedDateTime, so a message sharing the cursor's exact timestamp
+// would be skipped forever; Graph timestamps are millisecond-resolution, so
+// such collisions are possible. Re-reading a small overlap costs a handful of
+// messages per chat and is free of side effects: persistence upserts on
+// (source_id, source_message_id), and maxTime is seeded from the stored cursor
+// so a re-read of older messages cannot move it backwards.
+const chatCursorOverlap = time.Second
+
+// chatQuerySince rewinds a stored chat cursor by chatCursorOverlap. An empty
+// or unparseable cursor is passed through untouched, so a first sync stays
+// unfiltered and a malformed cursor degrades to the previous behavior rather
+// than dropping the filter entirely.
+func chatQuerySince(cursor string) string {
+	if cursor == "" {
+		return ""
+	}
+	t, err := time.Parse(time.RFC3339Nano, cursor)
+	if err != nil {
+		return cursor
+	}
+	return t.Add(-chatCursorOverlap).Format(time.RFC3339Nano)
+}
+
 func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) error {
 	chats, err := imp.client.ListChats(ctx)
 	if err != nil {
@@ -205,7 +230,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		}
 
 		since := state.ChatCursor(ch.ID)
-		msgs, pageTruncated, err := imp.client.ListChatMessages(ctx, ch.ID, since, opts.Limit)
+		msgs, pageTruncated, err := imp.client.ListChatMessages(ctx, ch.ID, chatQuerySince(since), opts.Limit)
 		if err != nil {
 			sum.Errors++
 			continue
@@ -213,6 +238,23 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		var maxTime time.Time
 		if since != "" {
 			maxTime, _ = time.Parse(time.RFC3339Nano, since)
+		}
+		// The overlap window deliberately re-reads messages at the cursor
+		// boundary, so "persisted" no longer implies "new". Resolve which of
+		// these IDs the archive already holds, so MessagesAdded stays a count
+		// of genuinely new messages. Identity is the only reliable test here:
+		// a message sharing the cursor timestamp may be a boundary re-read or
+		// the very tie the overlap exists to recover. On error, fall back to
+		// counting every persist, matching the pre-overlap behavior.
+		var preexisting map[string]int64
+		if since != "" && len(msgs) > 0 {
+			ids := make([]string, 0, len(msgs))
+			for i := range msgs {
+				ids = append(ids, chatSourceMessageID(ch.ID, msgs[i].ID))
+			}
+			if found, eerr := imp.store.MessageExistsBatch(sourceID, ids); eerr == nil {
+				preexisting = found
+			}
 		}
 		var convCount int
 		var persistedIDs []int64
@@ -229,7 +271,9 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 				persistedIDs = append(persistedIDs, messageID)
 			}
 			if added {
-				sum.MessagesAdded++
+				if _, seen := preexisting[chatSourceMessageID(ch.ID, gm.ID)]; !seen {
+					sum.MessagesAdded++
+				}
 			}
 			sum.MessagesProcessed++
 			convCount++

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2593,7 +2594,11 @@ func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
 	assert := assert.New(t)
 
 	const tieTS = "2026-01-01T00:00:00.123Z"
+	tie, err := time.Parse(time.RFC3339Nano, tieTS)
+	require.NoError(err)
+
 	var secondSync atomic.Bool
+	var filters graphFilterFake
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2604,21 +2609,21 @@ func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
 			_, _ = w.Write([]byte(`{"value":[]}`))
 		case strings.Contains(r.URL.Path, "/messages"):
 			// m2 lands after the first sync, sharing m1's exact timestamp.
-			msgs := map[string]string{"tm1": tieTS}
+			ids := []string{"tm1"}
 			if secondSync.Load() {
-				msgs["tm2"] = tieTS
+				ids = append(ids, "tm2")
 			}
-			cutoff := parseGraphGTFilter(t, r.URL.Query().Get("$filter"))
+			cutoff, ok := filters.cutoff(w, r.URL.Query().Get("$filter"))
+			if !ok {
+				return
+			}
 			var out []string
-			for id, ts := range msgs {
-				got, perr := time.Parse(time.RFC3339Nano, ts)
-				require.NoError(perr)
-				if cutoff != nil && !got.After(*cutoff) {
-					continue // exactly what Graph does for "gt"
+			if cutoff == nil || tie.After(*cutoff) { // exactly what Graph does for "gt"
+				for _, id := range ids {
+					out = append(out, `{"id":"`+id+`","createdDateTime":"`+tieTS+
+						`","lastModifiedDateTime":"`+tieTS+
+						`","body":{"contentType":"text","content":"`+id+`"}}`)
 				}
-				out = append(out, `{"id":"`+id+`","createdDateTime":"`+ts+
-					`","lastModifiedDateTime":"`+ts+
-					`","body":{"contentType":"text","content":"`+id+`"}}`)
 			}
 			_, _ = w.Write([]byte(`{"value":[` + strings.Join(out, ",") + `]}`))
 		default:
@@ -2643,31 +2648,177 @@ func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
 	assert.EqualValues(1, sum.MessagesAdded,
 		"only tm2 is new; the re-read of tm1 must not be counted as added")
 
-	var ids []string
+	filters.check(t)
+
+	var got []string
 	rows, err := st.DB().Query(`SELECT source_message_id FROM messages WHERE message_type='teams' ORDER BY source_message_id`)
 	require.NoError(err)
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var id string
 		require.NoError(rows.Scan(&id))
-		ids = append(ids, id)
+		got = append(got, id)
 	}
 	require.NoError(rows.Err())
-	assert.Len(ids, 2, "both messages persisted, no duplicate from the overlap re-read")
+	assert.Len(got, 2, "both messages persisted, no duplicate from the overlap re-read")
 }
 
-// parseGraphGTFilter extracts the timestamp from a
-// "lastModifiedDateTime gt <ts>" filter, returning nil when there is no
-// filter. It rejects any other operator the way Graph does.
-func parseGraphGTFilter(t *testing.T, filter string) *time.Time {
-	t.Helper()
+// graphFilterFake applies a Graph `$filter` inside a test double the way the
+// service does. A filter Graph would reject is answered 400 and recorded for
+// the test body to assert on rather than failed on the spot: a require inside
+// an HTTP handler aborts the server goroutine, not the test.
+type graphFilterFake struct {
+	mu  sync.Mutex
+	err error
+}
+
+// cutoff extracts the timestamp from a "lastModifiedDateTime gt <ts>" filter,
+// returning a nil cutoff when there is no filter. It rejects any other operator
+// the way Graph does. The bool reports whether the handler should carry on.
+func (g *graphFilterFake) cutoff(w http.ResponseWriter, filter string) (*time.Time, bool) {
 	if filter == "" {
-		return nil
+		return nil, true
 	}
 	const prefix = "lastModifiedDateTime gt "
-	require.True(t, strings.HasPrefix(filter, prefix),
-		"Graph rejects any operator but gt/lt on lastModifiedDateTime; got %q", filter)
+	if !strings.HasPrefix(filter, prefix) {
+		g.reject(w, fmt.Errorf("graph rejects any operator but gt/lt on lastModifiedDateTime; got %q", filter))
+		return nil, false
+	}
 	ts, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(filter, prefix))
+	if err != nil {
+		g.reject(w, fmt.Errorf("malformed $filter timestamp in %q: %w", filter, err))
+		return nil, false
+	}
+	return &ts, true
+}
+
+// reject records the first bad filter and answers the way Graph would.
+func (g *graphFilterFake) reject(w http.ResponseWriter, err error) {
+	g.mu.Lock()
+	if g.err == nil {
+		g.err = err
+	}
+	g.mu.Unlock()
+	http.Error(w, err.Error(), http.StatusBadRequest)
+}
+
+// check fails the test if the fake ever saw a filter Graph would have rejected.
+func (g *graphFilterFake) check(t *testing.T) {
+	t.Helper()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	require.NoError(t, g.err)
+}
+
+// roborev raised that the overlap is fetched under opts.Limit, so preexisting
+// boundary messages can exhaust the cap before a newly arrived tied message is
+// returned. That is real, but it is not data loss: a truncated read never
+// advances the cursor (see the truncated check in syncChats), so the tie stays
+// in range and any unlimited run recovers it.
+//
+// Tied messages have no deterministic secondary ordering, so the fake returns
+// them in a fixed order to make the truncation deterministic; the assertions
+// below do not depend on which tied message the cap happens to admit.
+func TestLimitedChatSyncDoesNotStrandTiedMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	const tieTS = "2026-01-01T00:00:00.123Z"
+	const chatID = "19:tielimit@thread.v2"
+	tie, err := time.Parse(time.RFC3339Nano, tieTS)
+	require.NoError(err)
+
+	var lateArrived atomic.Bool
+	var filters graphFilterFake
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[{"id":"` + chatID + `","chatType":"oneOnOne","topic":"TieLimit"}]}`))
+		case strings.HasSuffix(r.URL.Path, "/members"):
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.Contains(r.URL.Path, "/messages"):
+			ids := []string{"ta1", "ta2"}
+			if lateArrived.Load() {
+				ids = append(ids, "tlate")
+			}
+			cutoff, ok := filters.cutoff(w, r.URL.Query().Get("$filter"))
+			if !ok {
+				return
+			}
+			var out []string
+			if cutoff == nil || tie.After(*cutoff) {
+				for _, id := range ids {
+					out = append(out, `{"id":"`+id+`","createdDateTime":"`+tieTS+
+						`","lastModifiedDateTime":"`+tieTS+
+						`","body":{"contentType":"text","content":"`+id+`"}}`)
+				}
+			}
+			_, _ = w.Write([]byte(`{"value":[` + strings.Join(out, ",") + `]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+	base := ImportOptions{Email: "me@example.com", IncludeChannels: false}
+
+	_, err = imp.Import(context.Background(), base)
+	require.NoError(err)
+	require.Equal(2, teamsMessageCount(t, st), "first sync archives both tied messages")
+
+	// A third message arrives sharing the cursor timestamp; the cap is smaller
+	// than the number of tied messages now in range.
+	lateArrived.Store(true)
+	limited := base
+	limited.Limit = 1
+	for i := range 3 {
+		_, lerr := imp.Import(context.Background(), limited)
+		require.NoErrorf(lerr, "limited sync %d", i)
+	}
+
+	// Guard against the test going vacuous: the cap must actually be deferring
+	// the late message, otherwise the assertions below prove nothing.
+	require.Equal(2, teamsMessageCount(t, st),
+		"the cap should still be deferring the late tied message at this point")
+
+	// That deferral is fine. What must hold is that the cursor did not move
+	// past the deferred message.
+	cursor := chatCursorAfterLastSync(t, st, chatID)
+	require.NotEmpty(cursor, "cursor exists after the unlimited first sync")
+	parsed, perr := time.Parse(time.RFC3339Nano, cursor)
+	require.NoError(perr)
+	assert.False(parsed.After(tie),
+		"a capped run must not advance the cursor past the tied timestamp (cursor=%s)", cursor)
+
+	// Therefore an unlimited run still recovers it: nothing was lost.
+	_, err = imp.Import(context.Background(), base)
+	require.NoError(err)
+	assert.Equal(3, teamsMessageCount(t, st),
+		"an unlimited sync recovers the late tied message the cap had deferred")
+
+	filters.check(t)
+}
+
+func teamsMessageCount(t *testing.T, st *store.Store) int {
+	t.Helper()
+	var n int
+	require.NoError(t, st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE message_type='teams'`).Scan(&n))
+	return n
+}
+
+func chatCursorAfterLastSync(t *testing.T, st *store.Store, chatID string) string {
+	t.Helper()
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
 	require.NoError(t, err)
-	return &ts
+	run, err := st.GetLastSuccessfulSync(src.ID)
+	require.NoError(t, err)
+	require.True(t, run.CursorAfter.Valid)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(t, err)
+	return state.ChatCursor(chatID)
 }

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2577,4 +2579,95 @@ func messageIDBySourceMessageID(t *testing.T, st *store.Store, sourceMessageID s
 	require.NoError(t, st.DB().QueryRow(st.Rebind(
 		`SELECT id FROM messages WHERE source_message_id = ?`), sourceMessageID).Scan(&messageID))
 	return messageID
+}
+
+// A message can share the exact lastModifiedDateTime of the stored cursor.
+// Graph only supports an exclusive "gt" filter on that property and its
+// timestamps are millisecond-resolution, so without a backwards overlap such a
+// message would be filtered out on every subsequent sync and lost permanently.
+//
+// Unlike a mock that merely echoes $filter back, this server applies the
+// filter, so the test fails if the overlap is removed.
+func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	const tieTS = "2026-01-01T00:00:00.123Z"
+	var secondSync atomic.Bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[{"id":"19:tie@thread.v2","chatType":"oneOnOne","topic":"Tie"}]}`))
+		case strings.HasSuffix(r.URL.Path, "/members"):
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.Contains(r.URL.Path, "/messages"):
+			// m2 lands after the first sync, sharing m1's exact timestamp.
+			msgs := map[string]string{"tm1": tieTS}
+			if secondSync.Load() {
+				msgs["tm2"] = tieTS
+			}
+			cutoff := parseGraphGTFilter(t, r.URL.Query().Get("$filter"))
+			var out []string
+			for id, ts := range msgs {
+				got, perr := time.Parse(time.RFC3339Nano, ts)
+				require.NoError(perr)
+				if cutoff != nil && !got.After(*cutoff) {
+					continue // exactly what Graph does for "gt"
+				}
+				out = append(out, `{"id":"`+id+`","createdDateTime":"`+ts+
+					`","lastModifiedDateTime":"`+ts+
+					`","body":{"contentType":"text","content":"`+id+`"}}`)
+			}
+			_, _ = w.Write([]byte(`{"value":[` + strings.Join(out, ",") + `]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+	opts := ImportOptions{Email: "me@example.com", IncludeChannels: false}
+
+	sum, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	require.EqualValues(1, sum.MessagesAdded, "first sync stores tm1")
+
+	// The cursor is now exactly tieTS, the timestamp tm2 also carries.
+	secondSync.Store(true)
+	sum, err = imp.Import(context.Background(), opts)
+	require.NoError(err)
+	assert.EqualValues(2, sum.MessagesProcessed, "second sync re-reads tm1 and recovers tm2")
+	assert.EqualValues(1, sum.MessagesAdded,
+		"only tm2 is new; the re-read of tm1 must not be counted as added")
+
+	var ids []string
+	rows, err := st.DB().Query(`SELECT source_message_id FROM messages WHERE message_type='teams' ORDER BY source_message_id`)
+	require.NoError(err)
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		require.NoError(rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(rows.Err())
+	assert.Len(ids, 2, "both messages persisted, no duplicate from the overlap re-read")
+}
+
+// parseGraphGTFilter extracts the timestamp from a
+// "lastModifiedDateTime gt <ts>" filter, returning nil when there is no
+// filter. It rejects any other operator the way Graph does.
+func parseGraphGTFilter(t *testing.T, filter string) *time.Time {
+	t.Helper()
+	if filter == "" {
+		return nil
+	}
+	const prefix = "lastModifiedDateTime gt "
+	require.True(t, strings.HasPrefix(filter, prefix),
+		"Graph rejects any operator but gt/lt on lastModifiedDateTime; got %q", filter)
+	ts, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(filter, prefix))
+	require.NoError(t, err)
+	return &ts
 }


### PR DESCRIPTION

Teams chat sync only ingests messages on the first run for an account.
Every later run fails on all chats and reports success.

`ListChatMessages` built its incremental filter with `lastModifiedDateTime ge
<cursor>`. Microsoft Graph does not allow `ge` on that property for
`/chats/{id}/messages` and returns 400 BadRequest:

> The entity property 'lastModifiedDateTime' and operationKind
> 'GreaterThanOrEqual' is not allowed in $filter query.

Only `gt` and `lt` are accepted, and the cursor is non-empty on every run after
the first, so every incremental request failed.

This switches the filter to `gt`. Graph accepts nothing else here, so the
cursor is necessarily exclusive, and a message sharing the cursor's exact
`lastModifiedDateTime` would be skipped on every later sync. Graph timestamps
are millisecond-resolution, so such ties are possible rather than negligible.
The incremental query therefore starts a one-second overlap before the stored
cursor and relies on idempotent persistence to absorb the re-read; the
summary's added-message count is resolved by identity so the overlap does not
inflate it.

`TestListChatMessagesUsesInclusiveCursor` asserted the `ge` form against a mock
that echoes back any `$filter` it is given, so it passed while the request
shape was rejected by the real API. It is renamed and flipped to `gt` so the
suite stops asserting a contract Graph will not honor.

Behavior change for users: `sync-teams` now picks up new chat messages on runs
after the first. No migration or re-auth needed; existing cursors are reused
as-is.

Fixes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BT68iRsMWaYRd9hz7Yw7L4

