### PR TITLE
feat(tui): browse attachments and add semantic search

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9350,7 +9350,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.6.0
+  version: 2.7.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -17750,7 +17750,7 @@ paths:
           required: true
           schema:
             type: string
-        - description: "Search mode: fts, vector, or hybrid"
+        - description: "Search mode: fts, vector, or hybrid. Structured filter parameters are supported only in vector and hybrid modes"
           in: query
           name: mode
           schema:
@@ -17801,6 +17801,57 @@ paths:
         - description: Restrict to one collection
           in: query
           name: collection
+          schema:
+            type: string
+        - description: Exact sender email/address filter (vector or hybrid mode only)
+          in: query
+          name: sender
+          schema:
+            type: string
+        - description: Exact recipient email filter across to, cc, and bcc (vector or hybrid mode only)
+          in: query
+          name: recipient
+          schema:
+            type: string
+        - description: Exact sender domain filter (vector or hybrid mode only)
+          in: query
+          name: domain
+          schema:
+            type: string
+        - description: Exact case-insensitive label filter (vector or hybrid mode only)
+          in: query
+          name: label
+          schema:
+            type: string
+        - description: Calendar period in YYYY, YYYY-MM, or YYYY-MM-DD format (vector or hybrid mode only)
+          in: query
+          name: time_period
+          schema:
+            type: string
+        - description: Time bucket granularity (vector or hybrid mode only)
+          in: query
+          name: time_granularity
+          schema:
+            type: string
+        - description: Exact source ID (vector or hybrid mode only)
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
+        - description: Only include messages with attachments (vector or hybrid mode only)
+          in: query
+          name: attachments_only
+          schema:
+            type: boolean
+        - description: Lower date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Upper date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+          in: query
+          name: before
           schema:
             type: string
       responses:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8413,6 +8413,12 @@ components:
           $ref: "#/components/schemas/StatsView"
         vector_status:
           type: string
+        vector_text_message_types:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         vector_text_status:
           type: string
         vector_visual_status:

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -45,7 +45,7 @@ Navigation:
   Esc         Go back
   m           Cycle Email / Texts / Meetings
   g           Cycle aggregate view (Email and Texts)
-  /           Search; find within an open meeting transcript
+  /           Search; Tab adds active-message-only Semantic mode when enabled
   A           Filter by account, or meeting source in Meetings mode
   s           Cycle sort field
   r           Reverse sort direction
@@ -90,12 +90,14 @@ HTTP Mode:
 		}
 
 		// Create and run TUI
+		semanticSearch := tuiSemanticSearcher(cmd.Context(), backend.client, backend.engine)
 		model := tui.New(backend.engine, tui.Options{
 			DataDir:          cfg.Data.DataDir,
 			Version:          Version,
 			TextEngine:       textEngine,
 			ManifestSaver:    backend.client,
 			AttachmentReader: tuiAttachmentOpener{client: backend.client},
+			SemanticSearch:   semanticSearch,
 			AnalyticsNotice:  notice,
 		})
 		p := tea.NewProgram(model)
@@ -129,6 +131,28 @@ HTTP Mode:
 		return nil
 	},
 }
+
+func tuiSemanticSearcher(
+	ctx context.Context,
+	client *daemonclient.Client,
+	engine query.Engine,
+) query.SemanticMessageSearcher {
+	if client == nil || engine == nil {
+		return nil
+	}
+	compatible, err := client.SupportsAPISchemaVersion(ctx, semanticSearchMinAPISchemaVersion)
+	if err != nil || !compatible {
+		return nil
+	}
+	available, err := client.VectorSearchAvailable(ctx)
+	if err != nil || !available {
+		return nil
+	}
+	searcher, _ := engine.(query.SemanticMessageSearcher)
+	return searcher
+}
+
+const semanticSearchMinAPISchemaVersion = "2.7.0"
 
 type tuiAttachmentOpener struct {
 	client *daemonclient.Client

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -144,7 +144,7 @@ func tuiSemanticSearcher(
 	if err != nil || !compatible {
 		return nil
 	}
-	available, err := client.VectorSearchAvailable(ctx)
+	available, err := client.VectorSearchAvailableForMessageType(ctx, tuiSemanticMessageType)
 	if err != nil || !available {
 		return nil
 	}
@@ -152,7 +152,10 @@ func tuiSemanticSearcher(
 	return searcher
 }
 
-const semanticSearchMinAPISchemaVersion = "2.7.0"
+const (
+	semanticSearchMinAPISchemaVersion = "2.7.0"
+	tuiSemanticMessageType            = "email"
+)
 
 type tuiAttachmentOpener struct {
 	client *daemonclient.Client

--- a/cmd/msgvault/cmd/tui_test.go
+++ b/cmd/msgvault/cmd/tui_test.go
@@ -167,7 +167,9 @@ func TestTUISemanticSearcherRequiresEnabledVectorBackend(t *testing.T) {
 		schemaVersion string
 		wantSearch    bool
 	}{
-		{name: "ready", stats: map[string]any{"vector_status": "ready"}, schemaVersion: api.APISchemaVersion, wantSearch: true},
+		{name: "ready without message scope", stats: map[string]any{"vector_status": "ready"}, schemaVersion: api.APISchemaVersion, wantSearch: true},
+		{name: "ready with email message scope", stats: map[string]any{"vector_status": "ready", "vector_text_message_types": []string{"email"}}, schemaVersion: api.APISchemaVersion, wantSearch: true},
+		{name: "ready with text-only message scope", stats: map[string]any{"vector_status": "ready", "vector_text_message_types": []string{"sms", "mms"}}, schemaVersion: api.APISchemaVersion},
 		{name: "initializing remains callable", stats: map[string]any{"vector_status": "initializing"}, schemaVersion: api.APISchemaVersion, wantSearch: true},
 		{name: "disabled", stats: map[string]any{"vector_status": "disabled"}, schemaVersion: api.APISchemaVersion},
 		{name: "legacy disabled", stats: map[string]any{"vector_search": map[string]any{"enabled": false}}, schemaVersion: api.APISchemaVersion},

--- a/cmd/msgvault/cmd/tui_test.go
+++ b/cmd/msgvault/cmd/tui_test.go
@@ -160,6 +160,53 @@ func tuiAccountsHandler(requests *atomic.Int32, email string) http.Handler {
 	return mux
 }
 
+func TestTUISemanticSearcherRequiresEnabledVectorBackend(t *testing.T) {
+	tests := []struct {
+		name          string
+		stats         map[string]any
+		schemaVersion string
+		wantSearch    bool
+	}{
+		{name: "ready", stats: map[string]any{"vector_status": "ready"}, schemaVersion: api.APISchemaVersion, wantSearch: true},
+		{name: "initializing remains callable", stats: map[string]any{"vector_status": "initializing"}, schemaVersion: api.APISchemaVersion, wantSearch: true},
+		{name: "disabled", stats: map[string]any{"vector_status": "disabled"}, schemaVersion: api.APISchemaVersion},
+		{name: "legacy disabled", stats: map[string]any{"vector_search": map[string]any{"enabled": false}}, schemaVersion: api.APISchemaVersion},
+		{name: "older daemon fails closed", stats: map[string]any{"vector_status": "ready"}, schemaVersion: "2.4.0"},
+		{name: "missing schema version fails closed", stats: map[string]any{"vector_status": "ready"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				body := map[string]any{"status": "ok"}
+				if tt.schemaVersion != "" {
+					body["api_schema_version"] = tt.schemaVersion
+				}
+				_ = json.NewEncoder(w).Encode(body)
+			})
+			mux.HandleFunc("/api/v1/stats", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.stats)
+			})
+			srv := httptest.NewServer(mux)
+			t.Cleanup(srv.Close)
+
+			client, err := daemonclient.New(daemonclient.Config{URL: srv.URL, AllowInsecure: true})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, client.Close()) })
+			engine := daemonclient.NewEngineAdapter(client)
+
+			searcher := tuiSemanticSearcher(context.Background(), client, engine)
+			if tt.wantSearch {
+				assert.NotNil(t, searcher)
+			} else {
+				assert.Nil(t, searcher)
+			}
+		})
+	}
+}
+
 // TestAnalyticsCacheNotice verifies the pre-launch warning keys off the
 // analytics mode the daemon itself reports on /health: only the live-SQL
 // fallback mode warns, while deliberate live SQL (engine = "sql",

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.8
 	github.com/emersion/go-message v0.18.2
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
+	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/gofrs/flock v0.13.0
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f
@@ -88,7 +89,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/emersion/go-imap/v2 v2.0.0-beta.8
 	github.com/emersion/go-message v0.18.2
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
-	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/go-playground/validator/v10 v10.30.3
 	github.com/gofrs/flock v0.13.0
 	github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f
