### PR TITLE
feat(provider): add named OrcaRouter embedding and people-sweep providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ for the identity and profile model.
 
 ## Vector Search
 
-msgvault can search your archive semantically using vector embeddings in addition to the default FTS5 keyword search. Point it at a self-hosted OpenAI-compatible embedding endpoint (Ollama, llama.cpp, LM Studio) and three surfaces accept either pure semantic search or BM25+vector fused via Reciprocal Rank Fusion:
+msgvault can search your archive semantically using vector embeddings in addition to the default FTS5 keyword search. Point it at a self-hosted OpenAI-compatible embedding endpoint (Ollama, llama.cpp, LM Studio) or a hosted gateway such as [OrcaRouter](https://www.orcarouter.ai), and three surfaces accept either pure semantic search or BM25+vector fused via Reciprocal Rank Fusion:
 
 - **CLI:** `msgvault search "..." --mode vector` or `--mode hybrid`
 - **HTTP:** `GET /api/v1/search?q=...&mode=vector` or `mode=hybrid`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,6 +56,13 @@ All notable changes to msgvault, grouped by release.
   empty one, and the daemon marks vector search stale when the configured
   accounts resolve to a different source set than it was started with.
 
+- Named [OrcaRouter](https://www.orcarouter.ai) provider for the embedding
+  and people-sweep inference surfaces: `[vector.embeddings] api_format =
+  "orcarouter"` and `[people.sweep.provider] kind = "orcarouter"` each fill
+  in the gateway endpoint, model, dimension, and `ORCAROUTER_API_KEY`
+  environment variable so a minimal config block selects the gateway by
+  name.
+
 **Bug fixes**
 
 - Everything and Files now page narrow analytical metadata before enriching

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -682,10 +682,11 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 
 | Key | Default | Description |
 |---|---|---|
-| `endpoint` | (required) | HTTP(S) base URL for an OpenAI-compatible embeddings API. msgvault appends `/embeddings` (for example, set `http://localhost:11434/v1`, not `.../embeddings`). |
-| `model` | (required) | Model name to pass in each request (e.g., `nomic-embed-text`). |
-| `dimension` | (required) | Vector dimension. Must match the model's output dimension. |
-| `api_key_env` | — | Name of an environment variable containing the API key. Omit for anonymous endpoints. |
+| `api_format` | `openai` | Request contract: `openai` (any OpenAI-compatible endpoint), `orcarouter` ([OrcaRouter](https://www.orcarouter.ai) gateway), or `voyage-contextual` (Voyage contextualized embeddings). Selecting `orcarouter` fills in the gateway defaults below for any omitted endpoint/model/dimension/api_key_env. |
+| `endpoint` | (required) | HTTP(S) base URL for an OpenAI-compatible embeddings API. msgvault appends `/embeddings` (for example, set `http://localhost:11434/v1`, not `.../embeddings`). With `api_format = "orcarouter"` defaults to `https://api.orcarouter.ai/v1`. |
+| `model` | (required) | Model name to pass in each request (e.g., `nomic-embed-text`). With `api_format = "orcarouter"` defaults to `openai/text-embedding-3-small`. |
+| `dimension` | (required) | Vector dimension. Must match the model's output dimension. With `api_format = "orcarouter"` defaults to `1536`. |
+| `api_key_env` | — | Name of an environment variable containing the API key. With `api_format = "orcarouter"` defaults to `ORCAROUTER_API_KEY`. Omit for anonymous endpoints. |
 | `batch_size` | `32` | Embedding inputs per HTTP call. Long messages can contribute multiple chunk inputs. |
 | `timeout` | `30s` | Per-request timeout. |
 | `max_retries` | `3` | Retries per batch on transient failures. |
@@ -757,6 +758,25 @@ Optional background scheduling for the embed worker inside `msgvault serve`. Emp
 |---|---|---|
 | `cron` | — | 5-field cron expression. Empty string disables the standalone cron. |
 | `run_after_sync` | `false` | When `true`, an embed pass runs after every successful scheduled sync. |
+
+### `[people.sweep]`
+
+Consent-gated, model-backed maintenance of durable person profiles. Disabled by default. When enabled, every outbound request requires an exact, previously granted consent for the effective policy fingerprint, and the provider boundary is disclosed by `msgvault person provider`. The provider speaks the OpenAI-compatible Chat Completions protocol.
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Enable the people-sweep inference provider. Safe default: disabled. |
+| `provider.kind` | `openai_compatible` | Provider contract. `openai_compatible` (any OpenAI-compatible endpoint) or `orcarouter` ([OrcaRouter](https://www.orcarouter.ai) gateway). Selecting `orcarouter` fills in the gateway defaults below for any omitted endpoint/model/api_key_env. |
+| `provider.endpoint` | `https://api.openai.com/v1` | HTTP(S) base URL. With `provider.kind = "orcarouter"` defaults to `https://api.orcarouter.ai/v1`. |
+| `provider.model` | (required) | Model name. With `provider.kind = "orcarouter"` defaults to `orcarouter/auto`. |
+| `provider.api_key_env` | `OPENAI_API_KEY` | Name of an environment variable containing the API key. With `provider.kind = "orcarouter"` defaults to `ORCAROUTER_API_KEY`. Anonymous loopback mode omits it. |
+| `provider.allow_anonymous` | `false` | Permit anonymous inference to a loopback endpoint only. |
+| `provider.retention_posture` | (required) | Confirmed provider retention posture. |
+| `provider.training_posture` | (required) | Confirmed provider training posture. |
+| `provider.allowed_sources` | (required) | Source classes the provider may receive, e.g. `conversation_text`, `meeting_text`. |
+| `provider.source_since` / `provider.source_until` | — | Date range for consented source material. |
+| `provider.allow_sensitive` | `false` | Allow sensitive source material. |
+| `provider.request_timeout` | `1m` | Per-request timeout. |
 
 ## Overriding the Home Directory
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -141,6 +141,20 @@ run_after_sync = true                    # run a pass after every successful sch
 message_types = ["teams"]
 ```
 
+For a hosted gateway, [OrcaRouter](https://www.orcarouter.ai) serves the same
+OpenAI-compatible `/v1/embeddings` contract. Selecting `api_format =
+"orcarouter"` fills in the endpoint, model, dimension, and key environment
+variable so the block can stay minimal:
+
+```toml
+[vector]
+enabled = true
+backend = "sqlite-vec"
+
+[vector.embeddings]
+api_format = "orcarouter"     # fills in endpoint/model/dimension/api_key_env
+```
+
 The `[vector]` section only takes effect when `enabled = true` **and**
 the binary was built with the needed vector backend. If either is
 missing, msgvault behaves as before. Disabled vector search returns

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -104,7 +104,7 @@ var settingsCatalog = []settingDefinition{
 	stringSetting("vector.backend", "search", []string{"sqlite-vec", "pgvector"}, func(c *config.Config) string { return c.Vector.Backend }),
 	stringSetting("vector.db_path", "search", nil, func(c *config.Config) string { return c.Vector.DBPath }),
 	boolSetting("vector.skip_extension_create", "search", func(c *config.Config) bool { return c.Vector.SkipExtensionCreate }),
-	stringSetting("vector.embeddings.api_format", "search", []string{"openai", "voyage-contextual"}, func(c *config.Config) string {
+	stringSetting("vector.embeddings.api_format", "search", []string{"openai", "orcarouter", "voyage-contextual"}, func(c *config.Config) string {
 		return string(c.Vector.Embeddings.EffectiveAPIFormat())
 	}),
 	testableStringSetting("vector.embeddings.endpoint", "search", func(c *config.Config) string { return c.Vector.Embeddings.Endpoint }),

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -46,7 +46,7 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 	require.NotNil(byKey["vector.embeddings.api_format"].Value)
 	require.NotNil(byKey["vector.embeddings.api_format"].Value.String)
 	assert.Equal("openai", *byKey["vector.embeddings.api_format"].Value.String)
-	assert.Equal([]string{"openai", "voyage-contextual"}, byKey["vector.embeddings.api_format"].Options)
+	assert.Equal([]string{"openai", "orcarouter", "voyage-contextual"}, byKey["vector.embeddings.api_format"].Options)
 	require.NotNil(byKey["vector.people.enabled"].Value)
 	require.NotNil(byKey["vector.people.enabled"].Value.Boolean)
 	assert.False(*byKey["vector.people.enabled"].Value.Boolean)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -778,6 +778,22 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		// explicitly configured key remains visible to validation and is rejected.
 		cfg.People.Sweep.Provider.APIKeyEnv = ""
 	}
+	if cfg.People.Sweep.Provider.Kind == peoplesweep.ProviderOrcaRouter {
+		// The pre-decode defaults fill in the OpenAI-compatible
+		// endpoint/model/key before the TOML file is read. When the file
+		// names the OrcaRouter gateway without spelling out those fields,
+		// clear the unset ones so the named provider's defaults apply
+		// instead of silently retaining the OpenAI defaults.
+		if !metadata.IsDefined("people", "sweep", "provider", "endpoint") {
+			cfg.People.Sweep.Provider.Endpoint = ""
+		}
+		if !metadata.IsDefined("people", "sweep", "provider", "model") {
+			cfg.People.Sweep.Provider.Model = ""
+		}
+		if !metadata.IsDefined("people", "sweep", "provider", "api_key_env") {
+			cfg.People.Sweep.Provider.APIKeyEnv = ""
+		}
+	}
 	if cfg.People.Sweep.Provider.Kind == peoplesweep.ProviderCodexAppServer {
 		if !metadata.IsDefined("people", "sweep", "provider", "endpoint") {
 			cfg.People.Sweep.Provider.Endpoint = ""
@@ -792,6 +808,11 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 			cfg.People.Sweep.Provider.ExecutionBoundary = peoplesweep.CodexExecutionBoundaryV1
 		}
 	}
+	// Re-apply the people-sweep provider defaults over any zero-valued
+	// fields that survived decode. A config that names the provider
+	// (`kind = "orcarouter"`) without spelling out endpoint/model/key gets
+	// those filled here, mirroring the vector re-apply below.
+	cfg.People.Sweep.ApplyDefaults()
 	for _, key := range metadata.Undecoded() {
 		if key.String() == "carddav.password" {
 			return nil, errors.New("[carddav] password is not allowed in config; store it in tokens/carddav.json")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1760,6 +1760,31 @@ dimension = 768
 	assert.ErrorContains(t, err, "vector.multimodal.dimension")
 }
 
+func TestLoadVectorOrcaRouterEmbeddingFormatFillsDefaults(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	configContent := `
+[vector]
+enabled = true
+
+[vector.embeddings]
+api_format = "orcarouter"
+`
+	require.NoError(os.WriteFile(configPath, []byte(configContent), 0o644), "WriteFile")
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err, "Load")
+
+	assert.Equal("orcarouter", string(cfg.Vector.Embeddings.EffectiveAPIFormat()))
+	assert.Equal("https://api.orcarouter.ai/v1", cfg.Vector.Embeddings.Endpoint)
+	assert.Equal("openai/text-embedding-3-small", cfg.Vector.Embeddings.Model)
+	assert.Equal(1536, cfg.Vector.Embeddings.Dimension)
+	assert.Equal("ORCAROUTER_API_KEY", cfg.Vector.Embeddings.APIKeyEnv)
+}
+
 func TestLoadWithNamedOAuthApps_RelativePaths(t *testing.T) {
 	require := require.New(t)
 	tmpDir := t.TempDir()

--- a/internal/config/people_sweep_test.go
+++ b/internal/config/people_sweep_test.go
@@ -83,6 +83,31 @@ source_since = "2025-01-01"
 	assert.ErrorContains(t, err, "allowed_sources")
 }
 
+func TestLoadOrcaRouterPeopleSweepProviderFillsDefaults(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(path, []byte(`
+[people.sweep]
+enabled = true
+
+[people.sweep.provider]
+kind = "orcarouter"
+retention_posture = "zero_retention"
+training_posture = "no_training"
+allowed_sources = ["conversation_text"]
+source_since = "2025-01-01"
+`), 0o600))
+
+	loaded, err := Load(path, "")
+	require.NoError(err)
+	provider := loaded.People.Sweep.Provider
+	assert.Equal(peoplesweep.ProviderOrcaRouter, provider.Kind)
+	assert.Equal(peoplesweep.OrcaRouterDefaultEndpoint, provider.Endpoint)
+	assert.Equal(peoplesweep.OrcaRouterDefaultModel, provider.Model)
+	assert.Equal(peoplesweep.OrcaRouterDefaultAPIKeyEnv, provider.APIKeyEnv)
+}
+
 func TestLoadDoesNotReplaceExplicitEmptyPeopleProviderKeyEnv(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -20,9 +20,18 @@ import (
 const (
 	ProviderOpenAICompatible = "openai_compatible"
 	ProviderCodexAppServer   = "codex_app_server"
+	ProviderOrcaRouter       = "orcarouter"
 
 	CodexExecutionBoundaryV1 = "codex-app-server-packet-only-v1"
 	PacketRendererPolicyV1   = "person-sweep-packet-v1"
+
+	// OrcaRouter defaults for the [people.sweep.provider] block. The
+	// gateway serves the OpenAI-compatible Chat Completions contract, so
+	// the named provider shares the OpenAI-compatible transport.
+	OrcaRouterDefaultEndpoint  = "https://api.orcarouter.ai/v1"
+	OrcaRouterDefaultModel     = "orcarouter/auto"
+	OrcaRouterDefaultAPIKeyEnv = "ORCAROUTER_API_KEY"
+	OrcaRouterSignupURL        = "https://www.orcarouter.ai"
 
 	SourceConversationText  SourceClass = "conversation_text"
 	SourceMeetingText       SourceClass = "meeting_text"
@@ -184,6 +193,20 @@ func (c *Config) ApplyDefaults() {
 			c.Provider.APIKeyEnv = "OPENAI_API_KEY"
 		}
 	}
+	if c.Provider.Kind == ProviderOrcaRouter {
+		// Selecting the gateway by name fills in its defaults so an
+		// operator can point people-sweep at OrcaRouter with a minimal
+		// block. Explicit settings always win.
+		if c.Provider.Endpoint == "" {
+			c.Provider.Endpoint = OrcaRouterDefaultEndpoint
+		}
+		if c.Provider.Model == "" {
+			c.Provider.Model = OrcaRouterDefaultModel
+		}
+		if c.Provider.APIKeyEnv == "" && !c.Provider.AllowAnonymous {
+			c.Provider.APIKeyEnv = OrcaRouterDefaultAPIKeyEnv
+		}
+	}
 	if c.Provider.Kind == ProviderCodexAppServer {
 		setDefaultString(&c.Provider.Executable, "codex")
 		setDefaultString(&c.Provider.ExecutionBoundary, CodexExecutionBoundaryV1)
@@ -203,7 +226,7 @@ func (c Config) Validate() error {
 			c.Provider.RequestTimeout)
 	}
 	switch c.Provider.Kind {
-	case ProviderOpenAICompatible:
+	case ProviderOpenAICompatible, ProviderOrcaRouter:
 		return c.validateOpenAICompatible()
 	case ProviderCodexAppServer:
 		return c.validateCodexAppServer()

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -203,6 +203,57 @@ func TestPeopleSweepDefaults(t *testing.T) {
 	}, config.Budgets)
 }
 
+func TestOrcaRouterProviderDefaults(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	config := peoplesweep.Config{Enabled: true, Provider: peoplesweep.ProviderConfig{
+		Kind:             peoplesweep.ProviderOrcaRouter,
+		RetentionPosture: "zero_retention",
+		TrainingPosture:  "no_training",
+		AllowedSources: []peoplesweep.SourceClass{
+			peoplesweep.SourceMeetingText,
+			peoplesweep.SourceConversationText,
+		},
+		SourceSince: "2025-01-01",
+	}}
+	config.ApplyDefaults()
+
+	assert.Equal(peoplesweep.ProviderOrcaRouter, config.Provider.Kind)
+	assert.Equal(peoplesweep.OrcaRouterDefaultEndpoint, config.Provider.Endpoint)
+	assert.Equal(peoplesweep.OrcaRouterDefaultModel, config.Provider.Model)
+	assert.Equal(peoplesweep.OrcaRouterDefaultAPIKeyEnv, config.Provider.APIKeyEnv)
+	require.NoError(config.Validate())
+
+	profile, err := config.Profile()
+	require.NoError(err)
+	assert.Equal(peoplesweep.OrcaRouterDefaultEndpoint, profile.Endpoint)
+	assert.Equal(peoplesweep.OrcaRouterDefaultModel, profile.Model)
+	assert.Equal(peoplesweep.OrcaRouterDefaultAPIKeyEnv, profile.APIKeyEnv)
+}
+
+func TestOrcaRouterProviderKeepsExplicitSettings(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	config := peoplesweep.Config{Enabled: true, Provider: peoplesweep.ProviderConfig{
+		Kind:             peoplesweep.ProviderOrcaRouter,
+		Endpoint:         "https://proxy.example.test/v1",
+		Model:            "my-model",
+		APIKeyEnv:        "MY_KEY",
+		RetentionPosture: "zero_retention",
+		TrainingPosture:  "no_training",
+		AllowedSources: []peoplesweep.SourceClass{
+			peoplesweep.SourceMeetingText,
+		},
+		SourceSince: "2025-01-01",
+	}}
+	config.ApplyDefaults()
+
+	assert.Equal("https://proxy.example.test/v1", config.Provider.Endpoint)
+	assert.Equal("my-model", config.Provider.Model)
+	assert.Equal("MY_KEY", config.Provider.APIKeyEnv)
+	require.NoError(config.Validate())
+}
+
 func TestProviderProfileHasStableCanonicalPolicy(t *testing.T) {
 	assert := assert.New(t)
 	profile, err := validConfig().Profile()

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -23,10 +23,26 @@ type EmbeddingAPIFormat string
 const (
 	// APIFormatOpenAI uses the OpenAI-compatible embeddings contract.
 	APIFormatOpenAI EmbeddingAPIFormat = "openai"
+	// APIFormatOrcaRouter uses the OrcaRouter OpenAI-compatible embeddings
+	// gateway. It shares the plain OpenAI-compatible wire contract; the
+	// named format only changes the configuration defaults so an operator
+	// can select the gateway by name.
+	APIFormatOrcaRouter EmbeddingAPIFormat = "orcarouter"
 	// APIFormatVoyageContextual uses Voyage contextualized embeddings.
 	APIFormatVoyageContextual EmbeddingAPIFormat = "voyage-contextual"
 	// contextPolicyVersion identifies the contextual document assembly policy.
 	contextPolicyVersion = 2
+)
+
+// OrcaRouter defaults for the named embeddings format. The gateway serves
+// OpenAI-compatible /v1/embeddings and mirrors the text-embedding-3-small
+// contract (1536-dim).
+const (
+	OrcaRouterDefaultEndpoint  = "https://api.orcarouter.ai/v1"
+	OrcaRouterDefaultModel     = "openai/text-embedding-3-small"
+	OrcaRouterDefaultDimension = 1536
+	OrcaRouterDefaultAPIKeyEnv = "ORCAROUTER_API_KEY"
+	OrcaRouterSignupURL        = "https://www.orcarouter.ai"
 )
 
 // preprocessVersion identifies the embed/preprocess.go implementation
@@ -520,6 +536,12 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	switch c.Embeddings.EffectiveAPIFormat() {
+	case APIFormatOpenAI, APIFormatOrcaRouter, APIFormatVoyageContextual:
+	default:
+		return fmt.Errorf("vector.embeddings.api_format: unknown format %q (supported: %q, %q, %q)",
+			c.Embeddings.APIFormat, APIFormatOpenAI, APIFormatOrcaRouter, APIFormatVoyageContextual)
+	}
 	if !c.Enabled {
 		return nil
 	}
@@ -602,6 +624,25 @@ func normalizedMultimodalEndpoint(endpoint string) (string, error) {
 func (c *Config) ApplyDefaults() {
 	if c.Backend == "" {
 		c.Backend = "sqlite-vec"
+	}
+	if c.Embeddings.APIFormat == APIFormatOrcaRouter {
+		// Selecting the gateway by name fills in its defaults so an
+		// operator can enable vector search with a three-line block:
+		//   [vector.embeddings]
+		//   api_format = "orcarouter"
+		// An explicit endpoint/model/dimension/api_key_env always wins.
+		if c.Embeddings.Endpoint == "" {
+			c.Embeddings.Endpoint = OrcaRouterDefaultEndpoint
+		}
+		if c.Embeddings.Model == "" {
+			c.Embeddings.Model = OrcaRouterDefaultModel
+		}
+		if c.Embeddings.Dimension == 0 {
+			c.Embeddings.Dimension = OrcaRouterDefaultDimension
+		}
+		if c.Embeddings.APIKeyEnv == "" {
+			c.Embeddings.APIKeyEnv = OrcaRouterDefaultAPIKeyEnv
+		}
 	}
 	if c.Embeddings.BatchSize == 0 {
 		c.Embeddings.BatchSize = 32

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -68,6 +68,10 @@ func TestConfig_Validate(t *testing.T) {
 		{"HTTPS_OK", func(c *Config) { c.Embeddings.Endpoint = "https://host:8080/v1" }, ""},
 		{"PgvectorBackend_OK", func(c *Config) { c.Backend = "pgvector" }, ""},
 		{"OpenAIAPIFormat_OK", func(c *Config) { c.Embeddings.APIFormat = APIFormatOpenAI }, ""},
+		{"OrcaRouterAPIFormat_OK", func(c *Config) {
+			c.Embeddings.APIFormat = APIFormatOrcaRouter
+			c.ApplyDefaults()
+		}, ""},
 		{"VoyageContextualAPIFormat_OK", func(c *Config) {
 			c.Embeddings.APIFormat = APIFormatVoyageContextual
 			c.Embeddings.Model = "voyage-context-4"
@@ -298,6 +302,40 @@ func TestEmbeddingsConfig_APIFormatDefaultsToOpenAI(t *testing.T) {
 	cfg := Config{}
 	cfg.ApplyDefaults()
 	assert.Equal(t, APIFormatOpenAI, cfg.Embeddings.EffectiveAPIFormat())
+}
+
+// TestEmbeddingsConfig_OrcaRouterFormatAppliesGatewayDefaults catches the
+// named OrcaRouter format filling in the gateway endpoint, model,
+// dimension, and key env so an operator can enable vector search with a
+// minimal block.
+func TestEmbeddingsConfig_OrcaRouterFormatAppliesGatewayDefaults(t *testing.T) {
+	cfg := Config{}
+	cfg.Embeddings.APIFormat = APIFormatOrcaRouter
+	cfg.ApplyDefaults()
+	require.Equal(t, APIFormatOrcaRouter, cfg.Embeddings.EffectiveAPIFormat())
+	assert.Equal(t, OrcaRouterDefaultEndpoint, cfg.Embeddings.Endpoint)
+	assert.Equal(t, OrcaRouterDefaultModel, cfg.Embeddings.Model)
+	assert.Equal(t, OrcaRouterDefaultDimension, cfg.Embeddings.Dimension)
+	assert.Equal(t, OrcaRouterDefaultAPIKeyEnv, cfg.Embeddings.APIKeyEnv)
+	require.NoError(t, cfg.Validate())
+}
+
+// TestEmbeddingsConfig_OrcaRouterFormatKeepsExplicitSettings catches an
+// explicit endpoint/model/dimension/api_key_env winning over the gateway
+// defaults.
+func TestEmbeddingsConfig_OrcaRouterFormatKeepsExplicitSettings(t *testing.T) {
+	cfg := Config{}
+	cfg.Embeddings.APIFormat = APIFormatOrcaRouter
+	cfg.Embeddings.Endpoint = "https://proxy.example.test/v1"
+	cfg.Embeddings.Model = "my-embedding-model"
+	cfg.Embeddings.Dimension = 1024
+	cfg.Embeddings.APIKeyEnv = "MY_EMBED_KEY"
+	cfg.ApplyDefaults()
+	assert.Equal(t, "https://proxy.example.test/v1", cfg.Embeddings.Endpoint)
+	assert.Equal(t, "my-embedding-model", cfg.Embeddings.Model)
+	assert.Equal(t, 1024, cfg.Embeddings.Dimension)
+	assert.Equal(t, "MY_EMBED_KEY", cfg.Embeddings.APIKeyEnv)
+	require.NoError(t, cfg.Validate())
 }
 
 // TestGenerationFingerprint_ChangesForVoyageContextual catches contextual

--- a/web/src/lib/settings/catalog.test.ts
+++ b/web/src/lib/settings/catalog.test.ts
@@ -14,6 +14,7 @@ describe('settings catalog', () => {
     expect(settingsCatalog['vector.embeddings.endpoint'].testable).toBe(true);
     expect(settingsCatalog['vector.embeddings.api_format'].options).toEqual([
       'openai',
+      'orcarouter',
       'voyage-contextual'
     ]);
     expect(settingsCatalog['vector.embed.scope.accounts'].group).toBe('search');

--- a/web/src/lib/settings/catalog.ts
+++ b/web/src/lib/settings/catalog.ts
@@ -64,10 +64,10 @@ export const settingsCatalog: Record<string, CatalogEntry> = {
   'vector.embeddings.api_format': entry(
     'search',
     'Embedding API format',
-    'Select the OpenAI-compatible or Voyage contextual API.',
-    { options: ['openai', 'voyage-contextual'] }
+    'Select the OpenAI-compatible, OrcaRouter, or Voyage contextual API.',
+    { options: ['openai', 'orcarouter', 'voyage-contextual'] }
   ),
-  'vector.embeddings.endpoint': entry('search', 'Embedding endpoint', 'OpenAI-compatible or Voyage API base URL.', {
+  'vector.embeddings.endpoint': entry('search', 'Embedding endpoint', 'OpenAI-compatible, OrcaRouter, or Voyage API base URL.', {
     testable: true
   }),
   'vector.embeddings.api_key_env': entry('search', 'Embedding key environment variable', 'Environment variable containing the endpoint key.'),


### PR DESCRIPTION
## What changed

Add a named **[OrcaRouter](https://www.orcarouter.ai)** provider to the two OpenAI-compatible surfaces in msgvault, so an operator can select the gateway by name instead of hand-filling a generic endpoint.

- **`[vector.embeddings]`**: `api_format = "orcarouter"` fills in the gateway endpoint (`https://api.orcarouter.ai/v1`), model (`openai/text-embedding-3-small`), dimension (`1536`), and `ORCAROUTER_API_KEY` environment variable. The named format shares the existing OpenAI-compatible wire contract, so no transport changes are needed.
- **`[people.sweep.provider]`**: `kind = "orcarouter"` fills in the gateway endpoint, default model (`orcarouter/auto`), and `ORCAROUTER_API_KEY` env, reusing the existing OpenAI-compatible transport.
- Registered `orcarouter` in the settings catalog (Go `internal/api` + web `web/src/lib/settings/catalog.ts`), and documented both surfaces in `README.md`, `docs/configuration.md`, `docs/usage/vector-search.md`, and `docs/changelog.md`.

The gateway serves OpenAI-compatible embeddings and chat completions from the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

Selecting a named provider makes the supported gateway discoverable in the settings UI and gives a minimal config block for both the vector-search and people-sweep surfaces, matching how the existing `openai` / `voyage-contextual` formats are exposed.

Disclosure: I'm an engineer on the OrcaRouter team.
