### PR TITLE
Retrieve person files across metadata, documents, and visual search

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -269,6 +269,8 @@ components:
           type: integer
         mime_type:
           type: string
+        person_provenance:
+          $ref: "#/components/schemas/Provenance"
         rank:
           format: int64
           type: integer
@@ -2368,6 +2370,9 @@ components:
           type: integer
         containing_title:
           type: string
+        conversation_id:
+          format: int64
+          type: integer
         excerpt:
           type: string
         extraction_id:
@@ -2405,11 +2410,16 @@ components:
           type: string
         model:
           type: string
+        occurred_at:
+          format: date-time
+          type: string
         occurrence_key:
           type: string
         other_live_copies:
           format: int64
           type: integer
+        person_provenance:
+          $ref: "#/components/schemas/Provenance"
         profile_id:
           type: string
         provider:
@@ -2420,6 +2430,8 @@ components:
         source_id:
           format: int64
           type: integer
+        source_message_id:
+          type: string
         source_part_key:
           type: string
         truncated:
@@ -2427,6 +2439,7 @@ components:
       required:
         - attachment_id
         - message_id
+        - conversation_id
         - source_id
         - occurrence_key
         - canonical_blob_hash
@@ -7067,6 +7080,43 @@ components:
         - done
         - total
       type: object
+    Provenance:
+      additionalProperties: true
+      properties:
+        directions:
+          items:
+            enum:
+              - from_person
+              - to_person
+              - group
+            type: string
+          type:
+            - array
+            - "null"
+        participant_ids:
+          items:
+            format: int64
+            type: integer
+          type:
+            - array
+            - "null"
+        roles:
+          items:
+            enum:
+              - from
+              - to
+              - cc
+              - bcc
+              - conversation_member
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - participant_ids
+        - roles
+        - directions
+      type: object
     ProviderUsage:
       additionalProperties: true
       properties:
@@ -9219,6 +9269,12 @@ components:
           type: string
         cursor:
           type: string
+        directions:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
         filename:
           type: string
         limit:
@@ -9229,6 +9285,12 @@ components:
           type: integer
         mime_prefix:
           type: string
+        participant_id:
+          format: int64
+          type: integer
+        person_id:
+          format: int64
+          type: integer
         sender_person_id:
           format: int64
           type: integer
@@ -9247,7 +9309,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.4.0
+  version: 2.5.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -12069,6 +12131,35 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Durable person ID
+          in: query
+          name: person_id
+          schema:
+            format: int64
+            type: integer
+        - description: Observed participant ID; translated through its durable person when bound
+          in: query
+          name: participant_id
+          schema:
+            format: int64
+            type: integer
+        - description: Person relation; repeat or comma-separate from_person, to_person, or group
+          in: query
+          name: direction
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Only messages on or after an RFC3339 or YYYY-MM-DD date
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Only messages before an RFC3339 or YYYY-MM-DD date
+          in: query
+          name: before
+          schema:
+            type: string
         - description: Maximum results to return (default 20, max 100)
           in: query
           name: limit
@@ -12094,6 +12185,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error
         "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
           content:
             application/json:
               schema:
@@ -15203,7 +15300,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
         "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
           content:
             application/json:
               schema:
@@ -16137,6 +16246,73 @@ paths:
       summary: List a person's employment history
       tags:
         - API
+  /api/v1/people/{id}/files/search:
+    post:
+      operationId: searchPersonFiles
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersonFileSearchHTTPRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonFileSearchHTTPResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search one durable person's analytical files
+      tags:
+        - Exploration
   /api/v1/people/{id}/profile:
     get:
       description: Returns only current structured values at one person revision. Superseded values and archive observations are available from the separate history endpoint.
@@ -17589,6 +17765,14 @@ paths:
                   type: string
                 cursor:
                   type: string
+                direction:
+                  items:
+                    enum:
+                      - from_person
+                      - to_person
+                      - group
+                    type: string
+                  type: array
                 filename:
                   type: string
                 image:
@@ -17601,6 +17785,10 @@ paths:
                 message_id:
                   type: string
                 mime_prefix:
+                  type: string
+                participant_id:
+                  type: string
+                person_id:
                   type: string
                 sender_person_id:
                   type: string
@@ -17618,6 +17806,18 @@ paths:
                 $ref: "#/components/schemas/SearchResponse"
           description: OK
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
           content:
             application/json:
               schema:

--- a/cmd/msgvault/cmd/documents.go
+++ b/cmd/msgvault/cmd/documents.go
@@ -20,6 +20,8 @@ import (
 	"go.kenn.io/msgvault/internal/attachmentstore"
 	"go.kenn.io/msgvault/internal/documentindex"
 	"go.kenn.io/msgvault/internal/fileutil"
+	"go.kenn.io/msgvault/internal/personscope"
+	personresolver "go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -139,12 +141,45 @@ func newDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
 func newSearchDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
 	var request store.DocumentSearchRequest
 	var jsonOutput bool
+	var rawDirections []string
+	var afterValue, beforeValue string
 	command := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search extracted document attachments",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(command *cobra.Command, args []string) error {
 			request.Query = strings.Join(args, " ")
+			if command.Flags().Changed("person") && request.PersonID <= 0 {
+				return errors.New("--person must be a positive person ID")
+			}
+			if command.Flags().Changed("participant") && request.ParticipantID <= 0 {
+				return errors.New("--participant must be a positive participant ID")
+			}
+			if request.PersonID > 0 && request.ParticipantID > 0 {
+				return errors.New("--person and --participant are mutually exclusive")
+			}
+			if len(rawDirections) > 0 && request.PersonID == 0 && request.ParticipantID == 0 {
+				return errors.New("--direction requires --person or --participant")
+			}
+			request.Directions = make([]personscope.Direction, len(rawDirections))
+			for i, direction := range rawDirections {
+				request.Directions[i] = personscope.Direction(direction)
+			}
+			if len(request.Directions) > 0 {
+				if _, _, err := personresolver.NormalizeDirections(request.Directions); err != nil {
+					return err
+				}
+			}
+			var err error
+			if request.After, err = parseDocumentSearchDate(afterValue); err != nil {
+				return fmt.Errorf("invalid --after: %w", err)
+			}
+			if request.Before, err = parseDocumentSearchDate(beforeValue); err != nil {
+				return fmt.Errorf("invalid --before: %w", err)
+			}
+			if request.After != nil && request.Before != nil && !request.After.Before(*request.Before) {
+				return errors.New("--after must be before --before")
+			}
 			return runSearchDocuments(command, request, jsonOutput, deps)
 		},
 	}
