### PR TITLE
fix(search): add source deletion scope

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11239,7 +11239,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.11.0
+  version: 2.12.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -13841,6 +13841,11 @@ paths:
         - description: Message type filter; repeat or comma-separate for multiple values
           in: query
           name: message_type
+          schema:
+            type: string
+        - description: "Source deletion scope: active (default), deleted, or any"
+          in: query
+          name: deletion_scope
           schema:
             type: string
         - description: Restrict to one account/source

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -167,12 +167,20 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 	)
 	started := time.Now()
 
+	// Only send an explicitly requested scope: the daemon's default is
+	// already active-only, and a scoped request makes the client require
+	// API schema 2.12.0, which would break default searches against older
+	// daemons.
+	deletionScope := ""
+	if cmd.Flags().Changed("deletion-scope") {
+		deletionScope = searchDeletionScope
+	}
 	resp, err := s.GetCLISearch(cmd.Context(), daemonclient.CLISearchRequest{
 		Query:         queryStr,
 		Account:       searchAccount,
 		Collection:    searchCollection,
 		MessageTypes:  searchMessageTypes,
-		DeletionScope: searchDeletionScope,
+		DeletionScope: deletionScope,
 		Limit:         searchLimit,
 		Offset:        searchOffset,
 	})

--- a/cmd/msgvault/cmd/search.go
+++ b/cmd/msgvault/cmd/search.go
@@ -15,14 +15,15 @@ import (
 )
 
 var (
-	searchLimit        int
-	searchOffset       int
-	searchJSON         bool
-	searchAccount      string
-	searchCollection   string
-	searchMode         string
-	searchExplain      bool
-	searchMessageTypes []string
+	searchLimit         int
+	searchOffset        int
+	searchJSON          bool
+	searchAccount       string
+	searchCollection    string
+	searchMode          string
+	searchExplain       bool
+	searchDeletionScope string
+	searchMessageTypes  []string
 )
 
 var searchCmd = &cobra.Command{
@@ -70,6 +71,16 @@ Examples:
 		// Validate mode before any scope work so we fail fast on a typo.
 		if searchMode != "fts" && searchMode != "vector" && searchMode != "hybrid" {
 			return usageErr(cmd, fmt.Errorf("invalid --mode: %q (want fts|vector|hybrid)", searchMode))
+		}
+		if searchDeletionScope != "active" && searchDeletionScope != "deleted" && searchDeletionScope != "any" {
+			return usageErr(cmd, fmt.Errorf(
+				"invalid --deletion-scope: %q (want active|deleted|any)", searchDeletionScope))
+		}
+		if searchMode != "fts" && searchDeletionScope != "active" {
+			return usageErr(cmd, fmt.Errorf(
+				"--deletion-scope=%s is only supported with --mode=fts; vector and hybrid indexes cover active messages only",
+				searchDeletionScope,
+			))
 		}
 
 		// Validate --message-type against the known set, like --mode, so a
@@ -157,12 +168,13 @@ func runHTTPSearch(cmd *cobra.Command, queryStr string) error {
 	started := time.Now()
 
 	resp, err := s.GetCLISearch(cmd.Context(), daemonclient.CLISearchRequest{
-		Query:        queryStr,
-		Account:      searchAccount,
-		Collection:   searchCollection,
-		MessageTypes: searchMessageTypes,
-		Limit:        searchLimit,
-		Offset:       searchOffset,
+		Query:         queryStr,
+		Account:       searchAccount,
+		Collection:    searchCollection,
+		MessageTypes:  searchMessageTypes,
+		DeletionScope: searchDeletionScope,
+		Limit:         searchLimit,
+		Offset:        searchOffset,
 	})
 	stopStatus()
 	if err != nil {
@@ -285,6 +297,8 @@ func init() {
 	searchCmd.MarkFlagsMutuallyExclusive("account", "collection")
 	searchCmd.Flags().StringVar(&searchMode, "mode", "fts", "Search mode: fts|vector|hybrid")
 	searchCmd.Flags().BoolVar(&searchExplain, "explain", false, "Include per-signal scores in output (hybrid/vector modes)")
+	searchCmd.Flags().StringVar(&searchDeletionScope, "deletion-scope", "active",
+		"Source deletion scope: active|deleted|any (FTS mode only)")
 	searchCmd.Flags().StringSliceVar(&searchMessageTypes, "message-type", nil,
 		"Limit results to message type(s), e.g. email, sms, calendar_event, meeting_transcript")
 }

--- a/cmd/msgvault/cmd/search_test.go
+++ b/cmd/msgvault/cmd/search_test.go
@@ -942,10 +942,6 @@ func TestSearchCmd_JSONEmptyResultsEmitEmptyArray(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if r.URL.Path == "/api/v1/health" {
-			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.12.0"}`))
-			return
-		}
 		_, _ = w.Write([]byte(`{"results":[]}`))
 	}))
 	defer srv.Close()

--- a/cmd/msgvault/cmd/search_test.go
+++ b/cmd/msgvault/cmd/search_test.go
@@ -89,6 +89,7 @@ func resetSearchFlags() {
 	searchJSON = false
 	searchMode = "fts"
 	searchExplain = false
+	searchDeletionScope = "active"
 	searchMessageTypes = nil
 	// Cobra remembers per-flag `Changed` state on the global searchCmd
 	// across test invocations. Without clearing it, mutually-exclusive
@@ -205,6 +206,75 @@ func TestSearchCmd_MessageTypeFlagForwardsToRemoteMode(t *testing.T) {
 	err := root.Execute()
 	require.NoError(t, err, "message-type remote search should be forwarded")
 	assert.Equal(t, "lunch", gotQuery, "remote query should keep search terms")
+}
+
+func TestSearchCmd_DeletionScopeForwardsToRemoteFTS(t *testing.T) {
+	savedCfg := cfg
+	savedUseLocal := useLocal
+	defer func() {
+		cfg = savedCfg
+		useLocal = savedUseLocal
+		resetSearchFlags()
+	}()
+
+	searchRequests := &atomic.Int32{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.12.0"}`))
+			return
+		}
+		searchRequests.Add(1)
+		assert.Equal(t, "/api/v1/cli/search", r.URL.Path, "path")
+		assert.Equal(t, "deleted", r.URL.Query().Get("deletion_scope"), "deletion_scope query")
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	cfg = &config.Config{}
+	cfg.Remote.URL = srv.URL
+	cfg.Remote.AllowInsecure = true
+	useLocal = false
+
+	root := newTestRootCmd()
+	root.AddCommand(searchCmd)
+	root.SetArgs([]string{"search", "--deletion-scope", "deleted", "statement"})
+
+	err := root.Execute()
+	require.NoError(t, err, "source-deleted FTS search")
+	assert.Equal(t, int32(1), searchRequests.Load(), "search endpoint calls")
+}
+
+func TestSearchCmd_DeletionScopeRejectsInvalidValue(t *testing.T) {
+	defer resetSearchFlags()
+
+	root := newTestRootCmd()
+	root.AddCommand(searchCmd)
+	root.SetArgs([]string{"search", "--deletion-scope", "trash", "statement"})
+
+	err := root.Execute()
+	require.Error(t, err, "invalid deletion scope")
+	assert.ErrorContains(t, err, `invalid --deletion-scope: "trash" (want active|deleted|any)`)
+}
+
+func TestSearchCmd_DeletionScopeRejectsVectorAndHybrid(t *testing.T) {
+	for _, mode := range []string{"vector", "hybrid"} {
+		t.Run(mode, func(t *testing.T) {
+			defer resetSearchFlags()
+
+			root := newTestRootCmd()
+			root.AddCommand(searchCmd)
+			root.SetArgs([]string{
+				"search", "--mode", mode,
+				"--deletion-scope", "any", "statement",
+			})
+
+			err := root.Execute()
+			require.Error(t, err, "non-active semantic deletion scope")
+			assert.ErrorContains(t, err,
+				"--deletion-scope=any is only supported with --mode=fts; vector and hybrid indexes cover active messages only")
+		})
+	}
 }
 
 func TestSearchCmd_FTSUsesLocalDaemonHTTPAndPreservesJSONOutput(t *testing.T) {
@@ -872,6 +942,10 @@ func TestSearchCmd_JSONEmptyResultsEmitEmptyArray(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/health" {
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.12.0"}`))
+			return
+		}
 		_, _ = w.Write([]byte(`{"results":[]}`))
 	}))
 	defer srv.Close()

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1028,6 +1028,7 @@ msgvault search <query> [flags]
 | `--account` | Limit results to a specific account |
 | `--collection` | Limit results to all member accounts of a collection |
 | `--message-type` | Limit results to one or more message types, e.g. `email`, `teams`, `discord`, `calendar_event`, `sms` |
