### PR TITLE
fix(analytics): raise cache builder spill limit

### DIFF
--- a/internal/duckdbutil/connection.go
+++ b/internal/duckdbutil/connection.go
@@ -49,7 +49,7 @@ func BuilderPolicy(tempDirectory string) Policy {
 		MemoryLimit:          "2GB",
 		Threads:              min(runtime.GOMAXPROCS(0), 2),
 		TempDirectory:        tempDirectory,
-		MaxTempDirectorySize: "8GB",
+		MaxTempDirectorySize: "32GB",
 	}
 }
 

--- a/internal/duckdbutil/connection_test.go
+++ b/internal/duckdbutil/connection_test.go
@@ -19,7 +19,7 @@ func TestBuilderPolicyDefaults(t *testing.T) {
 	assertions.Equal("2GB", policy.MemoryLimit)
 	assertions.Equal(min(runtime.GOMAXPROCS(0), 2), policy.Threads)
 	assertions.Equal(tempDir, policy.TempDirectory)
-	assertions.Equal("8GB", policy.MaxTempDirectorySize)
+	assertions.Equal("32GB", policy.MaxTempDirectorySize)
 }
 
 func TestBuilderPolicyWithOverrides(t *testing.T) {

--- a/internal/tui/attachment_trust_darwin.go
+++ b/internal/tui/attachment_trust_darwin.go
@@ -14,5 +14,8 @@ import (
 // a downloaded attachment.
 func markAttachmentUntrusted(path string) error {
 	value := fmt.Sprintf("0081;%x;msgvault;", time.Now().Unix())
-	return unix.Setxattr(path, "com.apple.quarantine", []byte(value), 0)
+	if err := unix.Setxattr(path, "com.apple.quarantine", []byte(value), 0); err != nil {
+		return fmt.Errorf("set quarantine attribute: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
Full analytics rebuilds can exhaust DuckDB's 8 GB temporary-directory cap on large archives even when the host has ample storage. This raises the builder policy default to 32 GB; explicit `analytics.builder_temp_limit` overrides still win, and the value remains a spill ceiling rather than a reservation.

The branch also wraps macOS quarantine-attribute failures with operation context. That keeps the Go 1.27 / golangci-lint 2.13.1 contract clean on Darwin as well as Linux without changing the successful attachment-open path.
