### PR TITLE
fix(store): maintain SQLite planner statistics

### DIFF
--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -1,7 +1,10 @@
 package store
 
 import (
+	"database/sql"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,4 +78,70 @@ func TestSyncCheckpointRefreshesSQLitePlannerStatistics(t *testing.T) {
 	require.NoError(s.UpdateSyncCheckpoint(syncID, &Checkpoint{MessagesProcessed: 100}))
 	assert.Positive(messagePlannerStatisticCount(t, s),
 		"sync checkpoints must analyze populated message indexes")
+}
+
+func TestOptimizeSQLiteReloadsEveryPooledConnection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	s.db.SetMaxOpenConns(2)
+	s.db.SetMaxIdleConns(2)
+	require.NoError(s.InitSchema())
+	seedLiveMessages(t, s, 10_000)
+
+	args := make([]any, 51)
+	args[0] = 1
+	for i := 1; i < len(args); i++ {
+		args[i] = strconv.Itoa(i - 1)
+	}
+	query := `EXPLAIN QUERY PLAN
+		SELECT id FROM messages
+		WHERE source_id = ? AND source_message_id IN (` +
+		strings.TrimSuffix(strings.Repeat("?,", len(args)-1), ",") + `)
+		ORDER BY id`
+	plan := func(conn *sql.Conn) string {
+		rows, queryErr := conn.QueryContext(t.Context(), query, args...)
+		require.NoError(queryErr)
+		defer func() { require.NoError(rows.Close()) }()
+		var details strings.Builder
+		for rows.Next() {
+			var id, parent, unused int
+			var detail string
+			require.NoError(rows.Scan(&id, &parent, &unused, &detail))
+			details.WriteString(detail)
+			details.WriteByte('\n')
+		}
+		require.NoError(rows.Err())
+		return details.String()
+	}
+
+	first, err := s.db.Conn(t.Context())
+	require.NoError(err)
+	second, err := s.db.Conn(t.Context())
+	require.NoError(err)
+	for _, conn := range []*sql.Conn{first, second} {
+		assert.Contains(plan(conn), "idx_messages_source (source_id=?)",
+			"the fixture must preload the statistics-free plan on every connection")
+	}
+	require.NoError(first.Close())
+	require.NoError(second.Close())
+
+	require.NoError(s.optimizeSQLite(t.Context()))
+
+	first, err = s.db.Conn(t.Context())
+	require.NoError(err)
+	second, err = s.db.Conn(t.Context())
+	require.NoError(err)
+	defer func() { require.NoError(first.Close()) }()
+	defer func() { require.NoError(second.Close()) }()
+	for _, conn := range []*sql.Conn{first, second} {
+		refreshedPlan := plan(conn)
+		assert.Contains(refreshedPlan, "(source_id=? AND source_message_id=?)",
+			"every pooled connection must use the refreshed planner statistics")
+		assert.NotContains(refreshedPlan, "idx_messages_source (source_id=?)",
+			"no pooled connection may retain the statistics-free plan")
+	}
 }

--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -190,6 +190,31 @@ func TestOptimizeSQLiteSkipsConcurrentMaintenance(t *testing.T) {
 	require.NoError(<-firstDone)
 }
 