+| `--deletion-scope` | Source-deletion scope: `active` (default), `deleted`, or `any`. Non-active scopes require `--mode fts`. |
 | `--mode` | Search mode: `fts` (default), `vector`, or `hybrid`. `vector` and `hybrid` require vector search to be configured. |
 | `--explain` | Include per-signal scores (RRF, BM25, vector) in the output. Only applies to `--mode vector` and `--mode hybrid`. |
 
@@ -1037,7 +1038,7 @@ Ordinary aggregate views and statistics still default to email-only; use
 `--message-type` (or `message_type:` in the query) when you need an explicit
 search scope.
 
-`--mode vector` and `--mode hybrid` require at least one free-text term in the query (filter-only queries use `--mode fts`). They do not support pagination (`--offset` is rejected), so bump `--limit` to retrieve a larger candidate pool instead. See [Searching](/usage/searching/) for the operator reference and [Vector Search](/usage/vector-search/) for semantic setup.
+`--mode vector` and `--mode hybrid` require at least one free-text term in the query (filter-only queries use `--mode fts`). They do not support pagination (`--offset` is rejected) or non-active deletion scopes because the vector index covers active messages only. Bump `--limit` to retrieve a larger candidate pool instead. See [Searching](/usage/searching/) for the operator reference and [Vector Search](/usage/vector-search/) for semantic setup.
 
 ---
 

--- a/docs/usage/deletion.md
+++ b/docs/usage/deletion.md
@@ -8,7 +8,9 @@ msgvault supports a staged deletion workflow: select messages in the Web UI or
 TUI, or stage them via an AI assistant; review what will be deleted; then
 execute against Gmail or your IMAP provider. **Deletion only removes messages
 from the remote mail server. Your local archive is never modified.** This means
-you can always search, browse, and export deleted messages from your local copy.
+you can always browse and export deleted messages from your local copy, or find
+them with `msgvault search <query> --deletion-scope deleted`. Use
+`--deletion-scope any` to search active and source-deleted messages together.
 
 ## Staging in the Web UI
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -94,6 +94,28 @@ The two flags are mutually exclusive. Collection filters work in full-text, vect
 
 SQLite FTS ranking is weighted to better match PostgreSQL-backed search behavior, so subject/body weighting should feel more consistent across local tools. The rankers are still different; see [Search Ranking Across Backends](/architecture/search-ranking/).
 
+## Source-Deleted Messages
+
+Search excludes messages deleted from their source account by default. Full-text
+search can select that retained local history explicitly:
+
+```bash
+# Only messages deleted from their source account
+msgvault search "quarterly report" --deletion-scope deleted
+
+# Active and source-deleted messages
+msgvault search "quarterly report" --deletion-scope any
+```
+
+The accepted values are `active` (the default), `deleted`, and `any`. This scope
+applies to source deletion (`deleted_from_source_at`); rows hidden internally by
+deduplication are never returned. It is available only with `--mode fts` because
+the vector index intentionally covers active messages only. Vector and hybrid
+search reject non-active deletion scopes instead of returning incomplete results.
+
+HTTP clients can pass the same values as `deletion_scope` on
+`GET /api/v1/cli/search`.
+
 ## Filtering by Message Type
 
 Archives can hold more than email — Google Calendar events, Microsoft Teams

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1845,6 +1845,12 @@ func (s *Server) handleCLISearch(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_query", err.Error())
 		return
 	}
