### PR TITLE
fix(ci): enforce PostgreSQL package coverage guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           go-version-file: go.mod
           cache: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
+      - name: Check PostgreSQL build coverage
+        run: make pg-shipped-only-check
+
       - name: Install lint tools
         run: |
           make lint-tools


### PR DESCRIPTION
CI now runs `make pg-shipped-only-check` in the main Go test job, so a stale `PG_SHIPPED_ONLY_PKGS` list fails automatically instead of leaving `test-pg-both` broken until manual discovery.

The check remains database-free and does not change either PostgreSQL test lane or its runtime scope.

Closes #667