+func TestOptimizeSQLiteBoundsPoolReservation(t *testing.T) {
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	require.NoError(s.InitSchema())
+	s.db.SetMaxOpenConns(2)
+	s.db.SetMaxIdleConns(2)
+	blocker, err := s.db.Conn(t.Context())
+	require.NoError(err)
+
+	result := make(chan error, 1)
+	go func() { result <- s.optimizeSQLite(context.Background()) }()
+	select {
+	case optimizeErr := <-result:
+		require.ErrorIs(optimizeErr, context.DeadlineExceeded)
+	case <-time.After(2 * time.Second):
+		require.NoError(blocker.Close())
+		<-result
+		require.FailNow("planner maintenance did not bound pool reservation")
+	}
+	require.NoError(blocker.Close())
+}
+
 func TestCloseOptimizesWithoutDrainingSQLitePool(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -1,11 +1,13 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,5 +145,51 @@ func TestOptimizeSQLiteReloadsEveryPooledConnection(t *testing.T) {
 			"every pooled connection must use the refreshed planner statistics")
 		assert.NotContains(refreshedPlan, "idx_messages_source (source_id=?)",
 			"no pooled connection may retain the statistics-free plan")
+	}
+}
+
+func TestOptimizeSQLiteSerializesConcurrentMaintenance(t *testing.T) {
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	require.NoError(s.InitSchema())
+
+	const poolSize = 4
+	s.db.SetMaxOpenConns(poolSize)
+	s.db.SetMaxIdleConns(poolSize)
+	blockers := make([]*sql.Conn, 0, poolSize-1)
+	for range poolSize - 1 {
+		conn, connErr := s.db.Conn(t.Context())
+		require.NoError(connErr)
+		blockers = append(blockers, conn)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	started := make(chan struct{}, poolSize)
+	results := make(chan error, poolSize)
+	for range poolSize {
+		go func() {
+			started <- struct{}{}
+			results <- s.optimizeSQLite(ctx)
+		}()
+	}
+	for range poolSize {
+		<-started
+	}
+	require.Eventually(func() bool {
+		stats := s.db.Stats()
+		return stats.InUse == poolSize && stats.WaitCount > 0
+	}, time.Second, time.Millisecond)
+	// Give every unguarded call time to queue behind the exhausted pool.
+	time.Sleep(25 * time.Millisecond)
+	for _, conn := range blockers {
+		require.NoError(conn.Close())
+	}
+
+	for range poolSize {
+		require.NoError(<-results)
 	}
 }

--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -62,24 +62,37 @@ func TestCompleteSyncAndUpdateSourceCursorRefreshesSQLitePlannerStatistics(t *te
 		"successful sync must analyze populated message indexes")
 }
 