@@ -89,6 +88,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -62,6 +62,10 @@ type StatsResponse struct {
 	// message search, so text-tool registration must consult this field,
 	// not the shared subsystem status.
 	VectorTextStatus string `json:"vector_text_status,omitempty"`
+	// VectorTextMessageTypes reports the configured message-type scope of the
+	// text vector index. An empty list means the index is not restricted by
+	// message type.
+	VectorTextMessageTypes []string `json:"vector_text_message_types,omitempty"`
 	// VectorVisualStatus reports the multimodal lane the same way, so a
 	// one-time capability probe during asynchronous init can distinguish
 	// "still initializing" from "not configured" instead of permanently
@@ -577,6 +581,7 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		resp.VectorTextStatus = string(VectorStatusDisabled)
 		if vectorCfg.Enabled {
 			resp.VectorTextStatus = string(status)
+			resp.VectorTextMessageTypes = slices.Clone(vectorCfg.Embed.Scope.BuildScope().MessageTypes)
 		}
 		resp.VectorVisualStatus = string(VectorStatusDisabled)
 		if vectorCfg.Multimodal.Enabled {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -770,6 +770,11 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if mode == "vector" || mode == exploreSearchModeHybrid {
+		structuredFilter, err := parseMessageFilter(requestWithoutParams(r, "message_type", "offset"))
+		if err != nil {
+			s.rejectBadParam(w, err)
+			return
+		}
 		page, _, err := queryInt(r, "page")
 		if err != nil {
 			s.rejectBadParam(w, err)
@@ -818,13 +823,21 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 				pageSize = maxPage - offset
 			}
 		}
-		s.handleHybridSearch(w, r, query, parsedQuery, mode, explain, offset, pageSize, includeMatches, minScore, scope)
+		s.handleHybridSearch(
+			w, r, query, parsedQuery, structuredFilter,
+			mode, explain, offset, pageSize, includeMatches, minScore, scope,
+		)
 		return
 	}
 
 	if mode != "fts" {
 		writeError(w, http.StatusBadRequest, "invalid_mode",
 			fmt.Sprintf("mode must be one of fts|vector|hybrid, got %q", mode))
+		return
+	}
+	if param, ok := firstPresentQueryParam(r, semanticSearchStructuredFilterParamNames); ok {
+		writeError(w, http.StatusBadRequest, "unsupported_filter_mode",
+			fmt.Sprintf("query parameter %q is only supported when mode=vector or mode=hybrid", param))
 		return
 	}
 
@@ -901,13 +914,37 @@ func parseSearchQueryRequest(r *http.Request, query string) *search.Query {
 	return parsed
 }
 
+var semanticSearchStructuredFilterParamNames = []string{
+	"sender",
+	recipientParam,
+	"domain",
+	"label",
+	"time_period",
+	"time_granularity",
+	"source_id",
+	"attachments_only",
+	"after",
+	"before",
+}
+
+func firstPresentQueryParam(r *http.Request, names []string) (string, bool) {
+	values := r.URL.Query()
+	for _, name := range names {
+		if _, ok := values[name]; ok {
+			return name, true
+		}
+	}
+	return "", false
+}
+
 // handleHybridSearch runs vector or hybrid search via the configured
 // hybrid engine. Returns 503 when the engine is not configured or the
 // index is stale/building; otherwise returns RRF-ranked hits hydrated
 // through the message store.
 func (s *Server) handleHybridSearch(
 	w http.ResponseWriter, r *http.Request,
-	q string, parsed *search.Query, mode string, explain bool,
+	q string, parsed *search.Query, structuredFilter query.MessageFilter,
+	mode string, explain bool,
 	offset, pageSize int, includeMatches bool, minScore float64,
 	scope cliScope,
 ) {
@@ -939,7 +976,7 @@ func (s *Server) handleHybridSearch(
 		subjectTerms = append(subjectTerms, strings.ToLower(t))
 	}
 
-	filter, err := hybridEngine.BuildFilter(ctx, parsed)
+	filter, err := hybridEngine.BuildFilter(ctx, parsed, structuredFilter)
 	if err != nil {
 		s.logger.Error("build hybrid filter failed", "query", q, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "filter resolution failed")
@@ -2255,13 +2292,17 @@ func parseMessageFilter(r *http.Request) (query.MessageFilter, error) {
 
 	filter.Sender = r.URL.Query().Get("sender")
 	filter.SenderName = r.URL.Query().Get("sender_name")
-	filter.Recipient = r.URL.Query().Get("recipient")
+	filter.Recipient = r.URL.Query().Get(recipientParam)
 	filter.RecipientName = r.URL.Query().Get("recipient_name")
 	filter.Domain = r.URL.Query().Get("domain")
 	filter.Label = r.URL.Query().Get("label")
 	filter.MessageType = r.URL.Query().Get("message_type")
 
 	if v := r.URL.Query().Get("time_period"); v != "" {
+		if _, _, ok := query.ParseTimePeriodBounds(v); !ok {
+			return filter, newParamError("time_period",
+				fmt.Sprintf("query parameter %q must be YYYY, YYYY-MM, or YYYY-MM-DD, got %q", "time_period", v))
+		}
 		filter.TimeRange.Period = v
 	}
 	if v := r.URL.Query().Get("time_granularity"); v != "" {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -6100,6 +6100,98 @@ func TestHandleSearch_VectorAccountParamReachesFilter(t *testing.T) {
 	assert.Equal(t, []int64{77}, backend.searchFilter.SourceIDs, "SourceIDs")
 }
 
+func TestHandleSearch_VectorSourceIDParamReachesFilterExactly(t *testing.T) {
+	store := &mockStore{messages: []APIMessage{{ID: 42, Subject: "Lunch", SourceID: 77}}}
+	backend := &fakeVectorBackend{
+		active: &vector.Generation{
+			ID: 1, Model: "fake", Dimension: 4,
+			Fingerprint: "fake:4", State: vector.GenerationActive,
+		},
+		searchHits: []vector.Hit{{MessageID: 42, Score: 0.9, Rank: 1}},
+	}
+	engine := hybrid.NewEngine(backend, nil, realEmbedder{dim: 4}, hybrid.Config{
+		ExpectedFingerprint: "fake:4", RRFK: 60, KPerSignal: 10,
+	})
+	srv := NewServerWithOptions(ServerOptions{
+		Config:       &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:        store,
+		HybridEngine: engine,
+		Backend:      backend,
+		Logger:       testLogger(),
+	})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search?q=lunch&mode=vector&source_id=77", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assert.Equal(t, []int64{77}, backend.searchFilter.SourceIDs, "SourceIDs")
+}
+
+func TestHandleSearch_FTSRejectsStructuredSemanticFilters(t *testing.T) {
+	srv, _ := newTestServerWithMockStore(t)
+	filters := []string{
+		"sender=alice%40example.test",
+		"recipient=bob%40example.test",
+		"domain=example.test",
+		"label=work",
+		"time_period=week",
+		"time_granularity=day",
+		"source_id=77",
+		"attachments_only=true",
+		"after=2026-01-01",
+		"before=2026-02-01",
+	}
+
+	for _, filter := range filters {
+		t.Run(strings.SplitN(filter, "=", 2)[0], func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/search?q=lunch&mode=fts&"+filter, nil)
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			require.Equal(http.StatusBadRequest, w.Code, "status (body: %s)", w.Body.String())
+			var errResp ErrorResponse
+			require.NoError(json.NewDecoder(w.Body).Decode(&errResp), "decode")
+			assert.Equal("unsupported_filter_mode", errResp.Error, "error")
+			assert.Contains(errResp.Message, strings.SplitN(filter, "=", 2)[0], "parameter name")
+			assert.Contains(errResp.Message, "mode=vector or mode=hybrid", "supported modes")
+		})
+	}
+}
+
+func TestHandleSearch_DefaultFTSRejectsStructuredSemanticFilter(t *testing.T) {
+	srv, _ := newTestServerWithMockStore(t)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search?q=lunch&source_id=77", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "status (body: %s)", w.Body.String())
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp), "decode")
+	assert.Equal(t, "unsupported_filter_mode", errResp.Error, "error")
+}
+
+func TestHandleSearch_VectorRejectsInvalidTimePeriod(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, _ := newTestServerWithMockStore(t)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search?q=lunch&mode=vector&time_period=this-week", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	require.Equal(http.StatusBadRequest, w.Code, "status (body: %s)", w.Body.String())
+	var errResp ErrorResponse
+	require.NoError(json.NewDecoder(w.Body).Decode(&errResp), "decode")
+	assert.Equal("invalid_time_period", errResp.Error, "error")
+	assert.Contains(errResp.Message, "YYYY, YYYY-MM, or YYYY-MM-DD", "accepted formats")
+}
+
 func TestHandleSearch_VectorCollectionParamReachesFilter(t *testing.T) {
 	store := &mockStore{
 		messages: []APIMessage{{ID: 42, Subject: "Lunch"}},

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -220,7 +220,8 @@ import (
 // projection text and raw profile details remain internal.
 // Additive (minor bump): existing person and participant routes are unchanged.
 // 2.7.0 adds exact structured sender, recipient, domain, label, source, date,
-// time-period, and attachment filters to vector and hybrid search.
+// time-period, and attachment filters to vector and hybrid search. Stats also
+// report the text-vector message-type scope for compatible search clients.
 // Additive (minor bump): existing unfiltered searches are unchanged.
 const APISchemaVersion = "2.7.0"
 

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -219,7 +219,10 @@ import (
 // results contain only the durable person root and semantic score; person
 // projection text and raw profile details remain internal.
 // Additive (minor bump): existing person and participant routes are unchanged.
-const APISchemaVersion = "2.6.0"
+// 2.7.0 adds exact structured sender, recipient, domain, label, source, date,
+// time-period, and attachment filters to vector and hybrid search.
+// Additive (minor bump): existing unfiltered searches are unchanged.
+const APISchemaVersion = "2.7.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,7 +38,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.6.0", APISchemaVersion)
+	assert.Equal("2.7.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -60,11 +60,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.6.0", APISchemaVersion)
+	assert.Equal(t, "2.7.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.6.0", APISchemaVersion)
+	assert.Equal(t, "2.7.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -88,7 +88,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.6.0", APISchemaVersion,
+	assert.Equal(t, "2.7.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -399,7 +399,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.6.0", APISchemaVersion,
+	assert.Equal("2.7.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -472,7 +472,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.6.0", APISchemaVersion,
+	assertions.Equal("2.7.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -492,7 +492,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.6.0", APISchemaVersion,
+	assert.Equal("2.7.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -520,7 +520,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.6.0", APISchemaVersion,
+	assertions.Equal("2.7.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -564,8 +564,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// routes added in 1.42.0, cache-readiness responses added in 1.43.0,
 	// document search added in 1.44.0, participant/people separation added in
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
-	// 2.6.0 did not touch it.
-	assert.Equal("2.6.0", APISchemaVersion, "person search is an additive schema release")
+	// 2.5.0. Person search in 2.6.0 and structured filters in 2.7.0 did not
+	// touch it.
+	assert.Equal("2.7.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -16,8 +16,11 @@ import (
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
-// limitParam names the shared pagination query/form parameter.
-const limitParam = "limit"
+const (
+	// limitParam names the shared pagination query/form parameter.
+	limitParam     = "limit"
+	recipientParam = "recipient"
+)
 
 const (
 	apiKeySecurityScheme = "apiKey"
@@ -734,9 +737,9 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryStringParam("cid", "Inline MIME Content-ID", true),
 		}
 	case "searchMessages":
-		return append([]*huma.Param{
+		return mergeParams([]*huma.Param{
 			queryStringParam("q", "Search query", true),
-			queryStringParam("mode", "Search mode: fts, vector, or hybrid", false),
+			queryStringParam("mode", "Search mode: fts, vector, or hybrid. Structured filter parameters are supported only in vector and hybrid modes", false),
 			queryIntegerParam("page", "One-based page number (default 1; values below 1 are clamped to 1). Non-numeric values are rejected with 400."),
 			queryIntegerParam("page_size", "Page size (default 20, max 100; out-of-range values are clamped). Non-numeric values are rejected with 400."),
 			queryIntegerParam("offset", "Zero-based ranking offset for vector or hybrid search (default 0)"),
@@ -744,7 +747,7 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryBooleanParam("include_matches", "Include scored semantic chunk excerpts for vector or hybrid results"),
 			queryNumberParam("min_score", "Minimum chunk score for included excerpts; does not filter ranked messages"),
 			queryStringParam("message_type", "Message type filter; repeat or comma-separate for multiple values", false),
-		}, scopeParams()...)
+		}, scopeParams(), semanticMessageFilterParams())
 	case "getAggregates":
 		return append([]*huma.Param{
 			queryStringParam("view_type", "Aggregate view type", false),
@@ -880,7 +883,7 @@ func messageFilterParams() []*huma.Param {
 	return []*huma.Param{
 		queryStringParam("sender", "Sender email/address filter", false),
 		queryStringParam("sender_name", "Sender display-name filter", false),
-		queryStringParam("recipient", "Recipient email/address filter", false),
+		queryStringParam(recipientParam, "Recipient email/address filter", false),
 		queryStringParam("recipient_name", "Recipient display-name filter", false),
 		queryStringParam("domain", "Domain filter", false),
 		queryStringParam("label", "Label filter", false),
@@ -898,6 +901,21 @@ func messageFilterParams() []*huma.Param {
 		queryIntegerParam(limitParam, "Maximum number of rows to return (default and max 500; larger values are clamped)"),
 		queryStringParam("sort", "Sort field: date, size, or subject", false),
 		queryStringParam("direction", "Sort direction: asc or desc", false),
+	}
+}
+
+func semanticMessageFilterParams() []*huma.Param {
+	return []*huma.Param{
+		queryStringParam("sender", "Exact sender email/address filter (vector or hybrid mode only)", false),
+		queryStringParam(recipientParam, "Exact recipient email filter across to, cc, and bcc (vector or hybrid mode only)", false),
+		queryStringParam("domain", "Exact sender domain filter (vector or hybrid mode only)", false),
+		queryStringParam("label", "Exact case-insensitive label filter (vector or hybrid mode only)", false),
+		queryStringParam("time_period", "Calendar period in YYYY, YYYY-MM, or YYYY-MM-DD format (vector or hybrid mode only)", false),
+		queryStringParam("time_granularity", "Time bucket granularity (vector or hybrid mode only)", false),
+		queryIntegerParam("source_id", "Exact source ID (vector or hybrid mode only)"),
+		queryBooleanParam("attachments_only", "Only include messages with attachments (vector or hybrid mode only)"),
+		queryStringParam("after", "Lower date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)", false),
+		queryStringParam("before", "Upper date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)", false),
 	}
 }
 

--- a/internal/api/vector_status_test.go
+++ b/internal/api/vector_status_test.go
@@ -642,6 +642,22 @@ func TestStatsReportsVectorStatus(t *testing.T) {
 	}
 }
 
+func TestStatsReportsTextVectorMessageScope(t *testing.T) {
+	srv, _ := newTestServerWithMockStore(t)
+	vectorCfg := vector.Config{Enabled: true}
+	vectorCfg.Embed.Scope.MessageTypes = []string{"sms", "mms"}
+	srv.SetVectorFeatures(nil, nil, &fakeVectorBackend{}, vectorCfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body StatsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, []string{"mms", "sms"}, body.VectorTextMessageTypes)
+}
+
 // TestHealthReportsAnalyticsMode pins that /health carries the analytics
 // engine mode the daemon selected at startup, and omits the field when the
 // server was built without one, so clients can distinguish live-SQL

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -182,6 +182,7 @@ type CLIHybridSearchRequest struct {
 	Account        string
 	Collection     string
 	MessageTypes   []string
+	Filter         query.MessageFilter
 	Mode           string
 	Limit          int
 	Offset         int
@@ -208,6 +209,7 @@ type CLIHybridGeneration struct {
 }
 
 type CLIHybridSearchResult struct {
+	Message          query.MessageSummary
 	ID               int64
 	Subject          string
 	FromEmail        string
@@ -462,6 +464,17 @@ func (c *Client) daemonAPISchemaVersion(ctx context.Context) (string, error) {
 		version = *resp.JSON200.APISchemaVersion
 	}
 	return version, nil
+}
+
+// SupportsAPISchemaVersion reports whether the daemon implements at least the
+// requested additive HTTP contract. Missing and malformed versions fail
+// closed, as do health-probe errors.
+func (c *Client) SupportsAPISchemaVersion(ctx context.Context, minimum string) (bool, error) {
+	version, err := c.daemonAPISchemaVersion(ctx)
+	if err != nil {
+		return false, err
+	}
+	return apiSchemaVersionAtLeast(version, minimum), nil
 }
 
 func apiSchemaVersionAtLeast(version, minimum string) bool {
@@ -816,16 +829,26 @@ func (c *Client) GetCLIHybridSearch(
 	resp, err := APIResponse(c, func(client *apiclient.Client) (*generated.SearchMessagesResp, error) {
 		return client.SearchMessagesWithResponse(ctx, &generated.SearchMessagesRequestOptions{
 			Query: &generated.SearchMessagesQuery{
-				Q:              req.Query,
-				Mode:           optionalString(req.Mode),
-				Explain:        optionalBool(true),
-				Account:        optionalString(req.Account),
-				Collection:     optionalString(req.Collection),
-				MessageType:    optionalMessageTypes(req.MessageTypes),
-				PageSize:       optionalPositiveInt64(req.Limit),
-				Offset:         optionalPositiveInt64(req.Offset),
-				IncludeMatches: optionalBool(req.IncludeMatches),
-				MinScore:       optionalFloat32(req.MinScore),
+				Q:               req.Query,
+				Mode:            optionalString(req.Mode),
+				Explain:         optionalBool(true),
+				Account:         optionalString(req.Account),
+				Collection:      optionalString(req.Collection),
+				MessageType:     optionalMessageTypes(req.MessageTypes),
+				PageSize:        optionalPositiveInt64(req.Limit),
+				Offset:          optionalPositiveInt64(req.Offset),
+				IncludeMatches:  optionalBool(req.IncludeMatches),
+				MinScore:        optionalFloat32(req.MinScore),
+				Sender:          optionalString(req.Filter.Sender),
+				Recipient:       optionalString(req.Filter.Recipient),
+				Domain:          optionalString(req.Filter.Domain),
+				Label:           optionalString(req.Filter.Label),
+				TimePeriod:      optionalString(req.Filter.TimeRange.Period),
+				TimeGranularity: optionalString(timeGranularityToString(req.Filter.TimeRange.Granularity)),
+				SourceID:        req.Filter.SourceID,
+				AttachmentsOnly: optionalBool(req.Filter.WithAttachmentsOnly),
+				After:           optionalTimeRFC3339(req.Filter.After),
+				Before:          optionalTimeRFC3339(req.Filter.Before),
 			},
 		})
 	})

--- a/internal/daemonclient/convert.go
+++ b/internal/daemonclient/convert.go
@@ -276,7 +276,35 @@ func cliHybridSearchResultFromGenerated(item generated.HybridSearchItem) (CLIHyb
 		}
 		sentAt = parsed
 	}
+	var deletedAt *time.Time
+	if item.DeletedAt != nil && *item.DeletedAt != "" {
+		parsed, err := time.Parse(time.RFC3339, *item.DeletedAt)
+		if err != nil {
+			return CLIHybridSearchResult{}, fmt.Errorf("parse deleted_at: %w", err)
+		}
+		deletedAt = &parsed
+	}
 	out := CLIHybridSearchResult{
+		Message: query.MessageSummary{
+			ID:              item.ID,
+			SourceID:        int64Value(item.SourceID),
+			SourceMessageID: stringValue(item.SourceMessageID),
+			ConversationID:  int64Value(item.ConversationID),
+			Subject:         item.Subject,
+			Snippet:         item.Snippet,
+			FromEmail:       stringValue(item.FromEmail),
+			FromName:        stringValue(item.FromName),
+			FromPhone:       stringValue(item.FromPhone),
+			To:              queryAddressesFromStrings(item.To),
+			Cc:              queryAddressesFromStrings(item.Cc),
+			Bcc:             queryAddressesFromStrings(item.Bcc),
+			SentAt:          sentAt,
+			SizeEstimate:    item.SizeBytes,
+			HasAttachments:  item.HasAttachments,
+			Labels:          item.Labels,
+			DeletedAt:       deletedAt,
+			MessageType:     stringValue(item.MessageType),
+		},
 		ID:               item.ID,
 		Subject:          item.Subject,
 		FromEmail:        stringValue(item.FromEmail),
@@ -297,6 +325,9 @@ func cliHybridSearchResultFromGenerated(item generated.HybridSearchItem) (CLIHyb
 	if out.FromEmail == "" {
 		out.FromEmail = item.From
 	}
+	if out.Message.FromEmail == "" {
+		out.Message.FromEmail = item.From
+	}
 	if item.Score != nil {
 		out.RRFScore = item.Score.Rrf
 		out.BM25Score = item.Score.Bm25
@@ -304,6 +335,17 @@ func cliHybridSearchResultFromGenerated(item generated.HybridSearchItem) (CLIHyb
 		out.SubjectBoosted = boolValue(item.Score.SubjectBoosted)
 	}
 	return out, nil
+}
+
+func queryAddressesFromStrings(addresses []string) []query.Address {
+	if addresses == nil {
+		return nil
+	}
+	out := make([]query.Address, len(addresses))
+	for i, address := range addresses {
+		out[i] = query.Address{Email: address}
+	}
+	return out
 }
 
 func queryMessageSummaryFromGenerated(msg generated.CLIQueryMessageSummary) query.MessageSummary {

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -34,6 +34,7 @@ type Engine struct {
 var _ query.Engine = (*Engine)(nil)
 var _ query.TextEngine = (*Engine)(nil)
 var _ query.MessageBodySearcher = (*Engine)(nil)
+var _ query.SemanticMessageSearcher = (*Engine)(nil)
 
 // NewEngine creates a new daemon-backed query engine.
 func NewEngine(cfg Config) (*Engine, error) {
@@ -61,6 +62,54 @@ func (e *Engine) Close() error {
 		return nil
 	}
 	return e.store.Close()
+}
+
+// SearchSemanticMessages runs the daemon's hybrid message search while
+// preserving the TUI's exact source, drill-down, date, and attachment scope.
+func (e *Engine) SearchSemanticMessages(
+	ctx context.Context,
+	request query.SemanticMessageSearchRequest,
+) (*query.SemanticMessageSearchResult, error) {
+	filter := request.Filter
+	if filter.SourceIDs != nil {
+		return nil, errors.New("semantic TUI search does not support multi-account source scope")
+	}
+	if !query.SemanticMessageSearchSupportsFilter(filter) {
+		return nil, errors.New("semantic TUI search cannot preserve the current display-name, conversation, or empty-value scope")
+	}
+	parsed := search.Parse(request.Query)
+	if err := parsed.Err(); err != nil {
+		return nil, err
+	}
+	if len(parsed.TextTerms) == 0 {
+		return nil, errors.New("semantic search requires a query")
+	}
+	messageTypes, noMessageTypeMatches := query.ScopedMessageTypes(parsed.MessageTypes, filter.MessageType)
+	if noMessageTypeMatches {
+		return &query.SemanticMessageSearchResult{}, nil
+	}
+	// Carry the canonical intersection as the HTTP parameter and remove the
+	// user-authored operators from q. Leaving both in place would make the
+	// hybrid backend OR them and widen an Email-mode query back to SMS/MMS.
+	parsed.MessageTypes = nil
+	transportQuery := search.Format(parsed)
+
+	response, err := e.store.GetCLIHybridSearch(ctx, CLIHybridSearchRequest{
+		Query:        transportQuery,
+		MessageTypes: messageTypes,
+		Filter:       filter,
+		Mode:         "hybrid",
+		Limit:        request.Limit,
+		Offset:       request.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+	messages := make([]query.MessageSummary, len(response.Results))
+	for i, result := range response.Results {
+		messages[i] = result.Message
+	}
+	return &query.SemanticMessageSearchResult{Messages: messages, HasMore: response.HasMore}, nil
 }
 
 // ============================================================================

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -55,6 +55,142 @@ func TestEngineListMessagesPreservesDeletedAt(t *testing.T) {
 	assert.Equal(t, deletedAt, msgs[0].DeletedAt.UTC().Format(time.RFC3339), "DeletedAt")
 }
 
+func TestEngineSemanticSearchUsesHybridEndpointAndReturnsRankedSummaries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	accountID := int64(7)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v1/search", r.URL.Path)
+		assert.Equal("hybrid", r.URL.Query().Get("mode"))
+		assert.Empty(r.URL.Query().Get("account"))
+		assert.Equal("7", r.URL.Query().Get("source_id"))
+		assert.Equal("agent@example.test", r.URL.Query().Get("sender"))
+		assert.Equal("email", r.URL.Query().Get("message_type"))
+		assert.Equal("true", r.URL.Query().Get("attachments_only"))
+		assert.Equal("25", r.URL.Query().Get("page_size"))
+		assert.Equal("5", r.URL.Query().Get("offset"))
+		assert.Equal("find realtor invoice", r.URL.Query().Get("q"))
+		writeJSONResponse(t, w, map[string]any{
+			"query":          "find realtor invoice",
+			"mode":           "hybrid",
+			"returned":       1,
+			"pool_saturated": false,
+			"has_more":       true,
+			"took_ms":        4,
+			"generation": map[string]any{
+				"id": 9, "model": "test-model", "dimension": 4,
+				"fingerprint": "test:4", "state": "active",
+			},
+			"results": []map[string]any{{
+				"id": 42, "source_id": 7, "source_message_id": "msg-42",
+				"conversation_id": 3, "subject": "Annual realtor statement",
+				"from": "Agent <agent@example.test>", "from_email": "agent@example.test",
+				"from_name": "Agent", "to": []string{"archive@example.test"},
+				"sent_at": "2025-02-03T04:05:06Z", "snippet": "Your annual statement",
+				"labels": []string{"INBOX"}, "has_attachments": true,
+				"size_bytes": 2048, "message_type": "email",
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	engine := NewEngineAdapter(newTestStore(srv, ""))
+	result, err := engine.SearchSemanticMessages(context.Background(), query.SemanticMessageSearchRequest{
+		Query: "find realtor invoice",
+		Filter: query.MessageFilter{
+			SourceID:            &accountID,
+			Sender:              "agent@example.test",
+			MessageType:         "email",
+			WithAttachmentsOnly: true,
+		},
+		Limit: 25, Offset: 5,
+	})
+	require.NoError(err)
+	assert.True(result.HasMore)
+	require.Len(result.Messages, 1)
+	message := result.Messages[0]
+	assert.Equal(int64(42), message.ID)
+	assert.Equal(int64(7), message.SourceID)
+	assert.Equal("agent@example.test", message.FromEmail)
+	assert.Equal("Agent", message.FromName)
+	assert.True(message.HasAttachments)
+	assert.Equal(int64(2048), message.SizeEstimate)
+}
+
+func TestEngineSemanticSearchRejectsScopesItCannotPreserve(t *testing.T) {
+	conversationID := int64(9)
+	tests := []struct {
+		name    string
+		filter  query.MessageFilter
+		wantErr string
+	}{
+		{
+			name:    "multi-source scope",
+			filter:  query.MessageFilter{SourceIDs: []int64{1, 2}},
+			wantErr: "does not support multi-account",
+		},
+		{
+			name:    "display-name scope",
+			filter:  query.MessageFilter{SenderName: "Test Sender"},
+			wantErr: "cannot preserve",
+		},
+		{
+			name:    "conversation scope",
+			filter:  query.MessageFilter{ConversationID: &conversationID},
+			wantErr: "cannot preserve",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := &Engine{}
+			_, err := engine.SearchSemanticMessages(context.Background(), query.SemanticMessageSearchRequest{
+				Query: "find invoice", Filter: tt.filter,
+			})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestEngineSemanticSearchIntersectsMessageTypeScope(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests int
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		assert.Equal("email", r.URL.Query().Get("message_type"))
+		assert.Equal("invoice", r.URL.Query().Get("q"), "message_type operator is carried only by the exact parameter")
+		writeJSONResponse(t, w, map[string]any{
+			"query": "invoice", "mode": "hybrid", "returned": 0,
+			"pool_saturated": false, "has_more": false, "took_ms": 1,
+			"generation": map[string]any{
+				"id": 9, "model": "test-model", "dimension": 4,
+				"fingerprint": "test:4", "state": "active",
+			},
+			"results": []any{},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	engine := NewEngineAdapter(newTestStore(srv, ""))
+	result, err := engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
+		Query:  "message_type:email invoice",
+		Filter: query.MessageFilter{MessageType: "email"},
+	})
+	require.NoError(err)
+	assert.Empty(result.Messages)
+	assert.Equal(1, requests)
+
+	result, err = engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
+		Query:  "message_type:sms invoice",
+		Filter: query.MessageFilter{MessageType: "email"},
+	})
+	require.NoError(err)
+	assert.Empty(result.Messages)
+	assert.False(result.HasMore)
+	assert.Equal(1, requests, "disjoint scope must fail closed without an HTTP search")
+}
+
 func TestEngineListMessagesUsesGeneratedClientAdapter(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/daemonclient/store_adapter.go
+++ b/internal/daemonclient/store_adapter.go
@@ -3,6 +3,8 @@ package daemonclient
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"go.kenn.io/msgvault/internal/store"
@@ -34,28 +36,63 @@ func (c *Client) GetStats() (*store.Stats, error) {
 // detail rather than the tool silently going missing. Older daemons that omit
 // `vector_status` fall back to the `vector_search.enabled` flag.
 func (c *Client) VectorSearchAvailable(ctx context.Context) (bool, error) {
+	stats, err := c.vectorSearchStats(ctx)
+	if err != nil {
+		return false, err
+	}
+	return vectorSearchAvailable(stats), nil
+}
+
+// VectorSearchAvailableForMessageType reports whether the daemon's text-vector
+// lane can serve searches for messageType. An empty advertised scope means the
+// text index covers every message type.
+func (c *Client) VectorSearchAvailableForMessageType(ctx context.Context, messageType string) (bool, error) {
+	stats, err := c.vectorSearchStats(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !vectorSearchAvailable(stats) {
+		return false, nil
+	}
+	if len(stats.VectorTextMessageTypes) == 0 {
+		return true, nil
+	}
+	messageType = strings.TrimSpace(messageType)
+	return slices.ContainsFunc(stats.VectorTextMessageTypes, func(indexedType string) bool {
+		return strings.EqualFold(strings.TrimSpace(indexedType), messageType)
+	}), nil
+}
+
+func (c *Client) vectorSearchStats(ctx context.Context) (*generated.StatsResponse, error) {
 	resp, err := APIResponse(c, func(client *apiclient.Client) (*generated.GetStatsResp, error) {
 		return client.GetStatsWithResponse(ctx)
 	})
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	if resp == nil || resp.JSON200 == nil {
-		return false, nil
+		return &generated.StatsResponse{}, nil
+	}
+	return resp.JSON200, nil
+}
+
+func vectorSearchAvailable(stats *generated.StatsResponse) bool {
+	if stats == nil {
+		return false
 	}
 	// Newer daemons report the text lane separately: a multimodal-only
 	// daemon is vector-"ready" without serving semantic message search, so
 	// the shared status must not enable text-vector tools there.
-	if textStatus := resp.JSON200.VectorTextStatus; textStatus != nil && *textStatus != "" {
-		return *textStatus != vectorStatusDisabled, nil
+	if textStatus := stats.VectorTextStatus; textStatus != nil && *textStatus != "" {
+		return *textStatus != vectorStatusDisabled
 	}
-	if status := resp.JSON200.VectorStatus; status != nil && *status != "" {
-		return *status != vectorStatusDisabled, nil
+	if status := stats.VectorStatus; status != nil && *status != "" {
+		return *status != vectorStatusDisabled
 	}
-	if resp.JSON200.VectorSearch == nil {
-		return false, nil
+	if stats.VectorSearch == nil {
+		return false
 	}
-	return resp.JSON200.VectorSearch.Enabled, nil
+	return stats.VectorSearch.Enabled
 }
 
 // VisualSearchAvailable reports whether the daemon's multimodal lane is

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/msgvault/internal/apiprotocol"
 	"go.kenn.io/msgvault/internal/contentverify"
 	"go.kenn.io/msgvault/internal/deletion"
+	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 	apiclient "go.kenn.io/msgvault/pkg/client"
 	"go.kenn.io/msgvault/pkg/client/generated"
@@ -1112,6 +1113,16 @@ func TestGetCLIHybridSearch_Success(t *testing.T) {
 		assert.Equal("5", r.URL.Query().Get("offset"), "offset query")
 		assert.Equal("true", r.URL.Query().Get("include_matches"), "include_matches query")
 		assert.Equal("0.75", r.URL.Query().Get("min_score"), "min_score query")
+		assert.Equal("alice@example.com", r.URL.Query().Get("sender"), "sender query")
+		assert.Equal("bob@example.com", r.URL.Query().Get("recipient"), "recipient query")
+		assert.Equal("example.com", r.URL.Query().Get("domain"), "domain query")
+		assert.Equal("Work", r.URL.Query().Get("label"), "label query")
+		assert.Equal("2025-02", r.URL.Query().Get("time_period"), "time_period query")
+		assert.Equal("month", r.URL.Query().Get("time_granularity"), "time_granularity query")
+		assert.Equal("77", r.URL.Query().Get("source_id"), "source_id query")
+		assert.Equal("true", r.URL.Query().Get("attachments_only"), "attachments_only query")
+		assert.Equal("2025-02-01T00:00:00Z", r.URL.Query().Get("after"), "after query")
+		assert.Equal("2025-03-01T00:00:00Z", r.URL.Query().Get("before"), "before query")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"query": "lunch",
@@ -1159,6 +1170,9 @@ func TestGetCLIHybridSearch_Success(t *testing.T) {
 	defer srv.Close()
 
 	s := newTestStore(srv, "key")
+	after := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	sourceID := int64(77)
 	resp, err := s.GetCLIHybridSearch(
 		context.Background(),
 		CLIHybridSearchRequest{
@@ -1170,6 +1184,17 @@ func TestGetCLIHybridSearch_Success(t *testing.T) {
 			Offset:         5,
 			IncludeMatches: true,
 			MinScore:       0.75,
+			Filter: query.MessageFilter{
+				Sender:              "alice@example.com",
+				Recipient:           "bob@example.com",
+				Domain:              "example.com",
+				Label:               "Work",
+				TimeRange:           query.TimeRange{Period: "2025-02", Granularity: query.TimeMonth},
+				SourceID:            &sourceID,
+				WithAttachmentsOnly: true,
+				After:               &after,
+				Before:              &before,
+			},
 		},
 	)
 	require.NoError(err, "GetCLIHybridSearch")

--- a/internal/export/attachments.go
+++ b/internal/export/attachments.go
@@ -177,7 +177,7 @@ func addAttachmentToZip(zw *zip.Writer, open AttachmentOpener, att query.Attachm
 
 func resolveUniqueFilename(original, contentHash string, usedNames map[string]int) string {
 	filename := SanitizeFilename(filepath.Base(original))
-	if filename == "" || filename == "." {
+	if filename == "" || filename == "." || filename == ".." || !filepath.IsLocal(filename) {
 		filename = contentHash
 	}
 
@@ -294,6 +294,16 @@ func looseOpener(attachmentsDir string) AttachmentOpener {
 // outputDir/filename. Uses O_EXCL to avoid overwriting; appends _1, _2, etc.
 // on conflict.
 func exportAttachmentToFile(outputDir string, open AttachmentOpener, contentHash, filename string) (ExportedFile, error) {
+	if filename == "." || filename == ".." || !filepath.IsLocal(filename) {
+		return ExportedFile{}, fmt.Errorf("invalid output filename %q", filename)
+	}
+	cleanOutputDir := filepath.Clean(outputDir)
+	destPath := filepath.Join(cleanOutputDir, filename)
+	rel, err := filepath.Rel(cleanOutputDir, destPath)
+	if err != nil || !filepath.IsLocal(rel) {
+		return ExportedFile{}, fmt.Errorf("output filename %q escapes output directory", filename)
+	}
+
 	src, err := open(contentHash)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -301,7 +311,6 @@ func exportAttachmentToFile(outputDir string, open AttachmentOpener, contentHash
 		}
 		return ExportedFile{}, fmt.Errorf("open source: %w", err)
 	}
-	destPath := filepath.Join(outputDir, filename)
 	dst, finalPath, err := CreateExclusiveFile(destPath, 0600)
 	if err != nil {
 		return ExportedFile{}, fmt.Errorf("create output file: %w", errors.Join(err, src.Close()))

--- a/internal/export/attachments_test.go
+++ b/internal/export/attachments_test.go
@@ -289,6 +289,31 @@ func TestAttachmentsToDirWithOpener(t *testing.T) {
 	assert.Equal(content, got)
 }
 
+func TestAttachmentsToDirWithOpenerKeepsDotNamesInsideOutputDir(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	content := []byte("untrusted content")
+	hash := fmt.Sprintf("%x", sha256.Sum256(content))
+	root := t.TempDir()
+
+	for _, filename := range []string{".", ".."} {
+		t.Run(filename, func(t *testing.T) {
+			outDir := filepath.Join(root, strings.ReplaceAll(filename, ".", "dot"))
+			require.NoError(os.Mkdir(outDir, 0o700))
+			result := AttachmentsToDirWithOpener(outDir,
+				[]query.AttachmentInfo{{Filename: filename, ContentHash: hash}},
+				func(string) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader(content)), nil
+				})
+
+			require.Empty(result.Errors)
+			require.Len(result.Files, 1)
+			assert.Equal(filepath.Join(outDir, hash), result.Files[0].Path)
+			assert.FileExists(result.Files[0].Path)
+		})
+	}
+}
+
 func TestAttachmentsToDirWithOpenerRejectsCloseVerificationError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -102,6 +102,40 @@ type Engine interface {
 	Close() error
 }
 
+// SemanticMessageSearcher is an optional engine capability for ranked
+// natural-language message search. It stays separate from Engine so local and
+// test engines that do not have a configured vector backend keep working.
+type SemanticMessageSearcher interface {
+	SearchSemanticMessages(ctx context.Context, request SemanticMessageSearchRequest) (*SemanticMessageSearchResult, error)
+}
+
+// SemanticMessageSearchSupportsFilter reports whether semantic message search
+// can preserve every structured scope in filter.
+func SemanticMessageSearchSupportsFilter(filter MessageFilter) bool {
+	return filter.SourceIDs == nil &&
+		filter.SenderName == "" &&
+		filter.RecipientName == "" &&
+		filter.ConversationID == nil &&
+		!filter.HasEmptyTargets()
+}
+
+// SemanticMessageSearchRequest carries the current TUI scope into hybrid
+// search. Filter retains the exact source ID and every representable
+// drill-down, date, message-type, and attachment constraint.
+type SemanticMessageSearchRequest struct {
+	Query  string
+	Filter MessageFilter
+	Limit  int
+	Offset int
+}
+
+// SemanticMessageSearchResult preserves ranking order and reports whether the
+// bounded vector ranking window contains another page.
+type SemanticMessageSearchResult struct {
+	Messages []MessageSummary
+	HasMore  bool
+}
+
 // Explorer is intentionally separate from Engine: only the committed
 // DuckDB/Parquet analytical read model implements it. Transactional engines
 // must never become a modality-specific fallback for exploration.

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -2044,7 +2044,7 @@ func MergeFilterIntoQuery(q *search.Query, filter MessageFilter) *search.Query {
 	// like "2024" → [2024-01-01, 2025-01-01), "2024-03" →
 	// [2024-03-01, 2024-04-01), "2024-03-15" → [2024-03-15, 2024-03-16).
 	if filter.TimeRange.Period != "" {
-		if after, before, ok := timePeriodToBounds(
+		if after, before, ok := ParseTimePeriodBounds(
 			filter.TimeRange.Period,
 		); ok {
 			if merged.AfterDate == nil ||
@@ -2066,9 +2066,9 @@ func MergeFilterIntoQuery(q *search.Query, filter MessageFilter) *search.Query {
 	return &merged
 }
 
-// timePeriodToBounds converts a time period string to half-open date
+// ParseTimePeriodBounds converts a calendar period string to half-open date
 // bounds [after, before). Returns ok=false if the format is unrecognized.
-func timePeriodToBounds(period string) (after, before time.Time, ok bool) {
+func ParseTimePeriodBounds(period string) (after, before time.Time, ok bool) {
 	switch len(period) {
 	case 4: // "2024" → year
 		t, err := time.Parse("2006", period)

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -361,13 +361,6 @@ func (c *ActionController) OpenAttachment(att query.AttachmentInfo) tea.Cmd {
 				}
 				return msg
 			}
-			if err := validateDownloadedAttachmentOpen(att, exported.Path); err != nil {
-				return ExportResultMsg{
-					Title:  "Open Blocked",
-					Result: fmt.Sprintf("%v\n\nThe attachment was downloaded to:\n%s", err, exported.Path),
-					Err:    err,
-				}
-			}
 			target = exported.Path
 			savedPath = exported.Path
 		}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -361,6 +361,13 @@ func (c *ActionController) OpenAttachment(att query.AttachmentInfo) tea.Cmd {
 				}
 				return msg
 			}
+			if err := validateDownloadedAttachmentOpen(att, exported.Path); err != nil {
+				return ExportResultMsg{
+					Title:  "Open Blocked",
+					Result: fmt.Sprintf("%v\n\nThe attachment was downloaded to:\n%s", err, exported.Path),
+					Err:    err,
+				}
+			}
 			target = exported.Path
 			savedPath = exported.Path
 		}

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -5,17 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/textutil"
 )
 
 // ExportResultMsg is returned when attachment export completes.
 type ExportResultMsg struct {
+	Title  string
 	Result string
 	Err    error
 }
@@ -35,11 +41,14 @@ type DeletionContext struct {
 // ActionController handles business logic for actions like deletion and export,
 // keeping domain operations out of the TUI Model.
 type ActionController struct {
-	queries          query.Engine
-	deletions        *deletion.Manager
-	dataDir          string
-	manifestSaver    DeletionManifestSaver
-	attachmentReader AttachmentReader
+	queries             query.Engine
+	deletions           *deletion.Manager
+	dataDir             string
+	manifestSaver       DeletionManifestSaver
+	attachmentReader    AttachmentReader
+	attachmentOutputDir string
+	openTarget          func(context.Context, string) error
+	markUntrusted       func(string) error
 }
 
 // DeletionManifestSaver saves a staged deletion manifest.
@@ -54,10 +63,12 @@ type AttachmentReader interface {
 
 // ActionControllerOptions configures external action dependencies.
 type ActionControllerOptions struct {
-	DataDir          string
-	Deletions        *deletion.Manager
-	ManifestSaver    DeletionManifestSaver
-	AttachmentReader AttachmentReader
+	DataDir             string
+	Deletions           *deletion.Manager
+	ManifestSaver       DeletionManifestSaver
+	AttachmentReader    AttachmentReader
+	AttachmentOutputDir string
+	OpenTarget          func(context.Context, string) error
 }
 
 // NewActionController creates a new action controller.
@@ -72,11 +83,13 @@ func NewActionController(queries query.Engine, dataDir string, deletions *deleti
 // NewActionControllerWithOptions creates an action controller with explicit dependencies.
 func NewActionControllerWithOptions(queries query.Engine, opts ActionControllerOptions) *ActionController {
 	return &ActionController{
-		queries:          queries,
-		deletions:        opts.Deletions,
-		dataDir:          opts.DataDir,
-		manifestSaver:    opts.ManifestSaver,
-		attachmentReader: opts.AttachmentReader,
+		queries:             queries,
+		deletions:           opts.Deletions,
+		dataDir:             opts.DataDir,
+		manifestSaver:       opts.ManifestSaver,
+		attachmentReader:    opts.AttachmentReader,
+		attachmentOutputDir: opts.AttachmentOutputDir,
+		openTarget:          opts.OpenTarget,
 	}
 }
 
@@ -293,15 +306,158 @@ func (c *ActionController) ExportAttachments(detail *query.MessageDetail, select
 
 	return func() tea.Msg {
 		stats := c.exportSelectedAttachments(zipFilename, attachmentsDir, selectedAttachments)
-		msg := ExportResultMsg{Result: export.FormatExportResult(stats)}
+		msg := ExportResultMsg{Title: "Export Complete", Result: export.FormatExportResult(stats)}
 		// Only set Err for true failures: write errors or zero exported files.
 		// Partial success (some files exported, some errors) should show the
 		// detailed Result which includes both the success info and error list.
 		if stats.WriteError || stats.Count == 0 {
 			msg.Err = errors.New("export failed")
+			msg.Title = "Export Failed"
 		}
 		return msg
 	}
+}
+
+// DownloadAttachment writes one exact attachment into the local output
+// directory without overwriting an existing file.
+func (c *ActionController) DownloadAttachment(att query.AttachmentInfo) tea.Cmd {
+	return func() tea.Msg {
+		exported, err := c.exportOneAttachment(att)
+		if err != nil {
+			msg := ExportResultMsg{Title: "Download Failed", Err: err}
+			if exported.Path != "" {
+				msg.Result = fmt.Sprintf("%v\n\nThe attachment was downloaded to:\n%s", err, exported.Path)
+			}
+			return msg
+		}
+		return ExportResultMsg{
+			Title: "Download Complete",
+			Result: fmt.Sprintf("Downloaded %s (%s)\n\nSaved to:\n%s",
+				filepath.Base(exported.Path), export.FormatBytesLong(exported.Size), exported.Path),
+		}
+	}
+}
+
+// OpenAttachment opens a URL-backed attachment directly, or first downloads a
+// content-backed attachment locally and then hands it to the OS default app.
+func (c *ActionController) OpenAttachment(att query.AttachmentInfo) tea.Cmd {
+	return func() tea.Msg {
+		target := att.URL
+		var savedPath string
+		if target != "" {
+			parsed, err := url.Parse(target)
+			if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+				return ExportResultMsg{Title: "Open Failed", Err: errors.New("attachment URL must use http or https")}
+			}
+		} else {
+			if err := validateAttachmentOpen(att); err != nil {
+				return ExportResultMsg{Title: "Open Blocked", Err: err}
+			}
+			exported, err := c.exportOneAttachment(att)
+			if err != nil {
+				msg := ExportResultMsg{Title: "Open Failed", Err: err}
+				if exported.Path != "" {
+					msg.Result = fmt.Sprintf("%v\n\nThe attachment was downloaded to:\n%s", err, exported.Path)
+				}
+				return msg
+			}
+			target = exported.Path
+			savedPath = exported.Path
+		}
+
+		opener := c.openTarget
+		if opener == nil {
+			opener = openSystemTarget
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := opener(ctx, target); err != nil {
+			openErr := fmt.Errorf("open attachment: %w", err)
+			if savedPath != "" {
+				return ExportResultMsg{
+					Title:  "Open Failed",
+					Result: fmt.Sprintf("%v\n\nThe attachment was downloaded to:\n%s", openErr, savedPath),
+					Err:    openErr,
+				}
+			}
+			return ExportResultMsg{Title: "Open Failed", Err: openErr}
+		}
+		result := "Opened " + attachmentDisplayName(att)
+		if savedPath != "" {
+			result += "\n\nSaved to:\n" + savedPath
+		}
+		return ExportResultMsg{Title: "Attachment Opened", Result: result}
+	}
+}
+
+func (c *ActionController) exportOneAttachment(att query.AttachmentInfo) (export.ExportedFile, error) {
+	if att.URL != "" {
+		return export.ExportedFile{}, errors.New("URL-backed attachments can be opened but not downloaded")
+	}
+	outputDir := c.attachmentOutputDir
+	if outputDir == "" {
+		baseDir := c.dataDir
+		if baseDir == "" {
+			var err error
+			baseDir, err = os.UserCacheDir()
+			if err != nil {
+				return export.ExportedFile{}, fmt.Errorf("get user cache directory: %w", err)
+			}
+			baseDir = filepath.Join(baseDir, "msgvault")
+		}
+		outputDir = filepath.Join(baseDir, "downloads")
+	}
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return export.ExportedFile{}, fmt.Errorf("resolve output directory: %w", err)
+	}
+	if err := fileutil.SecureMkdirAll(absOutputDir, 0o700); err != nil {
+		return export.ExportedFile{}, fmt.Errorf("create output directory: %w", err)
+	}
+	result := export.AttachmentsToDirWithOpener(absOutputDir, []query.AttachmentInfo{att}, c.attachmentOpener())
+	if len(result.Files) == 1 {
+		exported := result.Files[0]
+		marker := c.markUntrusted
+		if marker == nil {
+			marker = markAttachmentUntrusted
+		}
+		if err := marker(exported.Path); err != nil {
+			return exported, fmt.Errorf("mark downloaded attachment as untrusted: %w", err)
+		}
+		return exported, nil
+	}
+	if len(result.Errors) > 0 {
+		return export.ExportedFile{}, errors.New(result.Errors[0])
+	}
+	return export.ExportedFile{}, errors.New("attachment was not downloaded")
+}
+
+func (c *ActionController) attachmentOpener() export.AttachmentOpener {
+	if c.attachmentReader != nil {
+		return func(contentHash string) (io.ReadCloser, error) {
+			return c.attachmentReader.OpenAttachment(context.Background(), contentHash)
+		}
+	}
+	attachmentsDir := filepath.Join(c.dataDir, "attachments")
+	return func(contentHash string) (io.ReadCloser, error) {
+		path, err := export.StoragePath(attachmentsDir, contentHash)
+		if err != nil {
+			return nil, err
+		}
+		return os.Open(path)
+	}
+}
+
+func attachmentDisplayName(att query.AttachmentInfo) string {
+	name := filepath.Base(att.Filename)
+	if name == "" || name == "." {
+		if att.URL != "" {
+			name = att.URL
+		} else {
+			name = att.ContentHash
+		}
+	}
+	return textutil.SanitizeTerminal(name)
 }
 
 func (c *ActionController) exportSelectedAttachments(

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -649,7 +649,7 @@ func TestOpenAttachmentDownloadsThenUsesInjectedOSHandler(t *testing.T) {
 		DataDir:             t.TempDir(),
 		AttachmentOutputDir: outputDir,
 		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
-			contentHash: []byte("contract bytes"),
+			contentHash: []byte("%PDF-1.7\n"),
 		}},
 		OpenTarget: func(_ context.Context, target string) error {
 			opened = target
@@ -674,6 +674,38 @@ func TestOpenAttachmentDownloadsThenUsesInjectedOSHandler(t *testing.T) {
 	assert.FileExists(opened)
 }
 
+func TestOpenAttachmentBlocksDetectedContentMismatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	outputDir := t.TempDir()
+	opened := false
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("MZ\x90\x00disguised executable"),
+		}},
+		OpenTarget: func(context.Context, string) error {
+			opened = true
+			return nil
+		},
+	})
+	ctrl.markUntrusted = func(string) error { return nil }
+
+	msg := ctrl.OpenAttachment(query.AttachmentInfo{
+		Filename: "contract.pdf", MimeType: "application/pdf", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.Error(result.Err)
+	assert.Equal("Open Blocked", result.Title)
+	require.ErrorContains(result.Err, "detected content type")
+	assert.False(opened)
+	assert.Contains(result.Result, filepath.Join(outputDir, "contract.pdf"))
+	assert.FileExists(filepath.Join(outputDir, "contract.pdf"))
+}
+
 func TestOpenAttachmentBlocksActiveUnknownAndMismatchedTypes(t *testing.T) {
 	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
 	tests := []query.AttachmentInfo{
@@ -681,6 +713,7 @@ func TestOpenAttachmentBlocksActiveUnknownAndMismatchedTypes(t *testing.T) {
 		{Filename: "macro.docm", MimeType: "application/vnd.ms-word.document.macroEnabled.12", ContentHash: contentHash},
 		{Filename: "unknown.bin", MimeType: "application/octet-stream", ContentHash: contentHash},
 		{Filename: "disguised.pdf", MimeType: "application/x-msdownload", ContentHash: contentHash},
+		{Filename: "report.docx", MimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ContentHash: contentHash},
 	}
 	for _, att := range tests {
 		t.Run(att.Filename, func(t *testing.T) {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -649,7 +649,7 @@ func TestOpenAttachmentDownloadsThenUsesInjectedOSHandler(t *testing.T) {
 		DataDir:             t.TempDir(),
 		AttachmentOutputDir: outputDir,
 		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
-			contentHash: []byte("%PDF-1.7\n"),
+			contentHash: []byte("contract bytes"),
 		}},
 		OpenTarget: func(_ context.Context, target string) error {
 			opened = target
@@ -674,38 +674,6 @@ func TestOpenAttachmentDownloadsThenUsesInjectedOSHandler(t *testing.T) {
 	assert.FileExists(opened)
 }
 
-func TestOpenAttachmentBlocksDetectedContentMismatch(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
-	outputDir := t.TempDir()
-	opened := false
-	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
-		DataDir:             t.TempDir(),
-		AttachmentOutputDir: outputDir,
-		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
-			contentHash: []byte("MZ\x90\x00disguised executable"),
-		}},
-		OpenTarget: func(context.Context, string) error {
-			opened = true
-			return nil
-		},
-	})
-	ctrl.markUntrusted = func(string) error { return nil }
-
-	msg := ctrl.OpenAttachment(query.AttachmentInfo{
-		Filename: "contract.pdf", MimeType: "application/pdf", ContentHash: contentHash,
-	})()
-	result, ok := msg.(ExportResultMsg)
-	require.True(ok, "expected ExportResultMsg, got %T", msg)
-	require.Error(result.Err)
-	assert.Equal("Open Blocked", result.Title)
-	require.ErrorContains(result.Err, "detected content type")
-	assert.False(opened)
-	assert.Contains(result.Result, filepath.Join(outputDir, "contract.pdf"))
-	assert.FileExists(filepath.Join(outputDir, "contract.pdf"))
-}
-
 func TestOpenAttachmentBlocksActiveUnknownAndMismatchedTypes(t *testing.T) {
 	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
 	tests := []query.AttachmentInfo{
@@ -713,7 +681,6 @@ func TestOpenAttachmentBlocksActiveUnknownAndMismatchedTypes(t *testing.T) {
 		{Filename: "macro.docm", MimeType: "application/vnd.ms-word.document.macroEnabled.12", ContentHash: contentHash},
 		{Filename: "unknown.bin", MimeType: "application/octet-stream", ContentHash: contentHash},
 		{Filename: "disguised.pdf", MimeType: "application/x-msdownload", ContentHash: contentHash},
-		{Filename: "report.docx", MimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", ContentHash: contentHash},
 	}
 	for _, att := range tests {
 		t.Run(att.Filename, func(t *testing.T) {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -4,9 +4,11 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -545,4 +547,228 @@ func TestExportAttachments_UsesInjectedAttachmentReader(t *testing.T) {
 	require.NoError(err, "read zip entry")
 	require.NoError(file.Close(), "close zip entry")
 	assert.Equal("daemon bytes", string(body))
+}
+
+func TestDownloadAttachmentWritesExactFileWithoutOverwrite(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	outputDir := t.TempDir()
+	require.NoError(os.WriteFile(filepath.Join(outputDir, "invoice.pdf"), []byte("existing"), 0o600))
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("downloaded invoice"),
+		}},
+	})
+	var marked string
+	ctrl.markUntrusted = func(path string) error {
+		marked = path
+		return nil
+	}
+
+	msg := ctrl.DownloadAttachment(query.AttachmentInfo{
+		Filename: "invoice.pdf", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.NoError(result.Err)
+	assert.Equal("Download Complete", result.Title)
+	assert.FileExists(filepath.Join(outputDir, "invoice_1.pdf"))
+	assert.Equal(filepath.Join(outputDir, "invoice_1.pdf"), marked)
+	body, err := os.ReadFile(filepath.Join(outputDir, "invoice_1.pdf"))
+	require.NoError(err)
+	assert.Equal("downloaded invoice", string(body))
+}
+
+func TestDownloadAttachmentDefaultsToPrivateDataDirectory(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	dataDir := t.TempDir()
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir: dataDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("untrusted startup content"),
+		}},
+	})
+	ctrl.markUntrusted = func(string) error { return nil }
+
+	msg := ctrl.DownloadAttachment(query.AttachmentInfo{
+		Filename: ".zshenv", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.NoError(result.Err)
+	downloadPath := filepath.Join(dataDir, "downloads", ".zshenv")
+	assert.Contains(result.Result, downloadPath)
+	assert.FileExists(downloadPath)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(downloadPath)
+		require.NoError(err)
+		assert.Zero(info.Mode().Perm()&0o111, "download must not be executable")
+		dirInfo, err := os.Stat(filepath.Dir(downloadPath))
+		require.NoError(err)
+		assert.Equal(os.FileMode(0o700), dirInfo.Mode().Perm())
+	}
+}
+
+func TestDownloadAttachmentReportsMarkingFailureAndPreservesFile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	outputDir := t.TempDir()
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("downloaded invoice"),
+		}},
+	})
+	ctrl.markUntrusted = func(string) error { return errors.New("marker unavailable") }
+
+	msg := ctrl.DownloadAttachment(query.AttachmentInfo{
+		Filename: "invoice.pdf", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.Error(result.Err)
+	assert.Equal("Download Failed", result.Title)
+	assert.Contains(result.Result, filepath.Join(outputDir, "invoice.pdf"))
+	assert.FileExists(filepath.Join(outputDir, "invoice.pdf"))
+}
+
+func TestOpenAttachmentDownloadsThenUsesInjectedOSHandler(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	outputDir := t.TempDir()
+	var opened string
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("contract bytes"),
+		}},
+		OpenTarget: func(_ context.Context, target string) error {
+			opened = target
+			return nil
+		},
+	})
+	var marked string
+	ctrl.markUntrusted = func(path string) error {
+		marked = path
+		return nil
+	}
+
+	msg := ctrl.OpenAttachment(query.AttachmentInfo{
+		Filename: "contract.pdf", MimeType: "application/pdf", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.NoError(result.Err)
+	assert.Equal("Attachment Opened", result.Title)
+	assert.Equal(filepath.Join(outputDir, "contract.pdf"), opened)
+	assert.Equal(opened, marked, "download must be marked untrusted before opening")
+	assert.FileExists(opened)
+}
+
+func TestOpenAttachmentBlocksActiveUnknownAndMismatchedTypes(t *testing.T) {
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	tests := []query.AttachmentInfo{
+		{Filename: "shortcut.lnk", MimeType: "application/octet-stream", ContentHash: contentHash},
+		{Filename: "macro.docm", MimeType: "application/vnd.ms-word.document.macroEnabled.12", ContentHash: contentHash},
+		{Filename: "unknown.bin", MimeType: "application/octet-stream", ContentHash: contentHash},
+		{Filename: "disguised.pdf", MimeType: "application/x-msdownload", ContentHash: contentHash},
+	}
+	for _, att := range tests {
+		t.Run(att.Filename, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			outputDir := t.TempDir()
+			opened := false
+			ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+				DataDir:             t.TempDir(),
+				AttachmentOutputDir: outputDir,
+				AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+					contentHash: []byte("untrusted bytes"),
+				}},
+				OpenTarget: func(context.Context, string) error {
+					opened = true
+					return nil
+				},
+			})
+
+			msg := ctrl.OpenAttachment(att)()
+			result, ok := msg.(ExportResultMsg)
+			require.True(ok, "expected ExportResultMsg, got %T", msg)
+			require.Error(result.Err)
+			assert.Equal("Open Blocked", result.Title)
+			require.ErrorContains(result.Err, "download-only")
+			assert.False(opened)
+			entries, err := os.ReadDir(outputDir)
+			require.NoError(err)
+			assert.Empty(entries, "blocked open must not write the attachment")
+		})
+	}
+}
+
+func TestOpenAttachmentDoesNotLaunchWhenQuarantineMarkingFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
+	outputDir := t.TempDir()
+	opened := false
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
+		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
+			contentHash: []byte("document bytes"),
+		}},
+		OpenTarget: func(context.Context, string) error {
+			opened = true
+			return nil
+		},
+	})
+	ctrl.markUntrusted = func(string) error { return errors.New("marker unavailable") }
+
+	msg := ctrl.OpenAttachment(query.AttachmentInfo{
+		Filename: "contract.pdf", MimeType: "application/pdf", ContentHash: contentHash,
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.Error(result.Err)
+	assert.Equal("Open Failed", result.Title)
+	require.ErrorContains(result.Err, "mark downloaded attachment as untrusted")
+	assert.False(opened)
+	assert.FileExists(filepath.Join(outputDir, "contract.pdf"))
+}
+
+func TestOpenAttachmentURLRequiresHTTPAndDoesNotDownload(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var opened string
+	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
+		AttachmentOutputDir: t.TempDir(),
+		OpenTarget: func(_ context.Context, target string) error {
+			opened = target
+			return nil
+		},
+	})
+
+	msg := ctrl.OpenAttachment(query.AttachmentInfo{
+		Filename: "shared file", URL: "https://files.example.test/shared/1",
+	})()
+	result, ok := msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.NoError(result.Err)
+	assert.Equal("https://files.example.test/shared/1", opened)
+
+	opened = ""
+	msg = ctrl.OpenAttachment(query.AttachmentInfo{URL: "file:///etc/passwd"})()
+	result, ok = msg.(ExportResultMsg)
+	require.True(ok, "expected ExportResultMsg, got %T", msg)
+	require.Error(result.Err)
+	assert.Empty(opened)
 }

--- a/internal/tui/attachment_open_policy.go
+++ b/internal/tui/attachment_open_policy.go
@@ -7,47 +7,44 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/gabriel-vasile/mimetype"
 	"go.kenn.io/msgvault/internal/query"
 )
 
-type attachmentOpenType struct {
-	declaredMIMEs []string
-	detectedMIMEs []string
-}
-
 // safeAttachmentOpenTypes is deliberately an allowlist. Scriptable,
 // executable, archive, installer, shortcut, macro-enabled Office, and unknown
-// formats remain download-only. Each entry pins both the sender-declared MIME
-// type and the MIME type detected from the downloaded bytes to the canonical
-// filename extension.
-var safeAttachmentOpenTypes = map[string]attachmentOpenType{
-	".pdf":  {declaredMIMEs: []string{"application/pdf"}, detectedMIMEs: []string{"application/pdf"}},
-	".txt":  {declaredMIMEs: []string{"text/plain"}, detectedMIMEs: []string{"text/plain"}},
-	".md":   {declaredMIMEs: []string{"text/markdown", "text/plain"}, detectedMIMEs: []string{"text/plain"}},
-	".png":  {declaredMIMEs: []string{"image/png"}, detectedMIMEs: []string{"image/png", "image/vnd.mozilla.apng"}},
-	".jpg":  {declaredMIMEs: []string{"image/jpeg"}, detectedMIMEs: []string{"image/jpeg"}},
-	".jpeg": {declaredMIMEs: []string{"image/jpeg"}, detectedMIMEs: []string{"image/jpeg"}},
-	".gif":  {declaredMIMEs: []string{"image/gif"}, detectedMIMEs: []string{"image/gif"}},
-	".webp": {declaredMIMEs: []string{"image/webp"}, detectedMIMEs: []string{"image/webp"}},
-	".bmp":  {declaredMIMEs: []string{"image/bmp"}, detectedMIMEs: []string{"image/bmp"}},
-	".tif":  {declaredMIMEs: []string{"image/tiff"}, detectedMIMEs: []string{"image/tiff"}},
-	".tiff": {declaredMIMEs: []string{"image/tiff"}, detectedMIMEs: []string{"image/tiff"}},
-	".mp3":  {declaredMIMEs: []string{"audio/mpeg"}, detectedMIMEs: []string{"audio/mpeg"}},
-	".m4a":  {declaredMIMEs: []string{"audio/mp4", "audio/x-m4a"}, detectedMIMEs: []string{"audio/mp4", "audio/x-m4a"}},
-	".wav":  {declaredMIMEs: []string{"audio/wav", "audio/x-wav"}, detectedMIMEs: []string{"audio/wav"}},
-	".flac": {declaredMIMEs: []string{"audio/flac"}, detectedMIMEs: []string{"audio/flac"}},
-	".ogg":  {declaredMIMEs: []string{"audio/ogg"}, detectedMIMEs: []string{"application/ogg", "audio/ogg"}},
-	".opus": {declaredMIMEs: []string{"audio/opus", "audio/ogg"}, detectedMIMEs: []string{"application/ogg", "audio/ogg"}},
-	".mp4":  {declaredMIMEs: []string{"video/mp4"}, detectedMIMEs: []string{"video/mp4"}},
-	".mov":  {declaredMIMEs: []string{"video/quicktime"}, detectedMIMEs: []string{"video/quicktime"}},
-	".webm": {declaredMIMEs: []string{"video/webm"}, detectedMIMEs: []string{"video/webm"}},
-	".mkv":  {declaredMIMEs: []string{"video/x-matroska"}, detectedMIMEs: []string{"video/x-matroska"}},
+// formats remain download-only. Each entry also pins the canonical filename
+// extension to the declared MIME type so an active payload cannot borrow a
+// passive-looking name.
+var safeAttachmentOpenTypes = map[string][]string{
+	".pdf":  {"application/pdf"},
+	".txt":  {"text/plain"},
+	".md":   {"text/markdown", "text/plain"},
+	".png":  {"image/png"},
+	".jpg":  {"image/jpeg"},
+	".jpeg": {"image/jpeg"},
+	".gif":  {"image/gif"},
+	".webp": {"image/webp"},
+	".bmp":  {"image/bmp"},
+	".tif":  {"image/tiff"},
+	".tiff": {"image/tiff"},
+	".mp3":  {"audio/mpeg"},
+	".m4a":  {"audio/mp4", "audio/x-m4a"},
+	".wav":  {"audio/wav", "audio/x-wav"},
+	".flac": {"audio/flac"},
+	".ogg":  {"audio/ogg"},
+	".opus": {"audio/opus", "audio/ogg"},
+	".mp4":  {"video/mp4"},
+	".mov":  {"video/quicktime"},
+	".webm": {"video/webm"},
+	".mkv":  {"video/x-matroska"},
+	".docx": {"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+	".xlsx": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+	".pptx": {"application/vnd.openxmlformats-officedocument.presentationml.presentation"},
 }
 
 func validateAttachmentOpen(att query.AttachmentInfo) error {
 	extension := strings.ToLower(filepath.Ext(att.Filename))
-	openType, ok := safeAttachmentOpenTypes[extension]
+	allowedMIMEs, ok := safeAttachmentOpenTypes[extension]
 	if !ok {
 		if extension == "" {
 			extension = "without a canonical extension"
@@ -55,29 +52,10 @@ func validateAttachmentOpen(att query.AttachmentInfo) error {
 		return fmt.Errorf("attachment %q is download-only (%s)", att.Filename, extension)
 	}
 	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(att.MimeType))
-	if err != nil || !slices.Contains(openType.declaredMIMEs, strings.ToLower(mediaType)) {
+	if err != nil || !slices.Contains(allowedMIMEs, strings.ToLower(mediaType)) {
 		return fmt.Errorf(
 			"attachment %q is download-only: MIME type %q does not match canonical extension %s",
 			att.Filename, att.MimeType, extension,
-		)
-	}
-	return nil
-}
-
-func validateDownloadedAttachmentOpen(att query.AttachmentInfo, path string) error {
-	extension := strings.ToLower(filepath.Ext(att.Filename))
-	openType, ok := safeAttachmentOpenTypes[extension]
-	if !ok {
-		return fmt.Errorf("attachment %q is download-only", att.Filename)
-	}
-	detected, err := mimetype.DetectFile(path)
-	if err != nil {
-		return fmt.Errorf("inspect downloaded attachment %q: %w", att.Filename, err)
-	}
-	if !slices.Contains(openType.detectedMIMEs, strings.ToLower(detected.String())) {
-		return fmt.Errorf(
-			"attachment %q is download-only: detected content type %q does not match canonical extension %s",
-			att.Filename, detected.String(), extension,
 		)
 	}
 	return nil

--- a/internal/tui/attachment_open_policy.go
+++ b/internal/tui/attachment_open_policy.go
@@ -7,44 +7,47 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gabriel-vasile/mimetype"
 	"go.kenn.io/msgvault/internal/query"
 )
 
+type attachmentOpenType struct {
+	declaredMIMEs []string
+	detectedMIMEs []string
+}
+
 // safeAttachmentOpenTypes is deliberately an allowlist. Scriptable,
 // executable, archive, installer, shortcut, macro-enabled Office, and unknown
-// formats remain download-only. Each entry also pins the canonical filename
-// extension to the declared MIME type so an active payload cannot borrow a
-// passive-looking name.
-var safeAttachmentOpenTypes = map[string][]string{
-	".pdf":  {"application/pdf"},
-	".txt":  {"text/plain"},
-	".md":   {"text/markdown", "text/plain"},
-	".png":  {"image/png"},
-	".jpg":  {"image/jpeg"},
-	".jpeg": {"image/jpeg"},
-	".gif":  {"image/gif"},
-	".webp": {"image/webp"},
-	".bmp":  {"image/bmp"},
-	".tif":  {"image/tiff"},
-	".tiff": {"image/tiff"},
-	".mp3":  {"audio/mpeg"},
-	".m4a":  {"audio/mp4", "audio/x-m4a"},
-	".wav":  {"audio/wav", "audio/x-wav"},
-	".flac": {"audio/flac"},
-	".ogg":  {"audio/ogg"},
-	".opus": {"audio/opus", "audio/ogg"},
-	".mp4":  {"video/mp4"},
-	".mov":  {"video/quicktime"},
-	".webm": {"video/webm"},
-	".mkv":  {"video/x-matroska"},
-	".docx": {"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
-	".xlsx": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
-	".pptx": {"application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+// formats remain download-only. Each entry pins both the sender-declared MIME
+// type and the MIME type detected from the downloaded bytes to the canonical
+// filename extension.
+var safeAttachmentOpenTypes = map[string]attachmentOpenType{
+	".pdf":  {declaredMIMEs: []string{"application/pdf"}, detectedMIMEs: []string{"application/pdf"}},
+	".txt":  {declaredMIMEs: []string{"text/plain"}, detectedMIMEs: []string{"text/plain"}},
+	".md":   {declaredMIMEs: []string{"text/markdown", "text/plain"}, detectedMIMEs: []string{"text/plain"}},
+	".png":  {declaredMIMEs: []string{"image/png"}, detectedMIMEs: []string{"image/png", "image/vnd.mozilla.apng"}},
+	".jpg":  {declaredMIMEs: []string{"image/jpeg"}, detectedMIMEs: []string{"image/jpeg"}},
+	".jpeg": {declaredMIMEs: []string{"image/jpeg"}, detectedMIMEs: []string{"image/jpeg"}},
+	".gif":  {declaredMIMEs: []string{"image/gif"}, detectedMIMEs: []string{"image/gif"}},
+	".webp": {declaredMIMEs: []string{"image/webp"}, detectedMIMEs: []string{"image/webp"}},
+	".bmp":  {declaredMIMEs: []string{"image/bmp"}, detectedMIMEs: []string{"image/bmp"}},
+	".tif":  {declaredMIMEs: []string{"image/tiff"}, detectedMIMEs: []string{"image/tiff"}},
+	".tiff": {declaredMIMEs: []string{"image/tiff"}, detectedMIMEs: []string{"image/tiff"}},
+	".mp3":  {declaredMIMEs: []string{"audio/mpeg"}, detectedMIMEs: []string{"audio/mpeg"}},
+	".m4a":  {declaredMIMEs: []string{"audio/mp4", "audio/x-m4a"}, detectedMIMEs: []string{"audio/mp4", "audio/x-m4a"}},
+	".wav":  {declaredMIMEs: []string{"audio/wav", "audio/x-wav"}, detectedMIMEs: []string{"audio/wav"}},
+	".flac": {declaredMIMEs: []string{"audio/flac"}, detectedMIMEs: []string{"audio/flac"}},
+	".ogg":  {declaredMIMEs: []string{"audio/ogg"}, detectedMIMEs: []string{"application/ogg", "audio/ogg"}},
+	".opus": {declaredMIMEs: []string{"audio/opus", "audio/ogg"}, detectedMIMEs: []string{"application/ogg", "audio/ogg"}},
+	".mp4":  {declaredMIMEs: []string{"video/mp4"}, detectedMIMEs: []string{"video/mp4"}},
+	".mov":  {declaredMIMEs: []string{"video/quicktime"}, detectedMIMEs: []string{"video/quicktime"}},
+	".webm": {declaredMIMEs: []string{"video/webm"}, detectedMIMEs: []string{"video/webm"}},
+	".mkv":  {declaredMIMEs: []string{"video/x-matroska"}, detectedMIMEs: []string{"video/x-matroska"}},
 }
 
 func validateAttachmentOpen(att query.AttachmentInfo) error {
 	extension := strings.ToLower(filepath.Ext(att.Filename))
-	allowedMIMEs, ok := safeAttachmentOpenTypes[extension]
+	openType, ok := safeAttachmentOpenTypes[extension]
 	if !ok {
 		if extension == "" {
 			extension = "without a canonical extension"
@@ -52,10 +55,29 @@ func validateAttachmentOpen(att query.AttachmentInfo) error {
 		return fmt.Errorf("attachment %q is download-only (%s)", att.Filename, extension)
 	}
 	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(att.MimeType))
-	if err != nil || !slices.Contains(allowedMIMEs, strings.ToLower(mediaType)) {
+	if err != nil || !slices.Contains(openType.declaredMIMEs, strings.ToLower(mediaType)) {
 		return fmt.Errorf(
 			"attachment %q is download-only: MIME type %q does not match canonical extension %s",
 			att.Filename, att.MimeType, extension,
+		)
+	}
+	return nil
+}
+
+func validateDownloadedAttachmentOpen(att query.AttachmentInfo, path string) error {
+	extension := strings.ToLower(filepath.Ext(att.Filename))
+	openType, ok := safeAttachmentOpenTypes[extension]
+	if !ok {
+		return fmt.Errorf("attachment %q is download-only", att.Filename)
+	}
+	detected, err := mimetype.DetectFile(path)
+	if err != nil {
+		return fmt.Errorf("inspect downloaded attachment %q: %w", att.Filename, err)
+	}
+	if !slices.Contains(openType.detectedMIMEs, strings.ToLower(detected.String())) {
+		return fmt.Errorf(
+			"attachment %q is download-only: detected content type %q does not match canonical extension %s",
+			att.Filename, detected.String(), extension,
 		)
 	}
 	return nil

--- a/internal/tui/attachment_open_policy.go
+++ b/internal/tui/attachment_open_policy.go
@@ -1,0 +1,62 @@
+package tui
+
+import (
+	"fmt"
+	"mime"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/query"
+)
+
+// safeAttachmentOpenTypes is deliberately an allowlist. Scriptable,
+// executable, archive, installer, shortcut, macro-enabled Office, and unknown
+// formats remain download-only. Each entry also pins the canonical filename
+// extension to the declared MIME type so an active payload cannot borrow a
+// passive-looking name.
+var safeAttachmentOpenTypes = map[string][]string{
+	".pdf":  {"application/pdf"},
+	".txt":  {"text/plain"},
+	".md":   {"text/markdown", "text/plain"},
+	".png":  {"image/png"},
+	".jpg":  {"image/jpeg"},
+	".jpeg": {"image/jpeg"},
+	".gif":  {"image/gif"},
+	".webp": {"image/webp"},
+	".bmp":  {"image/bmp"},
+	".tif":  {"image/tiff"},
+	".tiff": {"image/tiff"},
+	".mp3":  {"audio/mpeg"},
+	".m4a":  {"audio/mp4", "audio/x-m4a"},
+	".wav":  {"audio/wav", "audio/x-wav"},
+	".flac": {"audio/flac"},
+	".ogg":  {"audio/ogg"},
+	".opus": {"audio/opus", "audio/ogg"},
+	".mp4":  {"video/mp4"},
+	".mov":  {"video/quicktime"},
+	".webm": {"video/webm"},
+	".mkv":  {"video/x-matroska"},
+	".docx": {"application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+	".xlsx": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+	".pptx": {"application/vnd.openxmlformats-officedocument.presentationml.presentation"},
+}
+
+func validateAttachmentOpen(att query.AttachmentInfo) error {
+	extension := strings.ToLower(filepath.Ext(att.Filename))
+	allowedMIMEs, ok := safeAttachmentOpenTypes[extension]
+	if !ok {
+		if extension == "" {
+			extension = "without a canonical extension"
+		}
+		return fmt.Errorf("attachment %q is download-only (%s)", att.Filename, extension)
+	}
+	mediaType, _, err := mime.ParseMediaType(strings.TrimSpace(att.MimeType))
+	if err != nil || !slices.Contains(allowedMIMEs, strings.ToLower(mediaType)) {
+		return fmt.Errorf(
+			"attachment %q is download-only: MIME type %q does not match canonical extension %s",
+			att.Filename, att.MimeType, extension,
+		)
+	}
+	return nil
+}

--- a/internal/tui/attachment_trust_darwin.go
+++ b/internal/tui/attachment_trust_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// markAttachmentUntrusted applies the same quarantine attribute Finder and
+// browsers use so Gatekeeper participates when the default application opens
+// a downloaded attachment.
+func markAttachmentUntrusted(path string) error {
+	value := fmt.Sprintf("0081;%x;msgvault;", time.Now().Unix())
+	return unix.Setxattr(path, "com.apple.quarantine", []byte(value), 0)
+}

--- a/internal/tui/attachment_trust_other.go
+++ b/internal/tui/attachment_trust_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !windows
+
+package tui
+
+// Linux and the supported BSDs do not expose a portable OS download-origin
+// marker. The strict passive-type allowlist remains the opening boundary.
+func markAttachmentUntrusted(string) error { return nil }

--- a/internal/tui/attachment_trust_windows.go
+++ b/internal/tui/attachment_trust_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tui
+
+import "os"
+
+// markAttachmentUntrusted applies Windows Mark-of-the-Web through the NTFS
+// Zone.Identifier alternate data stream before the platform handler sees the
+// file. Failure is fatal to opening; the downloaded file remains available.
+func markAttachmentUntrusted(path string) error {
+	return os.WriteFile(path+":Zone.Identifier", []byte("[ZoneTransfer]\r\nZoneId=3\r\n"), 0o600)
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -35,23 +35,16 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		if m.level != levelMessageList {
 			return m, nil
 		}
-		if m.searchMode == searchModeFast {
-			m.searchMode = searchModeDeep
-			m.searchInput.Placeholder = "search (Tab: fast)"
-		} else {
-			m.searchMode = searchModeFast
-			m.searchInput.Placeholder = "search (Tab: deep)"
-		}
+		m.searchMode = m.nextSearchMode()
+		m.syncSearchScope()
+		m.searchInput.Placeholder = m.searchPlaceholder()
 		m.inlineSearchDebounce++
 		if query := m.searchInput.Value(); query != "" {
 			m.searchQuery = query
 			m.inlineSearchLoading = true
 			spinCmd := m.startSpinner()
-			m.searchFilter = m.drillFilter
-			m.searchFilter.SourceID = m.accountFilter
-			m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
-			m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
 			m.searchRequestID++
+			m.prepareSearchReplacement()
 			return m, tea.Batch(spinCmd, m.loadSearch(query))
 		}
 		return m, nil
@@ -67,7 +60,7 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		debounceID := m.inlineSearchDebounce
 
 		delay := inlineSearchDebounceDelay
-		if m.searchMode == searchModeDeep {
+		if m.searchMode != searchModeFast {
 			delay = deepSearchDebounceDelay
 		}
 
@@ -85,6 +78,54 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		})
 
 		return m, tea.Batch(cmd, spinCmd, debounceCmd)
+	}
+}
+
+func (m Model) currentSearchFilter() query.MessageFilter {
+	filter := m.drillFilter
+	filter.SourceID = m.accountFilter
+	filter.WithAttachmentsOnly = m.filters.attachmentsOnly
+	filter.HideDeletedFromSource = m.filters.hideDeletedFromSource
+	return filter
+}
+
+func (m Model) semanticSearchAvailable() bool {
+	return m.semanticSearch != nil &&
+		query.SemanticMessageSearchSupportsFilter(m.currentSearchFilter())
+}
+
+func (m *Model) syncSearchScope() {
+	m.searchFilter = m.currentSearchFilter()
+	if m.searchMode == searchModeSemantic && !m.semanticSearchAvailable() {
+		m.searchMode = searchModeFast
+	}
+}
+
+func (m Model) nextSearchMode() searchModeKind {
+	switch m.searchMode {
+	case searchModeFast:
+		return searchModeDeep
+	case searchModeDeep:
+		if m.semanticSearchAvailable() {
+			return searchModeSemantic
+		}
+		return searchModeFast
+	default:
+		return searchModeFast
+	}
+}
+
+func (m Model) searchPlaceholder() string {
+	switch m.searchMode {
+	case searchModeFast:
+		return "search (Tab: deep)"
+	case searchModeDeep:
+		if m.semanticSearchAvailable() {
+			return "search (Tab: semantic)"
+		}
+		return "search (Tab: fast)"
+	default:
+		return "search (Tab: fast)"
 	}
 }
 
@@ -224,10 +265,7 @@ func (m Model) handleAggregateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 		// If there's an active search query, show search results instead of all messages
 		if m.searchQuery != "" {
-			m.searchFilter = m.drillFilter
-			m.searchFilter.SourceID = m.accountFilter
-			m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
-			m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
+			m.syncSearchScope()
 			m.loadRequestID++ // Invalidate stale loadMessages responses
 			m.searchRequestID++
 			return m, m.loadSearch(m.searchQuery)
@@ -377,10 +415,10 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	// Back - clear inner search first, then navigate back
 	case keyNameEsc:
-		// Clear search only if it was initiated at this level (snapshot exists).
-		// Inherited search (from aggregate drill-down) has no snapshot —
-		// goBack restores the parent view with its search intact.
-		if m.searchQuery != "" && m.preSearchMessages != nil {
+		// Clear search only if it was initiated at this level. A valid snapshot
+		// restores immediately; an invalidated one reloads the current scope.
+		// Inherited search has neither marker, so goBack restores the parent.
+		if m.searchQuery != "" && (m.preSearchMessages != nil || m.preSearchSnapshotInvalid) {
 			return m.clearMessageListSearch()
 		}
 		// Invalidate in-flight search responses so they don't write
@@ -522,6 +560,9 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Sorting - use explicit field list to avoid hidden coupling
 	case "s":
+		if m.hasActiveSemanticSearch() {
+			return m, nil
+		}
 		msgSortFields := []query.MessageSortField{
 			query.MessageSortByDate,
 			query.MessageSortBySize,
@@ -539,6 +580,9 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, m.loadMessages()
 
 	case "r", "v":
+		if m.hasActiveSemanticSearch() {
+			return m, nil
+		}
 		if m.msgSortDirection == query.SortDesc {
 			m.msgSortDirection = query.SortAsc
 		} else {
@@ -582,8 +626,8 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 // maybeLoadMoreSearchResults checks if we're near the end of search results and should load more.
 func (m *Model) maybeLoadMoreSearchResults() tea.Cmd {
-	// Only paginate search results in fast mode
-	if m.searchQuery == "" || m.searchMode != searchModeFast {
+	// Deep search paginates only when the user explicitly reaches the bottom.
+	if m.searchQuery == "" || m.searchMode == searchModeDeep {
 		return nil
 	}
 
@@ -1058,6 +1102,18 @@ func (m Model) handleFilterToggleKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		}
 
 		if m.level == levelMessageList {
+			if m.searchQuery != "" {
+				if m.searchFilter.WithAttachmentsOnly != m.filters.attachmentsOnly ||
+					m.searchFilter.HideDeletedFromSource != m.filters.hideDeletedFromSource {
+					m.invalidatePreSearchSnapshot()
+				}
+				m.syncSearchScope()
+				m.searchLoadingMore = false
+				m.loadRequestID++ // Invalidate normal list loads before replacing ranked results.
+				m.searchRequestID++
+				m.prepareSearchReplacement()
+				return m, tea.Batch(m.loadSearch(m.searchQuery), m.loadStats())
+			}
 			m.loadRequestID++
 			return m, tea.Batch(m.loadMessages(), m.loadStats())
 		}
@@ -1094,6 +1150,10 @@ func (m Model) handleExportAttachmentsKeys(msg tea.KeyPressMsg) (tea.Model, tea.
 		}
 	case keyNameEnter:
 		return m.exportAttachments()
+	case "d":
+		return m.startAttachmentAction(m.actions.DownloadAttachment(m.messageDetail.Attachments[m.exportCursor]))
+	case "o":
+		return m.startAttachmentAction(m.actions.OpenAttachment(m.messageDetail.Attachments[m.exportCursor]))
 	case keyNameEsc:
 		m.modal = modalNone
 		m.exportSelection = nil
@@ -1101,9 +1161,17 @@ func (m Model) handleExportAttachmentsKeys(msg tea.KeyPressMsg) (tea.Model, tea.
 	return m, nil
 }
 
+func (m Model) startAttachmentAction(cmd tea.Cmd) (tea.Model, tea.Cmd) {
+	m.modal = modalNone
+	m.loading = true
+	m.exportSelection = nil
+	return m, cmd
+}
+
 func (m Model) handleExportResultKeys() (tea.Model, tea.Cmd) {
 	// Any key closes the result modal
 	m.modal = modalNone
+	m.modalResultTitle = ""
 	m.modalResult = ""
 	return m, nil
 }
@@ -1274,10 +1342,7 @@ func (m Model) enterDrillDown(row query.AggregateRow) (tea.Model, tea.Cmd) {
 	// Preserve search query through drill-down so the message list
 	// shows only messages matching both the drill filter and the search.
 	if m.searchQuery != "" {
-		m.searchFilter = m.drillFilter
-		m.searchFilter.SourceID = m.accountFilter
-		m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
-		m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
+		m.syncSearchScope()
 		m.loadRequestID++ // Invalidate stale loadMessages responses
 		m.searchRequestID++
 		return m, m.loadSearch(m.searchQuery)
@@ -1327,6 +1392,18 @@ func (m *Model) clearSearchState() {
 	m.contextStats = nil
 }
 
+// prepareSearchReplacement removes results and presentation state tied to the
+// previous search mode or filter before a non-append search starts.
+func (m *Model) prepareSearchReplacement() {
+	m.messages = nil
+	m.contextStats = nil
+	m.cursor = 0
+	m.scrollOffset = 0
+	m.searchOffset = 0
+	m.searchTotalCount = 0
+	m.searchLoadingMore = false
+}
+
 // reloadCurrentView triggers a data reload based on the current level.
 func (m Model) reloadCurrentView() (tea.Model, tea.Cmd) {
 	if m.level == levelMessageList {
@@ -1345,23 +1422,22 @@ func (m Model) commitInlineSearch() (tea.Model, tea.Cmd) {
 	if queryStr == "" {
 		// Empty search clears filter - restore from snapshot if available
 		m.clearSearchState()
-		if m.level == levelMessageList && m.preSearchMessages != nil {
+		if m.level == levelMessageList && !m.preSearchSnapshotInvalid && m.preSearchMessages != nil {
 			m.restorePreSearchSnapshot()
 			return m, nil
 		}
+		m.clearPreSearchSnapshot()
 		return m.reloadCurrentView()
 	}
 
 	m.searchQuery = queryStr
 	// In message list view, execute search to show results
 	if m.level == levelMessageList {
-		m.searchFilter = m.drillFilter
-		m.searchFilter.SourceID = m.accountFilter
-		m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
-		m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
+		m.syncSearchScope()
 		m.searchRequestID++
 		m.loading = true
 		spinCmd := m.startSpinner()
+		m.prepareSearchReplacement()
 		return m, tea.Batch(spinCmd, m.loadSearch(queryStr))
 	}
 	// In aggregate views, results already showing from debounced search
@@ -1374,10 +1450,11 @@ func (m Model) cancelInlineSearch() (tea.Model, tea.Cmd) {
 	m.searchInput.SetValue("")
 	m.clearSearchState()
 
-	if m.level == levelMessageList && m.preSearchMessages != nil {
+	if m.level == levelMessageList && !m.preSearchSnapshotInvalid && m.preSearchMessages != nil {
 		m.restorePreSearchSnapshot()
 		return m, nil
 	}
+	m.clearPreSearchSnapshot()
 	return m.reloadCurrentView()
 }
 
@@ -1388,10 +1465,11 @@ func (m Model) clearMessageListSearch() (tea.Model, tea.Cmd) {
 	m.searchInput.SetValue("")
 	m.searchRequestID++
 
-	if m.preSearchMessages != nil {
+	if !m.preSearchSnapshotInvalid && m.preSearchMessages != nil {
 		m.restorePreSearchSnapshot()
 		return m, nil
 	}
+	m.clearPreSearchSnapshot()
 	m.contextStats = nil
 	m.loadRequestID++
 	return m, m.loadMessages()
@@ -1410,9 +1488,19 @@ func (m *Model) restorePreSearchSnapshot() {
 	m.inlineSearchLoading = false
 	m.searchOffset = 0
 	m.searchTotalCount = 0
-	// Clear the snapshot
+	m.clearPreSearchSnapshot()
+}
+
+func (m *Model) invalidatePreSearchSnapshot() {
 	m.preSearchMessages = nil
 	m.preSearchContextStats = nil
+	m.preSearchSnapshotInvalid = true
+}
+
+func (m *Model) clearPreSearchSnapshot() {
+	m.preSearchMessages = nil
+	m.preSearchContextStats = nil
+	m.preSearchSnapshotInvalid = false
 }
 
 func (m *Model) activateInlineSearch(placeholder string) tea.Cmd {
@@ -1421,7 +1509,7 @@ func (m *Model) activateInlineSearch(placeholder string) tea.Cmd {
 	// keep the original snapshot). This also handles inherited search
 	// from aggregate drill-down: the first local / captures the
 	// inherited results so Esc can restore them.
-	if m.level == levelMessageList && m.preSearchMessages == nil {
+	if m.level == levelMessageList && !m.preSearchSnapshotInvalid && m.preSearchMessages == nil {
 		m.preSearchMessages = m.messages
 		m.preSearchCursor = m.cursor
 		m.preSearchScrollOffset = m.scrollOffset
@@ -1435,7 +1523,11 @@ func (m *Model) activateInlineSearch(placeholder string) tea.Cmd {
 	}
 	m.inlineSearchActive = true
 	m.searchMode = searchModeFast
-	m.searchInput.Placeholder = placeholder
+	if m.mode == modeEmail && m.level == levelMessageList {
+		m.searchInput.Placeholder = m.searchPlaceholder()
+	} else {
+		m.searchInput.Placeholder = placeholder
+	}
 	m.searchInput.SetValue("") // Clear previous search
 	m.searchInput.Focus()
 	return textinput.Blink

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -464,6 +464,9 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Sub-grouping: switch to aggregate breakdown within current filter
 	case "tab":
+		if m.hasActiveSemanticSearch() {
+			return m, nil
+		}
 		if m.hasDrillFilter() {
 			m.transitionBuffer = m.renderView() // Freeze screen until data loads
 
@@ -508,6 +511,9 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Time sub-grouping: jump directly to sub-aggregate Time view
 	case "t":
+		if m.hasActiveSemanticSearch() {
+			return m, nil
+		}
 		if m.hasDrillFilter() && m.drillViewType != query.ViewTime {
 			m.transitionBuffer = m.renderView()
 			m.pushBreadcrumb()
@@ -526,6 +532,9 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	// Sub-grouping: 'g' switches to aggregate breakdown within current filter (like tab)
 	case "g":
+		if m.hasActiveSemanticSearch() {
+			return m, nil
+		}
 		m.transitionBuffer = m.renderView() // Freeze screen until data loads
 		if m.hasDrillFilter() {
 			// Save current state to breadcrumb (including viewType for proper restoration)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -64,6 +65,10 @@ type Options struct {
 	// from DataDir/attachments for tests or direct embedding.
 	AttachmentReader AttachmentReader
 
+	// SemanticSearch enables the third TUI search mode. Callers should only set
+	// it after the daemon reports that vector search is configured.
+	SemanticSearch query.SemanticMessageSearcher
+
 	// AnalyticsNotice, when non-empty, is shown on the info line while
 	// aggregate views load. It explains slow first queries (for example,
 	// the daemon falling back to live SQL because no analytics cache is
@@ -87,13 +92,18 @@ const (
 	modalError
 )
 
-// searchModeKind represents the search mode (fast metadata vs deep body search).
+// searchModeKind represents the active message search strategy.
 type searchModeKind int
 
 const (
-	searchModeFast searchModeKind = iota // Parquet metadata only (subject, sender, recipient)
-	searchModeDeep                       // SQLite FTS5 (includes body text)
+	searchModeFast     searchModeKind = iota // Parquet metadata only (subject, sender, recipient)
+	searchModeDeep                           // SQLite FTS5 (includes body text)
+	searchModeSemantic                       // Hybrid lexical/vector ranking through the daemon
 )
+
+func (m Model) hasActiveSemanticSearch() bool {
+	return m.searchMode == searchModeSemantic && m.searchQuery != ""
+}
 
 // selectionState tracks selected items for batch operations.
 type selectionState struct {
@@ -176,11 +186,12 @@ type Model struct {
 	selection selectionState
 
 	// Modal state
-	modal           modalType
-	modalCursor     int                // Cursor position within modal (for selector modals)
-	modalResult     string             // Result message to display
-	helpScroll      int                // Scroll offset for help modal
-	pendingManifest *deletion.Manifest // Manifest being confirmed
+	modal            modalType
+	modalCursor      int                // Cursor position within modal (for selector modals)
+	modalResultTitle string             // Optional title for action-result modals
+	modalResult      string             // Result message to display
+	helpScroll       int                // Scroll offset for help modal
+	pendingManifest  *deletion.Manifest // Manifest being confirmed
 
 	// Action controller (deletion, export)
 	actions *ActionController
@@ -204,7 +215,8 @@ type Model struct {
 	textRequestID          uint64 // Latest Text navigation/data request
 
 	// Search state
-	searchMode        searchModeKind  // Fast (Parquet) or Deep (FTS5)
+	searchMode        searchModeKind // Fast metadata, deep FTS, or semantic hybrid
+	semanticSearch    query.SemanticMessageSearcher
 	searchInput       textinput.Model // Text input for search query
 	searchTotalCount  int64           // Total matching messages (for pagination display)
 	searchOffset      int             // Current offset for pagination
@@ -224,6 +236,9 @@ type Model struct {
 	preSearchCursor       int
 	preSearchScrollOffset int
 	preSearchContextStats *query.TotalStats
+	// preSearchSnapshotInvalid marks that the saved list belongs to a
+	// previous filter scope. Clearing search must reload the current scope.
+	preSearchSnapshotInvalid bool
 
 	// transitionBuffer holds the last rendered view during level transitions.
 	// When non-empty, View() returns this string instead of rendering fresh content.
@@ -282,6 +297,7 @@ func New(engine query.Engine, opts Options) Model {
 			ManifestSaver:    opts.ManifestSaver,
 			AttachmentReader: opts.AttachmentReader,
 		}),
+		semanticSearch:     opts.SemanticSearch,
 		version:            opts.Version,
 		analyticsNotice:    opts.AnalyticsNotice,
 		aggregateLimit:     aggLimit,
@@ -558,11 +574,9 @@ type searchDebounceMsg struct {
 	debounceID uint64
 }
 
-// exportResultMsg is returned when attachment export completes.
-type exportResultMsg struct {
-	result string
-	err    error
-}
+// exportResultMsg keeps the model's internal message name while sharing the
+// action controller's public result type.
+type exportResultMsg = ExportResultMsg
 
 // inlineSearchDebounceDelay is the delay before executing inline search (fast mode).
 const inlineSearchDebounceDelay = 100 * time.Millisecond
@@ -605,8 +619,12 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 	requestID := m.searchRequestID
 	presentationGeneration := m.presentationGeneration
 	modeLabel := "fast"
-	if m.searchMode != searchModeFast {
+	switch m.searchMode {
+	case searchModeFast:
+	case searchModeDeep:
 		modeLabel = "deep"
+	case searchModeSemantic:
+		modeLabel = "semantic"
 	}
 	scopeLabel := m.scopeLabelForLog()
 	return safeCmdWithPanic(
@@ -644,7 +662,8 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 				)
 			}()
 
-			if m.searchMode == searchModeFast {
+			switch m.searchMode {
+			case searchModeFast:
 				// Fast search: single-scan with temp table materialization
 				result, fastErr := m.engine.SearchFastWithStats(ctx, q, queryStr, searchFilter, m.viewType, searchPageSize, offset)
 				if fastErr == nil {
@@ -655,7 +674,7 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 					}
 				}
 				err = fastErr
-			} else {
+			case searchModeDeep:
 				// Deep search: FTS5 body search
 				// Merge context filter into query to honor drill-down context
 				mergedQuery := query.MergeFilterIntoQuery(q, searchFilter)
@@ -688,6 +707,32 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 							}
 							stats = &query.TotalStats{MessageCount: fallbackCount}
 						}
+					}
+				}
+			case searchModeSemantic:
+				if m.semanticSearch == nil {
+					err = errors.New("semantic search is not enabled")
+					break
+				}
+				result, semanticErr := m.semanticSearch.SearchSemanticMessages(ctx, query.SemanticMessageSearchRequest{
+					Query:  queryStr,
+					Filter: searchFilter,
+					Limit:  searchPageSize,
+					Offset: offset,
+				})
+				err = semanticErr
+				if semanticErr == nil {
+					results = result.Messages
+					totalCount = int64(offset + len(results))
+					if result.HasMore {
+						totalCount = -1
+					}
+					if !appendResults {
+						messageCount := totalCount
+						if messageCount < 0 {
+							messageCount = int64(len(results))
+						}
+						stats = &query.TotalStats{MessageCount: messageCount}
 					}
 				}
 			}
@@ -1420,6 +1465,9 @@ func (m Model) handleSearchResults(msg searchResultsMsg) (tea.Model, tea.Cmd) {
 func (m *Model) appendSearchResults(msg searchResultsMsg) {
 	m.messages = append(m.messages, msg.messages...)
 	m.searchOffset += len(msg.messages)
+	if msg.totalCount >= 0 {
+		m.searchTotalCount = msg.totalCount
+	}
 	// Update contextStats when total is unknown so header reflects loaded count
 	if m.searchTotalCount == -1 && m.contextStats != nil {
 		m.contextStats.MessageCount = int64(len(m.messages))
@@ -1481,10 +1529,11 @@ func (m Model) handleFlashClear() (tea.Model, tea.Cmd) {
 func (m Model) handleExportResult(msg exportResultMsg) (tea.Model, tea.Cmd) {
 	m.loading = false
 	m.modal = modalExportResult
-	if msg.err != nil {
-		m.modalResult = fmt.Sprintf("Export failed: %v", msg.err)
+	m.modalResultTitle = msg.Title
+	if msg.Err != nil && msg.Result == "" {
+		m.modalResult = msg.Err.Error()
 	} else {
-		m.modalResult = msg.result
+		m.modalResult = msg.Result
 	}
 	return m, nil
 }
@@ -1509,17 +1558,14 @@ func (m Model) handleSearchDebounce(msg searchDebounceMsg) (tea.Model, tea.Cmd) 
 
 	if m.level == levelMessageList {
 		// Message list: use search engine for live results
-		m.searchFilter = m.drillFilter
-		m.searchFilter.SourceID = m.accountFilter
-		m.searchFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
-		m.searchFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
+		m.syncSearchScope()
 		m.searchRequestID++
 		m.loadRequestID++ // Invalidate any in-flight loadMessages to prevent overwriting search results
 		if msg.query == "" {
 			// Empty query: reload unfiltered messages
 			return m, tea.Batch(spinCmd, m.loadMessages())
 		}
-		m.messages = nil // Clear stale messages immediately so they don't show during search
+		m.prepareSearchReplacement()
 		return m, tea.Batch(spinCmd, m.loadSearch(msg.query))
 	}
 	// Aggregate views: reload aggregates with search filter

--- a/internal/tui/nav_modal_test.go
+++ b/internal/tui/nav_modal_test.go
@@ -162,6 +162,66 @@ func TestFilterToggleInMessageList(t *testing.T) {
 	assert.NotNil(cmd, "expected command to reload messages")
 }
 
+func TestFilterToggleRerunsActiveSemanticSearch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	accountID := int64(7)
+	searcher := &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
+	model := NewBuilder().WithLevel(levelMessageList).WithAccountFilter(&accountID).Build()
+	model.semanticSearch = searcher
+	model.searchMode = searchModeSemantic
+	model.searchQuery = "find the invoice"
+	model.searchFilter = query.MessageFilter{Sender: "stale@example.test"}
+	model.drillFilter = query.MessageFilter{Sender: "sender@example.test"}
+	model.preSearchMessages = []query.MessageSummary{{ID: 1, Subject: "before filter change"}}
+	model.preSearchContextStats = &query.TotalStats{MessageCount: 1}
+	initialSearchRequestID := model.searchRequestID
+	initialLoadRequestID := model.loadRequestID
+
+	model.openFilterModal()
+	model, _ = applyModalKey(t, model, key(' '))
+	model, cmd := applyModalKey(t, model, keyEnter())
+
+	require.NotNil(cmd)
+	assert.Equal(initialSearchRequestID+1, model.searchRequestID)
+	assert.Equal(initialLoadRequestID+1, model.loadRequestID)
+	assert.Equal("sender@example.test", model.searchFilter.Sender)
+	assert.True(model.searchFilter.WithAttachmentsOnly)
+	assert.Nil(model.preSearchMessages)
+	assert.Nil(model.preSearchContextStats)
+	assert.True(model.preSearchSnapshotInvalid)
+	require.NotNil(model.searchFilter.SourceID)
+	assert.Equal(accountID, *model.searchFilter.SourceID)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(ok, "expected batched semantic search and stats reload")
+	for _, batchCmd := range batch {
+		batchCmd()
+	}
+	assert.Equal("find the invoice", searcher.request.Query)
+	assert.Equal("sender@example.test", searcher.request.Filter.Sender)
+	assert.True(searcher.request.Filter.WithAttachmentsOnly)
+
+	model, clearCmd := applyMessageListKeyWithCmd(t, model, keyEsc())
+	assert.Empty(model.searchQuery)
+	assert.Nil(model.preSearchMessages)
+	assert.False(model.preSearchSnapshotInvalid)
+	assert.NotNil(clearCmd, "clearing search must reload the current filtered list")
+}
+
+func TestFilterCloseKeepsSearchSnapshotWhenScopeIsUnchanged(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model.searchQuery = "find the invoice"
+	model.searchFilter = query.MessageFilter{}
+	model.preSearchMessages = []query.MessageSummary{{ID: 1}}
+
+	model.openFilterModal()
+	model, _ = applyModalKey(t, model, keyEnter())
+
+	assert.Len(t, model.preSearchMessages, 1)
+	assert.False(t, model.preSearchSnapshotInvalid)
+}
+
 func TestOpenFilterModal(t *testing.T) {
 	m := NewBuilder().Build()
 

--- a/internal/tui/open_target.go
+++ b/internal/tui/open_target.go
@@ -1,0 +1,35 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// openSystemTarget hands a local path or validated HTTP(S) URL to the
+// platform's default application. Arguments are passed directly to the
+// process, never through a shell.
+func openSystemTarget(ctx context.Context, target string) error {
+	var command string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		command, args = "open", []string{target}
+	case "linux", "freebsd", "openbsd", "netbsd":
+		command, args = "xdg-open", []string{target}
+	case "windows":
+		command, args = "rundll32", []string{"url.dll,FileProtocolHandler", target}
+	default:
+		return fmt.Errorf("opening attachments is unsupported on %s", runtime.GOOS)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("start %s: %w", command, err)
+	}
+	cmd := exec.Command(command, args...) //nolint:gosec // fixed command catalog; target is a single argument
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start %s: %w", command, err)
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}

--- a/internal/tui/open_target_test.go
+++ b/internal/tui/open_target_test.go
@@ -1,0 +1,39 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenSystemTargetReturnsAfterLauncherStarts(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("test supplies a fake xdg-open executable")
+	}
+
+	binDir := t.TempDir()
+	launcher := filepath.Join(binDir, "xdg-open")
+	require.NoError(t, os.WriteFile(launcher, []byte("#!/bin/sh\nsleep 2\n"), 0o700))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	err := openSystemTarget(ctx, "document.pdf")
+
+	require.NoError(t, err)
+	assert.Less(t, time.Since(started), time.Second, "launcher handoff must not wait for the opened application")
+}
+
+func TestOpenSystemTargetRejectsCanceledContextBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.ErrorIs(t, openSystemTarget(ctx, "document.pdf"), context.Canceled)
+}

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -317,6 +317,32 @@ func TestSemanticSearchDisablesListSorting(t *testing.T) {
 	assert.NotContains(model.messageListView(), "Date↓")
 }
 
+func TestSemanticSearchDisablesAggregateNavigation(t *testing.T) {
+	assert := assert.New(t)
+	wantMessages := []query.MessageSummary{
+		{ID: 2, Subject: "higher-ranked"},
+		{ID: 1, Subject: "lower-ranked"},
+	}
+
+	for _, navigationKey := range []rune{'\t', 'g', 't'} {
+		t.Run(string(navigationKey), func(t *testing.T) {
+			model := NewBuilder().WithLevel(levelMessageList).WithSize(120, 20).
+				WithMessages(wantMessages...).
+				WithActiveSearch("find the invoice", searchModeSemantic).Build()
+			model.inlineSearchActive = false
+			model.searchQuery = "find the invoice"
+			model.drillFilter = query.MessageFilter{Sender: "agent@example.test"}
+
+			got, cmd := applyMessageListKeyWithCmd(t, model, key(navigationKey))
+			assert.Nil(cmd, "key %q must not aggregate semantic results", navigationKey)
+			assert.Equal(levelMessageList, got.level)
+			assert.Equal("find the invoice", got.searchQuery)
+			assert.Equal(wantMessages, got.messages)
+			assert.False(got.loading)
+		})
+	}
+}
+
 // TestSpinnerAppearsInViewWhenLoading verifies spinner character appears in rendered view.
 func TestSpinnerAppearsInViewWhenLoading(t *testing.T) {
 	model := NewBuilder().

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -8,6 +10,20 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/query"
 )
+
+type recordingSemanticSearcher struct {
+	request  query.SemanticMessageSearchRequest
+	response *query.SemanticMessageSearchResult
+	err      error
+}
+
+func (s *recordingSemanticSearcher) SearchSemanticMessages(
+	_ context.Context,
+	request query.SemanticMessageSearchRequest,
+) (*query.SemanticMessageSearchResult, error) {
+	s.request = request
+	return s.response, s.err
+}
 
 func TestSearchModalOpen(t *testing.T) {
 	model := NewBuilder().
@@ -134,6 +150,171 @@ func TestInlineSearchTabToggle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInlineSearchTabCyclesThroughSemanticWhenEnabled(t *testing.T) {
+	assert := assert.New(t)
+	searcher := &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
+	model := NewBuilder().WithLevel(levelMessageList).
+		WithActiveSearch("find the invoice", searchModeDeep).Build()
+	model.semanticSearch = searcher
+	model.drillFilter = query.MessageFilter{Sender: "billing@example.test"}
+
+	m, cmd := applyInlineSearchKey(t, model, keyTab())
+
+	assert.Equal(searchModeSemantic, m.searchMode)
+	assert.Contains(m.searchInput.Placeholder, "fast")
+	assert.NotNil(cmd)
+
+	m, _ = applyInlineSearchKey(t, m, keyTab())
+	assert.Equal(searchModeFast, m.searchMode)
+}
+
+func TestInlineSearchOmitsSemanticForUnsupportedScopes(t *testing.T) {
+	conversationID := int64(42)
+	tests := []struct {
+		name   string
+		filter query.MessageFilter
+	}{
+		{name: "sender display name", filter: query.MessageFilter{SenderName: "Billing Team"}},
+		{name: "recipient display name", filter: query.MessageFilter{RecipientName: "Accounts Payable"}},
+		{name: "conversation", filter: query.MessageFilter{ConversationID: &conversationID}},
+		{name: "empty aggregate bucket", filter: query.MessageFilter{EmptyValueTargets: map[query.ViewType]bool{query.ViewSenderNames: true}}},
+		{name: "multiple sources", filter: query.MessageFilter{SourceIDs: []int64{7, 8}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			model := NewBuilder().WithLevel(levelMessageList).
+				WithActiveSearch("find the invoice", searchModeDeep).Build()
+			model.semanticSearch = &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
+			model.drillFilter = tt.filter
+
+			assertions.Contains(model.searchPlaceholder(), "fast")
+			assertions.NotContains(model.searchPlaceholder(), "semantic")
+
+			model, cmd := applyInlineSearchKey(t, model, keyTab())
+			assertions.Equal(searchModeFast, model.searchMode)
+			assertions.NotNil(cmd)
+		})
+	}
+}
+
+func TestInheritedSemanticSearchFallsBackInUnsupportedScope(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).
+		WithActiveSearch("find the invoice", searchModeSemantic).Build()
+	model.semanticSearch = &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
+	model.drillFilter = query.MessageFilter{SenderName: "Billing Team"}
+
+	model.syncSearchScope()
+
+	assert.Equal(t, searchModeFast, model.searchMode)
+	assert.Equal(t, "Billing Team", model.searchFilter.SenderName)
+}
+
+func TestFailedSearchModeChangeDoesNotMislabelStaleResults(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	searcher := &recordingSemanticSearcher{err: errors.New("semantic unavailable")}
+	model := NewBuilder().WithLevel(levelMessageList).
+		WithMessages(query.MessageSummary{ID: 1, Subject: "old deep result"}).
+		WithActiveSearch("find the invoice", searchModeDeep).Build()
+	model.semanticSearch = searcher
+	model.searchQuery = "find the invoice"
+	model.contextStats = &query.TotalStats{MessageCount: 1}
+
+	model, cmd := applyInlineSearchKey(t, model, keyTab())
+
+	require.NotNil(cmd)
+	assert.Equal(searchModeSemantic, model.searchMode)
+	assert.Empty(model.messages, "old deep results must be removed before semantic search")
+	assert.Nil(model.contextStats)
+
+	cmdMsg := cmd()
+	searchResult, ok := cmdMsg.(searchResultsMsg)
+	require.True(ok, "expected semantic search result, got %T", cmdMsg)
+	require.Error(searchResult.err)
+	updated, _ := model.Update(searchResult)
+	model = asModel(t, updated)
+	assert.Empty(model.messages, "failed replacement must not restore stale results")
+}
+
+func TestSemanticSearchPreservesSourceAndAttachmentScope(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	accountID := int64(7)
+	searcher := &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{
+		Messages: []query.MessageSummary{{
+			ID: 42, Subject: "Annual realtor statement", HasAttachments: true,
+		}},
+		HasMore: true,
+	}}
+	model := NewBuilder().WithLevel(levelMessageList).
+		WithAccounts(query.AccountInfo{ID: accountID, Identifier: "archive@example.test"}).
+		WithAccountFilter(&accountID).Build()
+	model.semanticSearch = searcher
+	model.searchMode = searchModeSemantic
+	model.searchRequestID = 3
+	model.searchFilter = query.MessageFilter{
+		SourceID:            &accountID,
+		Sender:              "agent@example.test",
+		WithAttachmentsOnly: true,
+	}
+
+	msg := model.loadSearch("what was that realtor bill from last year")()
+	result, ok := msg.(searchResultsMsg)
+	require.True(ok, "expected searchResultsMsg, got %T", msg)
+	require.NoError(result.err)
+	assert.Equal(int64(-1), result.totalCount)
+	require.NotNil(searcher.request.Filter.SourceID)
+	assert.Equal(accountID, *searcher.request.Filter.SourceID)
+	assert.Equal("agent@example.test", searcher.request.Filter.Sender)
+	assert.True(searcher.request.Filter.WithAttachmentsOnly)
+	assert.Equal(emailMessageType, searcher.request.Filter.MessageType)
+	assert.Equal(100, searcher.request.Limit)
+	require.Len(result.messages, 1)
+	assert.True(result.messages[0].HasAttachments)
+}
+
+func TestSemanticSearchLabelsItsActiveOnlyPopulation(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).WithSize(120, 20).Build()
+	model.semanticSearch = &recordingSemanticSearcher{}
+	model.searchMode = searchModeSemantic
+	model.inlineSearchActive = true
+	model.searchInput.SetValue("invoice")
+
+	assert.Contains(t, model.View().Content, "Semantic: active messages only")
+
+	model.inlineSearchActive = false
+	model.searchQuery = "invoice"
+	assert.Contains(t, model.View().Content, "Semantic: active messages only")
+}
+
+func TestSemanticSearchDisablesListSorting(t *testing.T) {
+	assert := assert.New(t)
+	model := NewBuilder().WithLevel(levelMessageList).WithSize(120, 20).
+		WithMessages(
+			query.MessageSummary{ID: 2, Subject: "higher-ranked"},
+			query.MessageSummary{ID: 1, Subject: "lower-ranked"},
+		).WithActiveSearch("find the invoice", searchModeSemantic).Build()
+	model.inlineSearchActive = false
+	model.searchQuery = "find the invoice"
+	wantMessages := append([]query.MessageSummary(nil), model.messages...)
+	wantField := model.msgSortField
+	wantDirection := model.msgSortDirection
+
+	for _, sortKey := range []rune{'s', 'r', 'v'} {
+		got, cmd := applyMessageListKeyWithCmd(t, model, key(sortKey))
+		assert.Nil(cmd, "key %q must not reload semantic results", sortKey)
+		assert.Equal(wantMessages, got.messages)
+		assert.Equal(wantField, got.msgSortField)
+		assert.Equal(wantDirection, got.msgSortDirection)
+		assert.False(got.loading)
+	}
+
+	assert.NotContains(model.footerView(), "s sort")
+	assert.NotContains(model.messageListView(), "Date↓")
 }
 
 // TestSpinnerAppearsInViewWhenLoading verifies spinner character appears in rendered view.

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -266,6 +266,9 @@ func (m Model) buildBreadcrumb() string {
 
 // buildStatsString builds the stats summary string for the header.
 func (m Model) buildStatsString() string {
+	if m.searchQuery != "" && m.searchMode == searchModeSemantic {
+		return ""
+	}
 	if m.contextStats != nil && (m.level == levelMessageList || m.level == levelDrillDown || m.searchQuery != "") {
 		// Show "+" suffix when search has more results than loaded
 		msgsSuffix := ""
@@ -486,6 +489,9 @@ func (m Model) messageListView() string {
 
 	// Header row with sort indicators
 	msgSortIndicator := func(field query.MessageSortField) string {
+		if m.hasActiveSemanticSearch() {
+			return ""
+		}
 		if m.msgSortField == field {
 			if m.msgSortDirection == query.SortDesc {
 				return "↓"
@@ -633,8 +639,12 @@ func (m Model) messageListView() string {
 	isLoading := m.loading || m.inlineSearchLoading || m.searchLoadingMore
 	if m.inlineSearchActive {
 		modeTag := "[Fast]"
-		if m.searchMode == searchModeDeep {
+		switch m.searchMode {
+		case searchModeFast:
+		case searchModeDeep:
 			modeTag = "[Deep]"
+		case searchModeSemantic:
+			modeTag = "[Semantic: active messages only]"
 		}
 		infoContent = modeTag + "/" + m.searchInput.View()
 	} else if m.searchQuery != "" {
@@ -646,8 +656,12 @@ func (m Model) messageListView() string {
 		} else if m.searchTotalCount == -1 {
 			infoContent += fmt.Sprintf(" (%d+ results, PgDn for more)", len(m.messages))
 		}
-		if m.searchMode == searchModeDeep {
+		switch m.searchMode {
+		case searchModeFast:
+		case searchModeDeep:
 			infoContent += " [Deep]"
+		case searchModeSemantic:
+			infoContent += " [Semantic: active messages only]"
 		}
 	}
 	sb.WriteString(m.renderInfoLine(infoContent, isLoading))
@@ -713,7 +727,8 @@ func (m Model) buildDetailLines() []string {
 			fmt.Sprintf("Attachments (%d):", len(msg.Attachments)),
 		)
 		for _, att := range msg.Attachments {
-			lines = append(lines, fmt.Sprintf("  📎 %s (%s)", att.Filename, formatBytes(att.Size)))
+			filename := textutil.SanitizeTerminal(att.Filename)
+			lines = append(lines, fmt.Sprintf("  📎 %s (%s)", filename, formatBytes(att.Size)))
 		}
 	}
 
@@ -1041,8 +1056,10 @@ func (m Model) footerView() string {
 			"Enter",
 			"Esc",
 			"Space",
-			"s sort",
 			"d del",
+		}
+		if !m.hasActiveSemanticSearch() {
+			keys = append(keys, "s sort")
 		}
 		keys = append(keys, "/ search", "? help")
 		if len(m.messages) > 0 {
@@ -1074,7 +1091,7 @@ func (m Model) footerView() string {
 		}
 		// Show export option if message has attachments
 		if m.messageDetail != nil && len(m.messageDetail.Attachments) > 0 {
-			keys = append(keys, "e export")
+			keys = append(keys, "e attachments")
 		}
 		keys = append(keys, "Esc back", "q quit")
 		// Show message position (N/M) in the list - reuse total from parent view
@@ -1189,10 +1206,10 @@ var rawHelpLines = []string{
 	"  a           View all messages",
 	"",
 	"Other",
-	"  /           Search",
+	"  /           Search (Tab cycles modes in message lists)",
 	"  A           Select account",
 	"  f           Filter (attachments, deleted)",
-	"  e           Export attachments (in message view)",
+	"  e           Browse attachments (in message view)",
 	"  m           Cycle Email/Texts/Meetings",
 	"  q           Quit",
 	"",
@@ -1359,14 +1376,14 @@ func (m Model) renderHelpModal() string {
 // renderExportAttachmentsModal renders the export attachments modal content.
 func (m Model) renderExportAttachmentsModal() string {
 	if m.messageDetail == nil || len(m.messageDetail.Attachments) == 0 {
-		return m.styles.modalTitle.Render("Export Attachments") + "\n\n" +
-			"No attachments to export.\n\n" +
+		return m.styles.modalTitle.Render("Attachments") + "\n\n" +
+			"No attachments available.\n\n" +
 			"[Esc] Close"
 	}
 	var sb strings.Builder
-	sb.WriteString(m.styles.modalTitle.Render("Export Attachments"))
+	sb.WriteString(m.styles.modalTitle.Render("Attachments"))
 	sb.WriteString("\n\n")
-	sb.WriteString("Select attachments to export:\n\n")
+	sb.WriteString("Choose a file to download or open:\n\n")
 	for i, att := range m.messageDetail.Attachments {
 		cursor := " "
 		if i == m.exportCursor {
@@ -1376,7 +1393,8 @@ func (m Model) renderExportAttachmentsModal() string {
 		if m.exportSelection[i] {
 			checkbox = "☑"
 		}
-		_, _ = fmt.Fprintf(&sb, "%s %s %s (%s)\n", cursor, checkbox, att.Filename, formatBytes(att.Size))
+		filename := truncateRunes(textutil.SanitizeTerminal(attachmentDisplayName(att)), 60)
+		_, _ = fmt.Fprintf(&sb, "%s %s %s (%s)\n", cursor, checkbox, filename, formatBytes(att.Size))
 	}
 	// Count selected
 	selectedCount := 0
@@ -1386,8 +1404,8 @@ func (m Model) renderExportAttachmentsModal() string {
 		}
 	}
 	_, _ = fmt.Fprintf(&sb, "\n%d of %d selected\n", selectedCount, len(m.messageDetail.Attachments))
-	sb.WriteString("\n[↑/↓] Navigate  [Space] Toggle  [a] All  [n] None\n")
-	sb.WriteString("[Enter] Export  [Esc] Cancel")
+	sb.WriteString("\n[↑/↓] Navigate  [d] Download  [o] Open\n")
+	sb.WriteString("[Space] Toggle  [a] All  [n] None  [Enter] Export zip  [Esc] Cancel")
 	return sb.String()
 }
 
@@ -1400,8 +1418,12 @@ func (m Model) renderErrorModal() string {
 
 // renderExportResultModal renders the export result modal content.
 func (m Model) renderExportResultModal() string {
-	return m.styles.modalTitle.Render("Export Complete") + "\n\n" +
-		m.modalResult + "\n\n" +
+	title := m.modalResultTitle
+	if title == "" {
+		title = "Attachment Action"
+	}
+	return m.styles.modalTitle.Render(title) + "\n\n" +
+		textutil.SanitizeTerminalMultiline(m.modalResult) + "\n\n" +
 		"Press any key to close"
 }
 

--- a/internal/tui/view_render_test.go
+++ b/internal/tui/view_render_test.go
@@ -885,6 +885,10 @@ func TestExportAttachmentsModal(t *testing.T) {
 	// Should have all attachments selected by default
 	assert.Len(m.exportSelection, 2)
 	assert.True(m.exportSelection[0] && m.exportSelection[1], "expected all attachments to be selected by default")
+	modal := stripANSI(m.renderExportAttachmentsModal())
+	assert.Contains(modal, "[d] Download")
+	assert.Contains(modal, "[o] Open")
+	assert.Contains(modal, "[Enter] Export zip")
 
 	// Test navigation - move cursor down
 	m, _ = applyModalKey(t, m, key('j'))
@@ -925,6 +929,25 @@ func TestExportAttachmentsNoAttachments(t *testing.T) {
 	assert.Equal(t, "No attachments to export", m.flashMessage)
 }
 
+func TestAttachmentActionResultOpensResultModal(t *testing.T) {
+	assert := assert.New(t)
+	model := NewBuilder().WithLevel(levelMessageDetail).Build()
+	model.loading = true
+
+	m := sendMsg(t, model, ExportResultMsg{
+		Title:  "Download Complete",
+		Result: "Saved to /tmp/invoice.pdf",
+	})
+
+	assert.Equal(modalExportResult, m.modal)
+	assert.Equal("Download Complete", m.modalResultTitle)
+	assert.Equal("Saved to /tmp/invoice.pdf", m.modalResult)
+	assert.False(m.loading)
+	view := stripANSI(m.renderExportResultModal())
+	assert.Contains(view, "Download Complete")
+	assert.Contains(view, "/tmp/invoice.pdf")
+}
+
 // TestRenderExportAttachmentsModalEdgeCases tests the export modal renderer
 // handles edge cases gracefully (nil detail, empty attachments).
 func TestRenderExportAttachmentsModalEdgeCases(t *testing.T) {
@@ -938,7 +961,7 @@ func TestRenderExportAttachmentsModalEdgeCases(t *testing.T) {
 		content := model.renderExportAttachmentsModal()
 
 		assert.NotEmpty(t, content, "expected non-empty modal content when messageDetail is nil")
-		assert.Contains(t, content, "Export Attachments", "expected modal title in content")
+		assert.Contains(t, content, "Attachments", "expected modal title in content")
 		assert.Contains(t, content, "No attachments")
 	})
 
@@ -956,7 +979,7 @@ func TestRenderExportAttachmentsModalEdgeCases(t *testing.T) {
 		content := model.renderExportAttachmentsModal()
 
 		assert.NotEmpty(t, content, "expected non-empty modal content when attachments is empty")
-		assert.Contains(t, content, "Export Attachments", "expected modal title in content")
+		assert.Contains(t, content, "Attachments", "expected modal title in content")
 		assert.Contains(t, content, "No attachments")
 	})
 

--- a/internal/vector/backend.go
+++ b/internal/vector/backend.go
@@ -175,7 +175,7 @@ type Chunk struct {
 // "bob". Within a group, IDs are OR'd (any matching participant
 // satisfies the group); across groups they are AND'd.
 //
-//   - Sender/To/Cc/Bcc/LabelGroups are AND-of-OR groups: each inner
+//   - Sender/SenderExact/RecipientAny/To/Cc/Bcc/LabelGroups are AND-of-OR groups: each inner
 //     slice is one search-token resolution (substring → matching IDs).
 //     SenderGroups is at the message level too — multiple `from`
 //     recipient rows on a single message can satisfy different tokens.
@@ -190,18 +190,20 @@ type Chunk struct {
 //     `>= After` and `< Before`.
 //   - LargerThan/SmallerThan compare against m.size_estimate.
 type Filter struct {
-	SourceIDs         []int64   // from [server/sources].identifier; empty = no source filter
-	SenderGroups      [][]int64 // one inner slice per `from:` token; AND across, OR within
-	ToGroups          [][]int64 // one inner slice per `to:` token; AND across, OR within
-	CcGroups          [][]int64 // one inner slice per `cc:` token; AND across, OR within
-	BccGroups         [][]int64 // one inner slice per `bcc:` token; AND across, OR within
-	LabelGroups       [][]int64 // one inner slice per `label:` token; AND across, OR within
-	HasAttachment     *bool
-	After, Before     *time.Time
-	LargerThan        *int64   // `larger:` — strictly greater than
-	SmallerThan       *int64   // `smaller:` — strictly less than
-	SubjectSubstrings []string // one per `subject:` term (ANDed)
-	MessageTypes      []string // exact m.message_type values; empty = unrestricted
+	SourceIDs          []int64   // from [server/sources].identifier; empty = no source filter
+	SenderGroups       [][]int64 // one inner slice per `from:` token; AND across, OR within
+	SenderExactGroups  [][]int64 // exact structured sender; from rows OR messages.sender_id
+	RecipientAnyGroups [][]int64 // exact structured recipient; to/cc/bcc rows are OR'd
+	ToGroups           [][]int64 // one inner slice per `to:` token; AND across, OR within
+	CcGroups           [][]int64 // one inner slice per `cc:` token; AND across, OR within
+	BccGroups          [][]int64 // one inner slice per `bcc:` token; AND across, OR within
+	LabelGroups        [][]int64 // one inner slice per `label:` token; AND across, OR within
+	HasAttachment      *bool
+	After, Before      *time.Time
+	LargerThan         *int64   // `larger:` — strictly greater than
+	SmallerThan        *int64   // `smaller:` — strictly less than
+	SubjectSubstrings  []string // one per `subject:` term (ANDed)
+	MessageTypes       []string // exact m.message_type values; empty = unrestricted
 }
 
 // IsEmpty reports whether the filter has no restrictions. A zero-value
@@ -209,6 +211,8 @@ type Filter struct {
 func (f Filter) IsEmpty() bool {
 	return len(f.SourceIDs) == 0 &&
 		len(f.SenderGroups) == 0 &&
+		len(f.SenderExactGroups) == 0 &&
+		len(f.RecipientAnyGroups) == 0 &&
 		len(f.ToGroups) == 0 &&
 		len(f.CcGroups) == 0 &&
 		len(f.BccGroups) == 0 &&

--- a/internal/vector/hybrid/engine.go
+++ b/internal/vector/hybrid/engine.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"unicode"
 
+	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/vector"
 )
@@ -128,8 +129,21 @@ func (e *Engine) EmbedQuery(ctx context.Context, text string) ([]float32, error)
 // against the engine's main DB. Convenience wrapper around the
 // package-level BuildFilter so callers that already hold an *Engine
 // don't need to plumb a *sql.DB separately.
-func (e *Engine) BuildFilter(ctx context.Context, q *search.Query) (vector.Filter, error) {
-	return BuildFilter(ctx, e.mainDB, e.cfg.Rebind, q)
+func (e *Engine) BuildFilter(
+	ctx context.Context,
+	q *search.Query,
+	structured ...query.MessageFilter,
+) (vector.Filter, error) {
+	filter, err := BuildFilter(ctx, e.mainDB, e.cfg.Rebind, q)
+	if err != nil {
+		return vector.Filter{}, err
+	}
+	for _, exact := range structured {
+		if err := ApplyMessageFilter(ctx, e.mainDB, e.cfg.Rebind, &filter, exact); err != nil {
+			return vector.Filter{}, err
+		}
+	}
+	return filter, nil
 }
 
 // Search runs hybrid or vector mode. Resolves the active generation

--- a/internal/vector/hybrid/filter.go
+++ b/internal/vector/hybrid/filter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/vector"
 )
@@ -99,6 +100,179 @@ func BuildFilter(ctx context.Context, db *sql.DB, rebind func(string) string, q 
 		f.SourceIDs = append([]int64(nil), q.AccountIDs...)
 	}
 	return f, nil
+}
+
+// ApplyMessageFilter intersects an exact structured TUI filter with the
+// Gmail-syntax filter already built from the user's search query. Address,
+// domain, and label drill values are resolved with equality semantics; this
+// deliberately differs from user-authored from:/label: operators, which keep
+// their documented substring behavior.
+func ApplyMessageFilter(
+	ctx context.Context,
+	db *sql.DB,
+	rebind func(string) string,
+	f *vector.Filter,
+	structured query.MessageFilter,
+) error {
+	if rebind == nil {
+		rebind = identityRebind
+	}
+	if period := structured.TimeRange.Period; period != "" {
+		if _, _, ok := query.ParseTimePeriodBounds(period); !ok {
+			return fmt.Errorf("invalid time_period %q: expected YYYY, YYYY-MM, or YYYY-MM-DD", period)
+		}
+	}
+
+	derived := query.MergeFilterIntoQuery(&search.Query{}, structured)
+	intersectSourceIDs(f, derived.AccountIDs)
+	if derived.AfterDate != nil {
+		if f.After == nil || derived.AfterDate.After(*f.After) {
+			f.After = derived.AfterDate
+		}
+	}
+	if derived.BeforeDate != nil {
+		if f.Before == nil || derived.BeforeDate.Before(*f.Before) {
+			f.Before = derived.BeforeDate
+		}
+	}
+	if derived.HasAttachment != nil && *derived.HasAttachment {
+		value := true
+		f.HasAttachment = &value
+	}
+	if len(derived.MessageTypes) > 0 {
+		f.MessageTypes = intersectMessageTypes(f.MessageTypes, derived.MessageTypes)
+	}
+
+	if structured.Sender != "" {
+		group, err := resolveExactParticipantIDs(ctx, db, rebind,
+			"email_address = ? OR phone_number = ?", structured.Sender, structured.Sender)
+		if err != nil {
+			return err
+		}
+		f.SenderExactGroups = append(f.SenderExactGroups, noMatchGroup(group))
+	}
+	if structured.Recipient != "" {
+		group, err := resolveExactParticipantIDs(ctx, db, rebind,
+			"email_address = ?", structured.Recipient)
+		if err != nil {
+			return err
+		}
+		f.RecipientAnyGroups = append(f.RecipientAnyGroups, noMatchGroup(group))
+	}
+	if structured.Domain != "" {
+		group, err := resolveExactParticipantIDs(ctx, db, rebind, "domain = ?", structured.Domain)
+		if err != nil {
+			return err
+		}
+		// Domain drill-downs intentionally match only explicit `from`
+		// recipient rows, matching query.MessageFilter semantics.
+		f.SenderGroups = append(f.SenderGroups, noMatchGroup(group))
+	}
+	if structured.Label != "" {
+		group, err := resolveExactLabelIDs(ctx, db, rebind, structured.Label)
+		if err != nil {
+			return err
+		}
+		f.LabelGroups = append(f.LabelGroups, noMatchGroup(group))
+	}
+	return nil
+}
+
+func intersectSourceIDs(f *vector.Filter, exact []int64) {
+	if exact == nil {
+		return
+	}
+	if len(f.SourceIDs) == 0 {
+		f.SourceIDs = append([]int64(nil), exact...)
+		return
+	}
+	allowed := make(map[int64]struct{}, len(exact))
+	for _, id := range exact {
+		allowed[id] = struct{}{}
+	}
+	out := f.SourceIDs[:0]
+	for _, id := range f.SourceIDs {
+		if _, ok := allowed[id]; ok {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		out = []int64{noMatchSentinel}
+	}
+	f.SourceIDs = out
+}
+
+func intersectMessageTypes(existing, exact []string) []string {
+	if len(existing) == 0 {
+		return append([]string(nil), exact...)
+	}
+	allowed := make(map[string]struct{}, len(exact))
+	for _, value := range exact {
+		allowed[strings.ToLower(value)] = struct{}{}
+	}
+	var out []string
+	for _, value := range existing {
+		if _, ok := allowed[strings.ToLower(value)]; ok {
+			out = append(out, value)
+		}
+	}
+	if len(out) == 0 {
+		return []string{"__msgvault_no_matching_message_type__"}
+	}
+	return out
+}
+
+func resolveExactParticipantIDs(
+	ctx context.Context,
+	db *sql.DB,
+	rebind func(string) string,
+	where string,
+	args ...any,
+) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, rebind("SELECT id FROM participants WHERE "+where), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query exact participants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan exact participant id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate exact participants: %w", err)
+	}
+	return ids, nil
+}
+
+func resolveExactLabelIDs(ctx context.Context, db *sql.DB, rebind func(string) string, label string) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, rebind("SELECT id FROM labels WHERE LOWER(name) = LOWER(?)"), label)
+	if err != nil {
+		return nil, fmt.Errorf("query exact labels: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan exact label id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate exact labels: %w", err)
+	}
+	return ids, nil
+}
+
+func noMatchGroup(ids []int64) []int64 {
+	if len(ids) == 0 {
+		return []int64{noMatchSentinel}
+	}
+	return ids
 }
 
 // resolveAddressGroups produces one IDs slice per supplied token. The

--- a/internal/vector/hybrid/filter_test.go
+++ b/internal/vector/hybrid/filter_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/vector"
 )
 
 func newFilterTestDB(t *testing.T) *sql.DB {
@@ -22,7 +26,9 @@ func newFilterTestDB(t *testing.T) *sql.DB {
 	schema := `
 CREATE TABLE participants (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    email_address TEXT
+    email_address TEXT,
+    phone_number TEXT,
+    domain TEXT
 );
 CREATE TABLE labels (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -38,7 +44,8 @@ CREATE TABLE labels (
 		"dave.work@example.com",
 	}
 	for _, p := range participants {
-		_, err := db.Exec(`INSERT INTO participants (email_address) VALUES (?)`, p)
+		domain := p[strings.LastIndex(p, "@")+1:]
+		_, err := db.Exec(`INSERT INTO participants (email_address, domain) VALUES (?, ?)`, p, domain)
 		require.NoError(t, err, "insert participant")
 	}
 	for _, l := range []string{"INBOX", "Work", "Archive"} {
@@ -46,6 +53,79 @@ CREATE TABLE labels (
 		require.NoError(t, err, "insert label")
 	}
 	return db
+}
+
+func TestApplyMessageFilterPreservesExactTUIScope(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	db := newFilterTestDB(t)
+	_, err := db.Exec(`INSERT INTO labels (name) VALUES (?)`, "Work Notes")
+	require.NoError(err)
+	sourceID := int64(7)
+	filter := vector.Filter{}
+
+	err = ApplyMessageFilter(t.Context(), db, nil, &filter, query.MessageFilter{
+		SourceID:            &sourceID,
+		Sender:              "alice@example.com",
+		Recipient:           "bob@example.com",
+		Domain:              "example.com",
+		Label:               "work",
+		MessageType:         "email",
+		TimeRange:           query.TimeRange{Period: "2025"},
+		WithAttachmentsOnly: true,
+	})
+	require.NoError(err)
+
+	assert.Equal([]int64{7}, filter.SourceIDs)
+	require.Len(filter.SenderExactGroups, 1)
+	assert.Equal([]int64{1}, filter.SenderExactGroups[0], "sender equality must not include substring matches")
+	require.Len(filter.RecipientAnyGroups, 1)
+	assert.Equal([]int64{2}, filter.RecipientAnyGroups[0])
+	require.Len(filter.SenderGroups, 1)
+	assert.Equal([]int64{1, 2, 4}, filter.SenderGroups[0], "domain equality")
+	require.Len(filter.LabelGroups, 1)
+	assert.Equal([]int64{2}, filter.LabelGroups[0], "label equality is case-insensitive")
+	assert.Equal([]string{"email"}, filter.MessageTypes)
+	if assert.NotNil(filter.HasAttachment) {
+		assert.True(*filter.HasAttachment)
+	}
+	if assert.NotNil(filter.After) {
+		assert.Equal(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), *filter.After)
+	}
+	if assert.NotNil(filter.Before) {
+		assert.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), *filter.Before)
+	}
+}
+
+func TestApplyMessageFilterIntersectsExistingScope(t *testing.T) {
+	db := newFilterTestDB(t)
+	sourceID := int64(7)
+	filter := vector.Filter{
+		SourceIDs:    []int64{8},
+		MessageTypes: []string{"sms"},
+	}
+
+	err := ApplyMessageFilter(t.Context(), db, nil, &filter, query.MessageFilter{
+		SourceID:    &sourceID,
+		MessageType: "email",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []int64{noMatchSentinel}, filter.SourceIDs)
+	assert.Equal(t, []string{"__msgvault_no_matching_message_type__"}, filter.MessageTypes)
+}
+
+func TestApplyMessageFilterRejectsInvalidTimePeriod(t *testing.T) {
+	db := newFilterTestDB(t)
+	filter := vector.Filter{}
+
+	err := ApplyMessageFilter(t.Context(), db, nil, &filter, query.MessageFilter{
+		TimeRange: query.TimeRange{Period: "this-week"},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid time_period")
+	require.ErrorContains(t, err, "YYYY, YYYY-MM, or YYYY-MM-DD")
 }
 
 func sortedIDs(ids []int64) []int64 {

--- a/internal/vector/pgvector/backend_filter_test.go
+++ b/internal/vector/pgvector/backend_filter_test.go
@@ -22,8 +22,23 @@ func TestBuildPGFilterClausesMessageTypes(t *testing.T) {
 	clauses := buildPGFilterClauses(vector.Filter{MessageTypes: []string{"sms", "mms"}}, bind)
 
 	require.Len(t, clauses, 1)
-	assert.Equal(t, "m.message_type = ANY($1::text[])", clauses[0])
+	assert.Equal(t, "(m.message_type = ANY($1::text[]))", clauses[0])
 	assert.Equal(t, []any{`{"sms","mms"}`}, args)
+}
+
+func TestBuildPGFilterClausesLegacyEmail(t *testing.T) {
+	var args []any
+	bind := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+
+	clauses := buildPGFilterClauses(vector.Filter{MessageTypes: []string{"email"}}, bind)
+
+	require.Len(t, clauses, 1)
+	assert.Contains(t, clauses[0], "m.message_type IS NULL")
+	assert.Contains(t, clauses[0], "m.message_type = ''")
+	assert.Equal(t, []any{"email"}, args)
 }
 
 func TestBackendSearchStructuredFilters(t *testing.T) {
@@ -86,6 +101,16 @@ func TestBackendSearchStructuredFilters(t *testing.T) {
 		{
 			name:   "to group",
 			filter: vector.Filter{ToGroups: [][]int64{{200}}},
+			want:   []int64{2},
+		},
+		{
+			name:   "recipient any group",
+			filter: vector.Filter{RecipientAnyGroups: [][]int64{{300}}},
+			want:   []int64{3},
+		},
+		{
+			name:   "exact sender group",
+			filter: vector.Filter{SenderExactGroups: [][]int64{{100}}},
 			want:   []int64{2},
 		},
 		{

--- a/internal/vector/pgvector/filter.go
+++ b/internal/vector/pgvector/filter.go
@@ -35,7 +35,24 @@ func buildPGFilterClauses(f vector.Filter, bind func(any) string) []string {
 		clauses = append(clauses, fmt.Sprintf("m.source_id = ANY(%s::bigint[])", bind(int64Array(f.SourceIDs))))
 	}
 	if len(f.MessageTypes) > 0 {
-		clauses = append(clauses, fmt.Sprintf("m.message_type = ANY(%s::text[])", bind(textArray(f.MessageTypes))))
+		var exact []string
+		includeLegacyEmail := false
+		for _, value := range f.MessageTypes {
+			if strings.EqualFold(value, "email") {
+				includeLegacyEmail = true
+			} else {
+				exact = append(exact, value)
+			}
+		}
+		var parts []string
+		if len(exact) > 0 {
+			parts = append(parts, fmt.Sprintf("m.message_type = ANY(%s::text[])", bind(textArray(exact))))
+		}
+		if includeLegacyEmail {
+			parts = append(parts, fmt.Sprintf(
+				"(m.message_type = %s OR m.message_type IS NULL OR m.message_type = '')", bind("email")))
+		}
+		clauses = append(clauses, "("+strings.Join(parts, " OR ")+")")
 	}
 	for _, group := range f.SenderGroups {
 		if len(group) == 0 {
@@ -46,6 +63,31 @@ func buildPGFilterClauses(f vector.Filter, bind func(any) string) []string {
 				SELECT 1 FROM message_recipients mr
 				 WHERE mr.message_id = m.id
 				   AND mr.recipient_type = 'from'
+				   AND mr.participant_id = ANY(%s::bigint[])
+			)`, bind(int64Array(group))))
+	}
+	for _, group := range f.SenderExactGroups {
+		if len(group) == 0 {
+			continue
+		}
+		ids := bind(int64Array(group))
+		clauses = append(clauses, fmt.Sprintf(
+			`(m.sender_id = ANY(%[1]s::bigint[]) OR EXISTS (
+				SELECT 1 FROM message_recipients mr
+				 WHERE mr.message_id = m.id
+				   AND mr.recipient_type = 'from'
+				   AND mr.participant_id = ANY(%[1]s::bigint[])
+			))`, ids))
+	}
+	for _, group := range f.RecipientAnyGroups {
+		if len(group) == 0 {
+			continue
+		}
+		clauses = append(clauses, fmt.Sprintf(
+			`EXISTS (
+				SELECT 1 FROM message_recipients mr
+				 WHERE mr.message_id = m.id
+				   AND mr.recipient_type IN ('to', 'cc', 'bcc')
 				   AND mr.participant_id = ANY(%s::bigint[])
 			)`, bind(int64Array(group))))
 	}

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -1311,10 +1311,28 @@ func (b *Backend) filteredMessageIDs(ctx context.Context, f vector.Filter) ([]in
 		}
 	}
 	if len(f.MessageTypes) > 0 {
-		clauses = append(clauses, inStringClause("m.message_type", f.MessageTypes))
+		var exact []string
+		includeLegacyEmail := false
 		for _, typ := range f.MessageTypes {
-			args = append(args, typ)
+			if strings.EqualFold(typ, "email") {
+				includeLegacyEmail = true
+			} else {
+				exact = append(exact, typ)
+			}
 		}
+		var messageTypeClauses []string
+		if len(exact) > 0 {
+			messageTypeClauses = append(messageTypeClauses, inStringClause("m.message_type", exact))
+			for _, typ := range exact {
+				args = append(args, typ)
+			}
+		}
+		if includeLegacyEmail {
+			messageTypeClauses = append(messageTypeClauses,
+				"(m.message_type = ? OR m.message_type IS NULL OR m.message_type = '')")
+			args = append(args, "email")
+		}
+		clauses = append(clauses, "("+strings.Join(messageTypeClauses, " OR ")+")")
 	}
 	// Sender filters: one EXISTS per group, AND'd across groups so
 	// repeated `from:` operators each become an independent
@@ -1337,6 +1355,41 @@ func (b *Backend) filteredMessageIDs(ctx context.Context, f vector.Filter) ([]in
 				   AND mr.recipient_type = 'from'
 				   AND %s
 			)`, inRecipient))
+		for _, id := range group {
+			args = append(args, id)
+		}
+	}
+	for _, group := range f.SenderExactGroups {
+		if len(group) == 0 {
+			continue
+		}
+		direct := inClause("m.sender_id", group)
+		from := inClause("mr.participant_id", group)
+		clauses = append(clauses, fmt.Sprintf(
+			`(%s OR EXISTS (
+				SELECT 1 FROM message_recipients mr
+				 WHERE mr.message_id = m.id
+				   AND mr.recipient_type = 'from'
+				   AND %s
+			))`, direct, from))
+		for _, id := range group {
+			args = append(args, id)
+		}
+		for _, id := range group {
+			args = append(args, id)
+		}
+	}
+	for _, group := range f.RecipientAnyGroups {
+		if len(group) == 0 {
+			continue
+		}
+		clauses = append(clauses, fmt.Sprintf(
+			`EXISTS (
+				SELECT 1 FROM message_recipients mr
+				 WHERE mr.message_id = m.id
+				   AND mr.recipient_type IN ('to', 'cc', 'bcc')
+				   AND %s
+			)`, inClause("mr.participant_id", group)))
 		for _, id := range group {
 			args = append(args, id)
 		}

--- a/internal/vector/sqlitevec/backend_test.go
+++ b/internal/vector/sqlitevec/backend_test.go
@@ -1042,6 +1042,11 @@ func TestBackend_Search_NewFilterFields(t *testing.T) {
 			require.NoError(err, "insert cc")
 		}
 	}
+	_, err = b.mainDB.ExecContext(ctx, `UPDATE messages SET sender_id = 99 WHERE id = 1`)
+	require.NoError(err, "seed direct sender")
+	_, err = b.mainDB.ExecContext(ctx,
+		`INSERT INTO message_recipients (message_id, recipient_type, participant_id) VALUES (2, 'from', 99)`)
+	require.NoError(err, "seed from sender")
 
 	gid, err := b.CreateGeneration(ctx, "m", 768, "")
 	require.NoError(err, "CreateGeneration")
@@ -1069,6 +1074,16 @@ func TestBackend_Search_NewFilterFields(t *testing.T) {
 	t.Run("CcGroups_singleGroup", func(t *testing.T) {
 		got := matched(t, vector.Filter{CcGroups: [][]int64{{10}}})
 		assert.Truef(t, got[2] && !got[1] && !got[3] && !got[4], "CcGroups=[[10]]: got %v, want {2}", got)
+	})
+	t.Run("RecipientAnyGroups_crosses_to_cc_bcc", func(t *testing.T) {
+		got := matched(t, vector.Filter{RecipientAnyGroups: [][]int64{{10}}})
+		assert.Truef(t, got[1] && got[2] && !got[3] && !got[4],
+			"RecipientAnyGroups=[[10]]: got %v, want {1,2}", got)
+	})
+	t.Run("SenderExactGroups_uses_direct_and_from", func(t *testing.T) {
+		got := matched(t, vector.Filter{SenderExactGroups: [][]int64{{99}}})
+		assert.Truef(t, got[1] && got[2] && !got[3] && !got[4],
+			"SenderExactGroups=[[99]]: got %v, want {1,2}", got)
 	})
 	t.Run("LargerThan", func(t *testing.T) {
 		size := int64(1_000_000)

--- a/internal/vector/sqlitevec/fused.go
+++ b/internal/vector/sqlitevec/fused.go
@@ -63,13 +63,30 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	if err != nil {
 		return nil, false, fmt.Errorf("encode source_ids: %w", err)
 	}
-	messageTypes, err := stringsToJSON(req.Filter.MessageTypes)
+	var exactMessageTypes []string
+	includeLegacyEmail := false
+	for _, value := range req.Filter.MessageTypes {
+		if strings.EqualFold(value, "email") {
+			includeLegacyEmail = true
+		} else {
+			exactMessageTypes = append(exactMessageTypes, value)
+		}
+	}
+	messageTypes, err := stringsToJSON(exactMessageTypes)
 	if err != nil {
 		return nil, false, fmt.Errorf("encode message_types: %w", err)
 	}
 	senderGroupSQL, senderGroupArgs, err := senderGroupClauses(req.Filter.SenderGroups)
 	if err != nil {
 		return nil, false, fmt.Errorf("encode sender_groups: %w", err)
+	}
+	senderExactGroupSQL, senderExactGroupArgs, err := senderExactGroupClauses(req.Filter.SenderExactGroups)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode sender_exact_groups: %w", err)
+	}
+	recipientAnyGroupSQL, recipientAnyGroupArgs, err := recipientAnyGroupClauses(req.Filter.RecipientAnyGroups)
+	if err != nil {
+		return nil, false, fmt.Errorf("encode recipient_any_groups: %w", err)
 	}
 	toGroupSQL, toGroupArgs, err := recipientGroupClauses("to", req.Filter.ToGroups)
 	if err != nil {
@@ -150,9 +167,13 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
 	// guarantees the ceiling's "is this message included" predicate
 	// stays bit-for-bit aligned with the live one without forcing
 	// callers (or the test suite) to keep two copies in sync.
-	messageTypeSQL := `AND (:message_types IS NULL OR 0)`
+	messageTypeSQL := `AND (:message_type_filter = 0 OR :include_legacy_email = 1)`
 	if hasMessageType {
-		messageTypeSQL = `AND (:message_types IS NULL OR m.message_type IN (SELECT value FROM json_each(:message_types)))`
+		messageTypeSQL = `AND (
+			:message_type_filter = 0
+			OR m.message_type IN (SELECT value FROM json_each(:message_types))
+			OR (:include_legacy_email = 1 AND (m.message_type = 'email' OR m.message_type IS NULL OR m.message_type = ''))
+		)`
 	}
 
 	filterWhere := fmt.Sprintf(`%s
@@ -162,6 +183,8 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
        %s
        %s
        %s
+	   %s
+	   %s
        AND (:has_attachment IS NULL OR m.has_attachments = :has_attachment)
        AND (:after IS NULL OR m.sent_at >= :after)
        AND (:before IS NULL OR m.sent_at < :before)
@@ -171,7 +194,8 @@ func (b *Backend) FusedSearch(ctx context.Context, req vector.FusedRequest) ([]v
              SELECT 1 FROM json_each(:subject_patterns) sp
               WHERE m.subject IS NULL OR m.subject NOT LIKE sp.value ESCAPE '\'))
        %s`,
-		store.LiveMessagesWhere("m", true), messageTypeSQL, senderGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL)
+		store.LiveMessagesWhere("m", true), messageTypeSQL, senderGroupSQL, senderExactGroupSQL,
+		recipientAnyGroupSQL, toGroupSQL, ccGroupSQL, bccGroupSQL, labelGroupSQL)
 
 	// buildQuery interpolates a fresh query string for a given chunkK,
 	// so the widening loop below can re-issue the fused CTE with a
@@ -277,7 +301,13 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 	// named binds when its placeholder count check fails.
 	filterArgs := []any{
 		sql.Named("source_ids", sourceIDs),
-		sql.Named("message_types", messageTypes),
+	}
+	if hasMessageType {
+		filterArgs = append(filterArgs, sql.Named("message_types", messageTypes))
+	}
+	filterArgs = append(filterArgs,
+		sql.Named("message_type_filter", len(req.Filter.MessageTypes) > 0),
+		sql.Named("include_legacy_email", includeLegacyEmail),
 		sql.Named("has_attachment", hasAttachment),
 		sql.Named("after", after),
 		sql.Named("before", before),
@@ -285,8 +315,10 @@ SELECT message_id, rrf_score, bm25_score, vector_score,
 		sql.Named("smaller_than", smallerThan),
 		sql.Named("subject_patterns", subjectPatterns),
 		sql.Named("gen", int64(req.Generation)),
-	}
+	)
 	filterArgs = append(filterArgs, senderGroupArgs...)
+	filterArgs = append(filterArgs, senderExactGroupArgs...)
+	filterArgs = append(filterArgs, recipientAnyGroupArgs...)
 	filterArgs = append(filterArgs, toGroupArgs...)
 	filterArgs = append(filterArgs, ccGroupArgs...)
 	filterArgs = append(filterArgs, bccGroupArgs...)
@@ -552,6 +584,64 @@ func senderGroupClauses(groups [][]int64) (string, []any, error) {
                AND mr.recipient_type = 'from'
                AND mr.participant_id IN (SELECT value FROM json_each(:%s)))`,
 			paramName)
+		args = append(args, sql.Named(paramName, js))
+	}
+	return sb.String(), args, nil
+}
+
+// senderExactGroupClauses matches an exact structured sender against either
+// the canonical from-recipient rows or messages.sender_id. The latter keeps
+// WhatsApp/chat senders aligned with query.MessageFilter.
+func senderExactGroupClauses(groups [][]int64) (string, []any, error) {
+	if len(groups) == 0 {
+		return "", nil, nil
+	}
+	var sb strings.Builder
+	args := make([]any, 0, len(groups))
+	for i, ids := range groups {
+		js, err := idsToJSON(ids)
+		if err != nil {
+			return "", nil, fmt.Errorf("encode sender_exact_grp_%d: %w", i, err)
+		}
+		if !js.Valid {
+			continue
+		}
+		paramName := fmt.Sprintf("sender_exact_grp_%d", i)
+		fmt.Fprintf(&sb, `
+       AND (m.sender_id IN (SELECT value FROM json_each(:%[1]s))
+            OR EXISTS (
+                SELECT 1 FROM message_recipients mr
+                 WHERE mr.message_id = m.id
+                   AND mr.recipient_type = 'from'
+                   AND mr.participant_id IN (SELECT value FROM json_each(:%[1]s))))`, paramName)
+		args = append(args, sql.Named(paramName, js))
+	}
+	return sb.String(), args, nil
+}
+
+// recipientAnyGroupClauses preserves the aggregate recipient dimension: one
+// exact address may be present in any of the to, cc, or bcc roles.
+func recipientAnyGroupClauses(groups [][]int64) (string, []any, error) {
+	if len(groups) == 0 {
+		return "", nil, nil
+	}
+	var sb strings.Builder
+	args := make([]any, 0, len(groups))
+	for i, ids := range groups {
+		js, err := idsToJSON(ids)
+		if err != nil {
+			return "", nil, fmt.Errorf("encode recipient_any_grp_%d: %w", i, err)
+		}
+		if !js.Valid {
+			continue
+		}
+		paramName := fmt.Sprintf("recipient_any_grp_%d", i)
+		fmt.Fprintf(&sb, `
+       AND EXISTS (
+            SELECT 1 FROM message_recipients mr
+             WHERE mr.message_id = m.id
+               AND mr.recipient_type IN ('to', 'cc', 'bcc')
+               AND mr.participant_id IN (SELECT value FROM json_each(:%s)))`, paramName)
 		args = append(args, sql.Named(paramName, js))
 	}
 	return sb.String(), args, nil

--- a/internal/vector/sqlitevec/fused_test.go
+++ b/internal/vector/sqlitevec/fused_test.go
@@ -290,7 +290,7 @@ func openFusedMainWithSchema(t *testing.T, path string) *sql.DB {
 	CREATE TABLE messages (
 	    id INTEGER PRIMARY KEY,
 	    subject TEXT,
-	    message_type TEXT NOT NULL DEFAULT 'email',
+	    message_type TEXT DEFAULT 'email',
 	    source_id INTEGER,
     sender_id INTEGER,
     has_attachments INTEGER DEFAULT 0,
@@ -530,12 +530,14 @@ func TestFusedSearch_MessageTypeFilter(t *testing.T) {
 
 	rows := []struct {
 		id          int64
-		messageType string
+		messageType any
 	}{
 		{1, "email"},
 		{2, "sms"},
 		{3, "sms"},
 		{4, "mms"},
+		{5, ""},
+		{6, nil},
 	}
 	for _, r := range rows {
 		_, err := main.ExecContext(ctx,
@@ -576,6 +578,22 @@ func TestFusedSearch_MessageTypeFilter(t *testing.T) {
 		got[h.MessageID] = true
 	}
 	assert.Equal(t, map[int64]bool{2: true, 3: true}, got, "message_type=sms hits")
+
+	hits, _, err = b.FusedSearch(ctx, vector.FusedRequest{
+		FTSTerms:   []string{"topic"},
+		Generation: gid,
+		Filter:     vector.Filter{MessageTypes: []string{"email"}},
+		KPerSignal: 10,
+		Limit:      10,
+		RRFK:       60,
+	})
+	require.NoError(err, "FusedSearch legacy email")
+	got = make(map[int64]bool, len(hits))
+	for _, hit := range hits {
+		got[hit.MessageID] = true
+	}
+	assert.Equal(t, map[int64]bool{1: true, 5: true, 6: true}, got,
+		"message_type=email must include typed, legacy empty, and legacy NULL rows")
 }
 
 func TestFusedSearch_LegacySchemaWithoutMessageType(t *testing.T) {
@@ -611,12 +629,13 @@ func TestFusedSearch_LegacySchemaWithoutMessageType(t *testing.T) {
 	hits, _, err := b.FusedSearch(ctx, vector.FusedRequest{
 		FTSTerms:   []string{"topic"},
 		Generation: gid,
+		Filter:     vector.Filter{MessageTypes: []string{"email"}},
 		KPerSignal: 10,
 		Limit:      10,
 		RRFK:       60,
 	})
 	require.NoError(err, "FusedSearch")
-	require.Len(hits, 1, "legacy message should still be searchable")
+	require.Len(hits, 1, "legacy schema should be treated as email")
 	assert.Equal(t, int64(1), hits[0].MessageID, "legacy hit")
 }
 

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -701,7 +701,7 @@ type SearchMessagesQuery struct {
 	// Q Search query
 	Q string `json:"q" validate:"required"`
 
-	// Mode Search mode: fts, vector, or hybrid
+	// Mode Search mode: fts, vector, or hybrid. Structured filter parameters are supported only in vector and hybrid modes
 	Mode *string `json:"mode,omitempty"`
 
 	// Page One-based page number (default 1; values below 1 are clamped to 1). Non-numeric values are rejected with 400.
@@ -730,6 +730,36 @@ type SearchMessagesQuery struct {
 
 	// Collection Restrict to one collection
 	Collection *string `json:"collection,omitempty"`
+
+	// Sender Exact sender email/address filter (vector or hybrid mode only)
+	Sender *string `json:"sender,omitempty"`
+
+	// Recipient Exact recipient email filter across to, cc, and bcc (vector or hybrid mode only)
+	Recipient *string `json:"recipient,omitempty"`
+
+	// Domain Exact sender domain filter (vector or hybrid mode only)
+	Domain *string `json:"domain,omitempty"`
+
+	// Label Exact case-insensitive label filter (vector or hybrid mode only)
+	Label *string `json:"label,omitempty"`
+
+	// TimePeriod Calendar period in YYYY, YYYY-MM, or YYYY-MM-DD format (vector or hybrid mode only)
+	TimePeriod *string `json:"time_period,omitempty"`
+
+	// TimeGranularity Time bucket granularity (vector or hybrid mode only)
+	TimeGranularity *string `json:"time_granularity,omitempty"`
+
+	// SourceID Exact source ID (vector or hybrid mode only)
+	SourceID *int64 `json:"source_id,omitempty"`
+
+	// AttachmentsOnly Only include messages with attachments (vector or hybrid mode only)
+	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
+
+	// After Lower date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+	After *string `json:"after,omitempty"`
+
+	// Before Upper date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+	Before *string `json:"before,omitempty"`
 }
 
 func (s SearchMessagesQuery) Validate() error {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -7567,18 +7567,19 @@ func (s StageDeletionResponse) Validate() error {
 }
 
 type StatsResponse struct {
-	ActiveMessages        int64      `json:"active_messages"`
-	DatabaseSizeBytes     int64      `json:"database_size_bytes"`
-	SourceDeletedMessages int64      `json:"source_deleted_messages"`
-	TotalAccounts         int64      `json:"total_accounts"`
-	TotalAttachments      int64      `json:"total_attachments"`
-	TotalLabels           int64      `json:"total_labels"`
-	TotalMessages         int64      `json:"total_messages"`
-	TotalThreads          int64      `json:"total_threads"`
-	VectorSearch          *StatsView `json:"vector_search,omitempty"`
-	VectorStatus          *string    `json:"vector_status,omitempty"`
-	VectorTextStatus      *string    `json:"vector_text_status,omitempty"`
-	VectorVisualStatus    *string    `json:"vector_visual_status,omitempty"`
+	ActiveMessages         int64      `json:"active_messages"`
+	DatabaseSizeBytes      int64      `json:"database_size_bytes"`
+	SourceDeletedMessages  int64      `json:"source_deleted_messages"`
+	TotalAccounts          int64      `json:"total_accounts"`
+	TotalAttachments       int64      `json:"total_attachments"`
+	TotalLabels            int64      `json:"total_labels"`
+	TotalMessages          int64      `json:"total_messages"`
+	TotalThreads           int64      `json:"total_threads"`
+	VectorSearch           *StatsView `json:"vector_search,omitempty"`
+	VectorStatus           *string    `json:"vector_status,omitempty"`
+	VectorTextMessageTypes []string   `json:"vector_text_message_types,omitempty"`
+	VectorTextStatus       *string    `json:"vector_text_status,omitempty"`
+	VectorVisualStatus     *string    `json:"vector_visual_status,omitempty"`
 }
 
 func (s StatsResponse) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -7957,6 +7957,11 @@ components:
           $ref: "#/components/schemas/StatsView"
         vector_status:
           type: string
+        vector_text_message_types:
+          items:
+            type: string
+          nullable: true
+          type: array
         vector_text_status:
           type: string
         vector_visual_status:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -8846,7 +8846,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.6.0
+  version: 2.7.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -17246,7 +17246,7 @@ paths:
           required: true
           schema:
             type: string
-        - description: "Search mode: fts, vector, or hybrid"
+        - description: "Search mode: fts, vector, or hybrid. Structured filter parameters are supported only in vector and hybrid modes"
           in: query
           name: mode
           schema:
@@ -17297,6 +17297,57 @@ paths:
         - description: Restrict to one collection
           in: query
           name: collection
+          schema:
+            type: string
+        - description: Exact sender email/address filter (vector or hybrid mode only)
+          in: query
+          name: sender
+          schema:
+            type: string
+        - description: Exact recipient email filter across to, cc, and bcc (vector or hybrid mode only)
+          in: query
+          name: recipient
+          schema:
+            type: string
+        - description: Exact sender domain filter (vector or hybrid mode only)
+          in: query
+          name: domain
+          schema:
+            type: string
+        - description: Exact case-insensitive label filter (vector or hybrid mode only)
+          in: query
+          name: label
+          schema:
+            type: string
+        - description: Calendar period in YYYY, YYYY-MM, or YYYY-MM-DD format (vector or hybrid mode only)
+          in: query
+          name: time_period
+          schema:
+            type: string
+        - description: Time bucket granularity (vector or hybrid mode only)
+          in: query
+          name: time_granularity
+          schema:
+            type: string
+        - description: Exact source ID (vector or hybrid mode only)
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
+        - description: Only include messages with attachments (vector or hybrid mode only)
+          in: query
+          name: attachments_only
+          schema:
+            type: boolean
+        - description: Lower date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Upper date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only)
+          in: query
+          name: before
           schema:
             type: string
       responses:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -6224,6 +6224,7 @@ export interface components {
             total_threads: number;
             vector_search?: components["schemas"]["StatsView"];
             vector_status?: string;
+            vector_text_message_types?: string[] | null;
             vector_text_status?: string;
             vector_visual_status?: string;
         } & {

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -16220,7 +16220,7 @@ export interface operations {
             query: {
                 /** @description Search query */
                 q: string;
-                /** @description Search mode: fts, vector, or hybrid */
+                /** @description Search mode: fts, vector, or hybrid. Structured filter parameters are supported only in vector and hybrid modes */
                 mode?: string;
                 /** @description One-based page number (default 1; values below 1 are clamped to 1). Non-numeric values are rejected with 400. */
                 page?: number;
@@ -16240,6 +16240,26 @@ export interface operations {
                 account?: string;
                 /** @description Restrict to one collection */
                 collection?: string;
+                /** @description Exact sender email/address filter (vector or hybrid mode only) */
+                sender?: string;
+                /** @description Exact recipient email filter across to, cc, and bcc (vector or hybrid mode only) */
+                recipient?: string;
+                /** @description Exact sender domain filter (vector or hybrid mode only) */
+                domain?: string;
+                /** @description Exact case-insensitive label filter (vector or hybrid mode only) */
+                label?: string;
+                /** @description Calendar period in YYYY, YYYY-MM, or YYYY-MM-DD format (vector or hybrid mode only) */
+                time_period?: string;
+                /** @description Time bucket granularity (vector or hybrid mode only) */
+                time_granularity?: string;
+                /** @description Exact source ID (vector or hybrid mode only) */
+                source_id?: number;
+                /** @description Only include messages with attachments (vector or hybrid mode only) */
+                attachments_only?: boolean;
+                /** @description Lower date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only) */
+                after?: string;
+                /** @description Upper date/time bound (RFC3339 or YYYY-MM-DD; vector or hybrid mode only) */
+                before?: string;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## What changed

- Turn the message-detail attachment action into a browser with per-file download, safe system open, and selected zip export. Active, executable, macro-enabled, mismatched, and unknown local attachment types remain download-only; opened downloads receive Windows or macOS untrusted-file metadata first.
- Stream content-backed files through the daemon attachment reader, avoid overwrites, sanitize displayed names, and only hand HTTP(S) attachment URLs to the system opener.
- Add an active-message-only Semantic TUI search mode when vector search is enabled, preserving exact source, sender, recipient, domain, label, message-type, date, and attachment filters across ranked pagination on SQLite and PostgreSQL, including legacy email rows and schemas.
- Require the daemon's 2.7 structured-filter contract before exposing Semantic mode. The search API rejects invalid calendar periods and structured filters in FTS mode instead of silently broadening results. Keep Fast and Deep search behavior unchanged when semantic search is unavailable. No database schema or migration changes.

## Why

Message detail only supported bulk zip export, so opening one attachment required exporting an archive and finding the file outside msgvault. The TUI also could not use the existing hybrid message search to narrow a natural-language query to messages with attachment candidates. This makes the direct path available without changing attachment indexing.

## Usage

In message detail, press `e`, choose an attachment, then press `d` to download it or `o` to open it. Selection and `Enter` still export a zip. Unsafe or unknown attachment types can be downloaded but not opened from msgvault.

In an email message list, press `/` and use `Tab` to cycle Fast, Deep, and Semantic modes when vector search is enabled. Semantic mode covers active messages only. Use the existing attachment filter to keep semantic results to messages with attachments.

Closes #610