+	deletionScope, err := search.ParseDeletionScope(r.URL.Query().Get("deletion_scope"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_deletion_scope", err.Error())
+		return
+	}
+	parsed.DeletionScope = deletionScope
 	for _, raw := range r.URL.Query()["message_type"] {
 		for typ := range strings.SplitSeq(raw, ",") {
 			typ = strings.TrimSpace(strings.ToLower(typ))

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3684,6 +3684,13 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	merged := query.MergeFilterIntoQuery(q, filter)
+	if filter.HideDeletedFromSource {
+		merged.DeletionScope = search.DeletionScopeActive
+	} else {
+		// Preserve the pre-2.12 deep-search contract: omitted or false
+		// hide_deleted includes retained source-deleted messages.
+		merged.DeletionScope = search.DeletionScopeAny
+	}
 
 	// Fetch one extra row to determine has_more accurately.
 	var messages []query.MessageSummary

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2135,6 +2135,64 @@ func TestHandleCLISearchDoesNotBlockOnIndexBuild(t *testing.T) {
 	assert.Empty(searchIndexState(), "state once the index is complete")
 }
 
+func TestHandleCLISearchDeletionScope(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawScope  string
+		wantScope search.DeletionScope
+	}{
+		{name: "default_active", wantScope: search.DeletionScopeActive},
+		{name: "explicit_active", rawScope: "active", wantScope: search.DeletionScopeActive},
+		{name: "deleted", rawScope: "deleted", wantScope: search.DeletionScopeDeleted},
+		{name: "any", rawScope: "any", wantScope: search.DeletionScopeAny},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotScope search.DeletionScope
+			engine := &querytest.MockEngine{
+				SearchFunc: func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
+					gotScope = q.DeletionScope
+					return nil, nil
+				},
+			}
+			srv := NewServerWithOptions(ServerOptions{
+				Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+				Store:  &mockStore{}, Engine: engine, Logger: testLogger(),
+			})
+			srv.ftsIndexComplete.Store(true)
+			target := "/api/v1/cli/search?q=scope"
+			if tt.rawScope != "" {
+				target += "&deletion_scope=" + tt.rawScope
+			}
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, httptest.NewRequest(http.MethodGet, target, nil))
+			require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+			assert.Equal(t, tt.wantScope, gotScope)
+		})
+	}
+}
+
+func TestHandleCLISearchRejectsInvalidDeletionScope(t *testing.T) {
+	called := false
+	engine := &querytest.MockEngine{
+		SearchFunc: func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  &mockStore{}, Engine: engine, Logger: testLogger(),
+	})
+	srv.ftsIndexComplete.Store(true)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, httptest.NewRequest(http.MethodGet,
+		"/api/v1/cli/search?q=scope&deletion_scope=bogus", nil))
+
+	assert.Equal(t, http.StatusBadRequest, resp.Code, resp.Body.String())
+	assert.False(t, called, "invalid scope must be rejected before search")
+}
+
 // TestHandleCLISearchProbeDiscardsResultStaleAfterRebuild reproduces the
 // probe/rebuild race (roborev finding on f91f6cb): the ensure worker's
 // completeness probe runs outside the operation gate, so a rebuild-fts can