-func TestSyncCheckpointRefreshesSQLitePlannerStatistics(t *testing.T) {
-	assert := assert.New(t)
+func TestSyncCheckpointDoesNotDrainSQLitePool(t *testing.T) {
 	require := require.New(t)
 
 	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
 	require.NoError(err)
 	defer func() { _ = s.Close() }()
 	require.NoError(s.InitSchema())
-
-	seedLiveMessages(t, s, 100)
-	assert.Zero(messagePlannerStatisticCount(t, s),
-		"message statistics must be absent before the maintenance boundary")
+	s.db.SetMaxOpenConns(2)
+	s.db.SetMaxIdleConns(2)
+	seedLiveMessages(t, s, 1)
 
 	syncID, err := s.StartSync(1, "full")
 	require.NoError(err)
-	require.NoError(s.UpdateSyncCheckpoint(syncID, &Checkpoint{MessagesProcessed: 100}))
-	assert.Positive(messagePlannerStatisticCount(t, s),
-		"sync checkpoints must analyze populated message indexes")
+	blocker, err := s.db.Conn(t.Context())
+	require.NoError(err)
+
+	checkpointDone := make(chan error, 1)
+	go func() {
+		checkpointDone <- s.UpdateSyncCheckpointContext(
+			context.Background(), syncID, &Checkpoint{MessagesProcessed: 100},
+		)
+	}()
+	select {
+	case checkpointErr := <-checkpointDone:
+		require.NoError(checkpointErr)
+	case <-time.After(250 * time.Millisecond):
+		require.NoError(blocker.Close())
+		<-checkpointDone
+		require.FailNow("sync checkpoint waited to reserve the SQLite pool")
+	}
+	require.NoError(blocker.Close())
 }
 
 func TestOptimizeSQLiteReloadsEveryPooledConnection(t *testing.T) {

--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func messagePlannerStatisticCount(t *testing.T, s *Store) int {
+	t.Helper()
+	var count int
+	require.NoError(t, s.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM sqlite_stat1
+		WHERE tbl = 'messages'
+	`).Scan(&count))
+	return count
+}
+
+func TestInitSchemaRefreshesSQLitePlannerStatistics(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	require.NoError(s.InitSchema())
+
+	seedLiveMessages(t, s, 100)
+	assert.Zero(messagePlannerStatisticCount(t, s),
+		"message statistics must be absent before the maintenance boundary")
+
+	require.NoError(s.InitSchema())
+	assert.Positive(messagePlannerStatisticCount(t, s),
+		"schema initialization must analyze populated message indexes")
+}
+
+func TestCompleteSyncAndUpdateSourceCursorRefreshesSQLitePlannerStatistics(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	require.NoError(s.InitSchema())
+
+	seedLiveMessages(t, s, 100)
+	assert.Zero(messagePlannerStatisticCount(t, s),
+		"message statistics must be absent before the maintenance boundary")
+
+	syncID, err := s.StartSync(1, "full")
+	require.NoError(err)
+	require.NoError(s.CompleteSyncAndUpdateSourceCursor(syncID, 1, "cursor-1"))
+	assert.Positive(messagePlannerStatisticCount(t, s),
+		"successful sync must analyze populated message indexes")
+}
+
+func TestSyncCheckpointRefreshesSQLitePlannerStatistics(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(err)
+	defer func() { _ = s.Close() }()
+	require.NoError(s.InitSchema())
+
+	seedLiveMessages(t, s, 100)
+	assert.Zero(messagePlannerStatisticCount(t, s),
+		"message statistics must be absent before the maintenance boundary")
+
+	syncID, err := s.StartSync(1, "full")
+	require.NoError(err)
+	require.NoError(s.UpdateSyncCheckpoint(syncID, &Checkpoint{MessagesProcessed: 100}))
+	assert.Positive(messagePlannerStatisticCount(t, s),
+		"sync checkpoints must analyze populated message indexes")
+}

--- a/internal/store/sqlite_optimize_test.go
+++ b/internal/store/sqlite_optimize_test.go
@@ -148,7 +148,7 @@ func TestOptimizeSQLiteReloadsEveryPooledConnection(t *testing.T) {
 	}
 }
 
-func TestOptimizeSQLiteSerializesConcurrentMaintenance(t *testing.T) {
+func TestOptimizeSQLiteSkipsConcurrentMaintenance(t *testing.T) {
 	require := require.New(t)
 
 	s, err := OpenForTest(filepath.Join(t.TempDir(), "archive.db"))
@@ -156,40 +156,70 @@ func TestOptimizeSQLiteSerializesConcurrentMaintenance(t *testing.T) {
 	defer func() { _ = s.Close() }()
 	require.NoError(s.InitSchema())
 
-	const poolSize = 4
-	s.db.SetMaxOpenConns(poolSize)
-	s.db.SetMaxIdleConns(poolSize)
-	blockers := make([]*sql.Conn, 0, poolSize-1)
-	for range poolSize - 1 {
-		conn, connErr := s.db.Conn(t.Context())
-		require.NoError(connErr)
-		blockers = append(blockers, conn)
-	}
+	s.db.SetMaxOpenConns(2)
+	s.db.SetMaxIdleConns(2)
+	blocker, err := s.db.Conn(t.Context())
+	require.NoError(err)
 
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	started := make(chan struct{}, poolSize)
-	results := make(chan error, poolSize)
-	for range poolSize {
-		go func() {
-			started <- struct{}{}
-			results <- s.optimizeSQLite(ctx)
-		}()
-	}
-	for range poolSize {
-		<-started
-	}
+	baselineWaitCount := s.db.Stats().WaitCount
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- s.optimizeSQLite(ctx) }()
 	require.Eventually(func() bool {
 		stats := s.db.Stats()
-		return stats.InUse == poolSize && stats.WaitCount > 0
+		return stats.InUse == 2 && stats.WaitCount > baselineWaitCount
 	}, time.Second, time.Millisecond)
-	// Give every unguarded call time to queue behind the exhausted pool.
-	time.Sleep(25 * time.Millisecond)
-	for _, conn := range blockers {
-		require.NoError(conn.Close())
+
+	canceledCtx, cancelDuplicate := context.WithCancel(t.Context())
+	cancelDuplicate()
+	duplicateDone := make(chan error, 1)
+	go func() { duplicateDone <- s.optimizeSQLite(canceledCtx) }()
+	select {
+	case duplicateErr := <-duplicateDone:
+		require.NoError(duplicateErr)
+	case <-time.After(250 * time.Millisecond):
+		cancel()
+		require.NoError(blocker.Close())
+		<-firstDone
+		<-duplicateDone
+		require.FailNow("duplicate maintenance waited for the active call")
 	}
 
-	for range poolSize {
-		require.NoError(<-results)
+	require.NoError(blocker.Close())
+	require.NoError(<-firstDone)
+}
+
+func TestCloseOptimizesWithoutDrainingSQLitePool(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+
+	s, err := OpenForTest(dbPath)
+	require.NoError(err)
+	require.NoError(s.InitSchema())
+	seedLiveMessages(t, s, 100)
+	assert.Zero(messagePlannerStatisticCount(t, s))
+	s.db.SetMaxOpenConns(2)
+	s.db.SetMaxIdleConns(2)
+	blocker, err := s.db.Conn(t.Context())
+	require.NoError(err)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- s.Close() }()
+	select {
+	case closeErr := <-closeDone:
+		require.NoError(closeErr)
+	case <-time.After(2 * time.Second):
+		require.NoError(blocker.Close())
+		<-closeDone
+		require.FailNow("store close waited to reserve the entire SQLite pool")
 	}
+	require.NoError(blocker.Close())
+
+	reopened, err := OpenForTest(dbPath)
+	require.NoError(err)
+	defer func() { _ = reopened.Close() }()
+	assert.Positive(messagePlannerStatisticCount(t, reopened),
+		"store close must persist planner statistics")
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -49,6 +50,8 @@ type Store struct {
 	readOnly      bool // Opened via OpenReadOnly; skips WAL checkpoint on close
 	fts5Available bool // Whether FTS5 is available for full-text search
 	closeCleanup  func()
+
+	sqliteOptimizeMu sync.Mutex
 
 	// Test-only seams into migration, backfill, and transaction paths, nil in
 	// production and settable only from export_test.go. They belong to the
@@ -447,6 +450,8 @@ func (s *Store) optimizeSQLite(ctx context.Context) error {
 	if s.IsPostgreSQL() || s.readOnly {
 		return nil
 	}
+	s.sqliteOptimizeMu.Lock()
+	defer s.sqliteOptimizeMu.Unlock()
 
 	// Reserve every pool slot before refreshing statistics. ANALYZE loads its
 	// results only into the SQLite connection that runs it; holding every slot

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -447,8 +447,34 @@ func (s *Store) optimizeSQLite(ctx context.Context) error {
 	if s.IsPostgreSQL() || s.readOnly {
 		return nil
 	}
-	if _, err := s.db.ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
+
+	// Reserve every pool slot before refreshing statistics. ANALYZE loads its
+	// results only into the SQLite connection that runs it; holding every slot
+	// lets us reload each existing connection and prevents database/sql from
+	// opening an unrefreshed one concurrently. Connections opened after this
+	// point load the persistent sqlite_stat tables when they read the schema.
+	poolSize := max(1, s.db.Stats().MaxOpenConnections)
+	connections := make([]*sql.Conn, 0, poolSize)
+	defer func() {
+		for _, conn := range connections {
+			_ = conn.Close()
+		}
+	}()
+	for range poolSize {
+		conn, err := s.db.Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("reserve SQLite connection pool for planner statistics: %w", err)
+		}
+		connections = append(connections, conn)
+	}
+
+	if _, err := connections[0].ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
 		return fmt.Errorf("optimize SQLite planner statistics: %w", err)
+	}
+	for _, conn := range connections {
+		if _, err := conn.ExecContext(ctx, "ANALYZE sqlite_schema"); err != nil {
+			return fmt.Errorf("reload SQLite planner statistics: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -416,10 +416,18 @@ func OpenPostgresDB(dbURL string) (*sql.DB, func(), error) {
 // Close checkpoints the WAL (unless read-only) and closes the database.
 func (s *Store) Close() error {
 	if !s.readOnly {
-		// Keep planner statistics current for short-lived commands. The
-		// all-tables bit avoids depending on which pooled connection happens to
-		// execute this statement and which queries that connection has seen.
-		s.optimizeSQLiteBestEffort(context.Background(), "store close")
+		if !s.IsPostgreSQL() {
+			// Persist statistics for short-lived commands without draining a pool
+			// that may still have a checked-out connection during shutdown.
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if _, err := s.db.ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
+				slog.Warn("SQLite planner statistics maintenance failed",
+					"trigger", "store close",
+					"error", err.Error(),
+				)
+			}
+			cancel()
+		}
 
 		// Checkpoint WAL before closing to fold it back into the main
 		// database. This prevents WAL accumulation across sessions and
@@ -450,7 +458,11 @@ func (s *Store) optimizeSQLite(ctx context.Context) error {
 	if s.IsPostgreSQL() || s.readOnly {
 		return nil
 	}
-	s.sqliteOptimizeMu.Lock()
+	// Maintenance is best-effort, and an active call is already performing the
+	// same update. Skip duplicates instead of making cancellation wait on it.
+	if !s.sqliteOptimizeMu.TryLock() {
+		return nil
+	}
 	defer s.sqliteOptimizeMu.Unlock()
 
 	// Reserve every pool slot before refreshing statistics. ANALYZE loads its

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -413,6 +413,11 @@ func OpenPostgresDB(dbURL string) (*sql.DB, func(), error) {
 // Close checkpoints the WAL (unless read-only) and closes the database.
 func (s *Store) Close() error {
 	if !s.readOnly {
+		// Keep planner statistics current for short-lived commands. The
+		// all-tables bit avoids depending on which pooled connection happens to
+		// execute this statement and which queries that connection has seen.
+		s.optimizeSQLiteBestEffort(context.Background(), "store close")
+
 		// Checkpoint WAL before closing to fold it back into the main
 		// database. This prevents WAL accumulation across sessions and
 		// reduces the risk of corruption from stale WAL entries.
@@ -432,6 +437,29 @@ func (s *Store) Close() error {
 // No-op for non-SQLite backends.
 func (s *Store) CheckpointWAL() error {
 	return s.dialect.CheckpointWAL(s.db.DB)
+}
+
+// optimizeSQLite refreshes persistent query-planner statistics when SQLite
+// decides they are missing or stale. The 0x10000 bit makes SQLite consider all
+// tables instead of relying on query history from whichever pooled connection
+// database/sql selects. PostgreSQL maintains planner statistics server-side.
+func (s *Store) optimizeSQLite(ctx context.Context) error {
+	if s.IsPostgreSQL() || s.readOnly {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
+		return fmt.Errorf("optimize SQLite planner statistics: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) optimizeSQLiteBestEffort(ctx context.Context, trigger string) {
+	if err := s.optimizeSQLite(ctx); err != nil {
+		slog.Warn("SQLite planner statistics maintenance failed",
+			"trigger", trigger,
+			"error", err.Error(),
+		)
+	}
 }
 
 // DB returns the underlying *sql.DB for consumers that need to
@@ -1634,6 +1662,11 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 	if err := s.EnsureDefaultCollectionContext(ctx); err != nil {
 		return fmt.Errorf("ensure default collection: %w", err)
 	}
+
+	// Schema initialization can add indexes to an existing archive. Refresh
+	// statistics after all schema work so SQLite can cost those indexes against
+	// the archive's actual data distribution.
+	s.optimizeSQLiteBestEffort(ctx, "schema initialization")
 
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -413,13 +413,15 @@ func OpenPostgresDB(dbURL string) (*sql.DB, func(), error) {
 	return openPostgresDB(dbURL, false)
 }
 
+const sqliteOptimizeTimeout = time.Second
+
 // Close checkpoints the WAL (unless read-only) and closes the database.
 func (s *Store) Close() error {
 	if !s.readOnly {
 		if !s.IsPostgreSQL() {
 			// Persist statistics for short-lived commands without draining a pool
 			// that may still have a checked-out connection during shutdown.
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), sqliteOptimizeTimeout)
 			if _, err := s.db.ExecContext(ctx, "PRAGMA optimize=0x10002"); err != nil {
 				slog.Warn("SQLite planner statistics maintenance failed",
 					"trigger", "store close",
@@ -464,6 +466,8 @@ func (s *Store) optimizeSQLite(ctx context.Context) error {
 		return nil
 	}
 	defer s.sqliteOptimizeMu.Unlock()
+	ctx, cancel := context.WithTimeout(ctx, sqliteOptimizeTimeout)
+	defer cancel()
 
 	// Reserve every pool slot before refreshing statistics. ANALYZE loads its
 	// results only into the SQLite connection that runs it; holding every slot

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -288,7 +288,7 @@ func (s *Store) UpdateSyncCheckpoint(syncID int64, cp *Checkpoint) error {
 // UpdateSyncCheckpointContext is the request-aware form of
 // UpdateSyncCheckpoint.
 func (s *Store) UpdateSyncCheckpointContext(ctx context.Context, syncID int64, cp *Checkpoint) error {
-	_, err := s.db.ExecContext(ctx, `
+	if _, err := s.db.ExecContext(ctx, `
 		UPDATE sync_runs
 		SET cursor_before = ?,
 		    messages_processed = ?,
@@ -296,8 +296,11 @@ func (s *Store) UpdateSyncCheckpointContext(ctx context.Context, syncID int64, c
 		    messages_updated = ?,
 		    errors_count = ?
 		WHERE id = ?
-	`, cp.PageToken, cp.MessagesProcessed, cp.MessagesAdded, cp.MessagesUpdated, cp.ErrorsCount, syncID)
-	return err
+	`, cp.PageToken, cp.MessagesProcessed, cp.MessagesAdded, cp.MessagesUpdated, cp.ErrorsCount, syncID); err != nil {
+		return err
+	}
+	s.optimizeSQLiteBestEffort(ctx, "sync checkpoint")
+	return nil
 }
 
 // RecordSyncRunItem records a per-item sync outcome for diagnostics.
@@ -407,6 +410,7 @@ func (s *Store) CompleteSyncContext(ctx context.Context, syncID int64, finalHist
 	if rows != 1 {
 		return fmt.Errorf("complete sync %d: %w", syncID, ErrSyncRunSuperseded)
 	}
+	s.optimizeSQLiteBestEffort(ctx, "successful sync")
 	return nil
 }
 
@@ -427,7 +431,7 @@ func (s *Store) CompleteSyncAndUpdateSourceCursor(
 func (s *Store) CompleteSyncAndUpdateSourceCursorContext(
 	ctx context.Context, syncID int64, sourceID int64, finalHistoryID string,
 ) error {
-	return s.withTxContext(ctx, func(tx *loggedTx) error {
+	if err := s.withTxContext(ctx, func(tx *loggedTx) error {
 		if err := validateCurrentSyncGeneration(
 			ctx, tx, sourceID, syncID, SyncStatusRunning,
 		); err != nil {
@@ -469,7 +473,11 @@ func (s *Store) CompleteSyncAndUpdateSourceCursorContext(
 			return fmt.Errorf("complete sync %d: %w", syncID, ErrSyncRunSuperseded)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	s.optimizeSQLiteBestEffort(ctx, "successful sync")
+	return nil
 }
 
 func validateCurrentSyncGeneration(

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -299,7 +299,6 @@ func (s *Store) UpdateSyncCheckpointContext(ctx context.Context, syncID int64, c
 	`, cp.PageToken, cp.MessagesProcessed, cp.MessagesAdded, cp.MessagesUpdated, cp.ErrorsCount, syncID); err != nil {
 		return err
 	}
-	s.optimizeSQLiteBestEffort(ctx, "sync checkpoint")
 	return nil
 }
 

--- a/internal/vector/pgvector/backfill_test.go
+++ b/internal/vector/pgvector/backfill_test.go
@@ -750,35 +750,19 @@ func TestReadOnlyOpen_PerformsNoWrites(t *testing.T) {
 	assert.Equal(0, marked, "ReadOnly Open must NOT mark the backfill ledger")
 }
 
-// lowTimeoutMS is the SESSION statement_timeout the low-timeout backfill handle
-// runs under. It is sized to sit comfortably ABOVE the backfill's cheap
-// pre-flight reads (catalog probe, ledger check, active-generation lookup —
-// sub-millisecond once the catalog cache is warmed, see openLowTimeoutHandle)
-// yet far BELOW the stamp UPDATE over lowTimeoutSeedRows rows (≈190ms,
-// measured). The fix's `SET LOCAL statement_timeout = 0` lifts it for the tx, so
-// post-fix the UPDATE completes; pre-fix it is cancelled with SQLSTATE 57014.
-const lowTimeoutMS = 50
+// lowTimeoutMS leaves ample time for the backfill's catalog and ledger probes.
+// A statement-level trigger below delays only the stamp UPDATE beyond this
+// limit, so the test does not depend on database or runner throughput.
+const lowTimeoutMS = 1000
 
-// lowTimeoutSeedRows is the number of embedded-but-unstamped messages the
-// regression test seeds. Sized so the stamp UPDATE's nested-loop semi-join over
-// these rows reliably exceeds lowTimeoutMS (≈190ms at 30k, ≈4x margin) while
-// staying cheap to seed (one bulk INSERT … SELECT generate_series).
-const lowTimeoutSeedRows = 30000
+const lowTimeoutSeedRows = 4
 
 // openLowTimeoutHandle opens a dedicated single-connection *sql.DB on the SAME
 // per-test schema as db, with the session statement_timeout pinned to
 // lowTimeoutMS. SetMaxOpenConns(1) makes the SET sticky: every query the
 // backfill issues on this handle runs on the one connection that carries the low
-// session timeout, so the test is deterministic — the timeout provably applies
-// to the exact connection the backfill uses (no pool flakiness). The schema is
-// read from db's live search_path so both handles see the same tables.
-//
-// The PostgreSQL catalog cache is WARMED (an information_schema probe of the
-// same shape the backfill's messagesHasEmbedGen guard issues) BEFORE the timeout
-// is lowered: the first such probe on a fresh connection is cold (~15ms), but
-// warm reruns are sub-millisecond, so warming guarantees the backfill's
-// pre-flight reads clear lowTimeoutMS with a large margin. Only the heavy stamp
-// UPDATE is meant to trip the timeout.
+// session timeout. The schema is read from db's live search_path so both
+// handles see the same tables.
 func openLowTimeoutHandle(t *testing.T, db *sql.DB) *sql.DB {
 	t.Helper()
 
@@ -805,17 +789,6 @@ func openLowTimeoutHandle(t *testing.T, db *sql.DB) *sql.DB {
 	low.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = low.Close() })
 
-	// Warm the catalog cache on this connection so the backfill's pre-flight
-	// reads (the same information_schema probe) are sub-millisecond, well under
-	// lowTimeoutMS. Done BEFORE lowering the timeout so the cold first probe is
-	// never itself cancelled.
-	var n int
-	require.NoError(t, low.QueryRow(
-		`SELECT COUNT(*) FROM information_schema.columns
-		  WHERE table_name = 'messages' AND column_name = 'embed_gen'
-		    AND table_schema = ANY (current_schemas(false))`).Scan(&n),
-		"warm catalog cache on low handle")
-
 	_, err = low.Exec(fmt.Sprintf(`SET statement_timeout = '%dms'`, lowTimeoutMS))
 	require.NoError(t, err, "set low statement_timeout on low handle")
 	return low
@@ -828,15 +801,11 @@ func openLowTimeoutHandle(t *testing.T, db *sql.DB) *sql.DB {
 // upgrade never completed. The fix adds `SET LOCAL statement_timeout = 0` as the
 // first statement inside the backfill tx (and the orphan-reset tx).
 //
-// Determinism: rather than reproduce 28s of work, we pin the SESSION
-// statement_timeout to lowTimeoutMS on a SINGLE-connection handle
-// (SetMaxOpenConns(1)) and run the backfill on that handle. With
-// lowTimeoutSeedRows embedded rows the stamp UPDATE takes ≈190ms — well over the
-// 50ms timeout — so PRE-FIX it is cancelled (57014); POST-FIX the tx's
-// `SET LOCAL statement_timeout = 0` lifts the timeout for exactly that tx, so
-// the backfill commits and stamps embed_gen. The backfill's cheap pre-flight
-// reads stay well under the timeout (catalog cache warmed in
-// openLowTimeoutHandle).
+// Determinism: rather than reproduce 28s of data-dependent work, a
+// statement-level trigger delays the stamp UPDATE for 1.5 seconds. The SESSION
+// statement_timeout is one second on a single-connection handle, so pre-fix the
+// UPDATE is cancelled (57014); post-fix the tx's `SET LOCAL statement_timeout =
+// 0` lifts the timeout for exactly that tx.
 //
 // Ordering matters: ALL seeding (schema, messages, embeddings, the embed_gen
 // reset, the ledger clear) runs on the NORMAL db handle BEFORE the low timeout
@@ -904,6 +873,24 @@ func TestBackfillEmbedGen_CompletesUnderLowStatementTimeout(t *testing.T) {
 		`DELETE FROM applied_migrations WHERE name = $1`, embedGenBackfillMigration)
 	require.NoError(
 		err, "clear backfill ledger")
+
+	// Delay the production UPDATE once per statement, independent of how fast
+	// this runner processes the small fixture. The trigger is added after setup
+	// so only the backfill stamp is delayed.
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION delay_embed_gen_backfill() RETURNS trigger
+		LANGUAGE plpgsql AS $$
+		BEGIN
+			PERFORM pg_sleep(1.5);
+			RETURN NULL;
+		END
+		$$`)
+	require.NoError(err, "create deterministic backfill delay")
+	_, err = db.ExecContext(ctx, `
+		CREATE TRIGGER delay_embed_gen_backfill
+		BEFORE UPDATE OF embed_gen ON messages
+		FOR EACH STATEMENT EXECUTE FUNCTION delay_embed_gen_backfill()`)
+	require.NoError(err, "install deterministic backfill delay")
 
 	// NOW switch to the low-timeout single-connection handle and run the backfill
 	// on it. Pre-fix the stamp UPDATE is cancelled (57014); post-fix the tx's


### PR DESCRIPTION
SQLite archives now refresh bounded planner statistics after schema setup,
after successful sync completion, and when a writable store closes. Existing
archives and completed syncs can therefore teach the planner that `source_id`
may be non-selective instead of retaining SQLite's default estimates for the
life of the database.

During normal operation, maintenance reserves the SQLite connection pool, runs
`PRAGMA optimize=0x10002`, and reloads the persisted statistics on every
connection before releasing the pool. Each refresh has a one-second limit that
respects any earlier caller cancellation; a busy pool abandons the best-effort
work, and an overlapping call skips the duplicate refresh. Page checkpoints
only persist sync progress, so they do not repeatedly reserve partially idle
pools. During close, a single bounded connection persists statistics without
draining or reloading the pool. PostgreSQL and read-only stores are unchanged.

Closes #682