@@ -152,10 +187,30 @@ func newSearchDocumentsCmd(deps documentsCommandDeps) *cobra.Command {
 	command.Flags().StringSliceVar(&request.MessageTypes, "message-type", nil, "Limit results to message types")
 	command.Flags().Int64Var(&request.AttachmentID, "attachment-id", 0, "Limit results to one attachment occurrence")
 	command.Flags().Int64Var(&request.MessageID, "message-id", 0, "Limit results to one containing message")
+	command.Flags().Int64Var(&request.PersonID, "person", 0, "Limit results to one durable person")
+	command.Flags().Int64Var(&request.ParticipantID, "participant", 0, "Limit results to one observed participant, translated through its durable person when bound")
+	command.Flags().StringSliceVar(&rawDirections, "direction", nil, "Person relation: from_person, to_person, or group")
+	command.Flags().StringVar(&afterValue, "after", "", "Only messages on or after YYYY-MM-DD or RFC3339")
+	command.Flags().StringVar(&beforeValue, "before", "", "Only messages before YYYY-MM-DD or RFC3339")
 	command.Flags().IntVarP(&request.PageSize, "limit", "n", 20, "Maximum results to return")
 	command.Flags().StringVar(&request.Cursor, "cursor", "", "Opaque cursor from the previous page")
 	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
 	return command
+}
+
+func parseDocumentSearchDate(value string) (*time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil //nolint:nilnil // An omitted optional date has no value and no error.
+	}
+	for _, layout := range []string{"2006-01-02", time.RFC3339} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			parsed = parsed.UTC()
+			return &parsed, nil
+		}
+	}
+	return nil, errors.New("must be YYYY-MM-DD or RFC3339")
 }
 
 func newProbeMistralCmd(deps documentsCommandDeps) *cobra.Command {
@@ -1009,6 +1064,23 @@ func (c localDocumentReadClient) SearchDocuments(
 	ctx context.Context,
 	request store.DocumentSearchRequest,
 ) (store.DocumentSearchResponse, error) {
+	if request.PersonID > 0 || request.ParticipantID > 0 {
+		reference := personresolver.Reference{Kind: personresolver.ReferencePerson, ID: request.PersonID}
+		if request.ParticipantID > 0 {
+			reference = personresolver.Reference{Kind: personresolver.ReferenceParticipant, ID: request.ParticipantID}
+		}
+		resolved, err := personresolver.Resolve(ctx, c.store, reference, request.Directions)
+		if err != nil {
+			if errors.Is(err, personresolver.ErrEmptyPopulation) {
+				return store.DocumentSearchResponse{}, fmt.Errorf(
+					"person %d has no linked identities; link participants first: %w",
+					reference.ID, err,
+				)
+			}
+			return store.DocumentSearchResponse{}, err
+		}
+		request.Person = &resolved.Scope
+	}
 	if err := reconcileDocumentOccurrencesForSearch(ctx, c.store); err != nil {
 		return store.DocumentSearchResponse{}, err
 	}

--- a/cmd/msgvault/cmd/documents_test.go
+++ b/cmd/msgvault/cmd/documents_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/documentindex"
 	internalmime "go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/scheduler"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
@@ -415,6 +416,10 @@ func TestDocumentsSearchUsesConfiguredReadClient(t *testing.T) {
 			request store.DocumentSearchRequest,
 		) (store.DocumentSearchResponse, error) {
 			assert.Equal("damage report", request.Query)
+			assert.Equal(int64(40), request.PersonID)
+			assert.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group}, request.Directions)
+			require.NotNil(t, request.After)
+			require.NotNil(t, request.Before)
 			return store.DocumentSearchResponse{Results: []store.DocumentSearchResult{{
 				AttachmentID: 3, MessageID: 4, Filename: "report.pdf", Rank: 1,
 			}}}, nil
@@ -432,11 +437,45 @@ func TestDocumentsSearchUsesConfiguredReadClient(t *testing.T) {
 	var output bytes.Buffer
 	command.SetOut(&output)
 	command.SetErr(&bytes.Buffer{})
-	command.SetArgs([]string{"search", "damage report", "--json"})
+	command.SetArgs([]string{"search", "damage report", "--person", "40",
+		"--direction", "from_person,group", "--after", "2026-08-01", "--before", "2026-08-20", "--json"})
 	require.NoError(t, command.ExecuteContext(t.Context()))
 	assert.False(openStoreCalled)
 	assert.True(cleanupCalled)
 	assert.Contains(output.String(), "report.pdf")
+}
+
+func TestDocumentsSearchRejectsNonPositivePersonScopeBeforeDispatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+	}{
+		{name: "zero person", flag: "--person", value: "0"},
+		{name: "negative person", flag: "--person", value: "-1"},
+		{name: "zero participant", flag: "--participant", value: "0"},
+		{name: "negative participant", flag: "--participant", value: "-1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatched := false
+			command := newDocumentsCmd(documentsCommandDeps{
+				openReadClient: func(context.Context) (documentReadClient, func(), error) {
+					dispatched = true
+					return nil, func() {}, errors.New("unexpected read client dispatch")
+				},
+			})
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs([]string{"search", "damage report", test.flag, test.value})
+
+			err := command.ExecuteContext(t.Context())
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "must be a positive")
+			assert.False(t, dispatched)
+		})
+	}
 }
 
 func TestDocumentsStatusUsesConfiguredReadClient(t *testing.T) {

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -13,6 +13,7 @@ import (
 	"go.kenn.io/msgvault/internal/deletion"
 	mcpserver "go.kenn.io/msgvault/internal/mcp"
 	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 var mcpForceSQL bool
@@ -80,12 +81,13 @@ Add to Claude Desktop config:
 
 func daemonMCPServeOptions(ctx context.Context, st *daemonclient.Client) (mcpserver.ServeOptions, error) {
 	opts := mcpserver.ServeOptions{
-		Engine:           daemonclient.NewEngineAdapter(st),
-		AttachmentsDir:   cfg.AttachmentsDir(),
-		AttachmentReader: st,
-		ManifestSaver:    daemonMCPManifestSaver{client: st},
-		DocumentSearcher: st,
-		DataDir:          cfg.Data.DataDir,
+		Engine:             daemonclient.NewEngineAdapter(st),
+		AttachmentsDir:     cfg.AttachmentsDir(),
+		AttachmentReader:   st,
+		ManifestSaver:      daemonMCPManifestSaver{client: st},
+		DocumentSearcher:   st,
+		PersonFileSearcher: daemonMCPPersonFileSearcher{client: st},
+		DataDir:            cfg.Data.DataDir,
 	}
 
 	vectorAvailable, err := st.VectorSearchAvailable(ctx)
@@ -114,12 +116,26 @@ func daemonMCPServeOptions(ctx context.Context, st *daemonclient.Client) (mcpser
 	return opts, nil
 }
 
+type daemonMCPPersonFileSearcher struct{ client *daemonclient.Client }
+
+func (s daemonMCPPersonFileSearcher) SearchPersonFiles(
+	ctx context.Context,
+	request mcpserver.PersonFileSearchRequest,
+) (generated.PersonFileSearchHTTPResponse, error) {
+	return s.client.SearchPersonFiles(ctx, daemonclient.PersonFileSearchOptions{
+		PersonID: request.PersonID, Directions: request.Directions,
+		After: request.After, Before: request.Before, Filename: request.Filename,
+		MIMEFamilies: request.MIMEFamilies, Limit: request.Limit, Cursor: request.Cursor,
+	})
+}
+
 type daemonMCPVisualSearcher struct{ client *daemonclient.Client }
 
 func (s daemonMCPVisualSearcher) SearchVisualAttachments(ctx context.Context, request mcpserver.VisualSearchRequest) (*visual.SearchResponse, error) {
 	return s.client.SearchVisualAttachmentsFiltered(ctx, daemonclient.VisualSearchOptions{
 		Text: request.Text, Image: request.Image, Limit: request.Limit, Cursor: request.Cursor,
 		SenderPersonID: request.SenderPersonID, SourceID: request.SourceID, MessageID: request.MessageID,
+		PersonID: request.PersonID, ParticipantID: request.ParticipantID, Directions: request.Directions,
 		Filename: request.Filename, MIMEPrefix: request.MIMEPrefix, After: request.After, Before: request.Before,
 	})
 }

--- a/cmd/msgvault/cmd/mcp_test.go
+++ b/cmd/msgvault/cmd/mcp_test.go
@@ -139,6 +139,7 @@ func TestDaemonMCPServeOptionsDisablesVectorToolsWhenDaemonVectorUnavailable(t *
 	assert.NotNil(opts.AttachmentReader, "attachment reader")
 	assert.NotNil(opts.ManifestSaver, "manifest saver")
 	assert.NotNil(opts.DocumentSearcher, "document searcher")
+	assert.NotNil(opts.PersonFileSearcher, "person file searcher")
 	assert.Nil(opts.HybridSearcher, "hybrid searcher")
 	assert.Nil(opts.SimilarSearcher, "similar searcher")
 }

--- a/cmd/msgvault/cmd/multimodal.go
+++ b/cmd/msgvault/cmd/multimodal.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/personscope"
+	personresolver "go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
@@ -22,6 +24,9 @@ var (
 	multimodalBuildYes        bool
 	multimodalStatusJSON      bool
 	multimodalSenderPersonID  int64
+	multimodalPersonID        int64
+	multimodalParticipantID   int64
+	multimodalDirections      []string
 	multimodalSearchAfter     string
 	multimodalSearchBefore    string
 	multimodalSearchCursor    string
@@ -53,8 +58,26 @@ var multimodalSearchCmd = &cobra.Command{
 		if multimodalSearchLimit < 1 || multimodalSearchLimit > 100 {
 			return usageErr(cmd, errors.New("--limit must be between 1 and 100"))
 		}
-		if multimodalSenderPersonID < 0 || multimodalSearchSourceID < 0 || multimodalSearchMessageID < 0 {
+		if multimodalSenderPersonID < 0 || multimodalPersonID < 0 || multimodalParticipantID < 0 || multimodalSearchSourceID < 0 || multimodalSearchMessageID < 0 {
 			return usageErr(cmd, errors.New("ID filters must be positive"))
+		}
+		if multimodalSenderPersonID > 0 && (multimodalPersonID > 0 || multimodalParticipantID > 0 || len(multimodalDirections) > 0) {
+			return usageErr(cmd, errors.New("--sender-person cannot be combined with --person, --participant, or --direction"))
+		}
+		if multimodalPersonID > 0 && multimodalParticipantID > 0 {
+			return usageErr(cmd, errors.New("--person and --participant are mutually exclusive"))
+		}
+		if len(multimodalDirections) > 0 && multimodalPersonID == 0 && multimodalParticipantID == 0 {
+			return usageErr(cmd, errors.New("--direction requires --person or --participant"))
+		}
+		directions := make([]personscope.Direction, len(multimodalDirections))
+		for i, direction := range multimodalDirections {
+			directions[i] = personscope.Direction(direction)
+		}
+		if len(directions) > 0 {
+			if _, _, err := personresolver.NormalizeDirections(directions); err != nil {
+				return usageErr(cmd, err)
+			}
 		}
 		var image []byte
 		if multimodalSearchImage != "" {
@@ -104,6 +127,7 @@ var multimodalSearchCmd = &cobra.Command{
 		response, err := client.SearchVisualAttachmentsFiltered(cmd.Context(), daemonclient.VisualSearchOptions{
 			Text: text, Image: image, Limit: multimodalSearchLimit, Cursor: multimodalSearchCursor,
 			SenderPersonID: multimodalSenderPersonID, SourceID: multimodalSearchSourceID,
+			PersonID: multimodalPersonID, ParticipantID: multimodalParticipantID, Directions: directions,
 			MessageID: multimodalSearchMessageID, Filename: multimodalSearchFilename,
 			MIMEPrefix: multimodalSearchMIME, After: after, Before: before,
 		})
@@ -250,6 +274,9 @@ func init() {
 	multimodalSearchCmd.Flags().IntVar(&multimodalSearchLimit, "limit", 20, "Maximum results")
 	multimodalSearchCmd.Flags().BoolVar(&multimodalSearchJSON, "json", false, "Output JSON")
 	multimodalSearchCmd.Flags().Int64Var(&multimodalSenderPersonID, "sender-person", 0, "Only attachments sent by this person ID")
+	multimodalSearchCmd.Flags().Int64Var(&multimodalPersonID, "person", 0, "Only attachments related to this durable person ID")
+	multimodalSearchCmd.Flags().Int64Var(&multimodalParticipantID, "participant", 0, "Only attachments related to this observed participant")
+	multimodalSearchCmd.Flags().StringSliceVar(&multimodalDirections, "direction", nil, "Person relation: from_person, to_person, or group")
 	multimodalSearchCmd.Flags().StringVar(&multimodalSearchAfter, "after", "", "Only messages on or after YYYY-MM-DD")
 	multimodalSearchCmd.Flags().StringVar(&multimodalSearchBefore, "before", "", "Only messages before YYYY-MM-DD")
 	multimodalSearchCmd.Flags().StringVar(&multimodalSearchCursor, "cursor", "", "Continue from an opaque search cursor")

--- a/cmd/msgvault/cmd/person.go
+++ b/cmd/msgvault/cmd/person.go
@@ -252,7 +252,8 @@ func init() {
 	rootCmd.AddCommand(personCmd)
 	personCmd.AddCommand(newPersonProviderCommand(defaultPersonProviderCommandDeps()))
 	personCmd.AddCommand(personPromoteCmd, personGetCmd, personListCmd,
-		personSetDisplayNameCmd, personDeleteCmd, personTrackCmd, personUntrackCmd)
+		personSetDisplayNameCmd, personDeleteCmd, personTrackCmd, personUntrackCmd,
+		newPersonFilesCommand(defaultPersonFilesCommandDeps()))
 	for _, command := range []*cobra.Command{
 		personPromoteCmd, personGetCmd, personListCmd, personSetDisplayNameCmd,
 		personTrackCmd, personUntrackCmd,

--- a/cmd/msgvault/cmd/person_files.go
+++ b/cmd/msgvault/cmd/person_files.go
@@ -1,0 +1,326 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/personscope"
+	personresolver "go.kenn.io/msgvault/internal/personscope/resolver"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+const (
+	personFilesLaneMetadata  = "metadata"
+	personFilesLaneDocuments = "documents"
+	personFilesLaneVisual    = "visual"
+	personFilesLaneAll       = "all"
+)
+
+type personFilesClient interface {
+	SearchPersonFiles(ctx context.Context, options daemonclient.PersonFileSearchOptions) (generated.PersonFileSearchHTTPResponse, error)
+	SearchDocuments(ctx context.Context, request store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
+	SearchVisualAttachmentsFiltered(ctx context.Context, options daemonclient.VisualSearchOptions) (*visual.SearchResponse, error)
+}
+
+type personFilesCommandDeps struct {
+	openClient func(context.Context) (personFilesClient, func(), error)
+}
+
+type personFilesLaneStatus struct {
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type personFilesOutput struct {
+	PersonID      int64                                   `json:"person_id"`
+	RequestedLane string                                  `json:"requested_lane"`
+	Availability  map[string]personFilesLaneStatus        `json:"availability"`
+	Metadata      *generated.PersonFileSearchHTTPResponse `json:"metadata,omitempty"`
+	Documents     *store.DocumentSearchResponse           `json:"documents,omitempty"`
+	Visual        *visual.SearchResponse                  `json:"visual,omitempty"`
+}
+
+func defaultPersonFilesCommandDeps() personFilesCommandDeps {
+	return personFilesCommandDeps{openClient: func(ctx context.Context) (personFilesClient, func(), error) {
+		client, _, err := OpenHTTPStore(ctx)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return client, func() { _ = client.Close() }, nil
+	}}
+}
+
+func newPersonFilesCommand(deps personFilesCommandDeps) *cobra.Command {
+	var lane, queryText, filename, afterValue, beforeValue, cursor string
+	var rawDirections, rawMIMEFamilies []string
+	var limit int
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "files <person-id>",
+		Short: "Retrieve files related to one durable person",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(command *cobra.Command, args []string) error {
+			personID, err := positivePersonCLIArg(command, args[0], personValue)
+			if err != nil {
+				return err
+			}
+			lane = strings.ToLower(strings.TrimSpace(lane))
+			switch lane {
+			case personFilesLaneMetadata, personFilesLaneDocuments, personFilesLaneVisual, personFilesLaneAll:
+			default:
+				return usageErr(command, errors.New("--lane must be metadata, documents, visual, or all"))
+			}
+			if limit < 1 || limit > 100 {
+				return usageErr(command, errors.New("--limit must be between 1 and 100"))
+			}
+			queryText = strings.TrimSpace(queryText)
+			filename = strings.TrimSpace(filename)
+			if lane != personFilesLaneMetadata && queryText == "" {
+				return usageErr(command, errors.New("--query is required for documents, visual, and all lanes"))
+			}
+			if lane == personFilesLaneMetadata && queryText != "" {
+				return usageErr(command, errors.New("--query requires the documents, visual, or all lane"))
+			}
+			if lane == personFilesLaneAll && cursor != "" {
+				return usageErr(command, errors.New("--cursor requires one lane because lane cursors are independent"))
+			}
+			directions := make([]personscope.Direction, len(rawDirections))
+			for i, raw := range rawDirections {
+				directions[i] = personscope.Direction(raw)
+			}
+			if len(directions) > 0 {
+				directions, _, err = personresolver.NormalizeDirections(directions)
+				if err != nil {
+					return usageErr(command, err)
+				}
+			}
+			mimeFamilies, err := parsePersonFileMIMEFamilies(rawMIMEFamilies)
+			if err != nil {
+				return usageErr(command, err)
+			}
+			after, err := parseDocumentSearchDate(afterValue)
+			if err != nil {
+				return usageErr(command, fmt.Errorf("invalid --after: %w", err))
+			}
+			before, err := parseDocumentSearchDate(beforeValue)
+			if err != nil {
+				return usageErr(command, fmt.Errorf("invalid --before: %w", err))
+			}
+			if after != nil && before != nil && !after.Before(*before) {
+				return usageErr(command, errors.New("--after must be before --before"))
+			}
+
+			client, cleanup, err := deps.openClient(command.Context())
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			output := personFilesOutput{
+				PersonID: personID, RequestedLane: lane,
+				Availability: make(map[string]personFilesLaneStatus, 3),
+			}
+			metadataRequest := daemonclient.PersonFileSearchOptions{
+				PersonID: personID, Directions: directions, After: after, Before: before,
+				Filename: filename, MIMEFamilies: mimeFamilies,
+				Limit: limit, Cursor: cursor,
+			}
+			if lane == personFilesLaneMetadata || lane == personFilesLaneAll {
+				metadata, metadataErr := client.SearchPersonFiles(command.Context(), metadataRequest)
+				if metadataErr != nil {
+					return metadataErr
+				}
+				output.Metadata = &metadata
+				status := personFilesLaneStatus{Available: true}
+				if lane == personFilesLaneAll {
+					status.Reason = "semantic query is not applied to authoritative metadata"
+				}
+				output.Availability[personFilesLaneMetadata] = status
+			}
+
+			documentUnsupported := ""
+			if filename != "" || len(mimeFamilies) > 0 {
+				documentUnsupported = "document lane cannot apply exact filename or MIME-family filters"
+			}
+			if lane == personFilesLaneDocuments || lane == personFilesLaneAll {
+				if documentUnsupported != "" {
+					if lane == personFilesLaneDocuments {
+						return usageErr(command, errors.New(documentUnsupported))
+					}
+					output.Availability[personFilesLaneDocuments] = personFilesLaneStatus{Reason: documentUnsupported}
+				} else {
+					documents, documentErr := client.SearchDocuments(command.Context(), store.DocumentSearchRequest{
+						Query: queryText, PersonID: personID, Directions: directions,
+						After: after, Before: before, PageSize: limit, Cursor: cursor,
+					})
+					if documentErr != nil {
+						if lane == personFilesLaneDocuments {
+							return documentErr
+						}
+						output.Availability[personFilesLaneDocuments] = personFilesLaneStatus{Reason: documentErr.Error()}
+					} else {
+						output.Documents = &documents
+						output.Availability[personFilesLaneDocuments] = personFilesLaneStatus{Available: true}
+					}
+				}
+			}
+
+			if lane == personFilesLaneVisual || lane == personFilesLaneAll {
+				mimePrefix, mimeErr := personFilesVisualMIMEPrefix(mimeFamilies)
+				if mimeErr != nil {
+					if lane == personFilesLaneVisual {
+						return usageErr(command, mimeErr)
+					}
+					output.Availability[personFilesLaneVisual] = personFilesLaneStatus{Reason: mimeErr.Error()}
+				} else {
+					visualResult, visualErr := client.SearchVisualAttachmentsFiltered(command.Context(), daemonclient.VisualSearchOptions{
+						Text: queryText, Limit: limit, Cursor: cursor, PersonID: personID,
+						Directions: directions, Filename: filename, MIMEPrefix: mimePrefix,
+						After: after, Before: before,
+					})
+					if visualErr != nil {
+						if lane == personFilesLaneVisual {
+							return visualErr
+						}
+						output.Availability[personFilesLaneVisual] = personFilesLaneStatus{Reason: visualErr.Error()}
+					} else {
+						output.Visual = visualResult
+						output.Availability[personFilesLaneVisual] = personFilesLaneStatus{Available: true}
+					}
+				}
+			}
+			if jsonOutput {
+				return json.NewEncoder(command.OutOrStdout()).Encode(output)
+			}
+			return writePersonFilesOutput(command, output)
+		},
+	}
+	command.Flags().StringSliceVar(&rawDirections, "direction", nil, "Person relation: from_person, to_person, or group")
+	command.Flags().StringVar(&afterValue, "after", "", "Only messages on or after YYYY-MM-DD or RFC3339")
+	command.Flags().StringVar(&beforeValue, "before", "", "Only messages before YYYY-MM-DD or RFC3339")
+	command.Flags().StringSliceVar(&rawMIMEFamilies, "mime-family", nil, "Stable MIME family (repeatable)")
+	command.Flags().StringVar(&filename, "filename", "", "Case-insensitive filename substring")
+	command.Flags().StringVar(&lane, "lane", personFilesLaneMetadata, "Retrieval lane: metadata, documents, visual, or all")
+	command.Flags().StringVar(&queryText, "query", "", "Semantic query required by documents, visual, and all lanes")
+	command.Flags().IntVarP(&limit, "limit", "n", 100, "Maximum results per lane")
+	command.Flags().StringVar(&cursor, "cursor", "", "Opaque cursor for one selected lane")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured grouped JSON")
+	return command
+}
+
+func parsePersonFileMIMEFamilies(raw []string) ([]query.FileMIMEFamily, error) {
+	allowed := map[query.FileMIMEFamily]bool{
+		query.FileMIMEImage: true, query.FileMIMEPDF: true, query.FileMIMEAudio: true,
+		query.FileMIMEVideo: true, query.FileMIMEText: true, query.FileMIMEDocument: true,
+		query.FileMIMEArchive: true, query.FileMIMEOther: true,
+	}
+	result := make([]query.FileMIMEFamily, 0, len(raw))
+	seen := make(map[query.FileMIMEFamily]bool, len(raw))
+	for _, value := range raw {
+		family := query.FileMIMEFamily(strings.ToLower(strings.TrimSpace(value)))
+		if !allowed[family] {
+			return nil, fmt.Errorf("unknown MIME family %q", value)
+		}
+		if !seen[family] {
+			seen[family] = true
+			result = append(result, family)
+		}
+	}
+	return result, nil
+}
+
+func personFilesVisualMIMEPrefix(families []query.FileMIMEFamily) (string, error) {
+	if len(families) == 0 {
+		return "", nil
+	}
+	if len(families) > 1 {
+		return "", errors.New("visual lane accepts at most one exactly mappable MIME family")
+	}
+	switch families[0] {
+	case query.FileMIMEImage:
+		return "image/", nil
+	case query.FileMIMEVideo:
+		return "video/", nil
+	default:
+		return "", fmt.Errorf("visual lane cannot exactly map MIME family %q", families[0])
+	}
+}
+
+func writePersonFilesOutput(command *cobra.Command, output personFilesOutput) error {
+	w := tabwriter.NewWriter(command.OutOrStdout(), 0, 0, 2, ' ', 0)
+	for _, lane := range []string{personFilesLaneMetadata, personFilesLaneDocuments, personFilesLaneVisual} {
+		status, selected := output.Availability[lane]
+		if !selected {
+			continue
+		}
+		state := "available"
+		if !status.Available {
+			state = "unavailable: " + status.Reason
+		} else if status.Reason != "" {
+			state += ": " + status.Reason
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", strings.ToUpper(lane), state)
+	}
+	_, _ = fmt.Fprintln(w, "LANE\tRANK\tATTACHMENT\tMESSAGE\tCONVERSATION\tSOURCE\tENTRY\tSOURCE-MESSAGE\tDATE\tFILE\tPARTICIPANTS\tROLES\tDIRECTIONS\tMATCH")
+	if output.Metadata != nil {
+		for i, result := range output.Metadata.Files {
+			_, _ = fmt.Fprintf(w, "metadata\t%d\t%d\t%d\t%d\t%d\t%s\t-\t%s\t%s\t%v\t%v\t%v\t-\n",
+				i+1, result.ID, result.MessageID, result.ConversationID, result.SourceID, result.EntryKey,
+				personFilesTimestamp(&result.OccurredAt), pointerString(result.Filename),
+				result.PersonProvenance.ParticipantIds, result.PersonProvenance.Roles,
+				result.PersonProvenance.Directions)
+		}
+	}
+	if output.Documents != nil {
+		for _, result := range output.Documents.Results {
+			participants, roles, directions := personProvenanceColumns(result.PersonProvenance)
+			_, _ = fmt.Fprintf(w, "documents\t%d\t%d\t%d\t%d\t%d\t-\t%s\t%s\t%s\t%v\t%v\t%v\t%s\n",
+				result.Rank, result.AttachmentID, result.MessageID, result.ConversationID, result.SourceID,
+				result.SourceMessageID, personFilesTimestamp(result.OccurredAt), result.Filename,
+				participants, roles, directions, strings.Join(strings.Fields(result.Excerpt), " "))
+		}
+	}
+	if output.Visual != nil {
+		for _, result := range output.Visual.Results {
+			participants, roles, directions := personProvenanceColumns(result.PersonProvenance)
+			_, _ = fmt.Fprintf(w, "visual\t%d\t%d\t%d\t%d\t%d\t-\t%s\t%s\t%s\t%v\t%v\t%v\t%.4f\n",
+				result.Rank, result.AttachmentID, result.MessageID, result.ConversationID, result.SourceID,
+				result.SourceMessageID, personFilesTimestamp(&result.SentAt), result.Filename,
+				participants, roles, directions, result.Score)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flush person files output: %w", err)
+	}
+	return nil
+}
+
+func personFilesTimestamp(value *time.Time) string {
+	if value == nil || value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func personProvenanceColumns(provenance *personscope.Provenance) ([]int64, []personscope.Role, []personscope.Direction) {
+	if provenance == nil {
+		return nil, nil, nil
+	}
+	return provenance.ParticipantIDs, provenance.Roles, provenance.Directions
+}
+
+func pointerString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/cmd/msgvault/cmd/person_files_test.go
+++ b/cmd/msgvault/cmd/person_files_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+type fakePersonFilesClient struct {
+	metadataRequest daemonclient.PersonFileSearchOptions
+	documentRequest store.DocumentSearchRequest
+	visualRequest   daemonclient.VisualSearchOptions
+	metadata        generated.PersonFileSearchHTTPResponse
+	documents       store.DocumentSearchResponse
+	visual          *visual.SearchResponse
+	documentErr     error
+	visualErr       error
+}
+
+func (f *fakePersonFilesClient) SearchPersonFiles(_ context.Context, request daemonclient.PersonFileSearchOptions) (generated.PersonFileSearchHTTPResponse, error) {
+	f.metadataRequest = request
+	return f.metadata, nil
+}
+
+func (f *fakePersonFilesClient) SearchDocuments(_ context.Context, request store.DocumentSearchRequest) (store.DocumentSearchResponse, error) {
+	f.documentRequest = request
+	return f.documents, f.documentErr
+}
+
+func (f *fakePersonFilesClient) SearchVisualAttachmentsFiltered(_ context.Context, request daemonclient.VisualSearchOptions) (*visual.SearchResponse, error) {
+	f.visualRequest = request
+	return f.visual, f.visualErr
+}
+
+func TestPersonFilesDefaultsToMetadataAndForwardsStableFilters(t *testing.T) {
+	assert := assert.New(t)
+	client := &fakePersonFilesClient{metadata: generated.PersonFileSearchHTTPResponse{Files: []generated.PersonFileSearchRow{}}}
+	command := newPersonFilesCommand(personFilesCommandDeps{openClient: func(context.Context) (personFilesClient, func(), error) {
+		return client, func() {}, nil
+	}})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"40", "--direction", "from_person,group", "--after", "2026-08-01",
+		"--before", "2026-08-20", "--filename", "inspection", "--mime-family", "image,pdf", "--limit", "25", "--json"})
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.Equal(int64(40), client.metadataRequest.PersonID)
+	assert.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group}, client.metadataRequest.Directions)
+	assert.Equal([]query.FileMIMEFamily{query.FileMIMEImage, query.FileMIMEPDF}, client.metadataRequest.MIMEFamilies)
+	assert.Equal("inspection", client.metadataRequest.Filename)
+	assert.Equal(25, client.metadataRequest.Limit)
+	assert.Contains(output.String(), `"metadata":{"available":true}`)
+}
+
+func TestPersonFilesAllReportsUnavailableOptionalLanes(t *testing.T) {
+	assert := assert.New(t)
+	client := &fakePersonFilesClient{
+		metadata:    generated.PersonFileSearchHTTPResponse{Files: []generated.PersonFileSearchRow{}},
+		documentErr: errors.New("document search is not configured"),
+		visual:      &visual.SearchResponse{Results: []visual.AttachmentSearchResult{}},
+	}
+	command := newPersonFilesCommand(personFilesCommandDeps{openClient: func(context.Context) (personFilesClient, func(), error) {
+		return client, func() {}, nil
+	}})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"40", "--lane", "all", "--query", "inspection diagram", "--json"})
+	require.NoError(t, command.ExecuteContext(t.Context()))
+	assert.Equal(int64(40), client.documentRequest.PersonID)
+	assert.Equal(int64(40), client.visualRequest.PersonID)
+	assert.Contains(output.String(), `"documents":{"available":false`)
+	assert.Contains(output.String(), `"visual":{"available":true}`)
+	assert.Contains(output.String(), `"metadata":{"available":true,"reason":"semantic query is not applied to authoritative metadata"}`)
+}
+
+func TestPersonFilesRejectsSemanticQueryForMetadataLane(t *testing.T) {
+	command := newPersonFilesCommand(personFilesCommandDeps{openClient: func(context.Context) (personFilesClient, func(), error) {
+		require.Fail(t, "lane validation must happen before opening the daemon")
+		return nil, func() {}, nil
+	}})
+	command.SetArgs([]string{"40", "--query", "diagram"})
+
+	err := command.ExecuteContext(t.Context())
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--query requires")
+}
+
+func TestPersonFilesRejectsSharedCursorForAllLanes(t *testing.T) {
+	command := newPersonFilesCommand(personFilesCommandDeps{openClient: func(context.Context) (personFilesClient, func(), error) {
+		require.Fail(t, "cursor validation must happen before opening the daemon")
+		return nil, func() {}, nil
+	}})
+	command.SetArgs([]string{"40", "--lane", "all", "--query", "diagram", "--cursor", "opaque"})
+	err := command.ExecuteContext(t.Context())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cursor")
+}
+
+func TestPersonFilesTextOutputKeepsEveryLaneAligned(t *testing.T) {
+	assert := assert.New(t)
+	filename, mimeType := "inspection.png", "image/png"
+	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	provenance := &personscope.Provenance{
+		ParticipantIDs: []int64{4}, Roles: []personscope.Role{personscope.RoleFrom},
+		Directions: []personscope.Direction{personscope.FromPerson},
+	}
+	command := &cobra.Command{}
+	var output bytes.Buffer
+	command.SetOut(&output)
+	record := personFilesOutput{
+		Availability: map[string]personFilesLaneStatus{
+			personFilesLaneMetadata:  {Available: true},
+			personFilesLaneDocuments: {Available: true},
+			personFilesLaneVisual:    {Available: true},
+		},
+		Metadata: &generated.PersonFileSearchHTTPResponse{Files: []generated.PersonFileSearchRow{{
+			ID: 11, MessageID: 12, ConversationID: 13, SourceID: 14, EntryKey: "entry-11",
+			OccurredAt: now, Filename: &filename, MimeType: &mimeType,
+			PersonProvenance: generated.PersonFileProvenance{
+				ParticipantIds: []int64{4}, Roles: []generated.PersonFileProvenanceRoles{generated.From},
+				Directions: []generated.PersonFileProvenanceDirections{generated.FromPerson},
+			},
+		}}},
+		Documents: &store.DocumentSearchResponse{Results: []store.DocumentSearchResult{{
+			Rank: 1, AttachmentID: 21, MessageID: 22, ConversationID: 23, SourceID: 24,
+			SourceMessageID: "source-22", OccurredAt: &now, Filename: "inspection.pdf",
+			Excerpt: "matching", PersonProvenance: provenance,
+		}}},
+		Visual: &visual.SearchResponse{Results: []visual.AttachmentSearchResult{{
+			Rank: 1, AttachmentID: 31, MessageID: 32, ConversationID: 33, SourceID: 34,
+			SourceMessageID: "source-32", SentAt: now, Filename: "inspection.png",
+			Score: 0.9, PersonProvenance: provenance,
+		}}},
+	}
+
+	require.NoError(t, writePersonFilesOutput(command, record))
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	var headerFields int
+	rows := 0
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if fields[0] == "LANE" {
+			headerFields = len(fields)
+			continue
+		}
+		if fields[0] == personFilesLaneMetadata || fields[0] == personFilesLaneDocuments || fields[0] == personFilesLaneVisual {
+			if len(fields) > 1 && (fields[1] == "available" || fields[1] == "unavailable:") {
+				continue
+			}
+			assert.Len(fields, headerFields, "row: %s", line)
+			rows++
+		}
+	}
+	assert.Equal(14, headerFields)
+	assert.Equal(3, rows)
+}

--- a/internal/api/document_search.go
+++ b/internal/api/document_search.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -59,7 +61,7 @@ func (s *Server) registerDocumentSearchRoute(api huma.API) {
 		"Search extracted document attachments",
 		s.documentSearchGuard("document search", s.handleDocumentSearch),
 		http.StatusBadRequest, http.StatusForbidden, http.StatusConflict,
-		http.StatusTooManyRequests, http.StatusServiceUnavailable,
+		http.StatusNotFound, http.StatusTooManyRequests, http.StatusServiceUnavailable,
 	)
 	registerAPIV1RawHumaJSONRouteWithErrors[store.DocumentIndexStatusResponse](
 		api, "getDocumentIndexStatus", http.MethodGet, "/documents/status",
@@ -175,6 +177,18 @@ func (s *Server) handleDocumentSearch(w http.ResponseWriter, r *http.Request) {
 		s.rejectBadParam(w, err)
 		return
 	}
+	if request.PersonID > 0 || request.ParticipantID > 0 {
+		reference := resolver.Reference{Kind: resolver.ReferencePerson, ID: request.PersonID}
+		if request.ParticipantID > 0 {
+			reference = resolver.Reference{Kind: resolver.ReferenceParticipant, ID: request.ParticipantID}
+		}
+		resolved, resolveErr := resolver.Resolve(r.Context(), s.store, reference, request.Directions)
+		if resolveErr != nil {
+			s.writePersonScopeError(w, reference, resolveErr, "document")
+			return
+		}
+		request.Person = &resolved.Scope
+	}
 	response, err := searcher.SearchDocuments(r.Context(), request)
 	if err != nil {
 		s.writeDocumentSearchError(w, err)
@@ -226,6 +240,47 @@ func parseDocumentSearchRequest(r *http.Request) (store.DocumentSearchRequest, e
 	}
 	if request.MessageID, _, err = queryInt64(r, "message_id"); err != nil {
 		return request, err
+	}
+	var personPresent bool
+	if request.PersonID, personPresent, err = queryInt64(r, "person_id"); err != nil {
+		return request, err
+	}
+	if personPresent && request.PersonID <= 0 {
+		return request, errors.New("person_id must be a positive integer")
+	}
+	var participantPresent bool
+	if request.ParticipantID, participantPresent, err = queryInt64(r, "participant_id"); err != nil {
+		return request, err
+	}
+	if participantPresent && request.ParticipantID <= 0 {
+		return request, errors.New("participant_id must be a positive integer")
+	}
+	if request.PersonID > 0 && request.ParticipantID > 0 {
+		return request, errors.New("person_id and participant_id are mutually exclusive")
+	}
+	for _, raw := range r.URL.Query()["direction"] {
+		for value := range strings.SplitSeq(raw, ",") {
+			request.Directions = append(request.Directions, personscope.Direction(strings.TrimSpace(value)))
+		}
+	}
+	if len(request.Directions) > 0 && request.PersonID == 0 && request.ParticipantID == 0 {
+		return request, errors.New("direction requires person_id or participant_id")
+	}
+	if _, _, err = resolver.NormalizeDirections(request.Directions); err != nil {
+		return request, err
+	}
+	if value, ok, dateErr := queryDate(r, "after"); dateErr != nil {
+		return request, dateErr
+	} else if ok {
+		request.After = &value
+	}
+	if value, ok, dateErr := queryDate(r, "before"); dateErr != nil {
+		return request, dateErr
+	} else if ok {
+		request.Before = &value
+	}
+	if request.After != nil && request.Before != nil && !request.After.Before(*request.Before) {
+		return request, errors.New("after must be before before")
 	}
 	return request, nil
 }

--- a/internal/api/document_search_test.go
+++ b/internal/api/document_search_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
@@ -50,6 +51,33 @@ func TestDocumentSearchHTTPPreservesDedicatedContract(t *testing.T) {
 	require.Len(t, body.Results, 1)
 	assert.Equal("damage-photo.docx", body.Results[0].Filename)
 	assert.Equal("next", body.NextCursor)
+}
+
+func TestDocumentSearchHTTPResolvesDurablePersonScope(t *testing.T) {
+	assertions := assert.New(t)
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.personContextFunc = func(_ context.Context, id int64) (*store.Person, error) {
+		assertions.Equal(int64(40), id)
+		return &store.Person{ID: id, ParticipantIDs: []int64{4, 9}}, nil
+	}
+	catalog.documentSearchFunc = func(
+		_ context.Context,
+		request store.DocumentSearchRequest,
+	) (store.DocumentSearchResponse, error) {
+		require.NotNil(t, request.Person)
+		assertions.Equal([]int64{4, 9}, request.Person.ParticipantIDs)
+		assertions.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group}, request.Person.Directions)
+		require.NotNil(t, request.After)
+		require.NotNil(t, request.Before)
+		assertions.Equal("2026-08-01", request.After.Format("2006-01-02"))
+		assertions.Equal("2026-08-20", request.Before.Format("2006-01-02"))
+		return store.DocumentSearchResponse{}, nil
+	}
+	request := httptest.NewRequest(http.MethodGet,
+		"/api/v1/documents/search?q=inspection&person_id=40&direction=from_person,group&after=2026-08-01&before=2026-08-20", nil)
+	response := httptest.NewRecorder()
+	server.Router().ServeHTTP(response, request)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
 }
 
 func TestDocumentSearchHTTPMapsCursorRevisionConflict(t *testing.T) {
@@ -202,7 +230,7 @@ func TestOpenAPIDocumentSearchParameters(t *testing.T) {
 		names = append(names, parameter.Name)
 	}
 	assert.ElementsMatch(t,
-		[]string{"q", "source_id", "message_type", "attachment_id", "message_id", "limit", "cursor"},
+		[]string{"q", "source_id", "message_type", "attachment_id", "message_id", "person_id", "participant_id", "direction", "after", "before", "limit", "cursor"},
 		names)
 }
 

--- a/internal/api/files.go
+++ b/internal/api/files.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector/visual"
@@ -181,9 +182,10 @@ func (s *Server) registerFilesRoutes(api huma.API) {
 	registerExploreRoute[FileSearchHTTPRequest, FileSearchHTTPResponse](
 		api, "searchFiles", "/files/search", "Search analytical files", s.handleSearchFiles,
 	)
-	registerExploreRoute[PersonFileSearchHTTPRequest, PersonFileSearchHTTPResponse](
-		api, "searchParticipantFiles", "/participants/{id}/files/search", "Search one participant cluster's analytical files", s.handleSearchParticipantFiles,
-	)
+	registerPersonFileRoute(api, "searchParticipantFiles", "/participants/{id}/files/search",
+		"Search one participant cluster's analytical files", "", s.handleSearchParticipantFiles)
+	registerPersonFileRoute(api, "searchPersonFiles", "/people/{id}/files/search",
+		"Search one durable person's analytical files", "Durable person ID", s.handleSearchPersonFiles)
 	registerExploreRoute[FileSearchHTTPRequest, FileSearchHTTPResponse](
 		api, "searchDomainFiles", "/domains/{domain}/files/search", "Search one domain's analytical files", s.handleSearchDomainFiles,
 	)
@@ -193,6 +195,27 @@ func (s *Server) registerFilesRoutes(api huma.API) {
 	registerAPIV1RawHumaJSONRoute[FileMetadataResponse](
 		api, "getFile", http.MethodGet, "/files/{id}", "Get authoritative file metadata", s.handleGetFile,
 	)
+}
+
+func registerPersonFileRoute(
+	api huma.API,
+	operationID, path, summary, idDescription string,
+	handler http.HandlerFunc,
+) {
+	op := rawAPIV1Operation(operationID, http.MethodPost, path, summary)
+	op.Tags = []string{"Exploration"}
+	if idDescription != "" {
+		op.Parameters = append(op.Parameters, &huma.Param{
+			Name: "id", In: "path", Required: true, Description: idDescription,
+			Schema: &huma.Schema{Type: huma.TypeInteger, Format: formatInt64},
+		})
+	}
+	op.RequestBody = jsonRequestBodyFor[PersonFileSearchHTTPRequest](api)
+	op.Responses = jsonResponsesFor[PersonFileSearchHTTPResponse](api)
+	addErrorResponses(api, op.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusUnprocessableEntity, http.StatusServiceUnavailable)
+	op.Responses[httpStatusKey(http.StatusServiceUnavailable)] = exploreUnavailableResponseFor(api)
+	registerRawHumaRoute(api, op, handler)
 }
 
 func (s *Server) handleGroupFiles(w http.ResponseWriter, r *http.Request) {
@@ -314,33 +337,48 @@ func (s *Server) handleSearchParticipantFiles(w http.ResponseWriter, r *http.Req
 	if !ok {
 		return
 	}
+	s.handleSearchPersonFilesReference(w, r, resolver.Reference{
+		Kind: resolver.ReferenceParticipant, ID: id,
+	})
+}
+
+func (s *Server) handleSearchPersonFiles(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v1/people/"), "/files/search")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id < 1 {
+		writeError(w, http.StatusBadRequest, "invalid_person_id", "person ID must be a positive integer")
+		return
+	}
+	s.handleSearchPersonFilesReference(w, r, resolver.Reference{
+		Kind: resolver.ReferencePerson, ID: id,
+	})
+}
+
+func (s *Server) handleSearchPersonFilesReference(
+	w http.ResponseWriter,
+	r *http.Request,
+	reference resolver.Reference,
+) {
 	var personRequest PersonFileSearchHTTPRequest
 	if !decodeFileSearchJSON(w, r, &personRequest) {
 		return
 	}
-	directions, err := normalizePersonFileDirections(personRequest.Directions)
+	_, _, err := resolver.NormalizeDirections(personRequest.Directions)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_person_file_directions", err.Error())
 		return
 	}
-	// Widen the scope to the person's whole identity cluster so files owned
-	// only by a linked alias are found — the same identity the person detail
-	// header and the relationship timeline report. clusterMemberIDs returns
-	// nil for an unlinked participant, leaving the scope on id alone.
-	members := s.clusterMemberIDs(id)
-	if len(members) < 2 {
-		members = []int64{id}
-	}
-	personScope := &query.PersonFileScope{
-		ParticipantIDs: members, Directions: directions,
-		IncludeUnclassifiedRosterRows: len(personRequest.Directions) == 0,
+	resolved, err := resolver.Resolve(r.Context(), s.store, reference, personRequest.Directions)
+	if err != nil {
+		s.writePersonScopeError(w, reference, err, "file")
+		return
 	}
 	s.handleSearchFilesRequest(w, r, FileSearchHTTPRequest{
 		Predicate: personRequest.Predicate, FilenameQuery: personRequest.FilenameQuery,
 		VisualQuery: personRequest.VisualQuery, VisualImageBase64: personRequest.VisualImageBase64,
 		MIMEFamilies: personRequest.MIMEFamilies, Sort: personRequest.Sort,
 		Cursor: personRequest.Cursor, Limit: personRequest.Limit,
-	}, nil, personScope)
+	}, nil, &resolved.Scope)
 }
 
 func (s *Server) handleSearchDomainFiles(w http.ResponseWriter, r *http.Request) {
@@ -577,6 +615,7 @@ func (s *Server) handleSearchFilesRequest(
 // index's native predicates where an exact mapping exists.
 func applyVisualSearchScope(visualQuery *visual.SearchQuery, request query.FileSearchRequest) {
 	context := request.Explore.Context
+	visualQuery.Person = request.Person
 	if len(context.SourceIDs) == 1 {
 		visualQuery.SourceID = context.SourceIDs[0]
 	}
@@ -817,35 +856,6 @@ func canonicalScopedFileSearchHash(
 		Scope   *ExploreFilter         `json:"identity_scope,omitempty"`
 		Person  *query.PersonFileScope `json:"person_scope,omitempty"`
 	}{Request: request, Scope: scope, Person: person}, false)
-}
-
-func normalizePersonFileDirections(
-	directions []query.PersonFileDirection,
-) ([]query.PersonFileDirection, error) {
-	if len(directions) == 0 {
-		return []query.PersonFileDirection{
-			query.PersonFileFromPerson, query.PersonFileToPerson, query.PersonFileGroup,
-		}, nil
-	}
-	selected := make(map[query.PersonFileDirection]struct{}, len(directions))
-	for _, raw := range directions {
-		direction := query.PersonFileDirection(strings.ToLower(strings.TrimSpace(string(raw))))
-		switch direction {
-		case query.PersonFileFromPerson, query.PersonFileToPerson, query.PersonFileGroup:
-			selected[direction] = struct{}{}
-		default:
-			return nil, fmt.Errorf("unknown person file direction %q", raw)
-		}
-	}
-	result := make([]query.PersonFileDirection, 0, len(selected))
-	for _, direction := range []query.PersonFileDirection{
-		query.PersonFileFromPerson, query.PersonFileToPerson, query.PersonFileGroup,
-	} {
-		if _, ok := selected[direction]; ok {
-			result = append(result, direction)
-		}
-	}
-	return result, nil
 }
 
 func (s *Server) handleGetFile(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/files_test.go
+++ b/internal/api/files_test.go
@@ -311,6 +311,44 @@ func TestPersonFilesSearchWidensScopeToIdentityCluster(t *testing.T) {
 		"an unlinked participant stays scoped to its own ID")
 }
 
+func TestPersonFilesSearchUsesOnePopulationForDurableAndParticipantReferences(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	primary, err := st.EnsureParticipant("scope-primary@example.test", "Primary", "example.test")
+	requirements.NoError(err)
+	secondary, err := st.EnsureParticipant("scope-secondary@example.test", "Secondary", "example.test")
+	requirements.NoError(err)
+	_, err = st.LinkParticipants(primary, secondary)
+	requirements.NoError(err)
+	person, created, err := st.CreatePersonFromParticipant(primary)
+	requirements.NoError(err)
+	requirements.True(created)
+	_, err = st.UnlinkParticipants(primary, secondary)
+	requirements.NoError(err)
+
+	engine := &fileSearchEngine{MockEngine: &querytest.MockEngine{}, result: &query.FileSearchResponse{
+		Files: []query.FileRow{}, TotalCount: 0, CacheRevision: "cache-person-files",
+	}}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  st, Engine: engine, Logger: testLogger(),
+	})
+	search := func(path string) []int64 {
+		response := postExploreJSON(t, srv, path, `{"predicate":{},"directions":["from_person"]}`)
+		requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+		requirements.NotNil(engine.request.Person)
+		return append([]int64(nil), engine.request.Person.ParticipantIDs...)
+	}
+
+	durableIDs := search(fmt.Sprintf("/api/v1/people/%d/files/search", person.ID))
+	participantIDs := search(fmt.Sprintf("/api/v1/participants/%d/files/search", primary))
+	assertions.Equal([]int64{primary, secondary}, durableIDs,
+		"a durable person keeps every explicit binding after its observed cluster splits")
+	assertions.Equal(durableIDs, participantIDs,
+		"a bound participant translates through the durable root instead of silently narrowing")
+}
+
 func TestPersonFilesSearchNormalizesDirectionsAndSerializesProvenance(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)

--- a/internal/api/files_visual_test.go
+++ b/internal/api/files_visual_test.go
@@ -46,6 +46,9 @@ func TestApplyVisualSearchScopeMapsHardFilters(t *testing.T) {
 			SourceIDs: []int64{7}, After: &after, Before: &before,
 		}},
 	}
+	request.Person = &query.PersonFileScope{
+		ParticipantIDs: []int64{4}, Directions: []query.PersonFileDirection{query.PersonFileFromPerson},
+	}
 	visualQuery := visual.SearchQuery{Text: "red square", Limit: 100}
 	applyVisualSearchScope(&visualQuery, request)
 	assert.Equal(int64(7), visualQuery.SourceID, "a single-account scope rides into the vector search")
@@ -53,6 +56,7 @@ func TestApplyVisualSearchScopeMapsHardFilters(t *testing.T) {
 	assert.Equal(&before, visualQuery.Before)
 	assert.Equal("image/", visualQuery.MIMEPrefix)
 	assert.Equal("diagram", visualQuery.Filename)
+	assert.Equal(request.Person, visualQuery.Person)
 
 	multi := query.FileSearchRequest{Explore: query.ExploreRequest{Context: query.Context{SourceIDs: []int64{1, 2}}}}
 	visualQuery = visual.SearchQuery{Text: "x", Limit: 100}

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -213,7 +213,9 @@ import (
 // 32 MiB of logical inline media, and documents the resulting 413 response.
 // 2.4.0 adds exact source selection to CLI sync and deletion transports. CLI
 // clients check this version before asking a daemon to perform a scoped sync.
-const APISchemaVersion = "2.4.0"
+// 2.5.0 adds durable-person attachment retrieval across metadata, document,
+// and visual lanes while keeping participant references compatible.
+const APISchemaVersion = "2.5.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -38,13 +38,14 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.4.0", APISchemaVersion)
+	assert.Equal("2.5.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
 		"/api/v1/participants/{id}/summary",
 		"/api/v1/participants/{id}/timeline",
 		"/api/v1/participants/{id}/files/search",
+		"/api/v1/people/{id}/files/search",
 		"/api/v1/people",
 		"/api/v1/people/{id}",
 		"/api/v1/people/{id}/profile",
@@ -59,16 +60,35 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.4.0", APISchemaVersion)
+	assert.Equal(t, "2.5.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.4.0", APISchemaVersion)
+	assert.Equal(t, "2.5.0", APISchemaVersion)
+}
+
+func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	for _, path := range []string{
+		"/api/v1/participants/{id}/files/search",
+		"/api/v1/people/{id}/files/search",
+	} {
+		operation := OpenAPIDocument().Paths[path].Post
+		require.NotNil(operation)
+		require.Len(operation.Parameters, 1)
+		parameter := operation.Parameters[0]
+		assert.Equal("id", parameter.Name)
+		assert.Equal("path", parameter.In)
+		assert.True(parameter.Required)
+		assert.Equal(huma.TypeInteger, parameter.Schema.Type)
+		assert.Equal(formatInt64, parameter.Schema.Format)
+	}
 }
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.4.0", APISchemaVersion,
+	assert.Equal(t, "2.5.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -347,8 +367,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-
-	assert.Equal("2.4.0", APISchemaVersion,
+	assert.Equal("2.5.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -421,7 +440,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.4.0", APISchemaVersion,
+	assertions.Equal("2.5.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -441,7 +460,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.4.0", APISchemaVersion,
+	assert.Equal("2.5.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -469,7 +488,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.4.0", APISchemaVersion,
+	assertions.Equal("2.5.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -513,8 +532,8 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// routes added in 1.42.0, cache-readiness responses added in 1.43.0,
 	// document search added in 1.44.0, participant/people separation added in
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
-	// 2.4.0 did not touch it.
-	assert.Equal("2.4.0", APISchemaVersion, "meeting import is an additive schema release")
+	// 2.5.0 did not touch it.
+	assert.Equal("2.5.0", APISchemaVersion, "person retrieval is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -399,6 +399,7 @@ var readOnlyPostRoutePatterns = []string{
 	"/api/v1/participants/{id}/summary",
 	"/api/v1/participants/{id}/timeline",
 	"/api/v1/participants/{id}/files/search",
+	"/api/v1/people/{id}/files/search",
 	"/api/v1/domains/search",
 	"/api/v1/domains/{domain}/summary",
 	"/api/v1/domains/{domain}/timeline",

--- a/internal/api/operation_gate_test.go
+++ b/internal/api/operation_gate_test.go
@@ -675,6 +675,7 @@ func TestOperationGateMiddlewareSkipsReadOnlyAnalyticalPosts(t *testing.T) {
 		"/api/v1/participants/7/summary",
 		"/api/v1/participants/7/timeline",
 		"/api/v1/participants/7/files/search",
+		"/api/v1/people/7/files/search",
 		"/api/v1/domains/search",
 		"/api/v1/domains/example.com/summary",
 		"/api/v1/domains/example.com/timeline",

--- a/internal/api/person_scope.go
+++ b/internal/api/person_scope.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"go.kenn.io/msgvault/internal/personscope/resolver"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func (s *Server) writePersonScopeError(
+	w http.ResponseWriter,
+	reference resolver.Reference,
+	err error,
+	operation string,
+) {
+	if s.writeIfContextError(w, err) {
+		return
+	}
+	switch {
+	case errors.Is(err, store.ErrPersonNotFound):
+		writeError(w, http.StatusNotFound, "person_not_found", "Person not found")
+	case errors.Is(err, store.ErrPersonBindingConflict):
+		writeError(w, http.StatusConflict, "person_binding_conflict",
+			"The identity clusters belong to different person profiles")
+	case errors.Is(err, resolver.ErrEmptyPopulation):
+		writeError(w, http.StatusUnprocessableEntity, "person_scope_empty",
+			"Person has no resolved identities")
+	case errors.Is(err, resolver.ErrUnavailable):
+		writeError(w, http.StatusServiceUnavailable, "person_scope_unavailable",
+			"Person scope resolution is unavailable")
+	default:
+		s.logger.Error("resolve "+operation+" person scope", "error", err,
+			"reference_kind", reference.Kind, "reference_id", reference.ID)
+		writeError(w, http.StatusInternalServerError, "person_scope_failed",
+			"Person scope resolution failed")
+	}
+}

--- a/internal/api/person_scope_test.go
+++ b/internal/api/person_scope_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.kenn.io/msgvault/internal/personscope/resolver"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestWritePersonScopeErrorMapsBindingConflict(t *testing.T) {
+	server, _ := newTestServerWithMockStore(t)
+	response := httptest.NewRecorder()
+
+	server.writePersonScopeError(response,
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 40},
+		fmt.Errorf("resolve participant: %w", store.ErrPersonBindingConflict), "file")
+
+	assert.Equal(t, http.StatusConflict, response.Code)
+	assert.Contains(t, response.Body.String(), `"error":"person_binding_conflict"`)
+}
+
+func TestWritePersonScopeErrorMapsMissingPerson(t *testing.T) {
+	server, _ := newTestServerWithMockStore(t)
+	response := httptest.NewRecorder()
+
+	server.writePersonScopeError(response,
+		resolver.Reference{Kind: resolver.ReferencePerson, ID: 40},
+		fmt.Errorf("resolve person: %w", store.ErrPersonNotFound), "visual")
+
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	assert.Contains(t, response.Body.String(), `"error":"person_not_found"`)
+}
+
+func TestWritePersonScopeErrorReportsEmptyIdentityPopulation(t *testing.T) {
+	server, _ := newTestServerWithMockStore(t)
+	response := httptest.NewRecorder()
+
+	server.writePersonScopeError(response,
+		resolver.Reference{Kind: resolver.ReferencePerson, ID: 40},
+		resolver.ErrEmptyPopulation, "file")
+
+	assert.Equal(t, http.StatusUnprocessableEntity, response.Code)
+	assert.Contains(t, response.Body.String(), `"error":"person_scope_empty"`)
+}
+
+func TestWritePersonScopeErrorPreservesStructuredContextErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "deadline", err: fmt.Errorf("resolve person: %w", context.DeadlineExceeded), code: "query_timeout"},
+		{name: "canceled", err: fmt.Errorf("resolve person: %w", context.Canceled), code: "query_canceled"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server, _ := newTestServerWithMockStore(t)
+			response := httptest.NewRecorder()
+
+			server.writePersonScopeError(response,
+				resolver.Reference{Kind: resolver.ReferencePerson, ID: 40}, test.err, "visual")
+
+			assert.Equal(t, http.StatusServiceUnavailable, response.Code)
+			assert.Contains(t, response.Body.String(), `"error":"`+test.code+`"`)
+		})
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -257,6 +257,8 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 			Properties: map[string]*huma.Schema{
 				"image":    {Type: huma.TypeString, Format: "binary", Description: "Query image (JPEG, PNG, WebP, or still GIF)"},
 				limitParam: {Type: huma.TypeString}, "sender_person_id": {Type: huma.TypeString},
+				"person_id": {Type: huma.TypeString}, "participant_id": {Type: huma.TypeString},
+				"direction": {Type: huma.TypeArray, Items: &huma.Schema{Type: huma.TypeString, Enum: []any{"from_person", "to_person", "group"}}},
 				"source_id": {Type: huma.TypeString}, "message_id": {Type: huma.TypeString},
 				"filename": {Type: huma.TypeString}, "mime_prefix": {Type: huma.TypeString},
 				"cursor": {Type: huma.TypeString}, "after": {Type: huma.TypeString}, "before": {Type: huma.TypeString},
@@ -265,7 +267,8 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 		},
 	}
 	visualSearchOp.Responses = jsonResponsesFor[visual.SearchResponse](apiV1)
-	addErrorResponses(apiV1, visualSearchOp.Responses, http.StatusBadRequest, http.StatusServiceUnavailable)
+	addErrorResponses(apiV1, visualSearchOp.Responses, http.StatusBadRequest, http.StatusConflict,
+		http.StatusNotFound, http.StatusServiceUnavailable)
 	registerRawHumaRoute(apiV1, visualSearchOp, s.handleVisualSearch)
 	registerAPIV1RawHumaJSONRoute[visual.Status](apiV1, "getVisualAttachmentStatus", http.MethodGet, "/multimodal/status", "Get visual attachment embedding status", s.handleVisualStatus)
 	registerAPIV1RawHumaJSONRouteWithRequest[visualBuildRequest, visual.Status](apiV1, "startVisualAttachmentBuild", http.MethodPost, "/multimodal/build", "Consent and run one bounded visual attachment embedding pass", s.handleVisualBuild)
@@ -617,6 +620,11 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryRefArrayParam("message_type", "Message types to include; repeat or comma-separate values"),
 			queryIntegerParam("attachment_id", "Exact attachment occurrence ID"),
 			queryIntegerParam("message_id", "Exact containing message ID"),
+			queryIntegerParam("person_id", "Durable person ID"),
+			queryIntegerParam("participant_id", "Observed participant ID; translated through its durable person when bound"),
+			queryRefArrayParam("direction", "Person relation; repeat or comma-separate from_person, to_person, or group"),
+			queryStringParam("after", "Only messages on or after an RFC3339 or YYYY-MM-DD date", false),
+			queryStringParam("before", "Only messages before an RFC3339 or YYYY-MM-DD date", false),
 			queryIntegerParam(limitParam, "Maximum results to return (default 20, max 100)"),
 			queryStringParam("cursor", "Opaque cursor from the previous document search page", false),
 		}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -285,6 +285,7 @@ type mockStore struct {
 		context.Context, store.DocumentExtractionRebuild, []string, []string,
 	) (int64, error)
 	documentReconcileFunc func(context.Context) error
+	personContextFunc     func(context.Context, int64) (*store.Person, error)
 
 	// Error injection for the context-aware read paths, used to verify
 	// handlers map context deadline/cancellation to a structured 503.
@@ -329,6 +330,13 @@ func (m *mockStore) SearchDocuments(
 		return store.DocumentSearchResponse{}, nil
 	}
 	return m.documentSearchFunc(ctx, request)
+}
+
+func (m *mockStore) GetPersonContext(ctx context.Context, id int64) (*store.Person, error) {
+	if m.personContextFunc == nil {
+		return nil, store.ErrPersonNotFound
+	}
+	return m.personContextFunc(ctx, id)
 }
 
 func (m *mockStore) GetDocumentIndexStatusForScope(

--- a/internal/api/visual_search.go
+++ b/internal/api/visual_search.go
@@ -8,22 +8,26 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
 type visualTextSearchRequest struct {
-	Text           string `json:"text"`
-	Limit          int    `json:"limit,omitempty"`
-	SenderPersonID int64  `json:"sender_person_id,omitempty"`
-	SourceID       int64  `json:"source_id,omitempty"`
-	MessageID      int64  `json:"message_id,omitempty"`
-	Filename       string `json:"filename,omitempty"`
-	MIMEPrefix     string `json:"mime_prefix,omitempty"`
-	Cursor         string `json:"cursor,omitempty"`
-	After          string `json:"after,omitempty"`
-	Before         string `json:"before,omitempty"`
+	Text           string                  `json:"text"`
+	Limit          int                     `json:"limit,omitempty"`
+	SenderPersonID int64                   `json:"sender_person_id,omitempty"`
+	PersonID       int64                   `json:"person_id,omitempty"`
+	ParticipantID  int64                   `json:"participant_id,omitempty"`
+	Directions     []personscope.Direction `json:"directions,omitempty"`
+	SourceID       int64                   `json:"source_id,omitempty"`
+	MessageID      int64                   `json:"message_id,omitempty"`
+	Filename       string                  `json:"filename,omitempty"`
+	MIMEPrefix     string                  `json:"mime_prefix,omitempty"`
+	Cursor         string                  `json:"cursor,omitempty"`
+	After          string                  `json:"after,omitempty"`
+	Before         string                  `json:"before,omitempty"`
 }
 
 func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
@@ -35,6 +39,8 @@ func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	query := visual.SearchQuery{}
+	var personID, participantID, senderPersonID int64
+	var directions []personscope.Direction
 	mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if strings.HasPrefix(mediaType, "multipart/") {
 		r.Body = http.MaxBytesReader(w, r.Body, visual.MaxQueryImageBytes+(1<<20))
@@ -65,15 +71,10 @@ func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		if raw := r.FormValue("sender_person_id"); raw != "" {
-			query.SenderPersonID, err = strconv.ParseInt(raw, 10, 64)
-			if err != nil || query.SenderPersonID < 1 {
-				writeError(w, http.StatusBadRequest, "invalid_sender_person_id", "sender_person_id must be positive")
-				return
-			}
-		}
 		for raw, target := range map[string]*int64{
 			"source_id": &query.SourceID, "message_id": &query.MessageID,
+			"person_id": &personID, "participant_id": &participantID,
+			"sender_person_id": &senderPersonID,
 		} {
 			value := r.FormValue(raw)
 			if value == "" {
@@ -86,6 +87,11 @@ func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			*target = parsed
 		}
+		for _, raw := range r.MultipartForm.Value["direction"] {
+			for value := range strings.SplitSeq(raw, ",") {
+				directions = append(directions, personscope.Direction(strings.TrimSpace(value)))
+			}
+		}
 		query.Filename, query.MIMEPrefix, query.Cursor = r.FormValue("filename"), r.FormValue("mime_prefix"), r.FormValue("cursor")
 		if !parseVisualSearchDates(w, r.FormValue("after"), r.FormValue("before"), &query) {
 			return
@@ -97,16 +103,21 @@ func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid_visual_query", "Invalid visual search request")
 			return
 		}
-		query.Text, query.Limit, query.SenderPersonID = request.Text, request.Limit, request.SenderPersonID
+		query.Text, query.Limit = request.Text, request.Limit
+		personID, participantID, senderPersonID = request.PersonID, request.ParticipantID, request.SenderPersonID
+		directions = request.Directions
 		query.SourceID, query.MessageID = request.SourceID, request.MessageID
 		query.Filename, query.MIMEPrefix, query.Cursor = request.Filename, request.MIMEPrefix, request.Cursor
-		if query.SenderPersonID < 0 || query.SourceID < 0 || query.MessageID < 0 {
+		if personID < 0 || participantID < 0 || senderPersonID < 0 || query.SourceID < 0 || query.MessageID < 0 {
 			writeError(w, http.StatusBadRequest, "invalid_visual_filter", "ID filters must be positive")
 			return
 		}
 		if !parseVisualSearchDates(w, request.After, request.Before, &query) {
 			return
 		}
+	}
+	if !s.resolveVisualPersonScope(w, r, &query, personID, participantID, senderPersonID, directions) {
+		return
 	}
 	response, err := service.Search(r.Context(), query)
 	if err != nil {
@@ -125,20 +136,67 @@ func (s *Server) handleVisualSearch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, response)
 }
 
+func (s *Server) resolveVisualPersonScope(
+	w http.ResponseWriter,
+	r *http.Request,
+	query *visual.SearchQuery,
+	personID, participantID, senderPersonID int64,
+	directions []personscope.Direction,
+) bool {
+	if senderPersonID > 0 {
+		if personID > 0 || participantID > 0 || len(directions) > 0 {
+			writeError(w, http.StatusBadRequest, "invalid_visual_person_scope",
+				"sender_person_id cannot be combined with person_id, participant_id, or directions")
+			return false
+		}
+		personID = senderPersonID
+		directions = []personscope.Direction{personscope.FromPerson}
+	}
+	if personID > 0 && participantID > 0 {
+		writeError(w, http.StatusBadRequest, "invalid_visual_person_scope",
+			"person_id and participant_id are mutually exclusive")
+		return false
+	}
+	if len(directions) > 0 && personID == 0 && participantID == 0 {
+		writeError(w, http.StatusBadRequest, "invalid_visual_person_scope",
+			"directions require person_id or participant_id")
+		return false
+	}
+	if _, _, err := resolver.NormalizeDirections(directions); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_visual_person_scope", err.Error())
+		return false
+	}
+	if personID == 0 && participantID == 0 {
+		return true
+	}
+	reference := resolver.Reference{Kind: resolver.ReferencePerson, ID: personID}
+	if participantID > 0 {
+		reference = resolver.Reference{Kind: resolver.ReferenceParticipant, ID: participantID}
+	}
+	resolved, err := resolver.Resolve(r.Context(), s.store, reference, directions)
+	if err != nil {
+		s.writePersonScopeError(w, reference, err, "visual")
+		return false
+	}
+	query.Person = &resolved.Scope
+	return true
+}
+
 func parseVisualSearchDates(w http.ResponseWriter, after, before string, query *visual.SearchQuery) bool {
 	var err error
 	if after != "" {
-		parsed, parseErr := time.Parse("2006-01-02", after)
+		parsed, parseErr := parseAPITime(after)
 		err = parseErr
 		query.After = &parsed
 	}
 	if err == nil && before != "" {
-		parsed, parseErr := time.Parse("2006-01-02", before)
+		parsed, parseErr := parseAPITime(before)
 		err = parseErr
 		query.Before = &parsed
 	}
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_visual_date", "after and before must use YYYY-MM-DD")
+		writeError(w, http.StatusBadRequest, "invalid_visual_date",
+			"after and before must use RFC3339 or YYYY-MM-DD")
 		return false
 	}
 	if query.After != nil && query.Before != nil && !query.After.Before(*query.Before) {

--- a/internal/api/visual_search_person_test.go
+++ b/internal/api/visual_search_person_test.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/vector/visual"
+)
+
+func TestResolveVisualPersonScopeUsesDurableBindingsAndLegacySenderAlias(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.personContextFunc = func(_ context.Context, id int64) (*store.Person, error) {
+		return &store.Person{ID: id, ParticipantIDs: []int64{4, 9}}, nil
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/search/attachments/visual", nil)
+	response := httptest.NewRecorder()
+	query := visual.SearchQuery{}
+	require.True(server.resolveVisualPersonScope(response, request, &query, 0, 0, 40, nil))
+	require.NotNil(query.Person)
+	assert.Equal([]int64{4, 9}, query.Person.ParticipantIDs)
+	assert.Equal([]personscope.Direction{personscope.FromPerson}, query.Person.Directions)
+}
+
+func TestResolveVisualLegacySenderAliasReportsMissingDurablePerson(t *testing.T) {
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.personContextFunc = func(context.Context, int64) (*store.Person, error) {
+		return nil, store.ErrPersonNotFound
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/search/attachments/visual", nil)
+	response := httptest.NewRecorder()
+
+	ok := server.resolveVisualPersonScope(response, request, &visual.SearchQuery{}, 0, 0, 40, nil)
+
+	assert.False(t, ok)
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	assert.Contains(t, response.Body.String(), `"error":"person_not_found"`)
+}
+
+func TestResolveVisualPersonScopeRejectsInvalidDirectionBeforeResolution(t *testing.T) {
+	server, catalog := newTestServerWithMockStore(t)
+	catalog.personContextFunc = func(context.Context, int64) (*store.Person, error) {
+		t.Fatal("invalid directions must not dispatch person resolution")
+		return nil, store.ErrPersonNotFound
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/search/attachments/visual", nil)
+	response := httptest.NewRecorder()
+
+	ok := server.resolveVisualPersonScope(response, request, &visual.SearchQuery{}, 40, 0, 0,
+		[]personscope.Direction{"sideways"})
+
+	assert.False(t, ok)
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+	assert.Contains(t, response.Body.String(), `"error":"invalid_visual_person_scope"`)
+}
+
+func TestParseVisualSearchDatesPreservesRFC3339Precision(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	after := "2026-08-20T12:34:56.123456789-07:00"
+	before := "2026-08-20T14:04:56.987654321-07:00"
+	response := httptest.NewRecorder()
+	query := visual.SearchQuery{}
+
+	requirements.True(parseVisualSearchDates(response, after, before, &query))
+	requirements.NotNil(query.After)
+	requirements.NotNil(query.Before)
+	assertions.Equal("2026-08-20T19:34:56.123456789Z", query.After.UTC().Format(time.RFC3339Nano))
+	assertions.Equal("2026-08-20T21:04:56.987654321Z", query.Before.UTC().Format(time.RFC3339Nano))
+}

--- a/internal/daemonclient/documents.go
+++ b/internal/daemonclient/documents.go
@@ -3,6 +3,7 @@ package daemonclient
 import (
 	"context"
 
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	apiclient "go.kenn.io/msgvault/pkg/client"
 	"go.kenn.io/msgvault/pkg/client/generated"
@@ -17,9 +18,14 @@ func (c *Client) SearchDocuments(
 		return client.SearchDocumentsWithResponse(ctx, &generated.SearchDocumentsRequestOptions{
 			Query: &generated.SearchDocumentsQuery{
 				Q: request.Query, SourceID: request.SourceIDs, MessageType: request.MessageTypes,
-				AttachmentID: optionalPositiveInt64Value(request.AttachmentID),
-				MessageID:    optionalPositiveInt64Value(request.MessageID),
-				Limit:        optionalPositiveInt64(request.PageSize), Cursor: optionalString(request.Cursor),
+				AttachmentID:  optionalPositiveInt64Value(request.AttachmentID),
+				MessageID:     optionalPositiveInt64Value(request.MessageID),
+				PersonID:      optionalPositiveInt64Value(request.PersonID),
+				ParticipantID: optionalPositiveInt64Value(request.ParticipantID),
+				Direction:     documentDirectionStrings(request.Directions),
+				After:         optionalTimeRFC3339(request.After),
+				Before:        optionalTimeRFC3339(request.Before),
+				Limit:         optionalPositiveInt64(request.PageSize), Cursor: optionalString(request.Cursor),
 			},
 		})
 	})
@@ -71,7 +77,9 @@ func documentSearchFromGenerated(response *generated.DocumentSearchResponse) sto
 	}
 	for index, row := range response.Results {
 		result.Results[index] = store.DocumentSearchResult{
-			AttachmentID: row.AttachmentID, MessageID: row.MessageID, SourceID: row.SourceID,
+			AttachmentID: row.AttachmentID, MessageID: row.MessageID,
+			ConversationID: row.ConversationID, SourceID: row.SourceID,
+			SourceMessageID: stringValue(row.SourceMessageID), OccurredAt: row.OccurredAt,
 			OccurrenceKey: row.OccurrenceKey, SourcePartKey: stringValue(row.SourcePartKey),
 			Filename: stringValue(row.Filename), ContainingTitle: stringValue(row.ContainingTitle),
 			MIMEType: stringValue(row.MimeType), CanonicalBlobHash: row.CanonicalBlobHash,
@@ -83,6 +91,30 @@ func documentSearchFromGenerated(response *generated.DocumentSearchResponse) sto
 			Provider: row.Provider, Model: row.Model, MatchedSignals: row.MatchedSignals,
 			Truncated: row.Truncated, Rank: int(row.Rank),
 		}
+		if row.PersonProvenance != nil {
+			result.Results[index].PersonProvenance = &personscope.Provenance{
+				ParticipantIDs: row.PersonProvenance.ParticipantIds,
+				Roles:          make([]personscope.Role, len(row.PersonProvenance.Roles)),
+				Directions:     make([]personscope.Direction, len(row.PersonProvenance.Directions)),
+			}
+			for i, role := range row.PersonProvenance.Roles {
+				result.Results[index].PersonProvenance.Roles[i] = personscope.Role(role)
+			}
+			for i, direction := range row.PersonProvenance.Directions {
+				result.Results[index].PersonProvenance.Directions[i] = personscope.Direction(direction)
+			}
+		}
+	}
+	return result
+}
+
+func documentDirectionStrings(directions []personscope.Direction) []string {
+	if len(directions) == 0 {
+		return nil
+	}
+	result := make([]string, len(directions))
+	for i, direction := range directions {
+		result[i] = string(direction)
 	}
 	return result
 }

--- a/internal/daemonclient/documents_test.go
+++ b/internal/daemonclient/documents_test.go
@@ -6,44 +6,67 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 )
 
 func TestSearchDocumentsUsesGeneratedDaemonContract(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal("/api/v1/documents/search", r.URL.Path)
 		assert.Equal("damaged carton", r.URL.Query().Get("q"))
 		assert.ElementsMatch([]string{"3", "7"}, r.URL.Query()["source_id"])
 		assert.Equal("22", r.URL.Query().Get("attachment_id"))
+		assert.Equal("40", r.URL.Query().Get("person_id"))
+		assert.ElementsMatch([]string{"from_person", "group"}, r.URL.Query()["direction"])
+		assert.Equal("2026-08-01T00:00:00Z", r.URL.Query().Get("after"))
+		assert.Equal("2026-08-20T00:00:00Z", r.URL.Query().Get("before"))
 		assert.Equal("5", r.URL.Query().Get("limit"))
 		w.Header().Set("Content-Type", "application/json")
+		occurredAt := time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)
 		assert.NoError(json.NewEncoder(w).Encode(store.DocumentSearchResponse{
 			Revision: 9, Truncated: true,
 			Results: []store.DocumentSearchResult{{
-				AttachmentID: 22, MessageID: 23, SourceID: 3,
+				AttachmentID: 22, MessageID: 23, ConversationID: 24, SourceID: 3,
+				SourceMessageID: "synthetic-message", OccurredAt: &occurredAt,
 				OccurrenceKey: "occurrence", CanonicalBlobHash: "hash", ChunkKey: "chunk",
 				Filename: "claim.docx", Excerpt: "damaged carton", ProfileID: "profile",
 				ExtractionID: "extraction", Provider: "mistral", Model: "ocr",
 				MatchedSignals: []string{"content"}, Rank: 1,
+				PersonProvenance: &personscope.Provenance{
+					ParticipantIDs: []int64{4}, Roles: []personscope.Role{personscope.RoleFrom},
+					Directions: []personscope.Direction{personscope.FromPerson},
+				},
 			}},
 		}))
 	}))
 	t.Cleanup(server.Close)
 	client, err := New(Config{URL: server.URL, AllowInsecure: true})
-	require.NoError(t, err)
+	require.NoError(err)
+	after := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
 	response, err := client.SearchDocuments(context.Background(), store.DocumentSearchRequest{
 		Query: "damaged carton", SourceIDs: []int64{3, 7}, AttachmentID: 22, PageSize: 5,
+		PersonID: 40, Directions: []personscope.Direction{personscope.FromPerson, personscope.Group},
+		After: &after, Before: &before,
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(int64(9), response.Revision)
 	assert.True(response.Truncated)
-	require.Len(t, response.Results, 1)
+	require.Len(response.Results, 1)
 	assert.Equal("claim.docx", response.Results[0].Filename)
+	assert.Equal(int64(24), response.Results[0].ConversationID)
+	assert.Equal("synthetic-message", response.Results[0].SourceMessageID)
+	require.NotNil(response.Results[0].OccurredAt)
+	assert.Equal(time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC), *response.Results[0].OccurredAt)
 	assert.Equal([]string{"content"}, response.Results[0].MatchedSignals)
+	require.NotNil(response.Results[0].PersonProvenance)
+	assert.Equal([]personscope.Role{personscope.RoleFrom}, response.Results[0].PersonProvenance.Roles)
 }
 
 func TestDocumentIndexStatusUsesGeneratedDaemonContract(t *testing.T) {

--- a/internal/daemonclient/person_files.go
+++ b/internal/daemonclient/person_files.go
@@ -1,0 +1,68 @@
+package daemonclient
+
+import (
+	"context"
+	"time"
+
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/query"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+type PersonFileSearchOptions struct {
+	PersonID     int64
+	Directions   []personscope.Direction
+	After        *time.Time
+	Before       *time.Time
+	Filename     string
+	MIMEFamilies []query.FileMIMEFamily
+	Limit        int
+	Cursor       string
+}
+
+func (c *Client) SearchPersonFiles(
+	ctx context.Context,
+	request PersonFileSearchOptions,
+) (generated.PersonFileSearchHTTPResponse, error) {
+	directions := make([]generated.PersonFileSearchHTTPRequestDirections, len(request.Directions))
+	for i, direction := range request.Directions {
+		directions[i] = generated.PersonFileSearchHTTPRequestDirections(direction)
+	}
+	mimeFamilies := make([]string, len(request.MIMEFamilies))
+	for i, family := range request.MIMEFamilies {
+		mimeFamilies[i] = string(family)
+	}
+	filters := make([]generated.ExploreFilter, 0, 2)
+	if request.After != nil {
+		filters = append(filters, generated.ExploreFilter{
+			Dimension: generated.ExploreFilterDimensionAfter,
+			Values:    []string{request.After.UTC().Format(time.RFC3339Nano)},
+		})
+	}
+	if request.Before != nil {
+		filters = append(filters, generated.ExploreFilter{
+			Dimension: generated.ExploreFilterDimensionBefore,
+			Values:    []string{request.Before.UTC().Format(time.RFC3339Nano)},
+		})
+	}
+	response, err := APIResponse(c, func(client *apiclient.Client) (*generated.SearchPersonFilesResp, error) {
+		return client.SearchPersonFilesWithResponse(ctx, &generated.SearchPersonFilesRequestOptions{
+			PathParams: &generated.SearchPersonFilesPath{ID: request.PersonID},
+			Body: &generated.PersonFileSearchHTTPRequest{
+				Predicate:  generated.ExploreHTTPRequest{Filters: filters},
+				Directions: directions, FilenameQuery: optionalString(request.Filename),
+				MimeFamilies: mimeFamilies, Limit: optionalPositiveInt64(request.Limit),
+				Cursor: optionalString(request.Cursor),
+				Sort:   generated.FileSearchSort{Field: "occurred_at", Direction: "desc"},
+			},
+		})
+	})
+	if err != nil {
+		return generated.PersonFileSearchHTTPResponse{}, err
+	}
+	if response.JSON200 == nil {
+		return generated.PersonFileSearchHTTPResponse{Files: []generated.PersonFileSearchRow{}}, nil
+	}
+	return *response.JSON200, nil
+}

--- a/internal/daemonclient/person_files_test.go
+++ b/internal/daemonclient/person_files_test.go
@@ -1,0 +1,74 @@
+package daemonclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+func TestSearchPersonFilesUsesGeneratedDaemonContract(t *testing.T) {
+	assertions := assert.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal(http.MethodPost, r.Method)
+		assertions.Equal("/api/v1/people/40/files/search", r.URL.Path)
+		var request generated.PersonFileSearchHTTPRequest
+		if !assertions.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			return
+		}
+		assertions.Equal([]generated.PersonFileSearchHTTPRequestDirections{
+			generated.PersonFileSearchHTTPRequestDirectionsFromPerson,
+			generated.PersonFileSearchHTTPRequestDirectionsGroup,
+		}, request.Directions)
+		assertions.Equal("inspection", *request.FilenameQuery)
+		assertions.Equal([]string{"image", "pdf"}, request.MimeFamilies)
+		assertions.Equal(int64(25), *request.Limit)
+		assertions.Equal("opaque", *request.Cursor)
+		if !assertions.Len(request.Predicate.Filters, 2) {
+			return
+		}
+		assertions.Equal("after", string(request.Predicate.Filters[0].Dimension))
+		assertions.Equal([]string{"2026-08-01T12:34:56.123456789Z"}, request.Predicate.Filters[0].Values)
+		assertions.Equal("before", string(request.Predicate.Filters[1].Dimension))
+		assertions.Equal([]string{"2026-08-20T13:45:56.987654321Z"}, request.Predicate.Filters[1].Values)
+
+		w.Header().Set("Content-Type", "application/json")
+		filename, mimeType := "inspection.png", "image/png"
+		assertions.NoError(json.NewEncoder(w).Encode(generated.PersonFileSearchHTTPResponse{
+			Files: []generated.PersonFileSearchRow{{
+				ID: 17, Key: "file:17", EntryKey: "source:20:message:synthetic-message",
+				MessageID: 18, ConversationID: 19, OccurredAt: time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC),
+				SourceID: 20, SourceType: "synthetic", SourceIdentifier: "synthetic-source",
+				ContainingTitle: "Synthetic inspection", Filename: &filename, MimeType: &mimeType,
+				MimeFamily: "image", ContentState: generated.PersonFileSearchRowContentStateMetadataOnly,
+				PersonProvenance: generated.PersonFileProvenance{
+					ParticipantIds: []int64{4}, Roles: []generated.PersonFileProvenanceRoles{generated.From},
+					Directions: []generated.PersonFileProvenanceDirections{generated.FromPerson},
+				},
+			}},
+			TotalCount: 1, CacheRevision: "synthetic-revision",
+		}))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(t, err)
+	after := time.Date(2026, 8, 1, 12, 34, 56, 123456789, time.UTC)
+	before := time.Date(2026, 8, 20, 13, 45, 56, 987654321, time.UTC)
+	response, err := client.SearchPersonFiles(t.Context(), PersonFileSearchOptions{
+		PersonID: 40, Directions: []personscope.Direction{personscope.FromPerson, personscope.Group},
+		After: &after, Before: &before, Filename: "inspection",
+		MIMEFamilies: []query.FileMIMEFamily{query.FileMIMEImage, query.FileMIMEPDF},
+		Limit:        25, Cursor: "opaque",
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Files, 1)
+	assertions.Equal(int64(18), response.Files[0].MessageID)
+	assertions.Equal([]generated.PersonFileProvenanceRoles{generated.From}, response.Files[0].PersonProvenance.Roles)
+}

--- a/internal/daemonclient/visual.go
+++ b/internal/daemonclient/visual.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
@@ -26,6 +27,9 @@ type VisualSearchOptions struct {
 	Limit          int
 	Cursor         string
 	SenderPersonID int64
+	PersonID       int64
+	ParticipantID  int64
+	Directions     []personscope.Direction
 	SourceID       int64
 	MessageID      int64
 	Filename       string
@@ -52,6 +56,15 @@ func (c *Client) SearchVisualAttachmentsFiltered(ctx context.Context, options Vi
 		if options.SenderPersonID > 0 {
 			_ = writer.WriteField("sender_person_id", strconv.FormatInt(options.SenderPersonID, 10))
 		}
+		if options.PersonID > 0 {
+			_ = writer.WriteField("person_id", strconv.FormatInt(options.PersonID, 10))
+		}
+		if options.ParticipantID > 0 {
+			_ = writer.WriteField("participant_id", strconv.FormatInt(options.ParticipantID, 10))
+		}
+		for _, direction := range options.Directions {
+			_ = writer.WriteField("direction", string(direction))
+		}
 		for key, value := range map[string]string{
 			"cursor": options.Cursor, "filename": options.Filename, "mime_prefix": options.MIMEPrefix,
 		} {
@@ -66,10 +79,10 @@ func (c *Client) SearchVisualAttachmentsFiltered(ctx context.Context, options Vi
 			_ = writer.WriteField("message_id", strconv.FormatInt(options.MessageID, 10))
 		}
 		if options.After != nil {
-			_ = writer.WriteField("after", options.After.Format("2006-01-02"))
+			_ = writer.WriteField("after", options.After.UTC().Format(time.RFC3339Nano))
 		}
 		if options.Before != nil {
-			_ = writer.WriteField("before", options.Before.Format("2006-01-02"))
+			_ = writer.WriteField("before", options.Before.UTC().Format(time.RFC3339Nano))
 		}
 		if err := writer.Close(); err != nil {
 			return nil, fmt.Errorf("close visual search form: %w", err)
@@ -79,13 +92,15 @@ func (c *Client) SearchVisualAttachmentsFiltered(ctx context.Context, options Vi
 		payload := map[string]any{
 			"text": options.Text, visualSearchLimitField: options.Limit, "cursor": options.Cursor,
 			"sender_person_id": options.SenderPersonID, "source_id": options.SourceID,
+			"person_id": options.PersonID, "participant_id": options.ParticipantID,
+			"directions": options.Directions,
 			"message_id": options.MessageID, "filename": options.Filename, "mime_prefix": options.MIMEPrefix,
 		}
 		if options.After != nil {
-			payload["after"] = options.After.Format("2006-01-02")
+			payload["after"] = options.After.UTC().Format(time.RFC3339Nano)
 		}
 		if options.Before != nil {
-			payload["before"] = options.Before.Format("2006-01-02")
+			payload["before"] = options.Before.UTC().Format(time.RFC3339Nano)
 		}
 		if err := json.NewEncoder(&body).Encode(payload); err != nil {
 			return nil, err

--- a/internal/daemonclient/visual_test.go
+++ b/internal/daemonclient/visual_test.go
@@ -1,0 +1,80 @@
+package daemonclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/vector/visual"
+)
+
+func TestVisualSearchUsesSharedPersonScopeContract(t *testing.T) {
+	require := require.New(t)
+	after := time.Date(2026, 8, 20, 12, 34, 56, 123456789, time.FixedZone("test", -7*60*60))
+	before := after.Add(90 * time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/search/attachments/visual", r.URL.Path)
+		var request struct {
+			PersonID   int64                   `json:"person_id"`
+			Directions []personscope.Direction `json:"directions"`
+			After      string                  `json:"after"`
+			Before     string                  `json:"before"`
+		}
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			return
+		}
+		assert.Equal(t, int64(40), request.PersonID)
+		assert.Equal(t, []personscope.Direction{personscope.ToPerson, personscope.Group}, request.Directions)
+		assert.Equal(t, after.UTC().Format(time.RFC3339Nano), request.After)
+		assert.Equal(t, before.UTC().Format(time.RFC3339Nano), request.Before)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(visual.SearchResponse{
+			Results: []visual.AttachmentSearchResult{{
+				AttachmentID: 17, MessageID: 18,
+				PersonProvenance: &personscope.Provenance{
+					ParticipantIDs: []int64{4}, Roles: []personscope.Role{personscope.RoleTo},
+					Directions: []personscope.Direction{personscope.ToPerson},
+				},
+			}},
+		}))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(err)
+	response, err := client.SearchVisualAttachmentsFiltered(t.Context(), VisualSearchOptions{
+		Text: "inspection diagram", PersonID: 40,
+		Directions: []personscope.Direction{personscope.ToPerson, personscope.Group},
+		After:      &after, Before: &before,
+	})
+	require.NoError(err)
+	require.Len(response.Results, 1)
+	assert.Equal(t, []personscope.Role{personscope.RoleTo}, response.Results[0].PersonProvenance.Roles)
+}
+
+func TestVisualImageSearchPreservesRFC3339Bounds(t *testing.T) {
+	after := time.Date(2026, 8, 20, 12, 34, 56, 123456789, time.FixedZone("test", -7*60*60))
+	before := after.Add(90 * time.Minute)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.NoError(t, r.ParseMultipartForm(1<<20)) {
+			return
+		}
+		assert.Equal(t, after.UTC().Format(time.RFC3339Nano), r.FormValue("after"))
+		assert.Equal(t, before.UTC().Format(time.RFC3339Nano), r.FormValue("before"))
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(visual.SearchResponse{}))
+	}))
+	t.Cleanup(server.Close)
+	client, err := New(Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(t, err)
+
+	_, err = client.SearchVisualAttachmentsFiltered(t.Context(), VisualSearchOptions{
+		Image: []byte("synthetic image"), After: &after, Before: &before,
+	})
+
+	require.NoError(t, err)
+}

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 const (
@@ -39,6 +40,8 @@ func visualSearchAvailable(capabilities catalogCapabilities) bool {
 }
 
 func searchVisualAttachmentsDefinition() toolDefinition {
+	direction := stringSchema("How the owning message relates to the person",
+		"from_person", "to_person", "group")
 	definition := readDefinition(
 		ToolSearchVisualAttachments,
 		"Search the visual content of authoritative standalone attachments by text or a bounded base64 query image. Results preserve exact attachment and owning-message provenance.",
@@ -46,14 +49,20 @@ func searchVisualAttachmentsDefinition() toolDefinition {
 			"text":             stringSchema("Natural-language visual query"),
 			"image_base64":     stringSchema("Base64 JPEG, PNG, or WebP query image; not persisted"),
 			"limit":            nonNegativeIntegerSchema("Maximum results (1-100, default 20)", 20),
-			"sender_person_id": safeIDSchema("Only attachments sent by this person ID"),
-			"source_id":        safeIDSchema("Only attachments from this source ID"),
-			"message_id":       safeIDSchema("Only attachments owned by this message ID"),
-			"filename":         stringSchema("Case-insensitive filename substring filter"),
-			"mime_prefix":      stringSchema("Case-insensitive MIME prefix filter, such as image/"),
-			"cursor":           stringSchema("Opaque next_cursor from the previous response"),
-			"after":            stringSchema("Only messages on or after YYYY-MM-DD"),
-			"before":           stringSchema("Only messages before YYYY-MM-DD"),
+			"sender_person_id": safeIDSchema("Legacy alias for person_id with from_person direction"),
+			"person_id":        safeIDSchema("Only attachments related to this durable person ID"),
+			"participant_id":   safeIDSchema("Only attachments related to this observed participant, translated through its durable person when bound"),
+			"directions": {
+				Type: "array", Description: "Optional union of from_person, to_person, and group; requires a person reference",
+				Items: direction,
+			},
+			"source_id":   safeIDSchema("Only attachments from this source ID"),
+			"message_id":  safeIDSchema("Only attachments owned by this message ID"),
+			"filename":    stringSchema("Case-insensitive filename substring filter"),
+			"mime_prefix": stringSchema("Case-insensitive MIME prefix filter, such as image/"),
+			"cursor":      stringSchema("Opaque next_cursor from the previous response"),
+			"after":       stringSchema("Only messages on or after YYYY-MM-DD"),
+			"before":      stringSchema("Only messages before YYYY-MM-DD"),
 		}),
 		outputSchemaFor[visual.SearchResponse](),
 		(*handlers).searchVisualAttachments,
@@ -142,6 +151,7 @@ func buildOperationCatalog(capabilities catalogCapabilities) []toolDefinition {
 		searchMessageBodiesDefinition(nil),
 		searchMessagesDefinition(nil, capabilities.semanticSearch),
 		searchMetadataDefinition(nil),
+		searchPersonFilesDefinition(nil),
 		searchVisualAttachmentsDefinition(),
 		semanticSearchMessagesDefinition(nil, capabilities.semanticSearch),
 		stageDeletionDefinition(nil),
@@ -647,6 +657,8 @@ func findSimilarMessagesDefinition(_ *handlers) toolDefinition {
 func searchDocumentsDefinition(_ *handlers) toolDefinition {
 	limit := boundedIntegerSchema("Maximum results to return (default 20, max 100)", 1, 100)
 	limit.Default = json.RawMessage("20")
+	direction := stringSchema("How the owning message relates to the person",
+		"from_person", "to_person", "group")
 	definition := readDefinition(
 		ToolSearchDocuments,
 		"Search locally indexed content and filenames from standalone document attachments extracted by the configured document provider. Results preserve the exact attachment occurrence, containing message, unit range, excerpt, and provider/model provenance. Paginate with the opaque cursor; restart when the index revision changes.",
@@ -660,16 +672,55 @@ func searchDocumentsDefinition(_ *handlers) toolDefinition {
 				Type: "array", Description: "Optional containing message type scope",
 				Items: stringSchema("Containing message type"),
 			},
-			"attachment_id": safeIDSchema("Optional exact attachment occurrence ID"),
-			"message_id":    safeIDSchema("Optional exact containing message ID"),
-			"limit":         limit,
-			"cursor":        stringSchema("Opaque cursor from the previous page"),
+			"attachment_id":  safeIDSchema("Optional exact attachment occurrence ID"),
+			"message_id":     safeIDSchema("Optional exact containing message ID"),
+			"person_id":      safeIDSchema("Optional durable person ID"),
+			"participant_id": safeIDSchema("Optional observed participant ID; translated through its durable person when bound"),
+			"directions": {
+				Type: "array", Description: "Optional union of from_person, to_person, and group; requires a person reference",
+				Items: direction,
+			},
+			"after":  stringSchema("Only messages on or after YYYY-MM-DD"),
+			"before": stringSchema("Only messages before YYYY-MM-DD"),
+			"limit":  limit,
+			"cursor": stringSchema("Opaque cursor from the previous page"),
 		}, "query"),
 		outputSchemaFor[store.DocumentSearchResponse](),
 		(*handlers).searchDocuments,
 	)
 	definition.availability = documentSearchAvailable
 	return definition
+}
+
+func searchPersonFilesDefinition(_ *handlers) toolDefinition {
+	limit := boundedIntegerSchema("Maximum metadata results to return (default 100, max 100)", 1, 100)
+	limit.Default = json.RawMessage("100")
+	direction := stringSchema("How the owning message relates to the person",
+		"from_person", "to_person", "group")
+	mimeFamily := stringSchema("Stable MIME family",
+		"image", "pdf", "audio", "video", "text", "document", "archive", "other")
+	return readDefinition(
+		ToolSearchPersonFiles,
+		"Search authoritative attachment metadata for one durable person. Results preserve exact attachment occurrence, owning message, conversation, source, matched participant, role, and direction provenance.",
+		closedObject(map[string]*jsonschema.Schema{
+			"person_id": safeIDSchema("Durable person ID"),
+			"directions": {
+				Type: "array", Description: "Optional union of from_person, to_person, and group",
+				Items: direction,
+			},
+			"after":    stringSchema("Only messages on or after YYYY-MM-DD"),
+			"before":   stringSchema("Only messages before YYYY-MM-DD"),
+			"filename": stringSchema("Case-insensitive filename substring filter"),
+			"mime_families": {
+				Type: "array", Description: "Optional stable MIME-family filter",
+				Items: mimeFamily,
+			},
+			"limit":  limit,
+			"cursor": stringSchema("Opaque cursor from the previous metadata page"),
+		}, "person_id"),
+		outputSchemaFor[generated.PersonFileSearchHTTPResponse](),
+		(*handlers).searchPersonFiles,
+	)
 }
 
 // The following named response types make every catalog output schema visible

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -270,6 +270,7 @@ func TestCatalogSchemas(t *testing.T) {
 					"search_message_bodies",
 					"search_messages",
 					"search_metadata",
+					ToolSearchPersonFiles,
 					"semantic_search_messages",
 				}
 				if shape.similar {
@@ -294,6 +295,10 @@ func TestCatalogSchemas(t *testing.T) {
 				sort.Strings(searchMessagesProperties)
 				checks.Equal(searchMessagesProperties, toolPropertyNames(t, byName[ToolSearchMessages]))
 				checks.Equal(semanticProperties, toolPropertyNames(t, byName[ToolSemanticSearchMessages]))
+				checks.Equal(
+					[]string{"after", "before", "cursor", "directions", "filename", "limit", "mime_families", "person_id"},
+					toolPropertyNames(t, byName[ToolSearchPersonFiles]),
+				)
 
 				searchInMessageProperties := []string{"id", "limit", "offset", "query"}
 				if shape.vectorInMessage {
@@ -309,7 +314,7 @@ func TestCatalogSchemas(t *testing.T) {
 				}
 				if shape.document {
 					checks.Equal(
-						[]string{"attachment_id", "cursor", "limit", "message_id", "message_types", "query", "source_ids"},
+						[]string{"after", "attachment_id", "before", "cursor", "directions", "limit", "message_id", "message_types", "participant_id", "person_id", "query", "source_ids"},
 						toolPropertyNames(t, byName[ToolSearchDocuments]),
 					)
 				}

--- a/internal/mcp/contract_integration_test.go
+++ b/internal/mcp/contract_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 var task5StableToolNames = []string{
@@ -33,6 +34,7 @@ var task5StableToolNames = []string{
 	ToolSearchMessageBodies,
 	ToolSearchMessages,
 	ToolSearchMetadata,
+	ToolSearchPersonFiles,
 	ToolSemanticSearchMessages,
 	ToolStageDeletion,
 }
@@ -152,7 +154,8 @@ func newTask5Fixture(t *testing.T, shape string) task5Fixture {
 			}
 			return slices.Clone(attachmentBytes), nil
 		}),
-		ManifestSaver: saver,
+		ManifestSaver:      saver,
+		PersonFileSearcher: &recordingPersonFileSearcher{},
 	}
 
 	rrf, vectorScore := 0.45, 0.91
@@ -237,6 +240,8 @@ func task5ToolArguments(name, shape, exportDir string) (map[string]any, bool) {
 		return map[string]any{"query": "needle", "limit": 1}, true
 	case ToolSearchMetadata:
 		return map[string]any{"query": "subject:archive", "account": "alice@example.com", "limit": 1}, true
+	case ToolSearchPersonFiles:
+		return map[string]any{"person_id": 40, "limit": 1}, true
 	case ToolSearchMessageBodies:
 		return map[string]any{"query": "needle", "limit": 1}, true
 	case ToolSemanticSearchMessages:
@@ -341,6 +346,11 @@ func task5AssertRepresentativeResult(
 	must := require.New(t)
 
 	switch toolName {
+	case ToolSearchPersonFiles:
+		value := task5StructuredAs[generated.PersonFileSearchHTTPResponse](t, result)
+		must.Len(value.Files, 1)
+		checks.Equal(int64(18), value.Files[0].MessageID)
+		checks.Equal([]generated.PersonFileProvenanceRoles{generated.From}, value.Files[0].PersonProvenance.Roles)
 	case ToolSearchMetadata:
 		value := task5StructuredAs[struct {
 			Data []struct {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -15,6 +15,8 @@ import (
 
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/personscope"
+	personresolver "go.kenn.io/msgvault/internal/personscope/resolver"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/store"
@@ -23,6 +25,7 @@ import (
 	"go.kenn.io/msgvault/internal/vector/embed"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
 	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 const (
@@ -101,14 +104,15 @@ func listLimitArg(args map[string]any) int {
 }
 
 type handlers struct {
-	engine           query.Engine
-	attachmentsDir   string
-	attachmentReader AttachmentReader
-	manifestSaver    DeletionManifestSaver
-	hybridSearcher   HybridSearcher
-	similarSearcher  SimilarSearcher
-	dataDir          string
-	documentSearcher DocumentSearcher
+	engine             query.Engine
+	attachmentsDir     string
+	attachmentReader   AttachmentReader
+	manifestSaver      DeletionManifestSaver
+	hybridSearcher     HybridSearcher
+	similarSearcher    SimilarSearcher
+	dataDir            string
+	documentSearcher   DocumentSearcher
+	personFileSearcher PersonFileSearcher
 
 	// Optional vector-search wiring. When hybridEngine is nil, the
 	// search_message_bodies handler rejects mode=vector and mode=hybrid with
@@ -131,6 +135,9 @@ type VisualSearchRequest struct {
 	Limit          int
 	Cursor         string
 	SenderPersonID int64
+	PersonID       int64
+	ParticipantID  int64
+	Directions     []personscope.Direction
 	SourceID       int64
 	MessageID      int64
 	Filename       string
@@ -180,6 +187,37 @@ func (h *handlers) searchVisualAttachments(ctx context.Context, req toolRequest)
 	if toolErr != nil {
 		return toolErr, nil
 	}
+	personID, toolErr := parsePositiveID("person_id")
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	participantID, toolErr := parsePositiveID("participant_id")
+	if toolErr != nil {
+		return toolErr, nil
+	}
+	rawDirections, err := stringArrayArg(args, "directions")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	var directions []personscope.Direction
+	if len(rawDirections) > 0 {
+		directions = make([]personscope.Direction, len(rawDirections))
+		for i, raw := range rawDirections {
+			directions[i] = personscope.Direction(raw)
+		}
+		if _, _, err := personresolver.NormalizeDirections(directions); err != nil {
+			return toolErrorResult(err.Error()), nil
+		}
+	}
+	if senderPersonID > 0 && (personID > 0 || participantID > 0 || len(directions) > 0) {
+		return toolErrorResult("sender_person_id cannot be combined with person_id, participant_id, or directions"), nil
+	}
+	if personID > 0 && participantID > 0 {
+		return toolErrorResult("person_id and participant_id are mutually exclusive"), nil
+	}
+	if len(directions) > 0 && personID == 0 && participantID == 0 {
+		return toolErrorResult("directions require person_id or participant_id"), nil
+	}
 	cursor, _ := args["cursor"].(string)
 	filename, _ := args["filename"].(string)
 	mimePrefix, _ := args["mime_prefix"].(string)
@@ -204,6 +242,7 @@ func (h *handlers) searchVisualAttachments(ctx context.Context, req toolRequest)
 	}
 	response, err := h.visualSearcher.SearchVisualAttachments(ctx, VisualSearchRequest{
 		Text: text, Image: image, Limit: limit, Cursor: cursor, SenderPersonID: senderPersonID,
+		PersonID: personID, ParticipantID: participantID, Directions: directions,
 		SourceID: sourceID, MessageID: messageID, Filename: filename, MIMEPrefix: mimePrefix,
 		After: after, Before: before,
 	})
@@ -218,6 +257,94 @@ func (h *handlers) searchVisualAttachments(ctx context.Context, req toolRequest)
 // process out of the archive database.
 type DocumentSearcher interface {
 	SearchDocuments(ctx context.Context, request store.DocumentSearchRequest) (store.DocumentSearchResponse, error)
+}
+
+type PersonFileSearcher interface {
+	SearchPersonFiles(ctx context.Context, request PersonFileSearchRequest) (generated.PersonFileSearchHTTPResponse, error)
+}
+
+type PersonFileSearchRequest struct {
+	PersonID     int64
+	Directions   []personscope.Direction
+	After        *time.Time
+	Before       *time.Time
+	Filename     string
+	MIMEFamilies []query.FileMIMEFamily
+	Limit        int
+	Cursor       string
+}
+
+func (h *handlers) searchPersonFiles(ctx context.Context, req toolRequest) (*toolResult, error) {
+	if h.personFileSearcher == nil {
+		return toolErrorResult("person_file_search_unavailable: person file search is not configured"), nil
+	}
+	args := req.GetArguments()
+	personID, err := getIDArg(args, "person_id")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	rawDirections, err := stringArrayArg(args, "directions")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	var directions []personscope.Direction
+	if len(rawDirections) > 0 {
+		directions = make([]personscope.Direction, len(rawDirections))
+	}
+	for i, raw := range rawDirections {
+		directions[i] = personscope.Direction(raw)
+	}
+	normalizedDirections, _, err := personresolver.NormalizeDirections(directions)
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	if len(directions) > 0 {
+		directions = normalizedDirections
+	}
+	after, err := getDateArg(args, "after")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	before, err := getDateArg(args, "before")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	if after != nil && before != nil && !after.Before(*before) {
+		return toolErrorResult("invalid date range: after must be before before"), nil
+	}
+	rawFamilies, err := stringArrayArg(args, "mime_families")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	families := make([]query.FileMIMEFamily, len(rawFamilies))
+	for i, raw := range rawFamilies {
+		family := query.FileMIMEFamily(strings.ToLower(strings.TrimSpace(raw)))
+		switch family {
+		case query.FileMIMEImage, query.FileMIMEPDF, query.FileMIMEAudio, query.FileMIMEVideo,
+			query.FileMIMEText, query.FileMIMEDocument, query.FileMIMEArchive, query.FileMIMEOther:
+			families[i] = family
+		default:
+			return toolErrorResult(fmt.Sprintf("unknown file MIME family %q", raw)), nil
+		}
+	}
+	limit := 100
+	if _, found := args["limit"]; found {
+		parsed, parseErr := positiveInt64Arg(args, "limit")
+		if parseErr != nil || parsed > 100 {
+			return toolErrorResult("limit must be an integer between 1 and 100"), nil //nolint:nilerr // MCP tool errors are successful protocol responses.
+		}
+		limit = int(parsed)
+	}
+	filename, _ := args["filename"].(string)
+	cursor, _ := args["cursor"].(string)
+	response, err := h.personFileSearcher.SearchPersonFiles(ctx, PersonFileSearchRequest{
+		PersonID: personID, Directions: directions, After: after, Before: before,
+		Filename: strings.TrimSpace(filename), MIMEFamilies: families, Limit: limit, Cursor: cursor,
+	})
+	if err != nil {
+		return toolErrorResult("person file search failed: " + err.Error()), nil //nolint:nilerr // MCP tool errors are successful protocol responses.
+	}
+	return jsonResult(response)
 }
 
 // AttachmentReader fetches content-addressed attachment bytes. It is optional:
@@ -563,6 +690,45 @@ func (h *handlers) searchDocuments(ctx context.Context, req toolRequest) (*toolR
 	if err != nil {
 		return toolErrorResult(err.Error()), nil
 	}
+	personID, err := positiveInt64Arg(args, "person_id")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	participantID, err := positiveInt64Arg(args, "participant_id")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	if personID > 0 && participantID > 0 {
+		return toolErrorResult("person_id and participant_id are mutually exclusive"), nil
+	}
+	rawDirections, err := stringArrayArg(args, "directions")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	if len(rawDirections) > 0 && personID == 0 && participantID == 0 {
+		return toolErrorResult("directions require person_id or participant_id"), nil
+	}
+	var directions []personscope.Direction
+	if len(rawDirections) > 0 {
+		directions = make([]personscope.Direction, len(rawDirections))
+		for i, raw := range rawDirections {
+			directions[i] = personscope.Direction(raw)
+		}
+		if _, _, err := personresolver.NormalizeDirections(directions); err != nil {
+			return toolErrorResult(err.Error()), nil
+		}
+	}
+	after, err := getDateArg(args, "after")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	before, err := getDateArg(args, "before")
+	if err != nil {
+		return toolErrorResult(err.Error()), nil
+	}
+	if after != nil && before != nil && !after.Before(*before) {
+		return toolErrorResult("invalid date range: after must be before before"), nil
+	}
 	limit := 20
 	if _, found := args["limit"]; found {
 		parsedLimit, parseErr := positiveInt64Arg(args, "limit")
@@ -577,7 +743,9 @@ func (h *handlers) searchDocuments(ctx context.Context, req toolRequest) (*toolR
 	cursor, _ := args["cursor"].(string)
 	response, err := h.documentSearcher.SearchDocuments(ctx, store.DocumentSearchRequest{
 		Query: queryText, SourceIDs: sourceIDs, MessageTypes: messageTypes,
-		AttachmentID: attachmentID, MessageID: messageID, PageSize: limit, Cursor: cursor,
+		AttachmentID: attachmentID, MessageID: messageID,
+		PersonID: personID, ParticipantID: participantID, Directions: directions,
+		After: after, Before: before, PageSize: limit, Cursor: cursor,
 	})
 	if err != nil {
 		return toolErrorResult(fmt.Sprintf("document search failed: %v", err)), nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -39,6 +39,7 @@ const (
 	ToolSearchVisualAttachments = "search_visual_attachments"
 	ToolSearchInMessage         = "search_in_message"
 	ToolSearchDocuments         = "search_document_attachments"
+	ToolSearchPersonFiles       = "search_person_files"
 )
 
 // search_message_bodies/search_in_message mode values (wire format).
@@ -53,14 +54,15 @@ const (
 // the search_message_bodies tool, and Backend additionally enables the
 // find_similar_messages tool.
 type ServeOptions struct {
-	Engine           query.Engine
-	AttachmentsDir   string
-	AttachmentReader AttachmentReader
-	ManifestSaver    DeletionManifestSaver
-	HybridSearcher   HybridSearcher
-	SimilarSearcher  SimilarSearcher
-	DataDir          string
-	DocumentSearcher DocumentSearcher
+	Engine             query.Engine
+	AttachmentsDir     string
+	AttachmentReader   AttachmentReader
+	ManifestSaver      DeletionManifestSaver
+	HybridSearcher     HybridSearcher
+	SimilarSearcher    SimilarSearcher
+	DataDir            string
+	DocumentSearcher   DocumentSearcher
+	PersonFileSearcher PersonFileSearcher
 
 	// HybridEngine is optional. When nil, semantic_search_messages rejects
 	// vector/hybrid searches with a vector_not_enabled error.
@@ -180,18 +182,19 @@ func newMCPServerWithPolicy(
 	)
 
 	h := &handlers{
-		engine:           opts.Engine,
-		attachmentsDir:   opts.AttachmentsDir,
-		attachmentReader: opts.AttachmentReader,
-		manifestSaver:    opts.ManifestSaver,
-		hybridSearcher:   opts.HybridSearcher,
-		similarSearcher:  opts.SimilarSearcher,
-		dataDir:          opts.DataDir,
-		documentSearcher: opts.DocumentSearcher,
-		hybridEngine:     opts.HybridEngine,
-		vectorCfg:        opts.VectorCfg,
-		backend:          opts.Backend,
-		visualSearcher:   opts.VisualSearcher,
+		engine:             opts.Engine,
+		attachmentsDir:     opts.AttachmentsDir,
+		attachmentReader:   opts.AttachmentReader,
+		manifestSaver:      opts.ManifestSaver,
+		hybridSearcher:     opts.HybridSearcher,
+		similarSearcher:    opts.SimilarSearcher,
+		dataDir:            opts.DataDir,
+		documentSearcher:   opts.DocumentSearcher,
+		personFileSearcher: opts.PersonFileSearcher,
+		hybridEngine:       opts.HybridEngine,
+		vectorCfg:          opts.VectorCfg,
+		backend:            opts.Backend,
+		visualSearcher:     opts.VisualSearcher,
 	}
 
 	for _, definition := range operationCatalog(opts, h) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/query/querytest"
 	"go.kenn.io/msgvault/internal/search"
@@ -33,6 +34,8 @@ import (
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/hybrid"
+	"go.kenn.io/msgvault/internal/vector/visual"
+	"go.kenn.io/msgvault/pkg/client/generated"
 )
 
 // stubEmbedder is an EmbeddingClient placeholder for tests where the
@@ -304,6 +307,94 @@ type recordingDocumentSearcher struct {
 	request store.DocumentSearchRequest
 }
 
+type recordingVisualSearcher struct{ request VisualSearchRequest }
+
+func (s *recordingVisualSearcher) SearchVisualAttachments(
+	_ context.Context,
+	request VisualSearchRequest,
+) (*visual.SearchResponse, error) {
+	s.request = request
+	return &visual.SearchResponse{Results: []visual.AttachmentSearchResult{}}, nil
+}
+
+func TestSearchVisualAttachmentsPreservesSharedPersonScope(t *testing.T) {
+	searcher := &recordingVisualSearcher{}
+	h := &handlers{visualSearcher: searcher}
+	runTool[visual.SearchResponse](t, ToolSearchVisualAttachments, h.searchVisualAttachments, map[string]any{
+		"text": "inspection diagram", "person_id": float64(40),
+		"directions": []any{"to_person", "group"},
+	})
+	assert.Equal(t, int64(40), searcher.request.PersonID)
+	assert.Equal(t, []personscope.Direction{personscope.ToPerson, personscope.Group}, searcher.request.Directions)
+}
+
+type recordingPersonFileSearcher struct {
+	request PersonFileSearchRequest
+}
+
+func (s *recordingPersonFileSearcher) SearchPersonFiles(
+	_ context.Context,
+	request PersonFileSearchRequest,
+) (generated.PersonFileSearchHTTPResponse, error) {
+	s.request = request
+	filename, mimeType := "inspection.png", "image/png"
+	return generated.PersonFileSearchHTTPResponse{
+		Files: []generated.PersonFileSearchRow{{
+			ID: 17, MessageID: 18, ConversationID: 19, SourceID: 20,
+			SourceIdentifier: "synthetic-source", Filename: &filename, MimeType: &mimeType,
+			PersonProvenance: generated.PersonFileProvenance{
+				ParticipantIds: []int64{4}, Roles: []generated.PersonFileProvenanceRoles{generated.From},
+				Directions: []generated.PersonFileProvenanceDirections{generated.FromPerson},
+			},
+		}},
+		TotalCount: 1, CacheRevision: "synthetic-revision",
+	}, nil
+}
+
+func TestSearchPersonFilesPreservesScopeAndProvenance(t *testing.T) {
+	assertions := assert.New(t)
+	searcher := &recordingPersonFileSearcher{}
+	h := &handlers{personFileSearcher: searcher}
+	response := runTool[generated.PersonFileSearchHTTPResponse](t, ToolSearchPersonFiles,
+		h.searchPersonFiles, map[string]any{
+			"person_id": float64(40), "directions": []any{"from_person", "group"},
+			"after": "2026-08-01", "before": "2026-08-20", "filename": "inspection",
+			"mime_families": []any{"image", "pdf"}, "limit": float64(25), "cursor": "opaque",
+		})
+
+	assertions.Equal(int64(40), searcher.request.PersonID)
+	assertions.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group}, searcher.request.Directions)
+	assertions.Equal("2026-08-01", searcher.request.After.Format("2006-01-02"))
+	assertions.Equal("2026-08-20", searcher.request.Before.Format("2006-01-02"))
+	assertions.Equal("inspection", searcher.request.Filename)
+	assertions.Equal([]query.FileMIMEFamily{query.FileMIMEImage, query.FileMIMEPDF}, searcher.request.MIMEFamilies)
+	assertions.Equal(25, searcher.request.Limit)
+	assertions.Equal("opaque", searcher.request.Cursor)
+	require.Len(t, response.Files, 1)
+	assertions.Equal(int64(18), response.Files[0].MessageID)
+	assertions.Equal([]generated.PersonFileProvenanceRoles{generated.From}, response.Files[0].PersonProvenance.Roles)
+}
+
+func TestSearchPersonFilesRejectsInvalidScopeBeforeDispatch(t *testing.T) {
+	searcher := &recordingPersonFileSearcher{}
+	h := &handlers{personFileSearcher: searcher}
+	result := runToolExpectError(t, ToolSearchPersonFiles, h.searchPersonFiles, map[string]any{
+		"person_id": float64(40), "directions": []any{"sideways"},
+	})
+	assert.Contains(t, resultText(t, result), "unknown person file direction")
+	assert.Zero(t, searcher.request.PersonID)
+}
+
+func TestSearchPersonFilesPreservesOmittedDirectionDefault(t *testing.T) {
+	searcher := &recordingPersonFileSearcher{}
+	h := &handlers{personFileSearcher: searcher}
+	runTool[generated.PersonFileSearchHTTPResponse](t, ToolSearchPersonFiles,
+		h.searchPersonFiles, map[string]any{"person_id": float64(40)})
+
+	assert.Nil(t, searcher.request.Directions,
+		"an omitted direction must let the metadata route include unclassified roster rows")
+}
+
 func (s *recordingDocumentSearcher) SearchDocuments(
 	_ context.Context,
 	request store.DocumentSearchRequest,
@@ -316,29 +407,43 @@ func (s *recordingDocumentSearcher) SearchDocuments(
 			OccurrenceKey: "occurrence", CanonicalBlobHash: "hash", ChunkKey: "chunk",
 			Excerpt: "carton damage", ProfileID: "profile", ExtractionID: "extraction",
 			Provider: "mistral", Model: "ocr", MatchedSignals: []string{"content"}, Rank: 1,
+			PersonProvenance: &personscope.Provenance{
+				ParticipantIDs: []int64{4}, Roles: []personscope.Role{personscope.RoleFrom},
+				Directions: []personscope.Direction{personscope.FromPerson},
+			},
 		}},
 	}, nil
 }
 
 func TestSearchDocumentAttachmentsPreservesScopeAndProvenance(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	searcher := &recordingDocumentSearcher{}
 	h := &handlers{documentSearcher: searcher}
 	response := runTool[store.DocumentSearchResponse](t, ToolSearchDocuments, h.searchDocuments, map[string]any{
 		"query": "carton damage", "source_ids": []any{float64(3), float64(7)},
 		"message_types": []any{"email", "mms"}, "attachment_id": float64(17),
-		"message_id": float64(18), "limit": float64(5), "cursor": "opaque",
+		"message_id": float64(18), "person_id": float64(40),
+		"directions": []any{"from_person", "group"},
+		"after":      "2026-08-01", "before": "2026-08-20",
+		"limit": float64(5), "cursor": "opaque",
 	})
 	assert.Equal("carton damage", searcher.request.Query)
 	assert.Equal([]int64{3, 7}, searcher.request.SourceIDs)
 	assert.Equal([]string{"email", "mms"}, searcher.request.MessageTypes)
 	assert.Equal(int64(17), searcher.request.AttachmentID)
 	assert.Equal(int64(18), searcher.request.MessageID)
+	assert.Equal(int64(40), searcher.request.PersonID)
+	assert.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group}, searcher.request.Directions)
+	require.NotNil(searcher.request.After)
+	require.NotNil(searcher.request.Before)
 	assert.Equal(5, searcher.request.PageSize)
 	assert.Equal("opaque", searcher.request.Cursor)
-	require.Len(t, response.Results, 1)
+	require.Len(response.Results, 1)
 	assert.Equal("inspection.xlsx", response.Results[0].Filename)
 	assert.Equal("mistral", response.Results[0].Provider)
+	require.NotNil(response.Results[0].PersonProvenance)
+	assert.Equal([]int64{4}, response.Results[0].PersonProvenance.ParticipantIDs)
 }
 
 func TestSearchDocumentAttachmentsRejectsOutOfRangeExactID(t *testing.T) {

--- a/internal/personscope/resolver/resolver.go
+++ b/internal/personscope/resolver/resolver.go
@@ -1,0 +1,159 @@
+// Package resolver translates public person references into one attachment
+// search population shared by every retrieval lane.
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type ReferenceKind string
+
+const (
+	ReferencePerson      ReferenceKind = "person"
+	ReferenceParticipant ReferenceKind = "participant"
+)
+
+type Reference struct {
+	Kind ReferenceKind
+	ID   int64
+}
+
+type Resolution struct {
+	Reference Reference
+	PersonID  int64
+	Scope     personscope.Scope
+}
+
+var (
+	ErrUnavailable     = errors.New("person scope resolution is unavailable")
+	ErrEmptyPopulation = errors.New("person has no resolved identities")
+)
+
+type DurablePersonStore interface {
+	GetPersonContext(ctx context.Context, id int64) (*store.Person, error)
+}
+
+type ClusterStore interface {
+	ClusterMembers(id int64) ([]int64, error)
+}
+
+type BindingStore interface {
+	PersonForParticipantsContext(ctx context.Context, participantIDs []int64) (*store.Person, error)
+}
+
+func Resolve(
+	ctx context.Context,
+	profiles any,
+	reference Reference,
+	directions []personscope.Direction,
+) (Resolution, error) {
+	if profiles == nil {
+		return Resolution{}, ErrUnavailable
+	}
+	if reference.ID <= 0 {
+		return Resolution{}, errors.New("person reference ID must be positive")
+	}
+	normalizedDirections, defaultDirections, err := NormalizeDirections(directions)
+	if err != nil {
+		return Resolution{}, err
+	}
+	resolved := Resolution{Reference: reference}
+	switch reference.Kind {
+	case ReferencePerson:
+		durable, ok := profiles.(DurablePersonStore)
+		if !ok {
+			return Resolution{}, ErrUnavailable
+		}
+		person, getErr := durable.GetPersonContext(ctx, reference.ID)
+		if getErr != nil {
+			return Resolution{}, fmt.Errorf("resolve durable person %d: %w", reference.ID, getErr)
+		}
+		resolved.PersonID = person.ID
+		resolved.Scope.ParticipantIDs = slices.Clone(person.ParticipantIDs)
+	case ReferenceParticipant:
+		members := []int64{reference.ID}
+		if clusters, ok := profiles.(ClusterStore); ok {
+			var clusterErr error
+			members, clusterErr = clusters.ClusterMembers(reference.ID)
+			if clusterErr != nil {
+				return Resolution{}, fmt.Errorf("resolve participant %d cluster: %w", reference.ID, clusterErr)
+			}
+		}
+		if len(members) == 0 {
+			members = []int64{reference.ID}
+		}
+		if bindings, ok := profiles.(BindingStore); ok {
+			person, personErr := bindings.PersonForParticipantsContext(ctx, members)
+			if personErr != nil {
+				return Resolution{}, fmt.Errorf("resolve participant %d durable person: %w", reference.ID, personErr)
+			}
+			if person != nil {
+				resolved.PersonID = person.ID
+				if len(person.ParticipantIDs) > 0 {
+					members = person.ParticipantIDs
+				}
+			}
+		}
+		resolved.Scope.ParticipantIDs = slices.Clone(members)
+	default:
+		return Resolution{}, fmt.Errorf("unknown person reference kind %q", reference.Kind)
+	}
+	resolved.Scope.ParticipantIDs, err = normalizeParticipantIDs(resolved.Scope.ParticipantIDs)
+	if err != nil {
+		return Resolution{}, err
+	}
+	resolved.Scope.Directions = normalizedDirections
+	resolved.Scope.IncludeUnclassifiedRosterRows = defaultDirections
+	return resolved, nil
+}
+
+func NormalizeDirections(
+	directions []personscope.Direction,
+) ([]personscope.Direction, bool, error) {
+	if len(directions) == 0 {
+		return []personscope.Direction{
+			personscope.FromPerson, personscope.ToPerson, personscope.Group,
+		}, true, nil
+	}
+	selected := make(map[personscope.Direction]struct{}, len(directions))
+	for _, raw := range directions {
+		direction := personscope.Direction(strings.ToLower(strings.TrimSpace(string(raw))))
+		switch direction {
+		case personscope.FromPerson, personscope.ToPerson, personscope.Group:
+			selected[direction] = struct{}{}
+		default:
+			return nil, false, fmt.Errorf("unknown person file direction %q", raw)
+		}
+	}
+	result := make([]personscope.Direction, 0, len(selected))
+	for _, direction := range []personscope.Direction{
+		personscope.FromPerson, personscope.ToPerson, personscope.Group,
+	} {
+		if _, ok := selected[direction]; ok {
+			result = append(result, direction)
+		}
+	}
+	return result, false, nil
+}
+
+func normalizeParticipantIDs(ids []int64) ([]int64, error) {
+	result := slices.Clone(ids)
+	for _, id := range result {
+		if id <= 0 {
+			return nil, errors.New("resolved person scope contains an invalid participant ID")
+		}
+	}
+	slices.Sort(result)
+	result = slices.Compact(result)
+	if len(result) == 0 {
+		return nil, ErrEmptyPopulation
+	}
+	return result, nil
+}

--- a/internal/personscope/resolver/resolver_test.go
+++ b/internal/personscope/resolver/resolver_test.go
@@ -1,0 +1,157 @@
+package resolver_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
+	"go.kenn.io/msgvault/internal/personscope/resolver"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type resolverStore struct {
+	persons  map[int64]*store.Person
+	clusters map[int64][]int64
+	bindings map[int64]*store.Person
+}
+
+type clusterOnlyStore struct{ members []int64 }
+
+func (s clusterOnlyStore) ClusterMembers(int64) ([]int64, error) {
+	return slices.Clone(s.members), nil
+}
+
+func (s resolverStore) GetPersonContext(_ context.Context, id int64) (*store.Person, error) {
+	person := s.persons[id]
+	if person == nil {
+		return nil, store.ErrPersonNotFound
+	}
+	clone := *person
+	clone.ParticipantIDs = slices.Clone(person.ParticipantIDs)
+	return &clone, nil
+}
+
+func (s resolverStore) ClusterMembers(id int64) ([]int64, error) {
+	members := s.clusters[id]
+	if len(members) == 0 {
+		return []int64{id}, nil
+	}
+	return slices.Clone(members), nil
+}
+
+func (s resolverStore) PersonForParticipantsContext(
+	_ context.Context,
+	participantIDs []int64,
+) (*store.Person, error) {
+	for _, participantID := range participantIDs {
+		if person := s.bindings[participantID]; person != nil {
+			clone := *person
+			clone.ParticipantIDs = slices.Clone(person.ParticipantIDs)
+			return &clone, nil
+		}
+	}
+	return nil, nil //nolint:nilnil // No matching durable binding is a valid lookup result.
+}
+
+func TestResolveDurablePersonUsesEveryBinding(t *testing.T) {
+	assert := assert.New(t)
+	profiles := resolverStore{persons: map[int64]*store.Person{
+		40: {ID: 40, ParticipantIDs: []int64{2, 7}},
+	}}
+
+	resolved, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferencePerson, ID: 40}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(int64(40), resolved.PersonID)
+	assert.Equal([]int64{2, 7}, resolved.Scope.ParticipantIDs)
+	assert.Equal([]personscope.Direction{
+		personscope.FromPerson, personscope.ToPerson, personscope.Group,
+	}, resolved.Scope.Directions)
+	assert.True(resolved.Scope.IncludeUnclassifiedRosterRows)
+}
+
+func TestResolveDurablePersonWithoutBindingsReportsEmptyPopulation(t *testing.T) {
+	profiles := resolverStore{persons: map[int64]*store.Person{40: {ID: 40}}}
+
+	_, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferencePerson, ID: 40}, nil)
+
+	require.ErrorIs(t, err, resolver.ErrEmptyPopulation)
+}
+
+func TestResolveParticipantTranslatesThroughDurablePerson(t *testing.T) {
+	assert := assert.New(t)
+	person := &store.Person{ID: 40, ParticipantIDs: []int64{2, 7}}
+	profiles := resolverStore{
+		clusters: map[int64][]int64{2: {2, 3}},
+		bindings: map[int64]*store.Person{2: person},
+	}
+
+	resolved, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 2},
+		[]personscope.Direction{personscope.Group, personscope.FromPerson, personscope.FromPerson})
+
+	require.NoError(t, err)
+	assert.Equal(int64(40), resolved.PersonID)
+	assert.Equal([]int64{2, 7}, resolved.Scope.ParticipantIDs,
+		"durable bindings remain the population even after the observed cluster splits")
+	assert.Equal([]personscope.Direction{personscope.FromPerson, personscope.Group},
+		resolved.Scope.Directions)
+	assert.False(resolved.Scope.IncludeUnclassifiedRosterRows)
+}
+
+func TestResolveParticipantKeepsClusterWhenDurableBindingHasNoParticipants(t *testing.T) {
+	profiles := resolverStore{
+		clusters: map[int64][]int64{2: {2, 3}},
+		bindings: map[int64]*store.Person{2: {ID: 40}},
+	}
+
+	resolved, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 2}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(40), resolved.PersonID)
+	assert.Equal(t, []int64{2, 3}, resolved.Scope.ParticipantIDs)
+}
+
+func TestResolveUnpromotedParticipantUsesIdentityCluster(t *testing.T) {
+	assert := assert.New(t)
+	profiles := resolverStore{clusters: map[int64][]int64{9: {9, 10}}}
+
+	resolved, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 9},
+		[]personscope.Direction{personscope.ToPerson})
+
+	require.NoError(t, err)
+	assert.Zero(resolved.PersonID)
+	assert.Equal([]int64{9, 10}, resolved.Scope.ParticipantIDs)
+	assert.Equal([]personscope.Direction{personscope.ToPerson}, resolved.Scope.Directions)
+}
+
+func TestResolveParticipantWorksWithoutDurableProfileCapability(t *testing.T) {
+	resolved, err := resolver.Resolve(t.Context(), clusterOnlyStore{members: []int64{5, 6}},
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 5}, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int64{5, 6}, resolved.Scope.ParticipantIDs)
+}
+
+func TestResolveRejectsUnknownPersonAndDirection(t *testing.T) {
+	require := require.New(t)
+	profiles := resolverStore{}
+
+	_, err := resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferencePerson, ID: 99}, nil)
+	require.Error(err)
+	require.ErrorIs(err, store.ErrPersonNotFound)
+
+	_, err = resolver.Resolve(t.Context(), profiles,
+		resolver.Reference{Kind: resolver.ReferenceParticipant, ID: 2},
+		[]personscope.Direction{"sideways"})
+	require.Error(err)
+	assert.ErrorContains(t, err, "unknown person file direction")
+}

--- a/internal/personscope/sql.go
+++ b/internal/personscope/sql.go
@@ -1,0 +1,98 @@
+package personscope
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Validate checks an internal person constraint. The public resolver rejects
+// zero participants; MessagePredicate still renders a directly-built empty
+// scope as FALSE for defense in depth.
+func Validate(scope Scope) error {
+	if len(scope.Directions) == 0 {
+		return errors.New("resolved person scope requires directions")
+	}
+	for _, id := range scope.ParticipantIDs {
+		if id <= 0 {
+			return errors.New("resolved person scope contains an invalid participant ID")
+		}
+	}
+	for _, direction := range scope.Directions {
+		switch direction {
+		case FromPerson, ToPerson, Group:
+		default:
+			return fmt.Errorf("resolved person scope contains unknown direction %q", direction)
+		}
+	}
+	return nil
+}
+
+// MessagePredicate returns a dialect-neutral SQL predicate (using ? bind
+// placeholders) for the shared message-person relation. Callers must provide
+// aliases for the messages and conversations tables.
+func MessagePredicate(scope Scope, message, conversation string) (string, []any) {
+	if len(scope.ParticipantIDs) == 0 || len(scope.Directions) == 0 {
+		return "FALSE", nil
+	}
+	var conditions []string
+	var args []any
+	appendIDs := func() string {
+		for _, id := range scope.ParticipantIDs {
+			args = append(args, id)
+		}
+		return placeholders(len(scope.ParticipantIDs))
+	}
+	directionEvidence := `(` + message + `.is_from_me = TRUE OR ` + message + `.sender_id IS NOT NULL OR EXISTS (
+		SELECT 1 FROM message_recipients known_from
+		WHERE known_from.message_id = ` + message + `.id
+		  AND LOWER(known_from.recipient_type) = 'from'))`
+	for _, direction := range scope.Directions {
+		switch direction {
+		case FromPerson:
+			senderIDs, envelopeIDs := appendIDs(), appendIDs()
+			conditions = append(conditions, `(`+message+`.sender_id IN (`+senderIDs+`) OR EXISTS (
+				SELECT 1 FROM message_recipients person_from
+				WHERE person_from.message_id = `+message+`.id
+				  AND LOWER(person_from.recipient_type) = 'from'
+				  AND person_from.participant_id IN (`+envelopeIDs+`)))`)
+		case ToPerson:
+			explicitIDs, rosterIDs := appendIDs(), appendIDs()
+			senderIDs, envelopeSenderIDs := appendIDs(), appendIDs()
+			conditions = append(conditions, `(EXISTS (
+				SELECT 1 FROM message_recipients person_to
+				WHERE person_to.message_id = `+message+`.id
+				  AND LOWER(person_to.recipient_type) IN ('to', 'cc', 'bcc')
+				  AND person_to.participant_id IN (`+explicitIDs+`)) OR (
+				LOWER(COALESCE(`+conversation+`.conversation_type, '')) = 'direct_chat'
+				AND `+directionEvidence+`
+				AND EXISTS (SELECT 1 FROM conversation_participants person_roster
+					WHERE person_roster.conversation_id = `+message+`.conversation_id
+					  AND person_roster.participant_id IN (`+rosterIDs+`))
+				AND NOT ((`+message+`.sender_id IS NOT NULL AND `+message+`.sender_id IN (`+senderIDs+`)) OR (
+					`+message+`.sender_id IS NULL AND EXISTS (
+						SELECT 1 FROM message_recipients scoped_sender
+						WHERE scoped_sender.message_id = `+message+`.id
+						  AND LOWER(scoped_sender.recipient_type) = 'from'
+						  AND scoped_sender.participant_id IN (`+envelopeSenderIDs+`))))))`)
+		case Group:
+			rosterIDs := appendIDs()
+			rosterType := `LOWER(COALESCE(` + conversation + `.conversation_type, '')) IN ('group_chat', 'channel')`
+			if scope.IncludeUnclassifiedRosterRows {
+				rosterType = `(LOWER(COALESCE(` + conversation + `.conversation_type, '')) <> 'direct_chat' OR NOT ` + directionEvidence + `)`
+			}
+			conditions = append(conditions, `(`+rosterType+` AND EXISTS (
+				SELECT 1 FROM conversation_participants person_group
+				WHERE person_group.conversation_id = `+message+`.conversation_id
+				  AND person_group.participant_id IN (`+rosterIDs+`)))`)
+		}
+	}
+	return strings.Join(conditions, " OR "), args
+}
+
+func placeholders(count int) string {
+	if count <= 0 {
+		return "NULL"
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}

--- a/internal/personscope/sql_test.go
+++ b/internal/personscope/sql_test.go
@@ -1,0 +1,29 @@
+package personscope_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
+)
+
+func TestEmptyPersonPopulationProducesFalsePredicate(t *testing.T) {
+	scope := personscope.Scope{Directions: []personscope.Direction{personscope.FromPerson}}
+	require.NoError(t, personscope.Validate(scope))
+
+	predicate, args := personscope.MessagePredicate(scope, "m", "c")
+
+	assert.Equal(t, "FALSE", predicate)
+	assert.Empty(t, args)
+}
+
+func TestPersonPredicateRejectsMissingDirectionsWithoutInvalidSQL(t *testing.T) {
+	scope := personscope.Scope{ParticipantIDs: []int64{4}}
+	require.Error(t, personscope.Validate(scope))
+
+	predicate, args := personscope.MessagePredicate(scope, "m", "c")
+
+	assert.Equal(t, "FALSE", predicate)
+	assert.Empty(t, args)
+}

--- a/internal/personscope/types.go
+++ b/internal/personscope/types.go
@@ -1,0 +1,44 @@
+// Package personscope owns the shared identity and direction contract used to
+// filter message-owned attachment occurrences across retrieval lanes.
+package personscope
+
+// Direction selects how an attachment's owning message relates to the
+// requested person. A search may select several directions; the population is
+// their union.
+type Direction string
+
+const (
+	FromPerson Direction = "from_person"
+	ToPerson   Direction = "to_person"
+	Group      Direction = "group"
+)
+
+// Role is the exact message edge that matched one resolved participant.
+type Role string
+
+const (
+	RoleFrom               Role = "from"
+	RoleTo                 Role = "to"
+	RoleCC                 Role = "cc"
+	RoleBCC                Role = "bcc"
+	RoleConversationMember Role = "conversation_member"
+)
+
+// Scope is an internal person constraint. The public resolver rejects an empty
+// ParticipantIDs population; SQL builders still short-circuit directly-built
+// empty scopes instead of emitting an invalid VALUES or IN expression.
+type Scope struct {
+	ParticipantIDs []int64     `json:"participant_ids"`
+	Directions     []Direction `json:"directions"`
+	// IncludeUnclassifiedRosterRows preserves the historical default for
+	// conversation types without a dedicated direction selector.
+	IncludeUnclassifiedRosterRows bool `json:"include_unclassified_roster_rows"`
+}
+
+// Provenance retains every matched participant and exact role on an
+// attachment's owning message. Arrays use stable enum order.
+type Provenance struct {
+	ParticipantIDs []int64     `json:"participant_ids"`
+	Roles          []Role      `json:"roles" enum:"from,to,cc,bcc,conversation_member"`
+	Directions     []Direction `json:"directions" enum:"from_person,to_person,group"`
+}

--- a/internal/query/files.go
+++ b/internal/query/files.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.kenn.io/msgvault/internal/identityindex"
+	"go.kenn.io/msgvault/internal/personscope"
 )
 
 const maxFileSearchLimit = 500
@@ -34,40 +35,35 @@ var fileMIMEFamilies = map[FileMIMEFamily]struct{}{
 // PersonFileDirection selects how an attachment's owning message relates to
 // the requested person. A person search may select several directions; the
 // resulting population is their union.
-type PersonFileDirection string
+type PersonFileDirection = personscope.Direction
 
 const (
-	PersonFileFromPerson PersonFileDirection = "from_person"
-	PersonFileToPerson   PersonFileDirection = "to_person"
-	PersonFileGroup      PersonFileDirection = "group"
+	PersonFileFromPerson = personscope.FromPerson
+	PersonFileToPerson   = personscope.ToPerson
+	PersonFileGroup      = personscope.Group
 )
 
 // PersonFileRole is the exact message edge that matched a member of the
 // requested person's identity cluster.
-type PersonFileRole string
+type PersonFileRole = personscope.Role
 
 const (
-	PersonFileRoleFrom               PersonFileRole = "from"
-	PersonFileRoleTo                 PersonFileRole = "to"
-	PersonFileRoleCC                 PersonFileRole = "cc"
-	PersonFileRoleBCC                PersonFileRole = "bcc"
-	PersonFileRoleConversationMember PersonFileRole = "conversation_member"
+	PersonFileRoleFrom               = personscope.RoleFrom
+	PersonFileRoleTo                 = personscope.RoleTo
+	PersonFileRoleCC                 = personscope.RoleCC
+	PersonFileRoleBCC                = personscope.RoleBCC
+	PersonFileRoleConversationMember = personscope.RoleConversationMember
 )
 
 // PersonFileScope is an internal, already-resolved person constraint. The API
 // supplies every current member of the identity cluster so linking or
 // splitting identities changes membership without moving attachment rows.
-type PersonFileScope struct {
-	ParticipantIDs []int64
-	Directions     []PersonFileDirection
-	// IncludeUnclassifiedRosterRows preserves the historical default scope for
-	// conversation types that do not have a dedicated direction selector.
-	IncludeUnclassifiedRosterRows bool
-}
+type PersonFileScope = personscope.Scope
 
 // PersonFileProvenance retains all matched cluster members and exact roles on
-// an attachment's owning message. Arrays use stable enum order and never
-// collapse a multi-role match to one inferred label.
+// an attachment's owning message. Keep this as a named public shape so the
+// generated client contract remains stable while the shared resolver types
+// stay internal to the retrieval lanes.
 type PersonFileProvenance struct {
 	ParticipantIDs []int64               `json:"participant_ids"`
 	Roles          []PersonFileRole      `json:"roles" enum:"from,to,cc,bcc,conversation_member"`
@@ -361,9 +357,6 @@ func validatePersonFileScope(scope *PersonFileScope) error {
 	if scope == nil {
 		return nil
 	}
-	if len(scope.ParticipantIDs) == 0 {
-		return fmt.Errorf("%w: person file participant IDs are required", ErrInvalidExploreRequest)
-	}
 	for _, participantID := range scope.ParticipantIDs {
 		if participantID <= 0 {
 			return fmt.Errorf("%w: person file participant IDs must be positive", ErrInvalidExploreRequest)
@@ -404,6 +397,10 @@ func personFileMatchCTEs(scope PersonFileScope) (string, []any) {
 		participantRows[i] = "(CAST(? AS BIGINT))"
 		args[i] = participantID
 	}
+	personIDRows := "VALUES " + strings.Join(participantRows, ",")
+	if len(participantRows) == 0 {
+		personIDRows = "SELECT CAST(NULL AS BIGINT) WHERE FALSE"
+	}
 	selectedDirections := make([]string, 0, len(scope.Directions))
 	for _, direction := range scope.Directions {
 		switch direction {
@@ -430,7 +427,7 @@ func personFileMatchCTEs(scope PersonFileScope) (string, []any) {
 	return `attachment_message_ids AS MATERIALIZED (
 	SELECT message_id FROM attachments GROUP BY message_id
 ), person_ids(participant_id) AS (
-	VALUES ` + strings.Join(participantRows, ",") + `
+	` + personIDRows + `
 ), person_edges AS (
 	SELECT mr.message_id, mr.participant_id, lower(mr.recipient_type) AS role
 	FROM attachment_message_ids ami

--- a/internal/query/files_test.go
+++ b/internal/query/files_test.go
@@ -436,7 +436,6 @@ func TestSearchFilesPersonScopeValidation(t *testing.T) {
 		name  string
 		scope PersonFileScope
 	}{
-		{name: "missing participant IDs", scope: PersonFileScope{Directions: []PersonFileDirection{PersonFileFromPerson}}},
 		{name: "non-positive participant ID", scope: PersonFileScope{ParticipantIDs: []int64{0}, Directions: []PersonFileDirection{PersonFileFromPerson}}},
 		{name: "missing directions", scope: PersonFileScope{ParticipantIDs: []int64{1}}},
 		{name: "unknown direction", scope: PersonFileScope{ParticipantIDs: []int64{1}, Directions: []PersonFileDirection{"sideways"}}},
@@ -447,6 +446,22 @@ func TestSearchFilesPersonScopeValidation(t *testing.T) {
 			require.ErrorIs(t, err, ErrInvalidExploreRequest)
 		})
 	}
+}
+
+func TestSearchFilesEmptyPersonPopulationReturnsNoFiles(t *testing.T) {
+	b := NewTestDataBuilder(t)
+	source := b.AddSource("archive@example.test")
+	message := b.AddMessage(MessageOpt{SourceID: source, Subject: "unrelated"})
+	b.AddAttachmentWithMIME(1, message, 10, "unrelated.pdf", "application/pdf")
+
+	result, err := b.BuildEngine().SearchFiles(context.Background(), FileSearchRequest{
+		Person: &PersonFileScope{Directions: []PersonFileDirection{PersonFileFromPerson}},
+		Page:   PageSpec{Limit: 10},
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result.Files)
+	assert.Zero(t, result.TotalCount)
 }
 
 func TestSearchFilesFlattensSnippetMarkupInContainingTitle(t *testing.T) {

--- a/internal/store/document_search.go
+++ b/internal/store/document_search.go
@@ -13,8 +13,11 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"go.kenn.io/msgvault/internal/personscope"
 )
 
 const (
@@ -36,13 +39,19 @@ var (
 )
 
 type DocumentSearchRequest struct {
-	Query        string
-	SourceIDs    []int64
-	MessageTypes []string
-	AttachmentID int64
-	MessageID    int64
-	PageSize     int
-	Cursor       string
+	Query         string
+	SourceIDs     []int64
+	MessageTypes  []string
+	AttachmentID  int64
+	MessageID     int64
+	PageSize      int
+	Cursor        string
+	After         *time.Time
+	Before        *time.Time
+	PersonID      int64
+	ParticipantID int64
+	Directions    []personscope.Direction
+	Person        *personscope.Scope
 }
 
 type DocumentSearchResponse struct {
@@ -53,31 +62,35 @@ type DocumentSearchResponse struct {
 }
 
 type DocumentSearchResult struct {
-	AttachmentID      int64    `json:"attachment_id"`
-	MessageID         int64    `json:"message_id"`
-	SourceID          int64    `json:"source_id"`
-	OccurrenceKey     string   `json:"occurrence_key"`
-	SourcePartKey     string   `json:"source_part_key,omitempty"`
-	Filename          string   `json:"filename,omitempty"`
-	ContainingTitle   string   `json:"containing_title,omitempty"`
-	MIMEType          string   `json:"mime_type,omitempty"`
-	CanonicalBlobHash string   `json:"canonical_blob_hash"`
-	OtherLiveCopies   int      `json:"other_live_copies"`
-	ChunkKey          string   `json:"chunk_key"`
-	ChunkOrdinal      int      `json:"chunk_ordinal"`
-	HeadingPath       []string `json:"heading_path,omitempty"`
-	FirstUnitIndex    int      `json:"first_unit_index"`
-	LastUnitIndex     int      `json:"last_unit_index"`
-	Excerpt           string   `json:"excerpt"`
-	HighlightStart    int      `json:"highlight_start"`
-	HighlightEnd      int      `json:"highlight_end"`
-	ProfileID         string   `json:"profile_id"`
-	ExtractionID      string   `json:"extraction_id"`
-	Provider          string   `json:"provider"`
-	Model             string   `json:"model"`
-	MatchedSignals    []string `json:"matched_signals"`
-	Truncated         bool     `json:"truncated"`
-	Rank              int      `json:"rank"`
+	AttachmentID      int64                   `json:"attachment_id"`
+	MessageID         int64                   `json:"message_id"`
+	ConversationID    int64                   `json:"conversation_id"`
+	SourceID          int64                   `json:"source_id"`
+	SourceMessageID   string                  `json:"source_message_id,omitempty"`
+	OccurredAt        *time.Time              `json:"occurred_at,omitempty"`
+	OccurrenceKey     string                  `json:"occurrence_key"`
+	SourcePartKey     string                  `json:"source_part_key,omitempty"`
+	Filename          string                  `json:"filename,omitempty"`
+	ContainingTitle   string                  `json:"containing_title,omitempty"`
+	MIMEType          string                  `json:"mime_type,omitempty"`
+	CanonicalBlobHash string                  `json:"canonical_blob_hash"`
+	OtherLiveCopies   int                     `json:"other_live_copies"`
+	ChunkKey          string                  `json:"chunk_key"`
+	ChunkOrdinal      int                     `json:"chunk_ordinal"`
+	HeadingPath       []string                `json:"heading_path,omitempty"`
+	FirstUnitIndex    int                     `json:"first_unit_index"`
+	LastUnitIndex     int                     `json:"last_unit_index"`
+	Excerpt           string                  `json:"excerpt"`
+	HighlightStart    int                     `json:"highlight_start"`
+	HighlightEnd      int                     `json:"highlight_end"`
+	ProfileID         string                  `json:"profile_id"`
+	ExtractionID      string                  `json:"extraction_id"`
+	Provider          string                  `json:"provider"`
+	Model             string                  `json:"model"`
+	MatchedSignals    []string                `json:"matched_signals"`
+	Truncated         bool                    `json:"truncated"`
+	Rank              int                     `json:"rank"`
+	PersonProvenance  *personscope.Provenance `json:"person_provenance,omitempty"`
 }
 
 type documentSearchCursor struct {
@@ -86,6 +99,18 @@ type documentSearchCursor struct {
 	RequestHash    string `json:"request_hash"`
 	Offset         int    `json:"offset"`
 	CandidateLimit int    `json:"candidate_limit"`
+}
+
+type documentSearchHashPayload struct {
+	Query        string             `json:"query"`
+	SourceIDs    []int64            `json:"source_ids"`
+	MessageTypes []string           `json:"message_types"`
+	AttachmentID int64              `json:"attachment_id"`
+	MessageID    int64              `json:"message_id"`
+	PageSize     int                `json:"page_size"`
+	After        *time.Time         `json:"after"`
+	Before       *time.Time         `json:"before"`
+	Person       *personscope.Scope `json:"person"`
 }
 
 type documentSearchRow struct {
@@ -135,6 +160,11 @@ func (s *Store) SearchDocuments(
 	if err := s.populateDocumentLiveCopyCounts(ctx, response.Results); err != nil {
 		return DocumentSearchResponse{}, err
 	}
+	if prepared.Person != nil {
+		if err := s.populateDocumentPersonProvenance(ctx, response.Results, *prepared.Person); err != nil {
+			return DocumentSearchResponse{}, err
+		}
+	}
 	if end < len(rows) {
 		response.NextCursor, err = encodeDocumentSearchCursor(documentSearchCursor{
 			Version: documentSearchCursorVersion, Revision: revision,
@@ -166,7 +196,9 @@ func (s *Store) prepareDocumentSearch(
 		request.PageSize = 20
 	}
 	if request.PageSize < 1 || request.PageSize > maxDocumentSearchPageSize ||
-		request.AttachmentID < 0 || request.MessageID < 0 {
+		request.AttachmentID < 0 || request.MessageID < 0 || request.PersonID < 0 || request.ParticipantID < 0 ||
+		(request.PersonID > 0 && request.ParticipantID > 0) ||
+		((request.PersonID > 0 || request.ParticipantID > 0) && request.Person == nil) {
 		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: request has invalid bounds", ErrDocumentSearchInvalidRequest)
 	}
 	var err error
@@ -178,6 +210,13 @@ func (s *Store) prepareDocumentSearch(
 	request.MessageTypes, err = sortedUniqueNonempty(request.MessageTypes)
 	if err != nil {
 		return request, nil, "", 0, 0, 0, err
+	}
+	request.Person, err = normalizeDocumentPersonScope(request.Person)
+	if err != nil {
+		return request, nil, "", 0, 0, 0, err
+	}
+	if request.After != nil && request.Before != nil && !request.After.Before(*request.Before) {
+		return request, nil, "", 0, 0, 0, fmt.Errorf("%w: after must be before before", ErrDocumentSearchInvalidRequest)
 	}
 	requestHash, err := hashDocumentSearchRequest(request)
 	if err != nil {
@@ -218,7 +257,7 @@ func (s *Store) searchDocumentContent(
 	limit int,
 ) ([]documentSearchRow, bool, error) {
 	ftsArg := s.dialect.BuildFTSArg(terms)
-	conditions, scopeArgs := documentSearchScope(request, "m", "a")
+	conditions, scopeArgs := documentSearchScope(request, "m", "a", "cv")
 	validity := documentSearchValidity("p", "c", "h", "o", "a", "m", "ds")
 	var query string
 	args := make([]any, 0, len(scopeArgs)+2)
@@ -298,7 +337,7 @@ func (s *Store) searchDocumentFilenames(
 	terms []string,
 	limit int,
 ) ([]documentSearchRow, bool, error) {
-	conditions, args := documentSearchScope(request, "m", "a")
+	conditions, args := documentSearchScope(request, "m", "a", "cv")
 	var filenameConditions strings.Builder
 	for _, term := range terms {
 		filenameConditions.WriteString(` AND LOWER(COALESCE(o.filename, '')) LIKE ? ESCAPE '!'`)
@@ -324,7 +363,10 @@ func (s *Store) searchDocumentFilenames(
 }
 
 const documentSearchSelectColumns = `
-		a.id, m.id, m.source_id, o.occurrence_key,
+		a.id, m.id, m.conversation_id, m.source_id,
+		COALESCE(m.source_message_id, ''),
+		COALESCE(m.sent_at, m.received_at, m.internal_date),
+		o.occurrence_key,
 		COALESCE(o.source_part_key, ''), COALESCE(o.filename, ''),
 		COALESCE(NULLIF(m.subject, ''), NULLIF(cv.title, ''), ''),
 		COALESCE(o.mime_type, ''), h.canonical_blob_hash,
@@ -334,7 +376,10 @@ const documentSearchSelectColumns = `
 		dc.truncated`
 
 const documentSearchRankedSelectColumns = `
-		a.id AS attachment_id, m.id AS message_id, m.source_id AS source_id,
+		a.id AS attachment_id, m.id AS message_id,
+		m.conversation_id AS conversation_id, m.source_id AS source_id,
+		COALESCE(m.source_message_id, '') AS source_message_id,
+		COALESCE(m.sent_at, m.received_at, m.internal_date) AS occurred_at,
 		o.occurrence_key AS occurrence_key,
 		COALESCE(o.source_part_key, '') AS source_part_key,
 		COALESCE(o.filename, '') AS filename,
@@ -349,7 +394,8 @@ const documentSearchRankedSelectColumns = `
 		p.provider AS provider, p.model AS model, dc.truncated AS truncated`
 
 const documentSearchOuterColumns = `
-		attachment_id, message_id, source_id, occurrence_key,
+		attachment_id, message_id, conversation_id, source_id,
+		source_message_id, occurred_at, occurrence_key,
 		source_part_key, filename, containing_title, mime_type,
 		canonical_blob_hash, chunk_key, chunk_ordinal, heading_path,
 		first_unit_index, last_unit_index, chunk_text,
@@ -419,7 +465,7 @@ func documentSearchValidity(profile, consent, head, occurrence, attachment, mess
 	)`
 }
 
-func documentSearchScope(request DocumentSearchRequest, message, attachment string) (string, []any) {
+func documentSearchScope(request DocumentSearchRequest, message, attachment, conversation string) (string, []any) {
 	var conditions strings.Builder
 	var args []any
 	if len(request.SourceIDs) > 0 {
@@ -446,6 +492,19 @@ func documentSearchScope(request DocumentSearchRequest, message, attachment stri
 		conditions.WriteString(` AND ` + message + `.id = ?`)
 		args = append(args, request.MessageID)
 	}
+	if request.After != nil {
+		conditions.WriteString(` AND COALESCE(` + message + `.sent_at, ` + message + `.received_at, ` + message + `.internal_date) >= ?`)
+		args = append(args, *request.After)
+	}
+	if request.Before != nil {
+		conditions.WriteString(` AND COALESCE(` + message + `.sent_at, ` + message + `.received_at, ` + message + `.internal_date) < ?`)
+		args = append(args, *request.Before)
+	}
+	if request.Person != nil {
+		personCondition, personArgs := personscope.MessagePredicate(*request.Person, message, conversation)
+		conditions.WriteString(" AND (" + personCondition + ")")
+		args = append(args, personArgs...)
+	}
 	return conditions.String(), args
 }
 
@@ -466,8 +525,10 @@ func (s *Store) scanDocumentSearchRows(
 	for rows.Next() {
 		var row documentSearchRow
 		var headingJSON string
+		var occurredAt nullableTimestamp
 		if err := rows.Scan(
-			&row.AttachmentID, &row.MessageID, &row.SourceID, &row.OccurrenceKey,
+			&row.AttachmentID, &row.MessageID, &row.ConversationID, &row.SourceID,
+			&row.SourceMessageID, &occurredAt, &row.OccurrenceKey,
 			&row.SourcePartKey, &row.Filename, &row.ContainingTitle, &row.MIMEType,
 			&row.CanonicalBlobHash, &row.ChunkKey, &row.ChunkOrdinal, &headingJSON,
 			&row.FirstUnitIndex, &row.LastUnitIndex, &row.Text,
@@ -475,6 +536,9 @@ func (s *Store) scanDocumentSearchRows(
 			&row.Truncated,
 		); err != nil {
 			return nil, false, fmt.Errorf("scan document search result: %w", err)
+		}
+		if occurredAt.Valid {
+			row.OccurredAt = &occurredAt.Time
 		}
 		if err := json.Unmarshal([]byte(headingJSON), &row.HeadingPath); err != nil {
 			return nil, false, fmt.Errorf("decode document search heading path: %w", err)
@@ -644,16 +708,10 @@ func documentSearchExcerpt(text string, terms []string) (string, int, int) {
 }
 
 func hashDocumentSearchRequest(request DocumentSearchRequest) (string, error) {
-	payload := struct {
-		Query        string   `json:"query"`
-		SourceIDs    []int64  `json:"source_ids"`
-		MessageTypes []string `json:"message_types"`
-		AttachmentID int64    `json:"attachment_id"`
-		MessageID    int64    `json:"message_id"`
-		PageSize     int      `json:"page_size"`
-	}{
+	payload := documentSearchHashPayload{
 		Query: request.Query, SourceIDs: request.SourceIDs, MessageTypes: request.MessageTypes,
 		AttachmentID: request.AttachmentID, MessageID: request.MessageID, PageSize: request.PageSize,
+		After: request.After, Before: request.Before, Person: request.Person,
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/store/document_search_test.go
+++ b/internal/store/document_search_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
@@ -28,6 +29,9 @@ func TestSearchDocumentsReturnsCurrentExactOccurrences(t *testing.T) {
 	require.Len(t, response.Results, 1)
 	result := response.Results[0]
 	assert.Equal("synthetic.pdf", result.Filename)
+	assert.Equal(f.ConvID, result.ConversationID)
+	assert.Equal("document-publication", result.SourceMessageID)
+	assert.Nil(result.OccurredAt)
 	assert.Equal(hash, result.CanonicalBlobHash)
 	assert.Equal(profile.ID, result.ProfileID)
 	assert.Equal("mistral", result.Provider)
@@ -38,6 +42,129 @@ func TestSearchDocumentsReturnsCurrentExactOccurrences(t *testing.T) {
 	assert.Equal(10, result.HighlightEnd)
 	assert.Zero(result.OtherLiveCopies)
 	assert.Equal(1, result.Rank)
+}
+
+func TestSearchDocumentsFiltersOwningMessagesByResolvedPerson(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	f := storetest.New(t)
+	profile, hash := seedDocumentPublicationAuthority(t, f)
+	publishSearchDocument(t, f, profile, hash, "person nebula evidence", "search-person")
+
+	firstParticipant := f.EnsureParticipant("first@example.test", "First", "example.test")
+	secondParticipant := f.EnsureParticipant("second@example.test", "Second", "example.test")
+	var firstAttachmentID, firstMessageID int64
+	requirements.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT id, message_id FROM attachments WHERE content_hash = ?`), hash).
+		Scan(&firstAttachmentID, &firstMessageID))
+	when := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	_, err := f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET sender_id = ?, sent_at = ? WHERE id = ?`),
+		firstParticipant, when, firstMessageID)
+	requirements.NoError(err)
+
+	secondMessageID := f.CreateMessage("document-search-other-person")
+	secondAttachmentID := addSearchAttachment(t, f, secondMessageID, hash, "other.pdf", "provider:other")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET sender_id = ?, sent_at = ? WHERE id = ?`),
+		secondParticipant, when, secondMessageID)
+	requirements.NoError(err)
+	_, eligible, err := f.Store.ReconcileDocumentOccurrence(t.Context(), secondAttachmentID, 2)
+	requirements.NoError(err)
+	requirements.True(eligible)
+
+	after := when.Add(-time.Hour)
+	before := when.Add(time.Hour)
+	response, err := f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", After: &after, Before: &before,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{firstParticipant},
+			Directions:     []personscope.Direction{personscope.FromPerson},
+		},
+	})
+	requirements.NoError(err)
+	requirements.Len(response.Results, 1)
+	assertions.Equal(firstMessageID, response.Results[0].MessageID)
+	assertions.Equal(&personscope.Provenance{
+		ParticipantIDs: []int64{firstParticipant},
+		Roles:          []personscope.Role{personscope.RoleFrom},
+		Directions:     []personscope.Direction{personscope.FromPerson},
+	}, response.Results[0].PersonProvenance)
+
+	var firstConversationID int64
+	requirements.NoError(f.Store.DB().QueryRow(f.Store.Rebind(
+		`SELECT conversation_id FROM messages WHERE id = ?`), firstMessageID).
+		Scan(&firstConversationID))
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE conversations SET conversation_type = 'direct_chat' WHERE id = ?`), firstConversationID)
+	requirements.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE messages SET sender_id = NULL, is_from_me = FALSE WHERE id = ?`), firstMessageID)
+	requirements.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'from')`),
+		firstMessageID, secondParticipant)
+	requirements.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`INSERT INTO conversation_participants (conversation_id, participant_id) VALUES (?, ?)`),
+		firstConversationID, firstParticipant)
+	requirements.NoError(err)
+
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", AttachmentID: firstAttachmentID,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{firstParticipant},
+			Directions:     []personscope.Direction{personscope.ToPerson},
+		},
+	})
+	requirements.NoError(err)
+	requirements.Len(response.Results, 1,
+		"a direct-chat roster member is the inferred recipient when a different sender is known only from the envelope")
+	assertions.Equal([]personscope.Direction{personscope.ToPerson},
+		response.Results[0].PersonProvenance.Directions)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`DELETE FROM message_recipients WHERE message_id = ? AND participant_id = ? AND recipient_type = 'from'`),
+		firstMessageID, secondParticipant)
+	requirements.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'from')`),
+		firstMessageID, firstParticipant)
+	requirements.NoError(err)
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", AttachmentID: firstAttachmentID,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{firstParticipant},
+			Directions:     []personscope.Direction{personscope.ToPerson},
+		},
+	})
+	requirements.NoError(err)
+	assertions.Empty(response.Results,
+		"a person known as the envelope sender cannot also be inferred as the direct recipient")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`DELETE FROM message_recipients WHERE message_id = ? AND participant_id = ? AND recipient_type = 'from'`),
+		firstMessageID, firstParticipant)
+	requirements.NoError(err)
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`INSERT INTO message_recipients (message_id, participant_id, recipient_type) VALUES (?, ?, 'from')`),
+		firstMessageID, secondParticipant)
+	requirements.NoError(err)
+
+	_, err = f.Store.DB().Exec(f.Store.Rebind(
+		`UPDATE conversations SET conversation_type = 'group_chat' WHERE id = ?`), firstConversationID)
+	requirements.NoError(err)
+	response, err = f.Store.SearchDocuments(t.Context(), store.DocumentSearchRequest{
+		Query: "nebula", AttachmentID: firstAttachmentID,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{firstParticipant},
+			Directions:     []personscope.Direction{personscope.Group},
+		},
+	})
+	requirements.NoError(err)
+	requirements.Len(response.Results, 1)
+	assertions.Equal([]personscope.Role{personscope.RoleConversationMember},
+		response.Results[0].PersonProvenance.Roles)
+	assertions.Equal([]personscope.Direction{personscope.Group},
+		response.Results[0].PersonProvenance.Directions)
 }
 
 func TestSearchDocumentsFailsCleanlyWithoutFTS(t *testing.T) {

--- a/internal/store/person_message_scope.go
+++ b/internal/store/person_message_scope.go
@@ -1,0 +1,195 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/personscope"
+)
+
+func normalizeDocumentPersonScope(scope *personscope.Scope) (*personscope.Scope, error) {
+	if scope == nil {
+		return nil, nil //nolint:nilnil // An omitted optional scope has no value and no error.
+	}
+	normalized := *scope
+	normalized.ParticipantIDs = slices.Clone(scope.ParticipantIDs)
+	slices.Sort(normalized.ParticipantIDs)
+	normalized.ParticipantIDs = slices.Compact(normalized.ParticipantIDs)
+	if len(normalized.ParticipantIDs) > 0 && normalized.ParticipantIDs[0] <= 0 {
+		return nil, fmt.Errorf("%w: resolved person scope has invalid participants", ErrDocumentSearchInvalidRequest)
+	}
+	selected := make(map[personscope.Direction]bool, len(scope.Directions))
+	for _, direction := range scope.Directions {
+		switch direction {
+		case personscope.FromPerson, personscope.ToPerson, personscope.Group:
+			selected[direction] = true
+		default:
+			return nil, fmt.Errorf("%w: unknown person direction %q", ErrDocumentSearchInvalidRequest, direction)
+		}
+	}
+	normalized.Directions = normalized.Directions[:0]
+	for _, direction := range []personscope.Direction{personscope.FromPerson, personscope.ToPerson, personscope.Group} {
+		if selected[direction] {
+			normalized.Directions = append(normalized.Directions, direction)
+		}
+	}
+	if len(normalized.Directions) == 0 {
+		return nil, fmt.Errorf("%w: resolved person scope has no directions", ErrDocumentSearchInvalidRequest)
+	}
+	return &normalized, nil
+}
+
+func (s *Store) populateDocumentPersonProvenance(
+	ctx context.Context,
+	results []DocumentSearchResult,
+	scope personscope.Scope,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+	messageIDs := make([]int64, 0, len(results))
+	for _, result := range results {
+		messageIDs = append(messageIDs, result.MessageID)
+	}
+	provenance, err := s.PersonProvenanceForMessages(ctx, messageIDs, scope)
+	if err != nil {
+		return err
+	}
+	for i := range results {
+		results[i].PersonProvenance = provenance[results[i].MessageID]
+		if results[i].PersonProvenance == nil {
+			return fmt.Errorf("document person provenance missing for message %d", results[i].MessageID)
+		}
+	}
+	return nil
+}
+
+// PersonProvenanceForMessages hydrates the exact participant, role, and
+// direction edges for a resolved scope over a bounded set of messages.
+func (s *Store) PersonProvenanceForMessages(
+	ctx context.Context,
+	messageIDs []int64,
+	scope personscope.Scope,
+) (map[int64]*personscope.Provenance, error) {
+	if len(messageIDs) == 0 {
+		return map[int64]*personscope.Provenance{}, nil
+	}
+	if len(scope.ParticipantIDs) == 0 {
+		return map[int64]*personscope.Provenance{}, nil
+	}
+	messageIDs = slices.Clone(messageIDs)
+	slices.Sort(messageIDs)
+	messageIDs = slices.Compact(messageIDs)
+	messageRows := make([]string, len(messageIDs))
+	participantRows := make([]string, len(scope.ParticipantIDs))
+	args := make([]any, 0, len(messageIDs)+len(scope.ParticipantIDs))
+	for i, id := range messageIDs {
+		messageRows[i] = "(CAST(? AS BIGINT))"
+		args = append(args, id)
+	}
+	for i, id := range scope.ParticipantIDs {
+		participantRows[i] = "(CAST(? AS BIGINT))"
+		args = append(args, id)
+	}
+	directionEvidence := `(m.is_from_me = TRUE OR m.sender_id IS NOT NULL OR EXISTS (
+		SELECT 1 FROM message_recipients known_from
+		WHERE known_from.message_id = m.id AND LOWER(known_from.recipient_type) = 'from'))`
+	rosterCondition := `LOWER(COALESCE(c.conversation_type, '')) IN ('group_chat', 'channel')`
+	if scope.IncludeUnclassifiedRosterRows {
+		rosterCondition = `(LOWER(COALESCE(c.conversation_type, '')) <> 'direct_chat' OR NOT ` + directionEvidence + `)`
+	}
+	query := `WITH selected_messages(message_id) AS (VALUES ` + strings.Join(messageRows, ",") + `),
+	person_ids(participant_id) AS (VALUES ` + strings.Join(participantRows, ",") + `),
+	person_edges AS (
+		SELECT mr.message_id, mr.participant_id, LOWER(mr.recipient_type) AS role
+		FROM selected_messages sm
+		JOIN message_recipients mr ON mr.message_id = sm.message_id
+		JOIN person_ids p ON p.participant_id = mr.participant_id
+		WHERE LOWER(mr.recipient_type) IN ('from', 'to', 'cc', 'bcc')
+		UNION ALL
+		SELECT m.id, m.sender_id, 'from'
+		FROM selected_messages sm JOIN messages m ON m.id = sm.message_id
+		JOIN person_ids p ON p.participant_id = m.sender_id
+		UNION ALL
+		SELECT m.id, cp.participant_id, 'to'
+		FROM selected_messages sm JOIN messages m ON m.id = sm.message_id
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN conversation_participants cp ON cp.conversation_id = m.conversation_id
+		JOIN person_ids p ON p.participant_id = cp.participant_id
+		WHERE LOWER(COALESCE(c.conversation_type, '')) = 'direct_chat'
+		  AND ` + directionEvidence + `
+		  AND NOT EXISTS (
+			SELECT 1 FROM person_ids sender_person
+			WHERE sender_person.participant_id = m.sender_id OR (
+				m.sender_id IS NULL AND EXISTS (
+					SELECT 1 FROM message_recipients mr_from
+					WHERE mr_from.message_id = m.id
+					  AND LOWER(mr_from.recipient_type) = 'from'
+					  AND mr_from.participant_id = sender_person.participant_id)))
+		UNION ALL
+		SELECT m.id, cp.participant_id, 'conversation_member'
+		FROM selected_messages sm JOIN messages m ON m.id = sm.message_id
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN conversation_participants cp ON cp.conversation_id = m.conversation_id
+		JOIN person_ids p ON p.participant_id = cp.participant_id
+		WHERE ` + rosterCondition + `
+	)
+	SELECT message_id, participant_id, role FROM person_edges
+	ORDER BY message_id, participant_id, role`
+	rows, err := s.db.QueryContext(ctx, s.dialect.Rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("read person message provenance: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	type edgeSet map[personscope.Role]bool
+	edges := make(map[int64]map[int64]edgeSet, len(messageIDs))
+	for rows.Next() {
+		var messageID, participantID int64
+		var role personscope.Role
+		if err := rows.Scan(&messageID, &participantID, &role); err != nil {
+			return nil, fmt.Errorf("scan person message provenance: %w", err)
+		}
+		if edges[messageID] == nil {
+			edges[messageID] = make(map[int64]edgeSet)
+		}
+		if edges[messageID][participantID] == nil {
+			edges[messageID][participantID] = make(edgeSet)
+		}
+		edges[messageID][participantID][role] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate person message provenance: %w", err)
+	}
+	result := make(map[int64]*personscope.Provenance, len(edges))
+	for messageID, messageEdges := range edges {
+		provenance := &personscope.Provenance{}
+		for participantID := range messageEdges {
+			provenance.ParticipantIDs = append(provenance.ParticipantIDs, participantID)
+		}
+		slices.Sort(provenance.ParticipantIDs)
+		for _, role := range []personscope.Role{
+			personscope.RoleFrom, personscope.RoleTo, personscope.RoleCC,
+			personscope.RoleBCC, personscope.RoleConversationMember,
+		} {
+			for _, participantID := range provenance.ParticipantIDs {
+				if messageEdges[participantID][role] {
+					provenance.Roles = append(provenance.Roles, role)
+					break
+				}
+			}
+		}
+		if slices.Contains(provenance.Roles, personscope.RoleFrom) {
+			provenance.Directions = append(provenance.Directions, personscope.FromPerson)
+		}
+		if slices.Contains(provenance.Roles, personscope.RoleTo) || slices.Contains(provenance.Roles, personscope.RoleCC) || slices.Contains(provenance.Roles, personscope.RoleBCC) {
+			provenance.Directions = append(provenance.Directions, personscope.ToPerson)
+		}
+		if slices.Contains(provenance.Roles, personscope.RoleConversationMember) {
+			provenance.Directions = append(provenance.Directions, personscope.Group)
+		}
+		result[messageID] = provenance
+	}
+	return result, nil
+}

--- a/internal/vector/pgvector/visual.go
+++ b/internal/vector/pgvector/visual.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
@@ -64,29 +66,27 @@ func (b *VisualBackend) Search(ctx context.Context, request visual.SearchRequest
 	if len(request.Vector) != visualDimension || !finiteVisualVector(request.Vector) {
 		return nil, errors.New("invalid visual query vector")
 	}
+	dimension := strconv.Itoa(visualDimension)
 	query := `
 		SELECT vv.vector_token,
-		       1 - (vv.embedding::vector(1024) <=> $2::vector(1024)) AS score
+		       1 - (vv.embedding::vector(` + dimension + `) <=> $2::vector(` + dimension + `)) AS score
 		FROM visual_vectors vv
 		JOIN visual_publications vp ON vp.current_vector_token = vv.vector_token
 		JOIN visual_generations vg ON vg.id = vp.generation_id
 		JOIN messages m ON m.id = vp.message_id
+		JOIN conversations c ON c.id = m.conversation_id
 		JOIN attachments a ON a.id = vp.representative_attachment_id
-		WHERE vp.generation_id = $1 AND vg.state = 'active'
+		WHERE vp.generation_id = $1 AND vg.state = 'active' AND vv.dimension = ` + dimension + `
 		  AND vp.state = 'current' AND ` + store.LiveMessagesWhere("m", true) + `
-		  AND a.message_id = vp.message_id AND a.attachment_role = 'standalone'
-		  AND vv.dimension = 1024`
+		  AND a.message_id = vp.message_id AND a.attachment_role = 'standalone'`
 	args := []any{int64(request.GenerationID), vectorLiteral(request.Vector), request.Limit}
-	if request.SenderPersonID > 0 {
-		// Legacy imports leave sender_id NULL and record the sender as a
-		// 'from' recipient row; fall back the same way the message list
-		// queries do so those results are not silently excluded.
-		query += fmt.Sprintf(` AND EXISTS (SELECT 1 FROM person_participants pp WHERE pp.person_id = $%d
-			AND pp.participant_id = COALESCE(m.sender_id, (
-				SELECT mr.participant_id FROM message_recipients mr
-				WHERE mr.message_id = m.id AND mr.recipient_type = 'from'
-				ORDER BY mr.id LIMIT 1)))`, len(args)+1)
-		args = append(args, request.SenderPersonID)
+	if request.Person != nil {
+		predicate, personArgs := personscope.MessagePredicate(*request.Person, "m", "c")
+		for _, arg := range personArgs {
+			predicate = strings.Replace(predicate, "?", fmt.Sprintf("$%d", len(args)+1), 1)
+			args = append(args, arg)
+		}
+		query += ` AND (` + predicate + `)`
 	}
 	if request.SourceID > 0 {
 		query += fmt.Sprintf(` AND m.source_id = $%d`, len(args)+1)
@@ -115,13 +115,13 @@ func (b *VisualBackend) Search(ctx context.Context, request visual.SearchRequest
 	if request.AfterScore != nil {
 		scoreArg := len(args) + 1
 		tokenArg := len(args) + 2
-		query += fmt.Sprintf(` AND ((1 - (vv.embedding::vector(1024) <=> $2::vector(1024))) < $%d
-			OR ((1 - (vv.embedding::vector(1024) <=> $2::vector(1024))) = $%d AND vv.vector_token > $%d))`,
-			scoreArg, scoreArg, tokenArg)
+		query += fmt.Sprintf(` AND ((1 - (vv.embedding::vector(%s) <=> $2::vector(%s))) < $%d
+			OR ((1 - (vv.embedding::vector(%s) <=> $2::vector(%s))) = $%d AND vv.vector_token > $%d))`,
+			dimension, dimension, scoreArg, dimension, dimension, scoreArg, tokenArg)
 		args = append(args, *request.AfterScore, string(request.AfterToken))
 	}
 	query += `
-		ORDER BY vv.embedding::vector(1024) <=> $2::vector(1024), vv.vector_token
+		ORDER BY vv.embedding::vector(` + dimension + `) <=> $2::vector(` + dimension + `), vv.vector_token
 		LIMIT $3`
 	rows, err := b.backend.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/vector/pgvector/visual_test.go
+++ b/internal/vector/pgvector/visual_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
 
@@ -18,6 +19,15 @@ func TestVisualBackendStoresSearchesAndDeletesActivePublication(t *testing.T) {
 	statements := []string{
 		`ALTER TABLE messages ADD COLUMN received_at TIMESTAMPTZ`,
 		`ALTER TABLE messages ADD COLUMN internal_date TIMESTAMPTZ`,
+		`ALTER TABLE messages ADD COLUMN conversation_id BIGINT`,
+		`ALTER TABLE messages ADD COLUMN is_from_me BOOLEAN NOT NULL DEFAULT FALSE`,
+		`CREATE TABLE conversations (
+			id BIGINT PRIMARY KEY, conversation_type TEXT NOT NULL
+		)`,
+		`CREATE TABLE conversation_participants (
+			conversation_id BIGINT NOT NULL, participant_id BIGINT NOT NULL,
+			PRIMARY KEY (conversation_id, participant_id)
+		)`,
 		`CREATE TABLE attachments (
 			id BIGINT PRIMARY KEY, message_id BIGINT NOT NULL REFERENCES messages(id),
 			filename TEXT, mime_type TEXT, size BIGINT, attachment_role TEXT NOT NULL
@@ -32,7 +42,10 @@ func TestVisualBackendStoresSearchesAndDeletesActivePublication(t *testing.T) {
 			current_vector_token TEXT, state TEXT NOT NULL
 		)`,
 		`INSERT INTO visual_generations (id, state) VALUES (7, 'active')`,
-		`UPDATE messages SET source_id = 3, sent_at = CURRENT_TIMESTAMP WHERE id = 1`,
+		`INSERT INTO conversations (id, conversation_type) VALUES (9, 'direct_chat')`,
+		`INSERT INTO conversation_participants (conversation_id, participant_id) VALUES (9, 50)`,
+		`UPDATE messages SET source_id = 3, conversation_id = 9, sender_id = 40,
+			sent_at = CURRENT_TIMESTAMP WHERE id = 1`,
 		`INSERT INTO attachments (id, message_id, filename, mime_type, size, attachment_role)
 		VALUES (11, 1, 'diagram.png', 'image/png', 128, 'standalone')`,
 	}
@@ -57,6 +70,28 @@ func TestVisualBackendStoresSearchesAndDeletesActivePublication(t *testing.T) {
 	requirements.Len(hits, 1)
 	assertions.Equal(visual.VectorToken("visual-token-1"), hits[0].Token)
 	assertions.InDelta(1, hits[0].Score, 1e-6)
+
+	personRequest := visual.SearchRequest{
+		GenerationID: 7, Vector: vector, Limit: 10,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{50},
+			Directions:     []personscope.Direction{personscope.ToPerson},
+		},
+	}
+	hits, err = visualBackend.Search(ctx, personRequest)
+	requirements.NoError(err)
+	requirements.Len(hits, 1, "the direct-chat roster member is the inferred recipient")
+	personRequest.Person.ParticipantIDs = []int64{40}
+	hits, err = visualBackend.Search(ctx, personRequest)
+	requirements.NoError(err)
+	assertions.Empty(hits, "the direct sender is not also the inferred recipient")
+	_, err = db.Exec(`UPDATE conversations SET conversation_type = 'group_chat' WHERE id = 9`)
+	requirements.NoError(err)
+	personRequest.Person.ParticipantIDs = []int64{50}
+	personRequest.Person.Directions = []personscope.Direction{personscope.Group}
+	hits, err = visualBackend.Search(ctx, personRequest)
+	requirements.NoError(err)
+	requirements.Len(hits, 1, "a group roster member must match the group direction")
 
 	loaded, err := visualBackend.LoadOwnerVector(ctx, 7, visual.Owner{
 		MessageID: 1, BlobHash: strings.Repeat("a", 64), MediaInputKey: "original",

--- a/internal/vector/sqlitevec/visual.go
+++ b/internal/vector/sqlitevec/visual.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/vector/visual"
 )
@@ -247,6 +248,7 @@ func sqliteLiveVisualTokens(ctx context.Context, db *sql.DB, request visual.Sear
 		FROM visual_publications vp
 		JOIN visual_generations vg ON vg.id = vp.generation_id
 		JOIN messages m ON m.id = vp.message_id
+		JOIN conversations c ON c.id = m.conversation_id
 		JOIN attachments a ON a.id = vp.representative_attachment_id
 		WHERE vp.generation_id = ? AND vg.state = 'active'
 		  AND vp.state = 'current' AND vp.current_vector_token IS NOT NULL
@@ -254,15 +256,10 @@ func sqliteLiveVisualTokens(ctx context.Context, db *sql.DB, request visual.Sear
 		  AND a.message_id = vp.message_id
 		  AND a.attachment_role = 'standalone'`
 	args := []any{int64(request.GenerationID)}
-	if request.SenderPersonID > 0 {
-		// Legacy imports leave sender_id NULL and record the sender as a
-		// 'from' recipient row; fall back the same way the message list
-		// queries do so those results are not silently excluded.
-		query += ` AND EXISTS (SELECT 1 FROM person_participants pp WHERE pp.person_id = ? AND pp.participant_id = COALESCE(m.sender_id, (
-			SELECT mr.participant_id FROM message_recipients mr
-			WHERE mr.message_id = m.id AND mr.recipient_type = 'from'
-			ORDER BY mr.id LIMIT 1)))`
-		args = append(args, request.SenderPersonID)
+	if request.Person != nil {
+		predicate, personArgs := personscope.MessagePredicate(*request.Person, "m", "c")
+		query += ` AND (` + predicate + `)`
+		args = append(args, personArgs...)
 	}
 	if request.SourceID > 0 {
 		query += ` AND m.source_id = ?`

--- a/internal/vector/sqlitevec/visual_test.go
+++ b/internal/vector/sqlitevec/visual_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
@@ -48,6 +49,24 @@ func TestVisualBackendPublishesOnlyCurrentLiveTokens(t *testing.T) {
 	require.Len(t, hits, 1)
 	assert.Equal(t, visual.VectorToken(token), hits[0].Token)
 	assert.Equal(t, 1, hits[0].Rank)
+	matchingParticipant := f.EnsureParticipant("matching-visual@example.test", "Matching", "example.test")
+	otherParticipant := f.EnsureParticipant("other-visual@example.test", "Other", "example.test")
+	_, err = f.Store.DB().Exec(f.Store.Rebind(`UPDATE messages SET sender_id = ? WHERE id = ?`), matchingParticipant, owner.MessageID)
+	require.NoError(t, err)
+	personRequest := visual.SearchRequest{
+		GenerationID: visual.GenerationID(generation.ID), Vector: query, Limit: 10,
+		Person: &personscope.Scope{
+			ParticipantIDs: []int64{matchingParticipant},
+			Directions:     []personscope.Direction{personscope.FromPerson},
+		},
+	}
+	hits, err = visualBackend.Search(t.Context(), personRequest)
+	require.NoError(t, err)
+	require.Len(t, hits, 1)
+	personRequest.Person.ParticipantIDs = []int64{otherParticipant}
+	hits, err = visualBackend.Search(t.Context(), personRequest)
+	require.NoError(t, err)
+	assert.Empty(t, hits, "person scope must filter before the nearest-neighbor result window")
 
 	loaded, err := visualBackend.LoadOwnerVector(t.Context(), visual.GenerationID(generation.ID), visual.Owner{
 		MessageID: owner.MessageID, BlobHash: owner.BlobHash, MediaInputKey: owner.MediaInputKey,
@@ -227,7 +246,10 @@ func TestVisualPersonFilterCoversLegacyFromRecipientSenders(t *testing.T) {
 
 	hits, err := visualBackend.Search(t.Context(), visual.SearchRequest{
 		GenerationID: visual.GenerationID(generation.ID), Vector: query, Limit: 10,
-		SenderPersonID: person.ID,
+		Person: &personscope.Scope{
+			ParticipantIDs: person.ParticipantIDs,
+			Directions:     []personscope.Direction{personscope.FromPerson},
+		},
 	})
 	require.NoError(t, err)
 	require.Len(t, hits, 1, "the from-recipient fallback must match legacy senders")

--- a/internal/vector/visual/provider.go
+++ b/internal/vector/visual/provider.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"go.kenn.io/msgvault/internal/personscope"
 )
 
 type GenerationID int64
@@ -27,18 +29,18 @@ type Provider interface {
 }
 
 type SearchRequest struct {
-	GenerationID   GenerationID
-	Vector         []float32
-	Limit          int
-	AfterScore     *float64
-	AfterToken     VectorToken
-	SenderPersonID int64
-	SourceID       int64
-	MessageID      int64
-	Filename       string
-	MIMEPrefix     string
-	After          *time.Time
-	Before         *time.Time
+	GenerationID GenerationID
+	Vector       []float32
+	Limit        int
+	AfterScore   *float64
+	AfterToken   VectorToken
+	Person       *personscope.Scope
+	SourceID     int64
+	MessageID    int64
+	Filename     string
+	MIMEPrefix   string
+	After        *time.Time
+	Before       *time.Time
 }
 
 type Hit struct {

--- a/internal/vector/visual/search.go
+++ b/internal/vector/visual/search.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -34,31 +35,32 @@ type SearchQuery struct {
 	// embed once via EmbedQueryVector and reuse the vector so each cursor
 	// continuation does not pay another hosted embedding request. It never
 	// participates in the cursor's query hash — the text or image does.
-	QueryVector    []float32
-	Limit          int
-	Cursor         string
-	SenderPersonID int64
-	SourceID       int64
-	MessageID      int64
-	Filename       string
-	MIMEPrefix     string
-	After          *time.Time
-	Before         *time.Time
+	QueryVector []float32
+	Limit       int
+	Cursor      string
+	Person      *personscope.Scope
+	SourceID    int64
+	MessageID   int64
+	Filename    string
+	MIMEPrefix  string
+	After       *time.Time
+	Before      *time.Time
 }
 
 type AttachmentSearchResult struct {
-	AttachmentID    int64     `json:"attachment_id"`
-	MessageID       int64     `json:"message_id"`
-	ConversationID  int64     `json:"conversation_id"`
-	SourceID        int64     `json:"source_id"`
-	SourceMessageID string    `json:"source_message_id"`
-	BlobHash        string    `json:"blob_hash"`
-	Filename        string    `json:"filename"`
-	MIMEType        string    `json:"mime_type"`
-	Size            int64     `json:"size"`
-	SentAt          time.Time `json:"sent_at"`
-	Score           float64   `json:"score"`
-	Rank            int       `json:"rank"`
+	AttachmentID     int64                   `json:"attachment_id"`
+	MessageID        int64                   `json:"message_id"`
+	ConversationID   int64                   `json:"conversation_id"`
+	SourceID         int64                   `json:"source_id"`
+	SourceMessageID  string                  `json:"source_message_id"`
+	BlobHash         string                  `json:"blob_hash"`
+	Filename         string                  `json:"filename"`
+	MIMEType         string                  `json:"mime_type"`
+	Size             int64                   `json:"size"`
+	SentAt           time.Time               `json:"sent_at"`
+	Score            float64                 `json:"score"`
+	Rank             int                     `json:"rank"`
+	PersonProvenance *personscope.Provenance `json:"person_provenance,omitempty"`
 }
 
 type SearchResponse struct {
@@ -75,6 +77,18 @@ type searchCursor struct {
 	QueryHash    string  `json:"query_hash"`
 	Score        float64 `json:"score"`
 	Token        string  `json:"token"`
+}
+
+type searchQueryHashPayload struct {
+	Text       string             `json:"text"`
+	ImageHash  string             `json:"image_hash"`
+	Filename   string             `json:"filename"`
+	MIMEPrefix string             `json:"mime_prefix"`
+	Person     *personscope.Scope `json:"person"`
+	SourceID   int64              `json:"source_id"`
+	MessageID  int64              `json:"message_id"`
+	After      *time.Time         `json:"after"`
+	Before     *time.Time         `json:"before"`
 }
 
 type SearchService struct {
@@ -239,9 +253,14 @@ func (s *SearchService) Search(ctx context.Context, query SearchQuery) (SearchRe
 	if query.Limit < 1 || query.Limit > 100 {
 		return SearchResponse{}, errors.New("visual search limit must be between 1 and 100")
 	}
-	if query.SenderPersonID < 0 || query.SourceID < 0 || query.MessageID < 0 ||
+	if query.SourceID < 0 || query.MessageID < 0 ||
 		(query.After != nil && query.Before != nil && !query.After.Before(*query.Before)) {
 		return SearchResponse{}, errors.New("invalid visual search filters")
+	}
+	if query.Person != nil {
+		if err := personscope.Validate(*query.Person); err != nil {
+			return SearchResponse{}, fmt.Errorf("invalid visual person scope: %w", err)
+		}
 	}
 	generation, err := s.activeGeneration(ctx)
 	if err != nil {
@@ -287,7 +306,8 @@ func (s *SearchService) Search(ctx context.Context, query SearchQuery) (SearchRe
 		vector = canonical
 	}
 	request := SearchRequest{GenerationID: GenerationID(generation.ID), Vector: vector, Limit: query.Limit + 1,
-		SenderPersonID: query.SenderPersonID, SourceID: query.SourceID, MessageID: query.MessageID,
+		SourceID: query.SourceID, MessageID: query.MessageID,
+		Person:   query.Person,
 		Filename: strings.TrimSpace(query.Filename), MIMEPrefix: strings.ToLower(strings.TrimSpace(query.MIMEPrefix)),
 		After: query.After, Before: query.Before}
 	if query.Cursor != "" {
@@ -318,6 +338,22 @@ func (s *SearchService) Search(ctx context.Context, query SearchQuery) (SearchRe
 			Filename: occurrence.Filename, MIMEType: occurrence.MIMEType, Size: occurrence.Size,
 			SentAt: occurrence.SentAt, Score: hit.Score, Rank: len(response.Results) + 1,
 		})
+	}
+	if query.Person != nil && len(response.Results) > 0 {
+		messageIDs := make([]int64, len(response.Results))
+		for i := range response.Results {
+			messageIDs[i] = response.Results[i].MessageID
+		}
+		provenance, provenanceErr := s.archive.PersonProvenanceForMessages(ctx, messageIDs, *query.Person)
+		if provenanceErr != nil {
+			return SearchResponse{}, provenanceErr
+		}
+		for i := range response.Results {
+			response.Results[i].PersonProvenance = provenance[response.Results[i].MessageID]
+			if response.Results[i].PersonProvenance == nil {
+				return SearchResponse{}, fmt.Errorf("visual person provenance missing for message %d", response.Results[i].MessageID)
+			}
+		}
 	}
 	if len(hits) > query.Limit {
 		last := hits[query.Limit-1]
@@ -374,19 +410,13 @@ func visualSearchQueryHash(query SearchQuery) (string, error) {
 		digest := sha256.Sum256(query.Image.Bytes)
 		imageHash = hex.EncodeToString(digest[:])
 	}
-	payload, err := json.Marshal(struct {
-		Text           string     `json:"text"`
-		ImageHash      string     `json:"image_hash"`
-		Filename       string     `json:"filename"`
-		MIMEPrefix     string     `json:"mime_prefix"`
-		SenderPersonID int64      `json:"sender_person_id"`
-		SourceID       int64      `json:"source_id"`
-		MessageID      int64      `json:"message_id"`
-		After          *time.Time `json:"after"`
-		Before         *time.Time `json:"before"`
-	}{strings.TrimSpace(query.Text), imageHash, strings.TrimSpace(query.Filename),
-		strings.ToLower(strings.TrimSpace(query.MIMEPrefix)), query.SenderPersonID, query.SourceID,
-		query.MessageID, query.After, query.Before})
+	payload, err := json.Marshal(searchQueryHashPayload{
+		Text: strings.TrimSpace(query.Text), ImageHash: imageHash,
+		Filename:   strings.TrimSpace(query.Filename),
+		MIMEPrefix: strings.ToLower(strings.TrimSpace(query.MIMEPrefix)),
+		Person:     query.Person, SourceID: query.SourceID, MessageID: query.MessageID,
+		After: query.After, Before: query.Before,
+	})
 	if err != nil {
 		return "", fmt.Errorf("marshal visual search query: %w", err)
 	}

--- a/internal/vector/visual/search_test.go
+++ b/internal/vector/visual/search_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/personscope"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
@@ -127,6 +128,49 @@ func TestSearchCursorSurvivesDeletionAndRejectsQueryMismatch(t *testing.T) {
 	_, err = service.Search(t.Context(), SearchQuery{Text: "different", Limit: 1, Cursor: first.NextCursor})
 	requirements.ErrorIs(err, ErrInvalidCursor)
 	assertions.Equal(queriesBeforeMismatch, provider.queries)
+}
+
+func TestSearchServicePassesResolvedPersonScopeAndHydratesProvenance(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	f := storetest.New(t)
+	generation := testVisualGeneration(t, f)
+	messageID := testVisualCandidate(t, f, "search-person", strings.Repeat("93", 32))
+	participantID := f.EnsureParticipant("visual-person@example.test", "Visual Person", "example.test")
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`UPDATE messages SET sender_id = ? WHERE id = ?`), participantID, messageID)
+	requirements.NoError(err)
+	reconciler := testReconciler(t, f, generation.ID, memoryOpener{data: encodedPNG(t, 2, 2)}, "visual-test/search-person")
+	for {
+		result, reconcileErr := reconciler.FullReconcile(t.Context())
+		requirements.NoError(reconcileErr)
+		if len(result.Work) == 0 {
+			break
+		}
+		for _, work := range result.Work {
+			publishReconciledWork(t, f, work)
+		}
+	}
+	requirements.NoError(f.Store.ConsentVisualGeneration(t.Context(), generation.ID, "synthetic-policy-fingerprint"))
+	_, err = reconciler.Activate(t.Context())
+	requirements.NoError(err)
+	publication := visualPublicationForMessage(t, f, generation.ID, messageID)
+	backend := &searchBackend{hits: []Hit{{Token: VectorToken(publication.CurrentVectorToken), Score: .9, Rank: 1}}}
+	service, err := NewSearchService(f.Store, &searchProvider{}, backend, true)
+	requirements.NoError(err)
+	scope := &personscope.Scope{
+		ParticipantIDs: []int64{participantID},
+		Directions:     []personscope.Direction{personscope.FromPerson},
+	}
+	response, err := service.Search(t.Context(), SearchQuery{Text: "diagram", Limit: 1, Person: scope})
+	requirements.NoError(err)
+	requirements.Len(backend.requests, 1)
+	assertions.Equal(scope, backend.requests[0].Person)
+	requirements.Len(response.Results, 1)
+	assertions.Equal(&personscope.Provenance{
+		ParticipantIDs: []int64{participantID},
+		Roles:          []personscope.Role{personscope.RoleFrom},
+		Directions:     []personscope.Direction{personscope.FromPerson},
+	}, response.Results[0].PersonProvenance)
 }
 
 func TestDecodeQueryImageRejectsNonImage(t *testing.T) {

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -591,6 +591,10 @@ type ClientInterface interface {
 	ListPersonEmployments(ctx context.Context, options *ListPersonEmploymentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonEmploymentsResponse, error)
 	ListPersonEmploymentsWithResponse(ctx context.Context, options *ListPersonEmploymentsRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ListPersonEmploymentsResp, error)
 
+	// SearchPersonFiles Search one durable person's analytical files
+	SearchPersonFiles(ctx context.Context, options *SearchPersonFilesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPersonFilesResponse, error)
+	SearchPersonFilesWithResponse(ctx context.Context, options *SearchPersonFilesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPersonFilesResp, error)
+
 	// GetPersonStructuredProfile Get a person's current structured profile
 	GetPersonStructuredProfile(ctx context.Context, options *GetPersonStructuredProfileRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetPersonStructuredProfileResponse, error)
 	GetPersonStructuredProfileWithResponse(ctx context.Context, options *GetPersonStructuredProfileRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetPersonStructuredProfileResp, error)
@@ -9340,6 +9344,70 @@ func (c *Client) ListPersonEmployments(ctx context.Context, options *ListPersonE
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people/{id}/employments")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// SearchPersonFiles Search one durable person's analytical files
+func (c *Client) SearchPersonFiles(ctx context.Context, options *SearchPersonFilesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPersonFilesResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/people/{id}/files/search",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*SearchPersonFilesResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(SearchPersonFilesErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "SearchPersonFilesErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(SearchPersonFilesResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "SearchPersonFilesResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people/{id}/files/search")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -5850,6 +5850,59 @@ func (o *ListPersonEmploymentsRequestOptions) GetHeader() (map[string]string, er
 	return nil, nil
 }
 
+// SearchPersonFilesRequestOptions is the options needed to make a request to SearchPersonFiles.
+type SearchPersonFilesRequestOptions struct {
+	PathParams *SearchPersonFilesPath
+	Body       *SearchPersonFilesBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *SearchPersonFilesRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *SearchPersonFilesRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *SearchPersonFilesRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *SearchPersonFilesRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *SearchPersonFilesRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // GetPersonStructuredProfileRequestOptions is the options needed to make a request to GetPersonStructuredProfile.
 type GetPersonStructuredProfileRequestOptions struct {
 	PathParams *GetPersonStructuredProfilePath

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -4930,6 +4930,22 @@ func (c *Client) SearchDocumentsWithResponse(ctx context.Context, options *Searc
 			}
 		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(SearchDocumentsErrorResponseJSON404)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchDocumentsErrorResponseJSON404",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	case 409:
 		out.JSON409 = new(SearchDocumentsErrorResponseJSON409)
 		bodyBytes := resp.Content
@@ -10179,8 +10195,24 @@ func (c *Client) SearchParticipantFilesWithResponse(ctx context.Context, options
 			}
 		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(SearchParticipantFilesErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchParticipantFilesErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	case 409:
-		out.JSON409 = new(SearchParticipantFilesErrorResponseJSON)
+		out.JSON409 = new(SearchParticipantFilesErrorResponseJSON409)
 		bodyBytes := resp.Content
 		if len(bodyBytes) > 0 {
 			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
@@ -10188,7 +10220,23 @@ func (c *Client) SearchParticipantFilesWithResponse(ctx context.Context, options
 					StatusCode:    resp.StatusCode,
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
-					TargetType:    "SearchParticipantFilesErrorResponseJSON",
+					TargetType:    "SearchParticipantFilesErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 422:
+		out.JSON422 = new(SearchParticipantFilesErrorResponseJSON422)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON422); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchParticipantFilesErrorResponseJSON422",
 					Body:          bodyBytes,
 					Err:           err,
 				}
@@ -11729,6 +11777,134 @@ func (c *Client) ListPersonEmploymentsWithResponse(ctx context.Context, options 
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
 					TargetType:    "ListPersonEmploymentsErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// SearchPersonFiles Search one durable person's analytical files
+func (c *Client) SearchPersonFilesWithResponse(ctx context.Context, options *SearchPersonFilesRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchPersonFilesResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/people/{id}/files/search",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/people/{id}/files/search")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &SearchPersonFilesResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(SearchPersonFilesResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(SearchPersonFilesErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(SearchPersonFilesErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SearchPersonFilesErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 422:
+		out.JSON422 = new(SearchPersonFilesErrorResponseJSON422)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON422); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesErrorResponseJSON422",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(SearchPersonFilesErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchPersonFilesErrorResponseJSON503",
 					Body:          bodyBytes,
 					Err:           err,
 				}
@@ -14359,8 +14535,40 @@ func (c *Client) SearchVisualAttachmentsWithResponse(ctx context.Context, option
 			}
 		}
 		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(SearchVisualAttachmentsErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchVisualAttachmentsErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(SearchVisualAttachmentsErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "SearchVisualAttachmentsErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
 	case 503:
-		out.JSON503 = new(SearchVisualAttachmentsErrorResponseJSON)
+		out.JSON503 = new(SearchVisualAttachmentsErrorResponseJSON503)
 		bodyBytes := resp.Content
 		if len(bodyBytes) > 0 {
 			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
@@ -14368,7 +14576,7 @@ func (c *Client) SearchVisualAttachmentsWithResponse(ctx context.Context, option
 					StatusCode:    resp.StatusCode,
 					ContentType:   resp.Headers.Get("Content-Type"),
 					ContentLength: len(bodyBytes),
-					TargetType:    "SearchVisualAttachmentsErrorResponseJSON",
+					TargetType:    "SearchVisualAttachmentsErrorResponseJSON503",
 					Body:          bodyBytes,
 					Err:           err,
 				}

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -851,6 +851,44 @@ func (p PersonFileSearchRowContentState) Validate() error {
 	}
 }
 
+type ProvenanceDirections string
+
+const (
+	ProvenanceDirectionsFromPerson ProvenanceDirections = "from_person"
+	ProvenanceDirectionsGroup      ProvenanceDirections = "group"
+	ProvenanceDirectionsToPerson   ProvenanceDirections = "to_person"
+)
+
+// Validate checks if the ProvenanceDirections value is valid
+func (p ProvenanceDirections) Validate() error {
+	switch p {
+	case ProvenanceDirectionsFromPerson, ProvenanceDirectionsGroup, ProvenanceDirectionsToPerson:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ProvenanceDirections value, got: %v", p))
+	}
+}
+
+type ProvenanceRoles string
+
+const (
+	ProvenanceRolesBcc                ProvenanceRoles = "bcc"
+	ProvenanceRolesCc                 ProvenanceRoles = "cc"
+	ProvenanceRolesConversationMember ProvenanceRoles = "conversation_member"
+	ProvenanceRolesFrom               ProvenanceRoles = "from"
+	ProvenanceRolesTo                 ProvenanceRoles = "to"
+)
+
+// Validate checks if the ProvenanceRoles value is valid
+func (p ProvenanceRoles) Validate() error {
+	switch p {
+	case ProvenanceRolesBcc, ProvenanceRolesCc, ProvenanceRolesConversationMember, ProvenanceRolesFrom, ProvenanceRolesTo:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ProvenanceRoles value, got: %v", p))
+	}
+}
+
 type RemoveResultCacheState string
 
 const (

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -407,6 +407,11 @@ type ListPersonEmploymentsPath struct {
 	ID int64 `json:"id"`
 }
 
+type SearchPersonFilesPath struct {
+	// ID Durable person ID
+	ID int64 `json:"id"`
+}
+
 type GetPersonStructuredProfilePath struct {
 	// ID Durable person ID
 	ID int64 `json:"id"`

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -118,6 +118,8 @@ type PatchPersonBody = PatchPersonRequest
 
 type SetPersonAttributeBody = SetPersonAttributeRequest
 
+type SearchPersonFilesBody = PersonFileSearchHTTPRequest
+
 type PatchPersonStructuredProfileBody = PersonProfilePatchRequest
 
 type SetPersonTrackingBody = PutPersonTrackingRequest

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -345,6 +345,21 @@ type SearchDocumentsQuery struct {
 	// MessageID Exact containing message ID
 	MessageID *int64 `json:"message_id,omitempty"`
 
+	// PersonID Durable person ID
+	PersonID *int64 `json:"person_id,omitempty"`
+
+	// ParticipantID Observed participant ID; translated through its durable person when bound
+	ParticipantID *int64 `json:"participant_id,omitempty"`
+
+	// Direction Person relation; repeat or comma-separate from_person, to_person, or group
+	Direction []string `json:"direction,omitempty"`
+
+	// After Only messages on or after an RFC3339 or YYYY-MM-DD date
+	After *string `json:"after,omitempty"`
+
+	// Before Only messages before an RFC3339 or YYYY-MM-DD date
+	Before *string `json:"before,omitempty"`
+
 	// Limit Maximum results to return (default 20, max 100)
 	Limit *int64 `json:"limit,omitempty"`
 

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -455,6 +455,8 @@ type SearchDocumentsErrorResponse = ErrorResponse
 
 type SearchDocumentsErrorResponseJSON = ErrorResponse
 
+type SearchDocumentsErrorResponseJSON404 = ErrorResponse
+
 type SearchDocumentsErrorResponseJSON409 = ErrorResponse
 
 type SearchDocumentsErrorResponseJSON429 = ErrorResponse
@@ -1419,6 +1421,10 @@ type SearchParticipantFilesErrorResponse = ErrorResponse
 
 type SearchParticipantFilesErrorResponseJSON = ErrorResponse
 
+type SearchParticipantFilesErrorResponseJSON409 = ErrorResponse
+
+type SearchParticipantFilesErrorResponseJSON422 = ErrorResponse
+
 type SearchParticipantFilesErrorResponseJSON503 struct {
 	SearchParticipantFiles_ErrorResponse_503_AnyOf *SearchParticipantFiles_ErrorResponse_503_AnyOf `json:"-"`
 }
@@ -1662,6 +1668,54 @@ type ListPersonEmploymentsErrorResponse = ErrorResponse
 type ListPersonEmploymentsErrorResponseJSON = ErrorResponse
 
 type ListPersonEmploymentsErrorResponseJSON503 = ErrorResponse
+
+type SearchPersonFilesResponse = PersonFileSearchHTTPResponse
+
+type SearchPersonFilesErrorResponse = ErrorResponse
+
+type SearchPersonFilesErrorResponseJSON = ErrorResponse
+
+type SearchPersonFilesErrorResponseJSON409 = ErrorResponse
+
+type SearchPersonFilesErrorResponseJSON422 = ErrorResponse
+
+type SearchPersonFilesErrorResponseJSON503 struct {
+	SearchPersonFiles_ErrorResponse_503_AnyOf *SearchPersonFiles_ErrorResponse_503_AnyOf `json:"-"`
+}
+
+func (s SearchPersonFilesErrorResponseJSON503) MarshalJSON() ([]byte, error) {
+	var parts []json.RawMessage
+
+	{
+		b, err := runtime.MarshalJSON(s.SearchPersonFiles_ErrorResponse_503_AnyOf)
+		if err != nil {
+			return nil, fmt.Errorf("SearchPersonFiles_ErrorResponse_503_AnyOf marshal: %w", err)
+		}
+		parts = append(parts, b)
+	}
+
+	return runtime.CoalesceOrMerge(parts...)
+}
+
+func (s *SearchPersonFilesErrorResponseJSON503) UnmarshalJSON(data []byte) error {
+	trim := bytes.TrimSpace(data)
+	if bytes.Equal(trim, []byte("null")) {
+		return nil
+	}
+	if len(trim) == 0 {
+		return fmt.Errorf("empty JSON input")
+	}
+
+	if s.SearchPersonFiles_ErrorResponse_503_AnyOf == nil {
+		s.SearchPersonFiles_ErrorResponse_503_AnyOf = &SearchPersonFiles_ErrorResponse_503_AnyOf{}
+	}
+
+	if err := runtime.UnmarshalJSON(data, s.SearchPersonFiles_ErrorResponse_503_AnyOf); err != nil {
+		return fmt.Errorf("SearchPersonFiles_ErrorResponse_503_AnyOf unmarshal: %w", err)
+	}
+
+	return nil
+}
 
 type GetPersonStructuredProfileResponse = StructuredPersonProfile
 
@@ -1994,6 +2048,10 @@ type SearchVisualAttachmentsResponse = SearchResponse
 type SearchVisualAttachmentsErrorResponse = ErrorResponse
 
 type SearchVisualAttachmentsErrorResponseJSON = ErrorResponse
+
+type SearchVisualAttachmentsErrorResponseJSON409 = ErrorResponse
+
+type SearchVisualAttachmentsErrorResponseJSON503 = ErrorResponse
 
 type GetSearchCoverageResponse = SearchCoverageResponse
 
@@ -2690,6 +2748,7 @@ type SearchDocumentsResp struct {
 	JSON200      *SearchDocumentsResponse
 	JSON400      *SearchDocumentsErrorResponse
 	JSON403      *SearchDocumentsErrorResponseJSON
+	JSON404      *SearchDocumentsErrorResponseJSON404
 	JSON409      *SearchDocumentsErrorResponseJSON409
 	JSON429      *SearchDocumentsErrorResponseJSON429
 	JSON503      *SearchDocumentsErrorResponseJSON503
@@ -3316,7 +3375,9 @@ type SearchParticipantFilesResp struct {
 	StatusCode   int
 	JSON200      *SearchParticipantFilesResponse
 	JSON400      *SearchParticipantFilesErrorResponse
-	JSON409      *SearchParticipantFilesErrorResponseJSON
+	JSON404      *SearchParticipantFilesErrorResponseJSON
+	JSON409      *SearchParticipantFilesErrorResponseJSON409
+	JSON422      *SearchParticipantFilesErrorResponseJSON422
 	JSON503      *SearchParticipantFilesErrorResponseJSON503
 }
 
@@ -3489,6 +3550,18 @@ type ListPersonEmploymentsResp struct {
 	JSON400      *ListPersonEmploymentsErrorResponse
 	JSON404      *ListPersonEmploymentsErrorResponseJSON
 	JSON503      *ListPersonEmploymentsErrorResponseJSON503
+}
+
+type SearchPersonFilesResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *SearchPersonFilesResponse
+	JSON400      *SearchPersonFilesErrorResponse
+	JSON404      *SearchPersonFilesErrorResponseJSON
+	JSON409      *SearchPersonFilesErrorResponseJSON409
+	JSON422      *SearchPersonFilesErrorResponseJSON422
+	JSON503      *SearchPersonFilesErrorResponseJSON503
 }
 
 type GetPersonStructuredProfileResp200Headers struct {
@@ -3820,7 +3893,9 @@ type SearchVisualAttachmentsResp struct {
 	StatusCode   int
 	JSON200      *SearchVisualAttachmentsResponse
 	JSON400      *SearchVisualAttachmentsErrorResponse
-	JSON503      *SearchVisualAttachmentsErrorResponseJSON
+	JSON404      *SearchVisualAttachmentsErrorResponseJSON
+	JSON409      *SearchVisualAttachmentsErrorResponseJSON409
+	JSON503      *SearchVisualAttachmentsErrorResponseJSON503
 }
 
 type GetSearchCoverageResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -207,22 +207,49 @@ func (a AttachmentInfo) Validate() error {
 }
 
 type AttachmentSearchResult struct {
-	AttachmentID    int64     `json:"attachment_id"`
-	BlobHash        string    `json:"blob_hash" validate:"required"`
-	ConversationID  int64     `json:"conversation_id"`
-	Filename        string    `json:"filename" validate:"required"`
-	MessageID       int64     `json:"message_id"`
-	MimeType        string    `json:"mime_type" validate:"required"`
-	Rank            int64     `json:"rank"`
-	Score           float64   `json:"score"`
-	SentAt          time.Time `json:"sent_at" validate:"required"`
-	Size            int64     `json:"size"`
-	SourceID        int64     `json:"source_id"`
-	SourceMessageID string    `json:"source_message_id" validate:"required"`
+	AttachmentID     int64       `json:"attachment_id"`
+	BlobHash         string      `json:"blob_hash" validate:"required"`
+	ConversationID   int64       `json:"conversation_id"`
+	Filename         string      `json:"filename" validate:"required"`
+	MessageID        int64       `json:"message_id"`
+	MimeType         string      `json:"mime_type" validate:"required"`
+	PersonProvenance *Provenance `json:"person_provenance,omitempty"`
+	Rank             int64       `json:"rank"`
+	Score            float64     `json:"score"`
+	SentAt           time.Time   `json:"sent_at" validate:"required"`
+	Size             int64       `json:"size"`
+	SourceID         int64       `json:"source_id"`
+	SourceMessageID  string      `json:"source_message_id" validate:"required"`
 }
 
 func (a AttachmentSearchResult) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(a))
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(a.BlobHash, "required"); err != nil {
+		errors = errors.Append("BlobHash", err)
+	}
+	if err := typesValidator.Var(a.Filename, "required"); err != nil {
+		errors = errors.Append("Filename", err)
+	}
+	if err := typesValidator.Var(a.MimeType, "required"); err != nil {
+		errors = errors.Append("MimeType", err)
+	}
+	if a.PersonProvenance != nil {
+		if v, ok := any(a.PersonProvenance).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PersonProvenance", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(a.SentAt, "required"); err != nil {
+		errors = errors.Append("SentAt", err)
+	}
+	if err := typesValidator.Var(a.SourceMessageID, "required"); err != nil {
+		errors = errors.Append("SourceMessageID", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type AttributeChoice struct {
@@ -1890,35 +1917,77 @@ func (d DocumentSearchResponse) Validate() error {
 }
 
 type DocumentSearchResult struct {
-	AttachmentID      int64    `json:"attachment_id"`
-	CanonicalBlobHash string   `json:"canonical_blob_hash" validate:"required"`
-	ChunkKey          string   `json:"chunk_key" validate:"required"`
-	ChunkOrdinal      int64    `json:"chunk_ordinal"`
-	ContainingTitle   *string  `json:"containing_title,omitempty"`
-	Excerpt           string   `json:"excerpt" validate:"required"`
-	ExtractionID      string   `json:"extraction_id" validate:"required"`
-	Filename          *string  `json:"filename,omitempty"`
-	FirstUnitIndex    int64    `json:"first_unit_index"`
-	HeadingPath       []string `json:"heading_path,omitempty"`
-	HighlightEnd      int64    `json:"highlight_end"`
-	HighlightStart    int64    `json:"highlight_start"`
-	LastUnitIndex     int64    `json:"last_unit_index"`
-	MatchedSignals    []string `json:"matched_signals,omitempty" validate:"required"`
-	MessageID         int64    `json:"message_id"`
-	MimeType          *string  `json:"mime_type,omitempty"`
-	Model             string   `json:"model" validate:"required"`
-	OccurrenceKey     string   `json:"occurrence_key" validate:"required"`
-	OtherLiveCopies   int64    `json:"other_live_copies"`
-	ProfileID         string   `json:"profile_id" validate:"required"`
-	Provider          string   `json:"provider" validate:"required"`
-	Rank              int64    `json:"rank"`
-	SourceID          int64    `json:"source_id"`
-	SourcePartKey     *string  `json:"source_part_key,omitempty"`
-	Truncated         bool     `json:"truncated"`
+	AttachmentID      int64       `json:"attachment_id"`
+	CanonicalBlobHash string      `json:"canonical_blob_hash" validate:"required"`
+	ChunkKey          string      `json:"chunk_key" validate:"required"`
+	ChunkOrdinal      int64       `json:"chunk_ordinal"`
+	ContainingTitle   *string     `json:"containing_title,omitempty"`
+	ConversationID    int64       `json:"conversation_id"`
+	Excerpt           string      `json:"excerpt" validate:"required"`
+	ExtractionID      string      `json:"extraction_id" validate:"required"`
+	Filename          *string     `json:"filename,omitempty"`
+	FirstUnitIndex    int64       `json:"first_unit_index"`
+	HeadingPath       []string    `json:"heading_path,omitempty"`
+	HighlightEnd      int64       `json:"highlight_end"`
+	HighlightStart    int64       `json:"highlight_start"`
+	LastUnitIndex     int64       `json:"last_unit_index"`
+	MatchedSignals    []string    `json:"matched_signals,omitempty" validate:"required"`
+	MessageID         int64       `json:"message_id"`
+	MimeType          *string     `json:"mime_type,omitempty"`
+	Model             string      `json:"model" validate:"required"`
+	OccurredAt        *time.Time  `json:"occurred_at,omitempty"`
+	OccurrenceKey     string      `json:"occurrence_key" validate:"required"`
+	OtherLiveCopies   int64       `json:"other_live_copies"`
+	PersonProvenance  *Provenance `json:"person_provenance,omitempty"`
+	ProfileID         string      `json:"profile_id" validate:"required"`
+	Provider          string      `json:"provider" validate:"required"`
+	Rank              int64       `json:"rank"`
+	SourceID          int64       `json:"source_id"`
+	SourceMessageID   *string     `json:"source_message_id,omitempty"`
+	SourcePartKey     *string     `json:"source_part_key,omitempty"`
+	Truncated         bool        `json:"truncated"`
 }
 
 func (d DocumentSearchResult) Validate() error {
-	return runtime.ConvertValidatorError(typesValidator.Struct(d))
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(d.CanonicalBlobHash, "required"); err != nil {
+		errors = errors.Append("CanonicalBlobHash", err)
+	}
+	if err := typesValidator.Var(d.ChunkKey, "required"); err != nil {
+		errors = errors.Append("ChunkKey", err)
+	}
+	if err := typesValidator.Var(d.Excerpt, "required"); err != nil {
+		errors = errors.Append("Excerpt", err)
+	}
+	if err := typesValidator.Var(d.ExtractionID, "required"); err != nil {
+		errors = errors.Append("ExtractionID", err)
+	}
+	if err := typesValidator.Var(d.MatchedSignals, "required"); err != nil {
+		errors = errors.Append("MatchedSignals", err)
+	}
+	if err := typesValidator.Var(d.Model, "required"); err != nil {
+		errors = errors.Append("Model", err)
+	}
+	if err := typesValidator.Var(d.OccurrenceKey, "required"); err != nil {
+		errors = errors.Append("OccurrenceKey", err)
+	}
+	if d.PersonProvenance != nil {
+		if v, ok := any(d.PersonProvenance).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PersonProvenance", err)
+			}
+		}
+	}
+	if err := typesValidator.Var(d.ProfileID, "required"); err != nil {
+		errors = errors.Append("ProfileID", err)
+	}
+	if err := typesValidator.Var(d.Provider, "required"); err != nil {
+		errors = errors.Append("Provider", err)
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
 }
 
 type DomainContextSummaryHTTPResponse struct {
@@ -6205,6 +6274,37 @@ type Progress struct {
 	Total int64 `json:"total"`
 }
 
+type Provenance struct {
+	Directions     []ProvenanceDirections `json:"directions,omitempty" validate:"required"`
+	ParticipantIds []int64                `json:"participant_ids,omitempty" validate:"required"`
+	Roles          []ProvenanceRoles      `json:"roles,omitempty" validate:"required"`
+}
+
+func (p Provenance) Validate() error {
+	var errors runtime.ValidationErrors
+	for i, item := range p.Directions {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Directions[%d]", i), err)
+			}
+		}
+	}
+	if err := typesValidator.Var(p.ParticipantIds, "required"); err != nil {
+		errors = errors.Append("ParticipantIds", err)
+	}
+	for i, item := range p.Roles {
+		if v, ok := any(item).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append(fmt.Sprintf("Roles[%d]", i), err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
 type ProviderUsage struct {
 	BilledUnits    float64 `json:"billed_units"`
 	InputBytes     int64   `json:"input_bytes"`
@@ -8125,16 +8225,19 @@ func (v VisualRetryRequest) Validate() error {
 }
 
 type VisualTextSearchRequest struct {
-	After          *string `json:"after,omitempty"`
-	Before         *string `json:"before,omitempty"`
-	Cursor         *string `json:"cursor,omitempty"`
-	Filename       *string `json:"filename,omitempty"`
-	Limit          *int64  `json:"limit,omitempty"`
-	MessageID      *int64  `json:"message_id,omitempty"`
-	MimePrefix     *string `json:"mime_prefix,omitempty"`
-	SenderPersonID *int64  `json:"sender_person_id,omitempty"`
-	SourceID       *int64  `json:"source_id,omitempty"`
-	Text           string  `json:"text" validate:"required"`
+	After          *string  `json:"after,omitempty"`
+	Before         *string  `json:"before,omitempty"`
+	Cursor         *string  `json:"cursor,omitempty"`
+	Directions     []string `json:"directions,omitempty"`
+	Filename       *string  `json:"filename,omitempty"`
+	Limit          *int64   `json:"limit,omitempty"`
+	MessageID      *int64   `json:"message_id,omitempty"`
+	MimePrefix     *string  `json:"mime_prefix,omitempty"`
+	ParticipantID  *int64   `json:"participant_id,omitempty"`
+	PersonID       *int64   `json:"person_id,omitempty"`
+	SenderPersonID *int64   `json:"sender_person_id,omitempty"`
+	SourceID       *int64   `json:"source_id,omitempty"`
+	Text           string   `json:"text" validate:"required"`
 }
 
 func (v VisualTextSearchRequest) Validate() error {

--- a/pkg/client/generated/unions.go
+++ b/pkg/client/generated/unions.go
@@ -560,6 +560,24 @@ func (g *GetParticipantTimeline_ErrorResponse_503_AnyOf) Validate() error {
 	return nil
 }
 
+type SearchPersonFiles_ErrorResponse_503_AnyOf struct {
+	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
+}
+
+func (s *SearchPersonFiles_ErrorResponse_503_AnyOf) Validate() error {
+	if s.IsA() {
+		if v, ok := any(s.A).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	if s.IsB() {
+		if v, ok := any(s.B).(runtime.Validator); ok {
+			return v.Validate()
+		}
+	}
+	return nil
+}
+
 type ListRelationships_ErrorResponse_503_AnyOf struct {
 	runtime.Either[ExploreCacheUnavailableResponse, ErrorResponse]
 }

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -256,6 +256,8 @@ components:
           type: integer
         mime_type:
           type: string
+        person_provenance:
+          $ref: "#/components/schemas/Provenance"
         rank:
           format: int64
           type: integer
@@ -2252,6 +2254,9 @@ components:
           type: integer
         containing_title:
           type: string
+        conversation_id:
+          format: int64
+          type: integer
         excerpt:
           type: string
         extraction_id:
@@ -2287,11 +2292,16 @@ components:
           type: string
         model:
           type: string
+        occurred_at:
+          format: date-time
+          type: string
         occurrence_key:
           type: string
         other_live_copies:
           format: int64
           type: integer
+        person_provenance:
+          $ref: "#/components/schemas/Provenance"
         profile_id:
           type: string
         provider:
@@ -2302,6 +2312,8 @@ components:
         source_id:
           format: int64
           type: integer
+        source_message_id:
+          type: string
         source_part_key:
           type: string
         truncated:
@@ -2309,6 +2321,7 @@ components:
       required:
         - attachment_id
         - message_id
+        - conversation_id
         - source_id
         - occurrence_key
         - canonical_blob_hash
@@ -6683,6 +6696,39 @@ components:
         - done
         - total
       type: object
+    Provenance:
+      properties:
+        directions:
+          items:
+            enum:
+              - from_person
+              - to_person
+              - group
+            type: string
+          nullable: true
+          type: array
+        participant_ids:
+          items:
+            format: int64
+            type: integer
+          nullable: true
+          type: array
+        roles:
+          items:
+            enum:
+              - from
+              - to
+              - cc
+              - bcc
+              - conversation_member
+            type: string
+          nullable: true
+          type: array
+      required:
+        - participant_ids
+        - roles
+        - directions
+      type: object
     ProviderUsage:
       properties:
         billed_units:
@@ -8722,6 +8768,11 @@ components:
           type: string
         cursor:
           type: string
+        directions:
+          items:
+            type: string
+          nullable: true
+          type: array
         filename:
           type: string
         limit:
@@ -8732,6 +8783,12 @@ components:
           type: integer
         mime_prefix:
           type: string
+        participant_id:
+          format: int64
+          type: integer
+        person_id:
+          format: int64
+          type: integer
         sender_person_id:
           format: int64
           type: integer
@@ -8750,7 +8807,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.4.0
+  version: 2.5.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -11572,6 +11629,35 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Durable person ID
+          in: query
+          name: person_id
+          schema:
+            format: int64
+            type: integer
+        - description: Observed participant ID; translated through its durable person when bound
+          in: query
+          name: participant_id
+          schema:
+            format: int64
+            type: integer
+        - description: Person relation; repeat or comma-separate from_person, to_person, or group
+          in: query
+          name: direction
+          schema:
+            items:
+              type: string
+            type: array
+        - description: Only messages on or after an RFC3339 or YYYY-MM-DD date
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Only messages before an RFC3339 or YYYY-MM-DD date
+          in: query
+          name: before
+          schema:
+            type: string
         - description: Maximum results to return (default 20, max 100)
           in: query
           name: limit
@@ -11597,6 +11683,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error
         "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
           content:
             application/json:
               schema:
@@ -14706,7 +14798,19 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
         "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
           content:
             application/json:
               schema:
@@ -15640,6 +15744,73 @@ paths:
       summary: List a person's employment history
       tags:
         - API
+  /api/v1/people/{id}/files/search:
+    post:
+      operationId: searchPersonFiles
+      parameters:
+        - description: Durable person ID
+          in: path
+          name: id
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PersonFileSearchHTTPRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PersonFileSearchHTTPResponse"
+          description: OK
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/ExploreCacheUnavailableResponse"
+                  - $ref: "#/components/schemas/ErrorResponse"
+          description: Service Unavailable
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Search one durable person's analytical files
+      tags:
+        - Exploration
   /api/v1/people/{id}/profile:
     get:
       description: Returns only current structured values at one person revision. Superseded values and archive observations are available from the separate history endpoint.
@@ -17092,6 +17263,14 @@ paths:
                   type: string
                 cursor:
                   type: string
+                direction:
+                  items:
+                    enum:
+                      - from_person
+                      - to_person
+                      - group
+                    type: string
+                  type: array
                 filename:
                   type: string
                 image:
@@ -17104,6 +17283,10 @@ paths:
                 message_id:
                   type: string
                 mime_prefix:
+                  type: string
+                participant_id:
+                  type: string
+                person_id:
                   type: string
                 sender_person_id:
                   type: string
@@ -17121,6 +17304,18 @@ paths:
                 $ref: "#/components/schemas/SearchResponse"
           description: OK
         "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
           content:
             application/json:
               schema:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -2030,6 +2030,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/people/{id}/files/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Search one durable person's analytical files */
+        post: operations["searchPersonFiles"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/people/{id}/profile": {
         parameters: {
             query?: never;
@@ -2783,6 +2800,7 @@ export interface components {
             /** Format: int64 */
             message_id: number;
             mime_type: string;
+            person_provenance?: components["schemas"]["Provenance"];
             /** Format: int64 */
             rank: number;
             /** Format: double */
@@ -3743,6 +3761,8 @@ export interface components {
             /** Format: int64 */
             chunk_ordinal: number;
             containing_title?: string;
+            /** Format: int64 */
+            conversation_id: number;
             excerpt: string;
             extraction_id: string;
             filename?: string;
@@ -3760,15 +3780,19 @@ export interface components {
             message_id: number;
             mime_type?: string;
             model: string;
+            /** Format: date-time */
+            occurred_at?: string;
             occurrence_key: string;
             /** Format: int64 */
             other_live_copies: number;
+            person_provenance?: components["schemas"]["Provenance"];
             profile_id: string;
             provider: string;
             /** Format: int64 */
             rank: number;
             /** Format: int64 */
             source_id: number;
+            source_message_id?: string;
             source_part_key?: string;
             truncated: boolean;
         } & {
@@ -5618,6 +5642,13 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        Provenance: {
+            directions: ("from_person" | "to_person" | "group")[] | null;
+            participant_ids: number[] | null;
+            roles: ("from" | "to" | "cc" | "bcc" | "conversation_member")[] | null;
+        } & {
+            [key: string]: unknown;
+        };
         ProviderUsage: {
             /** Format: double */
             billed_units: number;
@@ -6550,12 +6581,17 @@ export interface components {
             after?: string;
             before?: string;
             cursor?: string;
+            directions?: string[] | null;
             filename?: string;
             /** Format: int64 */
             limit?: number;
             /** Format: int64 */
             message_id?: number;
             mime_prefix?: string;
+            /** Format: int64 */
+            participant_id?: number;
+            /** Format: int64 */
+            person_id?: number;
             /** Format: int64 */
             sender_person_id?: number;
             /** Format: int64 */
@@ -9771,6 +9807,16 @@ export interface operations {
                 attachment_id?: number;
                 /** @description Exact containing message ID */
                 message_id?: number;
+                /** @description Durable person ID */
+                person_id?: number;
+                /** @description Observed participant ID; translated through its durable person when bound */
+                participant_id?: number;
+                /** @description Person relation; repeat or comma-separate from_person, to_person, or group */
+                direction?: string[];
+                /** @description Only messages on or after an RFC3339 or YYYY-MM-DD date */
+                after?: string;
+                /** @description Only messages before an RFC3339 or YYYY-MM-DD date */
+                before?: string;
                 /** @description Maximum results to return (default 20, max 100) */
                 limit?: number;
                 /** @description Opaque cursor from the previous document search page */
@@ -9802,6 +9848,15 @@ export interface operations {
             };
             /** @description Error */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -13317,7 +13372,25 @@ export interface operations {
                 };
             };
             /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -14338,6 +14411,87 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    searchPersonFiles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Durable person ID */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PersonFileSearchHTTPRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonFileSearchHTTPResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExploreCacheUnavailableResponse"] | components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */
@@ -16043,6 +16197,7 @@ export interface operations {
                     after?: string;
                     before?: string;
                     cursor?: string;
+                    direction?: ("from_person" | "to_person" | "group")[];
                     filename?: string;
                     /**
                      * Format: binary
@@ -16052,6 +16207,8 @@ export interface operations {
                     limit?: string;
                     message_id?: string;
                     mime_prefix?: string;
+                    participant_id?: string;
+                    person_id?: string;
                     sender_person_id?: string;
                     source_id?: string;
                 };
@@ -16069,6 +16226,24 @@ export interface operations {
             };
             /** @description Error */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Supersedes #658. Originally authored by @salmonumbrella.

## What changed

- adds one shared person-scope contract across attachment metadata, extracted documents, and visual search
- adds `msgvault person files <person-id>` with explicit metadata, documents, visual, and all-lane behavior
- adds the always-available MCP `search_person_files` tool and person filters on document and visual retrieval
- keeps exact attachment, message, conversation, source, matched identity, role, and direction provenance

## Why

The underlying indexes stay independent, but callers should not have to translate a durable person into separate participant filters for each retrieval lane. This gives them one stable person-scoped interface over the Docbank-backed document and visual indexes plus authoritative metadata.

The visual lane uses the shared visual index from #650.

## Usage

```bash
msgvault person files 42
msgvault person files 42 --lane documents --query "inspection notes"
msgvault person files 42 --lane visual --query "whiteboard diagram"
msgvault person files 42 --lane all --query "signed agreement" --json
```

Closes #623