@@ -5696,6 +5754,35 @@ func TestHandleDeepSearch(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
 	assert.Equal(t, "agenda", resp["query"], "query")
+}
+
+func TestHandleDeepSearchPreservesHideDeletedCompatibility(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantScope search.DeletionScope
+	}{
+		{name: "omitted includes retained source deletions", query: "", wantScope: search.DeletionScopeAny},
+		{name: "false includes retained source deletions", query: "&hide_deleted=false", wantScope: search.DeletionScopeAny},
+		{name: "true keeps active only", query: "&hide_deleted=true", wantScope: search.DeletionScopeActive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotScope search.DeletionScope
+			engine := &querytest.MockEngine{
+				SearchFunc: func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
+					gotScope = q.DeletionScope
+					return nil, nil
+				},
+			}
+			srv := newTestServerWithEngine(t, engine)
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, httptest.NewRequest(http.MethodGet,
+				"/api/v1/search/deep?q=agenda"+tt.query, nil))
+			require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+			assert.Equal(t, tt.wantScope, gotScope)
+		})
+	}
 }
 
 type bodySearchTestEngine struct {

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -237,7 +237,10 @@ import (
 // candidate, review, accept, or reject workflow.
 // Additive (minor bump): existing person, participant, relationship, calendar,
 // and CardDAV routes are unchanged.
-const APISchemaVersion = "2.11.0"
+// 2.12.0 adds deletion_scope=active|deleted|any to GET /api/v1/cli/search.
+// Omission preserves the active-only default. Additive (minor bump): existing
+// clients continue to receive the same result population.
+const APISchemaVersion = "2.12.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -34,8 +34,24 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 	assert.NotEmpty(t, doc.Paths, "paths")
 }
 
-func TestOpenAPISchemaVersionPersonFactsIs2110(t *testing.T) {
-	assert.Equal(t, "2.11.0", APISchemaVersion)
+func TestOpenAPISchemaVersionSearchDeletionScopeIs2120(t *testing.T) {
+	assert.Equal(t, "2.12.0", APISchemaVersion)
+}
+
+func TestCLISearchOpenAPIDocumentsDeletionScope(t *testing.T) {
+	assertions := assert.New(t)
+	operation := OpenAPIDocument().Paths["/api/v1/cli/search"].Get
+	require.NotNil(t, operation)
+	for _, parameter := range operation.Parameters {
+		if parameter.Name == "deletion_scope" {
+			assertions.Equal("query", parameter.In)
+			assertions.Contains(parameter.Description, "active")
+			assertions.Contains(parameter.Description, "deleted")
+			assertions.Contains(parameter.Description, "any")
+			return
+		}
+	}
+	assertions.Fail("deletion_scope query parameter is not documented")
 }
 
 func TestPersonFactOpenAPIOperationsContainNoReviewMutation(t *testing.T) {
@@ -117,7 +133,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.11.0", APISchemaVersion)
+	assert.Equal("2.12.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -139,11 +155,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.11.0", APISchemaVersion)
+	assert.Equal(t, "2.12.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.11.0", APISchemaVersion)
+	assert.Equal(t, "2.12.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -167,7 +183,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.11.0", APISchemaVersion,
+	assert.Equal(t, "2.12.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -478,7 +494,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.11.0", APISchemaVersion,
+	assert.Equal("2.12.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -592,7 +608,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.11.0", APISchemaVersion,
+	assertions.Equal("2.12.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -612,7 +628,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.11.0", APISchemaVersion,
+	assert.Equal("2.12.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -640,7 +656,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.11.0", APISchemaVersion,
+	assertions.Equal("2.12.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -686,8 +702,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// 2.0.0, tracking added in 2.1.0, and participant-scoped files added in
 	// 2.5.0. Person search in 2.6.0, structured filters in 2.7.0, CardDAV routes
 	// in 2.8.0, person merge/split operations in 2.9.0, and relationship
-	// calendars in 2.10.0 and person fact diagnostics in 2.11.0 did not touch it.
-	assert.Equal("2.11.0", APISchemaVersion, "meeting import is an additive schema release")
+	// calendars in 2.10.0, person fact diagnostics in 2.11.0, and lexical
+	// deletion scope in 2.12.0 did not touch it.
+	assert.Equal("2.12.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/relationship_calendar_test.go
+++ b/internal/api/relationship_calendar_test.go
@@ -177,7 +177,7 @@ func TestRelationshipCalendarRequestRejectsTrailingJSON(t *testing.T) {
 func TestRelationshipCalendarOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.Equal("2.11.0", APISchemaVersion)
+	assert.Equal("2.12.0", APISchemaVersion)
 	document := OpenAPIDocument()
 	path := document.Paths["/api/v1/relationships/{id}/calendar"]
 	require.NotNil(path)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -618,6 +618,7 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryIntegerParam(limitParam, "Maximum number of rows to return"),
 			queryIntegerParam("offset", "Zero-based row offset"),
 			queryStringParam("message_type", "Message type filter; repeat or comma-separate for multiple values", false),
+			queryStringParam("deletion_scope", "Source deletion scope: active (default), deleted, or any", false),
 		}, scopeParams()...)
 	case "searchDocuments":
 		return []*huma.Param{

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -157,12 +157,13 @@ type CLIInitDB struct {
 }
 
 type CLISearchRequest struct {
-	Query        string
-	Account      string
-	Collection   string
-	MessageTypes []string
-	Limit        int
-	Offset       int
+	Query         string
+	Account       string
+	Collection    string
+	DeletionScope string
+	MessageTypes  []string
+	Limit         int
+	Offset        int
 }
 
 type CLISearch struct {
@@ -437,7 +438,10 @@ func (c *Client) RunCLISync(
 	}, output)
 }
 
-const sourceIDSyncMinAPISchemaVersion = "2.4.0"
+const (
+	sourceIDSyncMinAPISchemaVersion   = "2.4.0"
+	searchDeletionMinAPISchemaVersion = "2.12.0"
+)
 
 func (c *Client) requireSourceIDSyncCapability(ctx context.Context) error {
 	version, err := c.daemonAPISchemaVersion(ctx)
@@ -811,15 +815,28 @@ func (c *Client) GetCLIStats(
 }
 
 func (c *Client) GetCLISearch(ctx context.Context, req CLISearchRequest) (*CLISearch, error) {
+	if req.DeletionScope != "" {
+		version, err := c.daemonAPISchemaVersion(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("check daemon search deletion-scope capability: %w", err)
+		}
+		if !apiSchemaVersionAtLeast(version, searchDeletionMinAPISchemaVersion) {
+			return nil, fmt.Errorf(
+				"search deletion scope requires daemon API schema %s or newer (daemon reports %q)",
+				searchDeletionMinAPISchemaVersion, version,
+			)
+		}
+	}
 	resp, err := APIResponse(c, func(client *apiclient.Client) (*generated.SearchCLIResp, error) {
 		return client.SearchCLIWithResponse(ctx, &generated.SearchCLIRequestOptions{
 			Query: &generated.SearchCLIQuery{
-				Q:           req.Query,
-				Account:     optionalString(req.Account),
-				Collection:  optionalString(req.Collection),
-				MessageType: optionalMessageTypes(req.MessageTypes),
-				Limit:       optionalPositiveInt64(req.Limit),
-				Offset:      optionalPositiveInt64(req.Offset),
+				Q:             req.Query,
+				Account:       optionalString(req.Account),
+				Collection:    optionalString(req.Collection),
+				DeletionScope: optionalString(req.DeletionScope),
+				MessageType:   optionalMessageTypes(req.MessageTypes),
+				Limit:         optionalPositiveInt64(req.Limit),
+				Offset:        optionalPositiveInt64(req.Offset),
 			},
 		})
 	})

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -1138,6 +1138,50 @@ func TestGetCLISearch_Success(t *testing.T) {
 	assert.Equal(1, resp.ScopeSourceCount, "ScopeSourceCount")
 }
 
+func TestGetCLISearch_DeletionScopeRequiresCompatibleDaemon(t *testing.T) {
+	tests := []struct {
+		name          string
+		schemaVersion string
+		deletionScope string
+		wantErr       bool
+		wantSearches  int
+	}{
+		{name: "older daemon rejects active", schemaVersion: "2.11.0", deletionScope: "active", wantErr: true},
+		{name: "older daemon rejects deleted", schemaVersion: "2.11.0", deletionScope: "deleted", wantErr: true},
+		{name: "compatible daemon accepts active", schemaVersion: "2.12.0", deletionScope: "active", wantSearches: 1},
+		{name: "compatible daemon accepts deleted", schemaVersion: "2.12.0", deletionScope: "deleted", wantSearches: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			searches := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/api/v1/health" {
+					_, _ = fmt.Fprintf(w, `{"status":"ok","api_schema_version":%q}`, tt.schemaVersion)
+					return
+				}
+				searches++
+				assert.Equal(t, "/api/v1/cli/search", r.URL.Path)
+				assert.Equal(t, tt.deletionScope, r.URL.Query().Get("deletion_scope"))
+				_, _ = w.Write([]byte(`{"results":[]}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			client := newTestStore(srv, "")
+			_, err := client.GetCLISearch(context.Background(), CLISearchRequest{
+				Query: "scope", DeletionScope: tt.deletionScope,
+			})
+			if tt.wantErr {
+				require.ErrorContains(t, err, "requires daemon API schema 2.12.0")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantSearches, searches,
+				"an incompatible daemon must not receive the scoped search")
+		})
+	}
+}
+
 func TestGetCLIHybridSearch_Success(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/query/deletion_scope.go
+++ b/internal/query/deletion_scope.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// searchMessageVisibilityWhere returns the message visibility predicate for
+// the lexical Search path. Source deletion is selectable, while dedup-hidden
+// rows remain excluded in every scope. Unknown values fail closed to active.
+func searchMessageVisibilityWhere(alias string, scope search.DeletionScope) string {
+	switch scope {
+	case search.DeletionScopeDeleted:
+		return store.SourceDeletedMessagesWhere(alias)
+	case search.DeletionScopeAny:
+		return store.LiveMessagesWhere(alias, false)
+	case search.DeletionScopeActive:
+		return store.LiveMessagesWhere(alias, true)
+	default:
+		return store.LiveMessagesWhere(alias, true)
+	}
+}

--- a/internal/query/deletion_scope.go
+++ b/internal/query/deletion_scope.go
@@ -6,16 +6,21 @@ import (
 )
 
 // searchMessageVisibilityWhere returns the message visibility predicate for
-// the lexical Search path. Source deletion is selectable, while dedup-hidden
-// rows remain excluded in every scope. Unknown values fail closed to active.
-func searchMessageVisibilityWhere(alias string, scope search.DeletionScope) string {
-	switch scope {
+// the lexical Search path. An explicit scope wins; the zero value keeps the
+// historical HideDeleted-driven visibility so callers that never set a scope
+// (the TUI, MCP staging, and the aggregate/stats search filters) are
+// unaffected. Dedup-hidden rows remain excluded in every scope, and unknown
+// non-empty values fail closed to active.
+func searchMessageVisibilityWhere(alias string, q *search.Query) string {
+	switch q.DeletionScope {
 	case search.DeletionScopeDeleted:
 		return store.SourceDeletedMessagesWhere(alias)
 	case search.DeletionScopeAny:
 		return store.LiveMessagesWhere(alias, false)
 	case search.DeletionScopeActive:
 		return store.LiveMessagesWhere(alias, true)
+	case "":
+		return store.LiveMessagesWhere(alias, q.HideDeleted)
 	default:
 		return store.LiveMessagesWhere(alias, true)
 	}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -2033,9 +2033,7 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	var args []any
 	var joins []string
 
-	// Exclude rows soft-deleted by deduplicate; gate source-deleted on
-	// q.HideDeleted via the helper.
-	conditions = append(conditions, store.LiveMessagesWhere("m", q.HideDeleted))
+	conditions = append(conditions, searchMessageVisibilityWhere("m", q.DeletionScope))
 
 	// From filter
 	if len(q.FromAddrs) > 0 {

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -2033,7 +2033,7 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	var args []any
 	var joins []string
 
-	conditions = append(conditions, searchMessageVisibilityWhere("m", q.DeletionScope))
+	conditions = append(conditions, searchMessageVisibilityWhere("m", q))
 
 	// From filter
 	if len(q.FromAddrs) > 0 {

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -485,11 +485,13 @@ func TestDuckDBEngine_SearchDeletionScopeSQLiteScanner(t *testing.T) {
 func assertSearchDeletionScopes(t *testing.T, engine Engine, activeIDs, deletedIDs, anyIDs []int64) {
 	t.Helper()
 	tests := []struct {
-		name    string
-		scope   search.DeletionScope
-		wantIDs []int64
+		name        string
+		scope       search.DeletionScope
+		hideDeleted bool
+		wantIDs     []int64
 	}{
-		{name: "zero_value_defaults_to_active", wantIDs: activeIDs},
+		{name: "zero_value_keeps_hide_deleted_off", wantIDs: anyIDs},
+		{name: "zero_value_keeps_hide_deleted_on", hideDeleted: true, wantIDs: activeIDs},
 		{name: "active", scope: search.DeletionScopeActive, wantIDs: activeIDs},
 		{name: "deleted", scope: search.DeletionScopeDeleted, wantIDs: deletedIDs},
 		{name: "any", scope: search.DeletionScopeAny, wantIDs: anyIDs},
@@ -499,6 +501,7 @@ func assertSearchDeletionScopes(t *testing.T, engine Engine, activeIDs, deletedI
 		t.Run(tt.name, func(t *testing.T) {
 			results, err := engine.Search(context.Background(), &search.Query{
 				DeletionScope: tt.scope,
+				HideDeleted:   tt.hideDeleted,
 			}, 100, 0)
 			require.NoError(t, err)
 			gotIDs := make([]int64, 0, len(results))

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -426,32 +426,88 @@ func TestDuckDBEngine_DeletedMessagesIncluded(t *testing.T) {
 	assert.NotNil(msg, "expected message 2")
 }
 
-// TestDuckDBEngine_SearchHideDeleted verifies that Search (deep FTS path)
-// respects search.Query.HideDeleted via the sqliteEngine delegation.
-func TestDuckDBEngine_SearchHideDeleted(t *testing.T) {
+// TestDuckDBEngine_SearchDeletionScope verifies the sqliteEngine delegation
+// applies the same source-deletion scope as the native SQLite engine.
+func TestDuckDBEngine_SearchDeletionScope(t *testing.T) {
 	require := require.New(t)
-	assert := assert.New(t)
 	env := newTestEnv(t)
 
-	// Mark message 1 as deleted
 	_, err := env.DB.Exec("UPDATE messages SET deleted_from_source_at = datetime('now') WHERE id = 1")
 	require.NoError(err, "mark deleted")
+	_, err = env.DB.Exec("UPDATE messages SET deleted_at = datetime('now') WHERE id = 2")
+	require.NoError(err, "mark dedup-hidden")
 
 	engine, err := NewDuckDBEngine("", "", env.DB)
 	require.NoError(err, "NewDuckDBEngine")
 	t.Cleanup(func() { _ = engine.Close() })
 
-	ctx := context.Background()
+	assertSearchDeletionScopes(t, engine,
+		[]int64{3, 4, 5}, []int64{1}, []int64{1, 3, 4, 5})
+}
 
-	// Search without HideDeleted: all 5 messages
-	all, err := engine.Search(ctx, &search.Query{}, 100, 0)
-	require.NoError(err, "Search")
-	assert.Len(all, 5, "Search without HideDeleted")
+// TestDuckDBEngine_SearchDeletionScopeSQLiteScanner exercises the alternate
+// DuckDB sqlite_scanner path instead of the direct SQLite delegation.
+func TestDuckDBEngine_SearchDeletionScopeSQLiteScanner(t *testing.T) {
+	require := require.New(t)
+	dbPath := filepath.Join(t.TempDir(), "scope.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(err, "open sqlite")
+	schema, err := os.ReadFile("../store/schema.sql")
+	require.NoError(err, "read schema")
+	_, err = db.Exec(string(schema))
+	require.NoError(err, "create schema")
+	_, err = db.Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES (1, 'gmail', 'scope@example.com');
+		INSERT INTO conversations (id, source_id, source_conversation_id, conversation_type, title)
+			VALUES (1, 1, 'scope-thread', 'email_thread', 'Scope');
+		INSERT INTO messages (
+			id, conversation_id, source_id, source_message_id, message_type,
+			sent_at, subject, snippet, size_estimate, has_attachments, attachment_count,
+			deleted_at, deleted_from_source_at
+		) VALUES
+			(1, 1, 1, 'scope-deleted', 'email', '2024-04-10 10:00:00', 'scope needle', '', 100, 0, 0, NULL, '2024-04-12 10:00:00'),
+			(2, 1, 1, 'scope-dedup', 'email', '2024-04-11 10:00:00', 'scope needle', '', 100, 0, 0, '2024-04-12 10:00:00', NULL),
+			(3, 1, 1, 'scope-live', 'email', '2024-04-12 10:00:00', 'scope needle', '', 100, 0, 0, NULL, NULL);
+	`)
+	require.NoError(err, "seed sqlite")
+	require.NoError(db.Close(), "close sqlite")
 
-	// Search with HideDeleted: 4 messages
-	hidden, err := engine.Search(ctx, &search.Query{HideDeleted: true}, 100, 0)
-	require.NoError(err, "Search(HideDeleted)")
-	assert.Len(hidden, 4, "Search with HideDeleted")
+	engine, err := NewDuckDBEngine("", dbPath, nil)
+	require.NoError(err, "NewDuckDBEngine")
+	t.Cleanup(func() { _ = engine.Close() })
+	if !engine.hasSQLite() {
+		t.Skip("DuckDB sqlite_scanner extension unavailable")
+	}
+
+	assertSearchDeletionScopes(t, engine, []int64{3}, []int64{1}, []int64{1, 3})
+}
+
+func assertSearchDeletionScopes(t *testing.T, engine Engine, activeIDs, deletedIDs, anyIDs []int64) {
+	t.Helper()
+	tests := []struct {
+		name    string
+		scope   search.DeletionScope
+		wantIDs []int64
+	}{
+		{name: "zero_value_defaults_to_active", wantIDs: activeIDs},
+		{name: "active", scope: search.DeletionScopeActive, wantIDs: activeIDs},
+		{name: "deleted", scope: search.DeletionScopeDeleted, wantIDs: deletedIDs},
+		{name: "any", scope: search.DeletionScopeAny, wantIDs: anyIDs},
+		{name: "unknown_fails_closed_to_active", scope: search.DeletionScope("bogus"), wantIDs: activeIDs},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := engine.Search(context.Background(), &search.Query{
+				DeletionScope: tt.scope,
+			}, 100, 0)
+			require.NoError(t, err)
+			gotIDs := make([]int64, 0, len(results))
+			for _, result := range results {
+				gotIDs = append(gotIDs, result.ID)
+			}
+			require.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
 }
 
 // TestDuckDBEngine_AggregateByRecipient verifies that recipient aggregation

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1558,7 +1558,7 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 // FTS join (ftsJoin); there is no separate non-EXISTS join slot.
 func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, ftsJoin string) {
 	return e.buildSearchQueryPartsWithVisibility(ctx, q,
-		searchMessageVisibilityWhere("m", q.DeletionScope))
+		searchMessageVisibilityWhere("m", q))
 }
 
 // buildSearchQueryPartsWithVisibility keeps the historical SearchFast

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -1557,9 +1557,15 @@ func (e *SQLiteEngine) SearchByDomains(ctx context.Context, domains []string, af
 // correlated subquery, so the only join this ever emits is the optional
 // FTS join (ftsJoin); there is no separate non-EXISTS join slot.
 func (e *SQLiteEngine) buildSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, ftsJoin string) {
-	// Exclude rows soft-deleted by deduplicate; gate source-deleted on
-	// q.HideDeleted via the helper.
-	conditions = append(conditions, store.LiveMessagesWhere("m", q.HideDeleted))
+	return e.buildSearchQueryPartsWithVisibility(ctx, q,
+		searchMessageVisibilityWhere("m", q.DeletionScope))
+}
+
+// buildSearchQueryPartsWithVisibility keeps the historical SearchFast
+// deletion context separate from Search's explicit DeletionScope while the
+// two paths continue sharing every other structured predicate.
+func (e *SQLiteEngine) buildSearchQueryPartsWithVisibility(ctx context.Context, q *search.Query, visibility string) (conditions []string, args []any, ftsJoin string) {
+	conditions = append(conditions, visibility)
 
 	// From filter - uses EXISTS to avoid join multiplication in aggregates.
 	// Handles both exact addresses and @domain patterns.
@@ -1785,7 +1791,8 @@ func metadataContainsExpression(d Dialect, column string) string {
 func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *search.Query) (conditions []string, args []any, ftsJoin string) {
 	structured := *q
 	structured.TextTerms = nil
-	conditions, args, ftsJoin = e.buildSearchQueryParts(ctx, &structured)
+	conditions, args, ftsJoin = e.buildSearchQueryPartsWithVisibility(ctx, &structured,
+		store.LiveMessagesWhere("m", q.HideDeleted))
 
 	for _, term := range q.TextTerms {
 		pattern := "%" + escapeSQLiteLike(term) + "%"

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -582,6 +582,22 @@ func TestHideDeletedFromSourceStats(t *testing.T) {
 	assert.Equal(t, int64(4), hiddenStats.MessageCount, "messages (deleted hidden)")
 }
 
+// TestHideDeletedFromSourceStatsWithSearchQuery pins that a SearchQuery keeps
+// the same source-deletion visibility as plain stats: only
+// HideDeletedFromSource gates it, never a deletion scope the caller never set.
+func TestHideDeletedFromSourceStatsWithSearchQuery(t *testing.T) {
+	env := newTestEnv(t)
+
+	// "Hello" matches messages 1 and 2; mark message 1 source-deleted.
+	env.MarkDeletedByID(1)
+
+	stats := env.MustGetTotalStats(StatsOptions{SearchQuery: "Hello"})
+	assert.Equal(t, int64(2), stats.MessageCount, "search stats (deleted included)")
+
+	hiddenStats := env.MustGetTotalStats(StatsOptions{SearchQuery: "Hello", HideDeletedFromSource: true})
+	assert.Equal(t, int64(1), hiddenStats.MessageCount, "search stats (deleted hidden)")
+}
+
 func TestDeletedMessagesIncludedWithFlag(t *testing.T) {
 	assert := assert.New(t)
 	env := newTestEnv(t)

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -539,29 +539,41 @@ func TestSearchByDomains_HidesDeleted(t *testing.T) {
 	}
 }
 
-func TestSearch_HideDeleted(t *testing.T) {
-	assert := assert.New(t)
+func TestSearch_DeletionScope(t *testing.T) {
 	env := newTestEnv(t)
 
-	// Mark message 1 as deleted
+	// Source deletion is selectable; dedup-hidden rows are never searchable.
 	env.MarkDeletedByID(1)
+	env.MarkDedupLoserByID(2)
 
-	// Search without HideDeleted: all messages returned
-	q := &search.Query{}
-	all := env.MustSearch(q, 100, 0)
-	assert.Len(all, 5, "Search without HideDeleted")
-
-	// Search with HideDeleted: deleted message excluded
-	q = &search.Query{HideDeleted: true}
-	filtered := env.MustSearch(q, 100, 0)
-	assert.Len(filtered, 4, "Search with HideDeleted")
+	tests := []struct {
+		name    string
+		scope   search.DeletionScope
+		wantIDs []int64
+	}{
+		{name: "zero_value_defaults_to_active", wantIDs: []int64{3, 4, 5}},
+		{name: "active", scope: search.DeletionScopeActive, wantIDs: []int64{3, 4, 5}},
+		{name: "deleted", scope: search.DeletionScopeDeleted, wantIDs: []int64{1}},
+		{name: "any", scope: search.DeletionScopeAny, wantIDs: []int64{1, 3, 4, 5}},
+		{name: "unknown_fails_closed_to_active", scope: search.DeletionScope("bogus"), wantIDs: []int64{3, 4, 5}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := env.MustSearch(&search.Query{DeletionScope: tt.scope}, 100, 0)
+			gotIDs := make([]int64, 0, len(results))
+			for _, result := range results {
+				gotIDs = append(gotIDs, result.ID)
+			}
+			require.ElementsMatch(t, tt.wantIDs, gotIDs)
+		})
+	}
 
 	// MergeFilterIntoQuery carries HideDeletedFromSource → HideDeleted
 	baseQ := &search.Query{}
 	filter := MessageFilter{HideDeletedFromSource: true}
 	merged := MergeFilterIntoQuery(baseQ, filter)
-	assert.True(merged.HideDeleted,
+	require.True(t, merged.HideDeleted,
 		"MergeFilterIntoQuery should set HideDeleted from HideDeletedFromSource")
 	results := env.MustSearch(merged, 100, 0)
-	assert.Len(results, 4, "Search via merged query")
+	require.Len(t, results, 3, "Search via merged query")
 }

--- a/internal/query/sqlite_search_test.go
+++ b/internal/query/sqlite_search_test.go
@@ -547,11 +547,13 @@ func TestSearch_DeletionScope(t *testing.T) {
 	env.MarkDedupLoserByID(2)
 
 	tests := []struct {
-		name    string
-		scope   search.DeletionScope
-		wantIDs []int64
+		name        string
+		scope       search.DeletionScope
+		hideDeleted bool
+		wantIDs     []int64
 	}{
-		{name: "zero_value_defaults_to_active", wantIDs: []int64{3, 4, 5}},
+		{name: "zero_value_keeps_hide_deleted_off", wantIDs: []int64{1, 3, 4, 5}},
+		{name: "zero_value_keeps_hide_deleted_on", hideDeleted: true, wantIDs: []int64{3, 4, 5}},
 		{name: "active", scope: search.DeletionScopeActive, wantIDs: []int64{3, 4, 5}},
 		{name: "deleted", scope: search.DeletionScopeDeleted, wantIDs: []int64{1}},
 		{name: "any", scope: search.DeletionScopeAny, wantIDs: []int64{1, 3, 4, 5}},
@@ -559,7 +561,10 @@ func TestSearch_DeletionScope(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results := env.MustSearch(&search.Query{DeletionScope: tt.scope}, 100, 0)
+			results := env.MustSearch(&search.Query{
+				DeletionScope: tt.scope,
+				HideDeleted:   tt.hideDeleted,
+			}, 100, 0)
 			gotIDs := make([]int64, 0, len(results))
 			for _, result := range results {
 				gotIDs = append(gotIDs, result.ID)

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -33,7 +33,8 @@ type Query struct {
 	// (messages.deleted_from_source_at). It is caller-set context — the
 	// parser never populates it — and the zero value keeps the historical
 	// active-only behavior, so callers that never set it are unaffected.
-	// The DuckDB SearchFast path ignores it and keeps honoring HideDeleted.
+	// SearchFast is an analytical path and keeps honoring its separate
+	// MessageFilter deletion context.
 	DeletionScope DeletionScope
 
 	// UnsupportedOperators records recognized Gmail operators that msgvault
@@ -65,6 +66,21 @@ const (
 	// DeletionScopeAny matches both live and source-deleted messages.
 	DeletionScopeAny DeletionScope = "any"
 )
+
+// ParseDeletionScope converts the public active|deleted|any spelling into
+// the internal scope. Empty input is the active-only default.
+func ParseDeletionScope(value string) (DeletionScope, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "active":
+		return DeletionScopeActive, nil
+	case "deleted":
+		return DeletionScopeDeleted, nil
+	case "any":
+		return DeletionScopeAny, nil
+	default:
+		return DeletionScopeActive, fmt.Errorf("invalid deletion scope %q (want active, deleted, or any)", value)
+	}
+}
 
 // Err returns a combined error describing every known operator that was
 // given an invalid value, or nil if the query parsed cleanly. Front doors

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -28,11 +28,13 @@ type Query struct {
 	MessageTypes  []string   // message_type filter (e.g. sms, mms, whatsapp, teams)
 	HideDeleted   bool       // exclude messages where deleted_from_source_at IS NOT NULL
 
-	// DeletionScope selects which messages the Store search path
-	// (Store.SearchMessagesQuery*) covers relative to source deletion
+	// DeletionScope selects which messages the Store and query-engine
+	// lexical search paths cover relative to source deletion
 	// (messages.deleted_from_source_at). It is caller-set context — the
-	// parser never populates it — and the zero value keeps the historical
-	// active-only behavior, so callers that never set it are unaffected.
+	// parser never populates it — and an explicit scope wins over
+	// HideDeleted. The zero value keeps each path's historical behavior
+	// (active-only on the Store path, HideDeleted-driven on the engine
+	// Search path), so callers that never set it are unaffected.
 	// SearchFast is an analytical path and keeps honoring its separate
 	// MessageFilter deletion context.
 	DeletionScope DeletionScope
@@ -57,9 +59,10 @@ type Query struct {
 type DeletionScope string
 
 const (
-	// DeletionScopeActive matches live messages only. It is the zero
-	// value so existing callers keep the historical active-only behavior.
-	DeletionScopeActive DeletionScope = ""
+	// DeletionScopeActive matches live messages only. It is distinct from
+	// the zero value so search paths can tell an explicit active request
+	// apart from a caller that never chose a scope.
+	DeletionScopeActive DeletionScope = "active"
 	// DeletionScopeDeleted matches archived messages that were deleted
 	// from their source account.
 	DeletionScopeDeleted DeletionScope = "deleted"

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -477,7 +477,8 @@ func (s *Store) searchMessagesQueryImpl(
 	case search.DeletionScopeActive:
 		conditions = append(conditions, LiveMessagesWhere("m", true))
 	default:
-		// Unknown scope values fail closed to the narrowest population.
+		// The zero value (no scope chosen) and unknown values fail
+		// closed to the narrowest population.
 		conditions = append(conditions, LiveMessagesWhere("m", true))
 	}
 

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -189,6 +189,9 @@ type SearchCLIQuery struct {
 	// MessageType Message type filter; repeat or comma-separate for multiple values
 	MessageType *string `json:"message_type,omitempty"`
 
+	// DeletionScope Source deletion scope: active (default), deleted, or any
+	DeletionScope *string `json:"deletion_scope,omitempty"`
+
 	// Account Restrict to one account/source
 	Account *string `json:"account,omitempty"`
 

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -10647,7 +10647,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.11.0
+  version: 2.12.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -13249,6 +13249,11 @@ paths:
         - description: Message type filter; repeat or comma-separate for multiple values
           in: query
           name: message_type
+          schema:
+            type: string
+        - description: "Source deletion scope: active (default), deleted, or any"
+          in: query
+          name: deletion_scope
           schema:
             type: string
         - description: Restrict to one account/source

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -11059,6 +11059,8 @@ export interface operations {
                 offset?: number;
                 /** @description Message type filter; repeat or comma-separate for multiple values */
                 message_type?: string;
+                /** @description Source deletion scope: active (default), deleted, or any */
+                deletion_scope?: string;
                 /** @description Restrict to one account/source */
                 account?: string;
                 /** @description Restrict to one collection */


### PR DESCRIPTION
## What changed

- Add `--deletion-scope active|deleted|any` to lexical search and the matching `deletion_scope` API parameter.
- Apply the scope consistently in SQLite and DuckDB while keeping dedup-hidden messages excluded.
- Reject non-active scopes in vector and hybrid modes, and require API schema 2.12.0 for scoped remote searches so older daemons cannot silently return the wrong population.

## Why

Messages deleted from their source remain in the local archive, but `msgvault search` could only return active messages. This makes retained history selectable without changing the active-only default.

## Usage

```sh
msgvault search "quarterly report" --deletion-scope deleted
msgvault search "quarterly report" --deletion-scope any
```

Omitting `--deletion-scope` keeps the active-only default.

Closes #681
