### PR TITLE
fix(sync): classify Gmail chat transcripts as chats

### DIFF
--- a/internal/identityindex/schema.go
+++ b/internal/identityindex/schema.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	TextMessageTypes = []string{
-		"whatsapp", "imessage", "sms", "mms", "rcs",
+		"google_chat", "whatsapp", "imessage", "sms", "mms", "rcs",
 		"google_voice_text", "teams", "discord", "beeper", "slack", "fbmessenger",
 	}
 	ChatFallbackMessageTypes = []string{"", "chat", "text"}

--- a/internal/query/explore_test.go
+++ b/internal/query/explore_test.go
@@ -28,6 +28,7 @@ func TestSharedChatClassificationSQL(t *testing.T) {
 	}{
 		{name: "email thread", messageType: "email", conversationType: "email_thread", want: false},
 		{name: "known text type", messageType: "iMessage", conversationType: "email_thread", want: true},
+		{name: "Gmail chat", messageType: "google_chat", conversationType: "chat", want: true},
 		{name: "fallback chat type", messageType: "", conversationType: "group_chat", want: true},
 		{name: "fallback outside chat", messageType: "text", conversationType: "email_thread", want: false},
 		{name: "unknown type in chat", messageType: "unknown", conversationType: "direct_chat", want: false},

--- a/internal/query/text_models.go
+++ b/internal/query/text_models.go
@@ -158,6 +158,7 @@ func IsTextMessageType(mt string) bool {
 // values instead of silently returning no results.
 var KnownMessageTypes = []string{
 	messageTypeEmail,
+	"google_chat",
 	messageTypeCalendar,
 	messageTypeMeetingTranscript,
 	messageTypeSMS,

--- a/internal/store/activity.go
+++ b/internal/store/activity.go
@@ -1166,7 +1166,7 @@ func validateActivityEventToken(event ActivityEvent, token ActivityProjectionTok
 		switch token.ConversationType {
 		case "email_thread":
 			expectedChannel = ChannelEmail
-		case "group_chat", "direct_chat", "channel":
+		case "chat", "group_chat", "direct_chat", "channel":
 			expectedChannel = ChannelChat
 		}
 	}

--- a/internal/store/activity_classify.go
+++ b/internal/store/activity_classify.go
@@ -156,7 +156,7 @@ func activityChannelFor(conversationType string, meeting bool) ActivityChannel {
 	switch conversationType {
 	case "email_thread":
 		return ChannelEmail
-	case "group_chat", "direct_chat", "channel":
+	case "chat", "group_chat", "direct_chat", "channel":
 		return ChannelChat
 	default:
 		return ChannelOther

--- a/internal/store/activity_test.go
+++ b/internal/store/activity_test.go
@@ -444,6 +444,39 @@ func TestConversationTypeMutationReopensEveryAffectedActivityCandidate(t *testin
 	}
 }
 
+func TestGmailChatConversationProjectsChatActivity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f, personID := activityProjectionFixture(t)
+	occurredAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	conversationID, err := f.Store.EnsureConversationWithType(
+		f.Source.ID, "default-thread", "chat", "Default Thread")
+	require.NoError(err)
+	require.Equal(f.ConvID, conversationID)
+	messageID := f.NewMessage().
+		WithSourceMessageID("gmail-chat-activity").
+		WithSentAt(occurredAt).
+		Create(t, f.Store)
+
+	candidates, err := f.Store.LoadQueuedActivityCandidatesContext(t.Context(), 10)
+	require.NoError(err)
+	require.Len(candidates, 1)
+	assert.Equal(messageID, candidates[0].MessageID)
+	assert.Equal("chat", candidates[0].ConversationType)
+	classification := store.ClassifyActivityCandidate(candidates[0], 25)
+	assert.Equal(store.ChannelChat, classification.Channel)
+
+	projection := activityProjectionFromCandidate(
+		t, candidates[0], personID, occurredAt)
+	projection.Event.Channel = store.ChannelChat
+	_, err = f.Store.ProjectActivityBatchContext(
+		t.Context(), []store.ActivityProjection{projection})
+	require.NoError(err)
+	state, err := f.Store.ContactStateContext(t.Context(), personID, occurredAt)
+	require.NoError(err)
+	assert.Equal(store.ChannelChat, state.LastContactChannel)
+}
+
 func TestProcessedActivityQueueRowsReopenWithoutRevisionABA(t *testing.T) {
 	t.Run("message mutation", func(t *testing.T) {
 		f := storetest.New(t)

--- a/internal/store/gmail_chat_migration_test.go
+++ b/internal/store/gmail_chat_migration_test.go
@@ -1,0 +1,84 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestInitSchemaClassifiesLegacyGmailChatMessages(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	st := storetest.New(t).Store
+
+	gmail, err := st.GetOrCreateSource("gmail", "archive@example.com")
+	requirements.NoError(err)
+	gmailLabels, err := st.EnsureLabelsBatch(gmail.ID, map[string]store.LabelInfo{
+		"CHAT": {Name: "CHAT", Type: "system"},
+	})
+	requirements.NoError(err)
+	chatConversation, err := st.EnsureConversation(gmail.ID, "chat-thread", "")
+	requirements.NoError(err)
+	chatMessage, err := st.UpsertMessage(&store.Message{
+		SourceID: gmail.ID, ConversationID: chatConversation,
+		SourceMessageID: "legacy-chat", MessageType: "email",
+	})
+	requirements.NoError(err)
+	requirements.NoError(st.ReplaceMessageLabels(chatMessage, []int64{gmailLabels["CHAT"]}))
+	emailConversation, err := st.EnsureConversation(gmail.ID, "email-thread", "")
+	requirements.NoError(err)
+	_, err = st.UpsertMessage(&store.Message{
+		SourceID: gmail.ID, ConversationID: emailConversation,
+		SourceMessageID: "ordinary-email", MessageType: "email",
+	})
+	requirements.NoError(err)
+
+	imap, err := st.GetOrCreateSource("imap", "imap@example.com")
+	requirements.NoError(err)
+	imapLabels, err := st.EnsureLabelsBatch(imap.ID, map[string]store.LabelInfo{
+		"CHAT": {Name: "CHAT", Type: "user"},
+	})
+	requirements.NoError(err)
+	imapConversation, err := st.EnsureConversation(imap.ID, "imap-thread", "")
+	requirements.NoError(err)
+	imapMessage, err := st.UpsertMessage(&store.Message{
+		SourceID: imap.ID, ConversationID: imapConversation,
+		SourceMessageID: "imap-chat-folder", MessageType: "email",
+	})
+	requirements.NoError(err)
+	requirements.NoError(st.ReplaceMessageLabels(imapMessage, []int64{imapLabels["CHAT"]}))
+
+	_, err = st.DB().ExecContext(t.Context(), st.Rebind(`
+		DELETE FROM applied_migrations WHERE name = ?
+	`), "gmail_chat_classification_v1")
+	requirements.NoError(err)
+	requirements.NoError(st.InitSchemaContext(t.Context()))
+
+	for _, want := range []struct {
+		sourceMessageID  string
+		messageType      string
+		conversationType string
+	}{
+		{sourceMessageID: "legacy-chat", messageType: "google_chat", conversationType: "chat"},
+		{sourceMessageID: "ordinary-email", messageType: "email", conversationType: "email_thread"},
+		{sourceMessageID: "imap-chat-folder", messageType: "email", conversationType: "email_thread"},
+	} {
+		var messageType, conversationType string
+		err := st.DB().QueryRowContext(t.Context(), st.Rebind(`
+			SELECT m.message_type, c.conversation_type
+			FROM messages m
+			JOIN conversations c ON c.id = m.conversation_id
+			WHERE m.source_message_id = ?
+		`), want.sourceMessageID).Scan(&messageType, &conversationType)
+		requirements.NoError(err)
+		assertions.Equal(want.messageType, messageType)
+		assertions.Equal(want.conversationType, conversationType)
+	}
+
+	applied, err := st.IsMigrationApplied("gmail_chat_classification_v1")
+	requirements.NoError(err)
+	assertions.True(applied)
+}

--- a/internal/store/message_type.go
+++ b/internal/store/message_type.go
@@ -1,7 +1,10 @@
 package store
 
-// MessageTypeEmail is the canonical messages.message_type value for email rows.
-const MessageTypeEmail = "email"
+// Canonical message types shared across import and migration paths.
+const (
+	MessageTypeEmail      = "email"
+	MessageTypeGoogleChat = "google_chat"
+)
 
 // IsEmailMessageType reports whether a messages.message_type value denotes an
 // email row. Rows imported before message_type existed carry a NULL/empty

--- a/internal/store/migrations.go
+++ b/internal/store/migrations.go
@@ -62,6 +62,7 @@ const (
 	migrationIdentityMatchSourceSupport  = "identity_match_source_support_v1"
 	migrationVCardSourceResourceIdentity = "vcard_source_resource_identity_v1"
 	migrationOrganizationDomainIDNA      = "organization_domain_idna_v1"
+	migrationGmailChatClassification     = "gmail_chat_classification_v1"
 	// v3: the SQLite conversation trigger narrowed from a blanket
 	// AFTER UPDATE to conversation_type changes only; archives that
 	// installed the blanket trigger need the repair to re-run.
@@ -70,6 +71,45 @@ const (
 	// FTS bookkeeping sweeps no longer requeue the archive.
 	migrationActivityProjectionTriggers = "activity_projection_triggers_v4"
 )
+
+func (s *Store) classifyLegacyGmailChats(ctx context.Context, tx *loggedTx) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE conversations
+		SET conversation_type = 'chat', updated_at = `+s.dialect.Now()+`
+		WHERE conversation_type = 'email_thread'
+		  AND id IN (
+			SELECT m.conversation_id
+			FROM labels label
+			JOIN sources source ON source.id = label.source_id
+			JOIN message_labels ml ON ml.label_id = label.id
+			JOIN messages m ON m.id = ml.message_id AND m.source_id = source.id
+			WHERE source.source_type = 'gmail'
+			  AND label.source_label_id = 'CHAT'
+			  AND m.message_type = 'email'
+		  )
+	`); err != nil {
+		return fmt.Errorf("classify legacy Gmail chat conversations: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE messages
+		SET message_type = ?
+		WHERE message_type = 'email'
+		  AND id IN (
+			SELECT ml.message_id
+			FROM labels label
+			JOIN sources source ON source.id = label.source_id
+			JOIN message_labels ml ON ml.label_id = label.id
+			JOIN messages candidate ON candidate.id = ml.message_id
+				AND candidate.source_id = source.id
+			WHERE source.source_type = 'gmail'
+			  AND label.source_label_id = 'CHAT'
+		  )
+	`, MessageTypeGoogleChat); err != nil {
+		return fmt.Errorf("classify legacy Gmail chat messages: %w", err)
+	}
+	return nil
+}
 
 type legacyOrganizationDomainIdentifier struct {
 	id, organizationID int64

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1403,6 +1403,22 @@ func (s *Store) InitSchemaContext(ctx context.Context) error {
 		return fmt.Errorf("ensure activity projection triggers: %w", err)
 	}
 
+	// Gmail exposes archived chat transcripts as MIME messages carrying its
+	// system CHAT label. Older syncs stored every Gmail payload as email, which
+	// made the archive present these transcripts as separate email items. Run
+	// after the message and activity triggers exist so reclassified rows
+	// invalidate analytical and relationship projections like a normal update.
+	if err := s.runOnceMigration(
+		ctx, migrationGmailChatClassification, false,
+		func(ctx context.Context) error {
+			return s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
+				return s.classifyLegacyGmailChats(ctx, tx)
+			})
+		},
+	); err != nil {
+		return err
+	}
+
 	// Initialize explicit attribution provenance for every legacy message once
 	// under the maintenance timeout escape hatch. Granola and Circleback
 	// historically derived is_from_me from confirmed organizer identities.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +27,8 @@ var ErrHistoryExpired = errors.New("history expired - run full sync")
 
 const (
 	labelTypeSystem               = "system"
+	labelIDChat                   = "CHAT"
+	conversationTypeChat          = "chat"
 	sourceTypeIMAP                = "imap"
 	invalidatedIMAPSourceIDPrefix = "msgvault-invalidated:"
 )
@@ -1126,7 +1129,16 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 	if convSubject == "" {
 		convSubject = "(no subject)"
 	}
-	conversationID, err := s.store.EnsureConversation(sourceID, threadID, convSubject)
+	messageType := store.MessageTypeEmail
+	var conversationID int64
+	if s.isGmailChat(raw.LabelIDs) {
+		messageType = store.MessageTypeGoogleChat
+		conversationID, err = s.store.EnsureConversationWithType(
+			sourceID, threadID, conversationTypeChat, convSubject,
+		)
+	} else {
+		conversationID, err = s.store.EnsureConversation(sourceID, threadID, convSubject)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("ensure conversation: %w", err)
 	}
@@ -1143,7 +1155,7 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		SourceID:        sourceID,
 		SourceMessageID: raw.ID,
 		RFC822MessageID: rfc822ID,
-		MessageType:     "email",
+		MessageType:     messageType,
 		SenderID:        senderID,
 		Subject:         sql.NullString{String: subject, Valid: subject != ""},
 		Snippet:         sql.NullString{String: snippet, Valid: snippet != ""},
@@ -1190,6 +1202,13 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		attachments:    parsed.Attachments,
 		participantMap: participantMap,
 	}, nil
+}
+
+func (s *Syncer) isGmailChat(labelIDs []string) bool {
+	if s.opts.SourceType != "" && s.opts.SourceType != "gmail" {
+		return false
+	}
+	return slices.Contains(labelIDs, labelIDChat)
 }
 
 // persistMessage stores a parsed message and all related data, returning

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -231,6 +231,40 @@ func TestFullSync(t *testing.T) {
 	assertMessageCount(t, env.Store, 3)
 }
 
+func TestFullSyncClassifiesGmailChatMessages(t *testing.T) {
+	env := newTestEnv(t)
+	env.Mock.Labels = []*gmail.Label{
+		{ID: "INBOX", Name: "INBOX", Type: "system"},
+		{ID: "CHAT", Name: "CHAT", Type: "system"},
+	}
+	env.Mock.Profile.MessagesTotal = 2
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.AddMessage("chat-message", testMIME(), []string{"CHAT"})
+	env.Mock.AddMessage("email-message", testMIME(), []string{"INBOX"})
+
+	runFullSync(t, env)
+
+	for _, want := range []struct {
+		sourceMessageID  string
+		messageType      string
+		conversationType string
+	}{
+		{sourceMessageID: "chat-message", messageType: "google_chat", conversationType: "chat"},
+		{sourceMessageID: "email-message", messageType: "email", conversationType: "email_thread"},
+	} {
+		var messageType, conversationType string
+		err := env.Store.DB().QueryRow(env.Store.Rebind(`
+			SELECT m.message_type, c.conversation_type
+			FROM messages m
+			JOIN conversations c ON c.id = m.conversation_id
+			WHERE m.source_message_id = ?
+		`), want.sourceMessageID).Scan(&messageType, &conversationType)
+		require.NoError(t, err)
+		assert.Equal(t, want.messageType, messageType)
+		assert.Equal(t, want.conversationType, conversationType)
+	}
+}
+
 func TestFullSyncProviderHookFailureWarnsOnceAfterSuccessfulCompletion(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)


### PR DESCRIPTION
Gmail's `CHAT` system label identifies archived Google Chat transcripts, but msgvault stored those payloads as email. This made short chat lines appear as standalone emails in message views.

New syncs now store those items as `google_chat` messages in chat conversations. Existing archives are reclassified automatically on the next schema initialization. Ordinary Gmail email and IMAP folders named `CHAT` are unchanged.
