### PR TITLE
fix(sync): reconcile Gmail after history expiry

### DIFF
--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -2845,21 +2845,15 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 		return nil, fmt.Errorf("post-source-create migrations: %w", err)
 	}
 
-	summary, err := syncer.Incremental(ctx, source)
-	if err != nil {
-		// Once the history baseline expires (Gmail keeps only ~7 days),
-		// every future incremental sync fails too; without a fallback the
-		// account stays stuck until someone runs sync-full by hand. The
-		// full sync is resumable and skips already-archived messages.
-		if errors.Is(err, sync.ErrHistoryExpired) {
-			logger.Warn("gmail history expired; falling back to full sync", keyEmail, email)
-			summary, err = syncer.Full(ctx, source.Identifier)
-			if err != nil {
-				return nil, fmt.Errorf("full sync fallback failed: %w", err)
-			}
-			return summary, nil
+	summary, err := syncer.IncrementalWithHistoryRecovery(ctx, source, func(resumed bool) {
+		if resumed {
+			logger.Warn("resuming interrupted Gmail history recovery", keyEmail, email)
+		} else {
+			logger.Warn("gmail history expired; reconciling complete mailbox", keyEmail, email)
 		}
-		return nil, fmt.Errorf("incremental sync failed: %w", err)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gmail sync failed: %w", err)
 	}
 	return summary, nil
 }

--- a/cmd/msgvault/cmd/sync.go
+++ b/cmd/msgvault/cmd/sync.go
@@ -34,8 +34,8 @@ UIDVALIDITY/UIDNEXT high water marks are available.
 If no email is specified, syncs all accounts that have credentials configured.
 Accounts without tokens or history IDs are skipped.
 
-If history is too old (Gmail returns 404), automatically falls back to a full
-sync, which is resumable and skips already-archived messages.
+If history is too old (Gmail returns 404), automatically reconciles the complete
+mailbox, preserving archived content while repairing source-deletion metadata.
 
 Examples:
   msgvault sync                 # Sync all accounts
@@ -270,21 +270,19 @@ func runIncrementalSync(ctx context.Context, s *store.Store, getOAuthMgr func(st
 	fmt.Printf("Starting incremental sync for %s\n", email)
 	fmt.Printf("Last history ID: %s\n", source.SyncCursor.String)
 
-	summary, err := syncer.Incremental(ctx, source)
+	summary, err := syncer.IncrementalWithHistoryRecovery(ctx, source, func(resumed bool) {
+		if resumed {
+			fmt.Println("Resuming complete mailbox reconciliation after interruption.")
+		} else {
+			fmt.Println("History ID has expired (Gmail keeps only ~7 days of history).")
+			fmt.Println("Reconciling the complete mailbox; already-archived messages are skipped.")
+		}
+		fmt.Println()
+	})
 	if err != nil {
 		if ctx.Err() != nil {
 			fmt.Println("\nSync interrupted. Run again to resume.")
 			return nil
-		}
-		// The history baseline is gone (Gmail keeps only ~7 days), so an
-		// incremental sync can never succeed again for this account. Fall
-		// back to a full sync instead of telling the user to run one:
-		// it is resumable and skips already-archived messages.
-		if errors.Is(err, sync.ErrHistoryExpired) {
-			fmt.Println("History ID has expired (Gmail keeps only ~7 days of history).")
-			fmt.Println("Falling back to a full sync; already-archived messages are skipped.")
-			fmt.Println()
-			return runFullSync(ctx, s, getOAuthMgr, source)
 		}
 		return fmt.Errorf("sync failed: %w", err)
 	}

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -33,6 +33,13 @@ type MessageReader interface {
 	ListHistory(ctx context.Context, startHistoryID uint64, pageToken string) (*HistoryResponse, error)
 }
 
+// CompleteMessageSnapshotReader lists every message still present in Gmail,
+// including messages in Spam and Trash. The returned IDs are suitable for
+// source-presence reconciliation only after every page has been consumed.
+type CompleteMessageSnapshotReader interface {
+	ListCompleteMessageSnapshot(ctx context.Context, pageToken string) (*MessageListResponse, error)
+}
+
 // MessageDeleter provides write operations for deleting Gmail messages.
 type MessageDeleter interface {
 	// TrashMessage moves a message to trash (recoverable for 30 days).

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -353,8 +353,21 @@ func (c *Client) ListLabels(ctx context.Context) ([]*Label, error) {
 
 // ListMessages returns message IDs matching the query.
 func (c *Client) ListMessages(ctx context.Context, query string, pageToken string) (*MessageListResponse, error) {
+	return c.listMessages(ctx, query, pageToken, false)
+}
+
+// ListCompleteMessageSnapshot returns every message still present in Gmail,
+// including Spam and Trash, for source-presence reconciliation.
+func (c *Client) ListCompleteMessageSnapshot(ctx context.Context, pageToken string) (*MessageListResponse, error) {
+	return c.listMessages(ctx, "", pageToken, true)
+}
+
+func (c *Client) listMessages(ctx context.Context, query, pageToken string, includeSpamTrash bool) (*MessageListResponse, error) {
 	params := url.Values{}
 	params.Set("maxResults", "500")
+	if includeSpamTrash {
+		params.Set("includeSpamTrash", "true")
+	}
 	if query != "" {
 		params.Set("q", query)
 	}

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -413,6 +413,33 @@ func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
 	require.Error(batch[2].Err, "batch[2].Err")
 }
 
+func TestListCompleteMessageSnapshotIncludesSpamAndTrash(t *testing.T) {
+	requirements := require.New(t)
+	checks := assert.New(t)
+	var query string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"messages": []map[string]string{{"id": "message-1", "threadId": "thread-1"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		httpClient:  &http.Client{Transport: &rewriteTransport{base: srv.URL, wrapped: http.DefaultTransport}},
+		userID:      "me",
+		concurrency: 1,
+		logger:      slog.Default(),
+		rateLimiter: NewRateLimiter(1000),
+	}
+
+	response, err := client.ListCompleteMessageSnapshot(t.Context(), "")
+	requirements.NoError(err, "ListCompleteMessageSnapshot")
+	requirements.Len(response.Messages, 1, "snapshot messages")
+	checks.Contains(query, "includeSpamTrash=true")
+	checks.NotContains(query, "q=")
+}
+
 // rewriteTransport rewrites requests from the Gmail API baseURL to a test server URL.
 type rewriteTransport struct {
 	base    string // test server URL

--- a/internal/gmail/mock.go
+++ b/internal/gmail/mock.go
@@ -44,6 +44,7 @@ type MockAPI struct {
 	ProfileCalls      int
 	LabelsCalls       int
 	ListMessagesCalls int
+	SnapshotListCalls int
 	LastQuery         string // Last query passed to ListMessages
 	GetMessageCalls   []string
 	HistoryCalls      []uint64
@@ -115,7 +116,19 @@ func (m *MockAPI) ListMessages(ctx context.Context, query string, pageToken stri
 	defer m.mu.Unlock()
 	m.ListMessagesCalls++
 	m.LastQuery = query
+	return m.listMessages(pageToken)
+}
 
+// ListCompleteMessageSnapshot returns all mock message IDs as one complete
+// Gmail presence snapshot.
+func (m *MockAPI) ListCompleteMessageSnapshot(ctx context.Context, pageToken string) (*MessageListResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SnapshotListCalls++
+	return m.listMessages(pageToken)
+}
+
+func (m *MockAPI) listMessages(pageToken string) (*MessageListResponse, error) {
 	if m.ListMessagesError != nil {
 		return nil, m.ListMessagesError
 	}
@@ -329,6 +342,7 @@ func (m *MockAPI) Reset() {
 	m.ProfileCalls = 0
 	m.LabelsCalls = 0
 	m.ListMessagesCalls = 0
+	m.SnapshotListCalls = 0
 	m.LastQuery = ""
 	m.GetMessageCalls = nil
 	m.HistoryCalls = nil

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -2375,6 +2375,63 @@ func (s *Store) MarkMessagesDeletedBatch(sourceID int64, sourceMessageIDs []stri
 	return s.withTx(func(tx *loggedTx) error { return write(tx) })
 }
 
+// ReconcileSourceMessageSnapshot tombstones locally live messages that are
+// absent from one complete provider snapshot. The sync-scoped Store fences the
+// current generation before reading or writing, and the transaction ensures an
+// incomplete reconciliation cannot publish partial tombstones.
+func (s *Store) ReconcileSourceMessageSnapshot(
+	ctx context.Context, sourceID int64, present map[string]struct{},
+) (int64, error) {
+	if present == nil {
+		return 0, errors.New("reconcile source message snapshot: nil snapshot")
+	}
+	if err := s.requireSyncSource(sourceID); err != nil {
+		return 0, err
+	}
+
+	var missing []string
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		rows, err := tx.QueryContext(ctx, `
+			SELECT source_message_id
+			FROM messages
+			WHERE source_id = ?
+			  AND deleted_at IS NULL
+			  AND deleted_from_source_at IS NULL
+		`, sourceID)
+		if err != nil {
+			return fmt.Errorf("reconcile source message snapshot: list live messages: %w", err)
+		}
+		for rows.Next() {
+			var sourceMessageID string
+			if err := rows.Scan(&sourceMessageID); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("reconcile source message snapshot: scan live message: %w", err)
+			}
+			if _, ok := present[sourceMessageID]; !ok {
+				missing = append(missing, sourceMessageID)
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return fmt.Errorf("reconcile source message snapshot: close live messages: %w", err)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("reconcile source message snapshot: list live messages: %w", err)
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		if err := execInChunksContext(ctx, tx, missing, []any{sourceID},
+			fmt.Sprintf(`UPDATE messages SET deleted_from_source_at = %s WHERE source_id = ? AND source_message_id IN (%%s) AND deleted_from_source_at IS NULL`, s.dialect.Now())); err != nil {
+			return fmt.Errorf("reconcile source message snapshot: mark missing messages: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(missing)), nil
+}
+
 // MarkMessagesDeletedFromReader consumes newline-delimited source message IDs
 // in bounded batches and commits all tombstones atomically. Any late reader or
 // update failure rolls back earlier batches.

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -479,6 +479,49 @@ func TestClearMessageDeletedFromSource(t *testing.T) {
 	assert.True(otherDeletedAt.Valid)
 }
 
+func TestReconcileSourceMessageSnapshotIsSourceScopedAndGenerationFenced(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+
+	source, err := st.GetOrCreateSource("gmail", "primary@example.com")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(
+		source.ID, "primary-thread", "email_thread", "Primary",
+	)
+	require.NoError(err)
+	insertStoreTestMessage(t, st, source.ID, conversationID, "missing")
+	insertStoreTestMessage(t, st, source.ID, conversationID, "present")
+
+	otherSource, err := st.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err)
+	otherConversationID, err := st.EnsureConversationWithType(
+		otherSource.ID, "other-thread", "email_thread", "Other",
+	)
+	require.NoError(err)
+	insertStoreTestMessage(t, st, otherSource.ID, otherConversationID, "missing")
+
+	syncID, err := st.StartSync(source.ID, "full")
+	require.NoError(err)
+	scoped := st.ScopedToSync(source.ID, syncID)
+	reconciled, err := scoped.ReconcileSourceMessageSnapshot(
+		t.Context(), source.ID, map[string]struct{}{"present": {}},
+	)
+	require.NoError(err)
+	assert.Equal(int64(1), reconciled)
+	assertMessageDeletedFromSource(t, st, source.ID, "missing", true)
+	assertMessageDeletedFromSource(t, st, source.ID, "present", false)
+	assertMessageDeletedFromSource(t, st, otherSource.ID, "missing", false)
+
+	staleSyncID, err := st.StartSync(source.ID, "full")
+	require.NoError(err)
+	stale := st.ScopedToSync(source.ID, staleSyncID)
+	_, err = st.StartSync(source.ID, "full")
+	require.NoError(err)
+	_, err = stale.ReconcileSourceMessageSnapshot(t.Context(), source.ID, map[string]struct{}{})
+	require.ErrorIs(err, store.ErrSyncRunSuperseded)
+}
+
 func TestMarkMessagesDeletedFromReaderIsAtomicOnLateReadFailure(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -533,6 +576,19 @@ func assertSourceMessageIDNotDeleted(t *testing.T, st *store.Store, sourceID int
 	).Scan(&deletedAt)
 	require.NoError(t, err, "scan deleted_from_source_at")
 	assert.False(t, deletedAt.Valid, "deleted_from_source_at should be cleared")
+}
+
+func assertMessageDeletedFromSource(
+	t *testing.T, st *store.Store, sourceID int64, sourceMessageID string, want bool,
+) {
+	t.Helper()
+	var deletedAt sql.NullTime
+	err := st.DB().QueryRow(
+		st.Rebind(`SELECT deleted_from_source_at FROM messages WHERE source_id = ? AND source_message_id = ?`),
+		sourceID, sourceMessageID,
+	).Scan(&deletedAt)
+	require.NoError(t, err, "scan deleted_from_source_at")
+	assert.Equal(t, want, deletedAt.Valid, "deleted_from_source_at validity")
 }
 
 func TestEnsureParticipantByPhone_IdentifierType(t *testing.T) {

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -485,6 +485,29 @@ func (s *Store) UpdateSyncCheckpointContext(ctx context.Context, syncID int64, c
 	return write(boundQuerier{ctx: ctx, q: s.db})
 }
 
+// PinSyncHandoffCursorContext records the history cursor a resumable recovery
+// must catch up from after its full enumeration. A completed sync overwrites
+// cursor_after with the same value when it publishes the source cursor.
+func (s *Store) PinSyncHandoffCursorContext(ctx context.Context, syncID int64, cursor string) error {
+	if cursor == "" {
+		return errors.New("pin sync handoff cursor: empty cursor")
+	}
+	if s.syncGeneration == nil {
+		return errors.New("pin sync handoff cursor: sync-scoped store required")
+	}
+	if syncID != s.syncGeneration.runID {
+		return fmt.Errorf("pin handoff cursor for sync run %d through scoped run %d: %w",
+			syncID, s.syncGeneration.runID, ErrSyncRunSuperseded)
+	}
+	write := func(q querier) error {
+		_, err := q.Exec(`UPDATE sync_runs SET cursor_after = ? WHERE id = ?`, cursor, syncID)
+		return err
+	}
+	return s.withTxContext(ctx, func(tx *loggedTx) error {
+		return write(boundQuerier{ctx: ctx, q: tx})
+	})
+}
+
 // RecordSyncRunItem records a per-item sync outcome for diagnostics.
 func (s *Store) RecordSyncRunItem(item SyncRunItem) error {
 	_, err := s.db.Exec(fmt.Sprintf(`

--- a/internal/store/sync_test.go
+++ b/internal/store/sync_test.go
@@ -253,6 +253,9 @@ func TestScopedStoreRejectsEveryImporterMutationAfterSupersession(t *testing.T) 
 		{name: "checkpoint", write: func() error {
 			return stale.UpdateSyncCheckpoint(oldID, &store.Checkpoint{PageToken: "stale"})
 		}},
+		{name: "history recovery handoff", write: func() error {
+			return stale.PinSyncHandoffCursorContext(t.Context(), oldID, "12345")
+		}},
 		{name: "attachment metadata", write: func() error {
 			return stale.UpdateAttachmentMediaMetadataContext(
 				t.Context(), messageID, "hash", "image", sql.NullInt64{}, sql.NullInt64{}, sql.NullInt64{})

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -13,8 +13,8 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 )
 
-// Incremental performs an incremental sync using the Gmail History API.
-// Falls back to full sync if history is too old (404 error).
+// Incremental performs an incremental sync using the Gmail History API. It
+// returns ErrHistoryExpired when Gmail requires a full history recovery.
 //
 // The caller must resolve the correct *store.Source before calling this
 // method. This avoids ambiguity when multiple sources share the same

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -335,10 +335,15 @@ func (s *Syncer) drainIdentityDiscoveryBacklog(ctx context.Context, sourceID int
 
 // syncState holds the state for a sync operation.
 type syncState struct {
-	syncID     int64
-	checkpoint *store.Checkpoint
-	pageToken  string
-	wasResumed bool
+	syncID        int64
+	checkpoint    *store.Checkpoint
+	pageToken     string
+	handoffCursor string
+	wasResumed    bool
+}
+
+func isPinnedHistoryRecovery(run *store.SyncRun) bool {
+	return run != nil && run.CursorAfter.Valid && run.CursorAfter.String != ""
 }
 
 // failSyncUnlessCanceled marks the run failed for real errors. A cancelled
@@ -389,6 +394,46 @@ func (s *Syncer) initSyncState(sourceID int64) (*syncState, error) {
 	}
 	state.syncID = syncID
 	return state, nil
+}
+
+// initHistoryRecoveryState only resumes a full run that already pinned its
+// history handoff cursor. An ordinary full-sync checkpoint cannot be reused:
+// its processed prefix may have changed before recovery captured a cursor.
+func (s *Syncer) initHistoryRecoveryState(sourceID int64) (*syncState, error) {
+	if !s.opts.NoResume {
+		activeSync, err := s.store.GetActiveSync(sourceID)
+		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
+			return nil, fmt.Errorf("check active history recovery: %w", err)
+		}
+		if isPinnedHistoryRecovery(activeSync) {
+			state := &syncState{
+				syncID:        activeSync.ID,
+				checkpoint:    &store.Checkpoint{},
+				handoffCursor: activeSync.CursorAfter.String,
+				wasResumed:    true,
+			}
+			if activeSync.CursorBefore.Valid {
+				state.pageToken = activeSync.CursorBefore.String
+			}
+			state.checkpoint = &store.Checkpoint{
+				PageToken:         state.pageToken,
+				MessagesProcessed: activeSync.MessagesProcessed,
+				MessagesAdded:     activeSync.MessagesAdded,
+				MessagesUpdated:   activeSync.MessagesUpdated,
+				ErrorsCount:       activeSync.ErrorsCount,
+			}
+			s.logger.Info("resuming Gmail history recovery",
+				"messages_processed", state.checkpoint.MessagesProcessed,
+				"handoff_cursor", state.handoffCursor)
+			return state, nil
+		}
+	}
+
+	syncID, err := s.store.StartSync(sourceID, "full")
+	if err != nil {
+		return nil, fmt.Errorf("start history recovery: %w", err)
+	}
+	return &syncState{syncID: syncID, checkpoint: &store.Checkpoint{}}, nil
 }
 
 // batchResult holds the result of processing a batch.
@@ -814,6 +859,98 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 
 // Full performs a full synchronization.
 func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSummary, err error) {
+	sourceType := s.opts.SourceType
+	if sourceType == "" {
+		sourceType = "gmail"
+	}
+	if sourceType == "gmail" && !s.opts.NoResume {
+		source, sourceErr := s.store.GetOrCreateSource(sourceType, email)
+		if sourceErr != nil {
+			return nil, fmt.Errorf("get/create source: %w", sourceErr)
+		}
+		active, activeErr := s.store.GetActiveSync(source.ID)
+		if activeErr != nil && !errors.Is(activeErr, store.ErrSyncRunNotFound) {
+			return nil, fmt.Errorf("check active history recovery: %w", activeErr)
+		}
+		if isPinnedHistoryRecovery(active) {
+			return s.RecoverExpiredHistory(ctx, source)
+		}
+	}
+	return s.full(ctx, email, false)
+}
+
+// RecoverExpiredHistory rebuilds the archive from a complete Gmail listing,
+// reconciles source-presence metadata, then consumes changes made after the
+// full run pinned its starting history cursor.
+func (s *Syncer) RecoverExpiredHistory(
+	ctx context.Context, source *store.Source,
+) (*gmail.SyncSummary, error) {
+	if source == nil {
+		return nil, errors.New("recover expired history: no source provided")
+	}
+	if source.SourceType != "gmail" {
+		return nil, fmt.Errorf("recover expired history: source %d is %s, not gmail", source.ID, source.SourceType)
+	}
+	if s.opts.Query != "" || s.opts.Limit > 0 {
+		return nil, errors.New("recover expired history requires an unfiltered, unlimited full sync")
+	}
+
+	fullSummary, err := s.full(ctx, source.Identifier, true)
+	if err != nil {
+		return nil, fmt.Errorf("recover expired history: full sync: %w", err)
+	}
+	refreshed, err := s.store.GetSourceByID(source.ID)
+	if err != nil {
+		return nil, fmt.Errorf("recover expired history: reload source: %w", err)
+	}
+	catchup, err := s.Incremental(ctx, refreshed)
+	if err != nil {
+		return nil, fmt.Errorf("recover expired history: catch up from full-sync cursor: %w", err)
+	}
+	fullSummary.MessagesFound += catchup.MessagesFound
+	fullSummary.MessagesAdded += catchup.MessagesAdded
+	fullSummary.MessagesUpdated += catchup.MessagesUpdated
+	fullSummary.MessagesSkipped += catchup.MessagesSkipped
+	fullSummary.BytesDownloaded += catchup.BytesDownloaded
+	fullSummary.Errors += catchup.Errors
+	fullSummary.EndTime = catchup.EndTime
+	fullSummary.Duration = fullSummary.EndTime.Sub(fullSummary.StartTime)
+	fullSummary.FinalHistoryID = catchup.FinalHistoryID
+	return fullSummary, nil
+}
+
+// IncrementalWithHistoryRecovery resumes an interrupted history recovery
+// before starting a new incremental run. If Gmail reports an expired cursor,
+// it starts recovery immediately. onRecovery runs before the potentially long
+// recovery; resumed distinguishes a saved recovery from a newly expired cursor.
+func (s *Syncer) IncrementalWithHistoryRecovery(
+	ctx context.Context, source *store.Source, onRecovery func(resumed bool),
+) (*gmail.SyncSummary, error) {
+	if source == nil {
+		return nil, errors.New("no source provided - run full sync first")
+	}
+	active, err := s.store.GetActiveSync(source.ID)
+	if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
+		return nil, fmt.Errorf("check active history recovery: %w", err)
+	}
+	if !s.opts.NoResume && isPinnedHistoryRecovery(active) {
+		if onRecovery != nil {
+			onRecovery(true)
+		}
+		return s.RecoverExpiredHistory(ctx, source)
+	}
+
+	summary, err := s.Incremental(ctx, source)
+	if !errors.Is(err, ErrHistoryExpired) {
+		return summary, err
+	}
+	if onRecovery != nil {
+		onRecovery(false)
+	}
+	return s.RecoverExpiredHistory(ctx, source)
+}
+
+func (s *Syncer) full(ctx context.Context, email string, reconcilePresence bool) (summary *gmail.SyncSummary, err error) {
 	startTime := time.Now()
 	summary = &gmail.SyncSummary{StartTime: startTime}
 
@@ -827,8 +964,14 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		return nil, fmt.Errorf("get/create source: %w", err)
 	}
 
-	// Initialize sync state (resume or start new)
-	state, err := s.initSyncState(source.ID)
+	// Recovery may only resume a run that pinned its history handoff cursor.
+	// Ordinary full-sync checkpoints predate that cursor and are unsafe to reuse.
+	var state *syncState
+	if reconcilePresence {
+		state, err = s.initHistoryRecoveryState(source.ID)
+	} else {
+		state, err = s.initSyncState(source.ID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -857,6 +1000,22 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 	if err != nil {
 		s.failSyncUnlessCanceled(state.syncID, err)
 		return nil, fmt.Errorf("get profile: %w", err)
+	}
+	handoffHistoryID := profile.HistoryID
+	if reconcilePresence {
+		if state.handoffCursor == "" {
+			state.handoffCursor = strconv.FormatUint(profile.HistoryID, 10)
+			if err := s.store.PinSyncHandoffCursorContext(ctx, state.syncID, state.handoffCursor); err != nil {
+				s.failSyncUnlessCanceled(state.syncID, err)
+				return nil, fmt.Errorf("pin Gmail history recovery cursor: %w", err)
+			}
+		} else {
+			handoffHistoryID, err = strconv.ParseUint(state.handoffCursor, 10, 64)
+			if err != nil {
+				s.failSyncUnlessCanceled(state.syncID, err)
+				return nil, fmt.Errorf("parse Gmail history recovery cursor %q: %w", state.handoffCursor, err)
+			}
+		}
 	}
 
 	s.logger.Info("syncing account", "email", profile.EmailAddress, "messages", profile.MessagesTotal)
@@ -958,6 +1117,22 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 		}
 	}
 
+	if reconcilePresence {
+		present, err := s.listCompleteMessageSnapshot(ctx)
+		if err != nil {
+			s.failSyncUnlessCanceled(state.syncID, err)
+			return nil, err
+		}
+		reconciled, err := s.store.ReconcileSourceMessageSnapshot(ctx, source.ID, present)
+		if err != nil {
+			s.failSyncUnlessCanceled(state.syncID, err)
+			return nil, fmt.Errorf("reconcile Gmail message snapshot: %w", err)
+		}
+		if reconciled > 0 {
+			s.logger.Info("reconciled Gmail source deletions", "source_id", source.ID, "messages", reconciled)
+		}
+	}
+
 	// Debt parked by an earlier page of this run is settled now, provided the
 	// run showed discovery recovering.
 	if discoveryHealth.shouldDrainAtCompletion() {
@@ -967,7 +1142,7 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 	// Update source with final history ID.
 	// Full sync always advances the cursor (it records the starting point
 	// for future incremental syncs), but warn when errors occurred.
-	historyIDStr := strconv.FormatUint(profile.HistoryID, 10)
+	historyIDStr := strconv.FormatUint(handoffHistoryID, 10)
 	if state.checkpoint.ErrorsCount > 0 {
 		s.logger.Warn("full sync completed with errors",
 			"errors", state.checkpoint.ErrorsCount,
@@ -993,10 +1168,37 @@ func (s *Syncer) Full(ctx context.Context, email string) (summary *gmail.SyncSum
 	summary.MessagesUpdated = state.checkpoint.MessagesUpdated
 	summary.MessagesSkipped = state.checkpoint.MessagesProcessed - state.checkpoint.MessagesAdded - state.checkpoint.MessagesUpdated
 	summary.Errors = state.checkpoint.ErrorsCount
-	summary.FinalHistoryID = profile.HistoryID
+	summary.FinalHistoryID = handoffHistoryID
 
 	s.progress.OnComplete(summary)
 	return summary, nil
+}
+
+func (s *Syncer) listCompleteMessageSnapshot(ctx context.Context) (map[string]struct{}, error) {
+	lister, ok := s.client.(gmail.CompleteMessageSnapshotReader)
+	if !ok {
+		return nil, errors.New("complete Gmail message snapshot is unavailable")
+	}
+
+	present := make(map[string]struct{})
+	pageToken := ""
+	for {
+		response, err := lister.ListCompleteMessageSnapshot(ctx, pageToken)
+		if err != nil {
+			return nil, fmt.Errorf("list complete Gmail message snapshot: %w", err)
+		}
+		for _, message := range response.Messages {
+			present[message.ID] = struct{}{}
+		}
+		next := response.NextPageToken
+		if next == "" {
+			return present, nil
+		}
+		if next == pageToken {
+			return nil, fmt.Errorf("list complete Gmail message snapshot: page token did not advance from %q", pageToken)
+		}
+		pageToken = next
+	}
 }
 
 // syncLabels syncs all labels and returns a map of Gmail label ID to internal ID.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1524,6 +1524,252 @@ func TestIncrementalSyncHistoryExpired(t *testing.T) {
 	assert.ErrorIs(t, err, ErrHistoryExpired)
 }
 
+func TestRecoverExpiredHistoryMarksOnlyMissingSourceMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	seedMessages(env, 2, 1000, "present", "missing")
+	runFullSync(t, env)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(t, err, "GetSourceByIdentifier")
+
+	delete(env.Mock.Messages, "missing")
+	env.Mock.MessagePages = [][]string{{"present"}}
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 2000
+	env.Mock.HistoryID = 2000
+
+	_, err = env.Syncer.RecoverExpiredHistory(env.Context, source)
+	require.NoError(t, err, "RecoverExpiredHistory")
+
+	assertDeletedFromSource(t, env.Store, "present", false)
+	assertDeletedFromSource(t, env.Store, "missing", true)
+	assertRawDataExists(t, env.Store, "missing")
+}
+
+type recoveryProfileSequenceAPI struct {
+	*gmail.MockAPI
+
+	historyIDs []uint64
+	calls      int
+}
+
+func (a *recoveryProfileSequenceAPI) GetProfile(context.Context) (*gmail.Profile, error) {
+	profile := *a.Profile
+	if a.calls < len(a.historyIDs) {
+		profile.HistoryID = a.historyIDs[a.calls]
+	}
+	a.calls++
+	return &profile, nil
+}
+
+func TestRecoverExpiredHistoryConsumesChangesAfterSnapshotCursor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	env := newTestEnv(t)
+	seedMessages(env, 1, 1000, "present")
+	runFullSync(t, env)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+
+	env.Mock.MessagePages = [][]string{{"present"}}
+	env.Mock.AddMessage("arrived-during-recovery", testMIME(), []string{"INBOX"})
+	env.Mock.HistoryRecords = []gmail.HistoryRecord{historyAdded("arrived-during-recovery")}
+	env.Mock.HistoryID = 2000
+	syncer := New(&recoveryProfileSequenceAPI{
+		MockAPI:    env.Mock,
+		historyIDs: []uint64{1500, 2000},
+	}, env.Store, nil)
+
+	summary, err := syncer.RecoverExpiredHistory(env.Context, source)
+	require.NoError(err, "RecoverExpiredHistory")
+
+	assertRawDataExists(t, env.Store, "arrived-during-recovery")
+	assert.Equal(uint64(2000), summary.FinalHistoryID, "final history cursor")
+	refreshed, err := env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID")
+	assert.Equal("2000", refreshed.SyncCursor.String, "persisted history cursor")
+}
+
+func TestRecoverExpiredHistoryRejectsPartialEnumerationOptions(t *testing.T) {
+	tests := []struct {
+		name   string
+		modify func(*Options)
+	}{
+		{
+			name: "query",
+			modify: func(options *Options) {
+				options.Query = "from:alice@example.com"
+			},
+		},
+		{
+			name: "limit",
+			modify: func(options *Options) {
+				options.Limit = 1
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			seedMessages(env, 2, 1000, "present", "outside-partial-enumeration")
+			runFullSync(t, env)
+			source, err := env.Store.GetSourceByIdentifier(testEmail)
+			require.NoError(t, err, "GetSourceByIdentifier")
+
+			delete(env.Mock.Messages, "outside-partial-enumeration")
+			env.Mock.MessagePages = [][]string{{"present"}}
+			env.Mock.Profile.HistoryID = 2000
+			env.Mock.HistoryID = 2000
+			options := DefaultOptions()
+			test.modify(options)
+			syncer := New(env.Mock, env.Store, options)
+
+			_, err = syncer.RecoverExpiredHistory(env.Context, source)
+			require.Error(t, err, "partial enumeration must not reconcile absence")
+			assertDeletedFromSource(t, env.Store, "outside-partial-enumeration", false)
+		})
+	}
+}
+
+type interruptedRecoverySnapshotAPI struct {
+	*gmail.MockAPI
+
+	calls int
+}
+
+func (a *interruptedRecoverySnapshotAPI) ListCompleteMessageSnapshot(
+	context.Context, string,
+) (*gmail.MessageListResponse, error) {
+	a.calls++
+	if a.calls == 1 {
+		return &gmail.MessageListResponse{
+			Messages:      []gmail.MessageID{{ID: "present", ThreadID: "thread_present"}},
+			NextPageToken: "second-page",
+		}, nil
+	}
+	return nil, errors.New("snapshot interrupted")
+}
+
+func TestRecoverExpiredHistoryDoesNotReconcileIncompleteSnapshot(t *testing.T) {
+	env := newTestEnv(t)
+	seedMessages(env, 2, 1000, "present", "not-yet-enumerated")
+	runFullSync(t, env)
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(t, err, "GetSourceByIdentifier")
+
+	delete(env.Mock.Messages, "not-yet-enumerated")
+	env.Mock.MessagePages = [][]string{{"present"}}
+	env.Mock.Profile.HistoryID = 2000
+	env.Mock.HistoryID = 2000
+	syncer := New(&interruptedRecoverySnapshotAPI{MockAPI: env.Mock}, env.Store, nil)
+
+	_, err = syncer.RecoverExpiredHistory(env.Context, source)
+	require.Error(t, err, "an incomplete snapshot must fail recovery")
+	assertDeletedFromSource(t, env.Store, "not-yet-enumerated", false)
+}
+
+func TestRecoverExpiredHistoryDoesNotReuseUnmarkedFullCheckpoint(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.HistoryID = 12345
+	seedPagedMessages(env, 4)
+	runFullSync(t, env)
+
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+	syncID, err := env.Store.StartSync(source.ID, "full")
+	require.NoError(err, "StartSync")
+	require.NoError(env.Store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         "page_1",
+		MessagesProcessed: 2,
+		MessagesAdded:     2,
+	}), "UpdateSyncCheckpoint")
+	env.Mock.ListMessagesCalls = 0
+	env.Mock.SnapshotListCalls = 0
+
+	summary, err := env.Syncer.RecoverExpiredHistory(env.Context, source)
+	require.NoError(err, "RecoverExpiredHistory")
+	assert.False(summary.WasResumed, "an ordinary full checkpoint has no pinned recovery cursor")
+	assert.Empty(summary.ResumedFromToken, "recovery restarts ordinary full enumeration")
+	assert.Equal(2, env.Mock.ListMessagesCalls, "recovery content enumeration starts at page zero")
+	assert.Equal(2, env.Mock.SnapshotListCalls, "presence snapshot starts at page zero")
+	assertDeletedFromSource(t, env.Store, "msg1", false)
+	assertDeletedFromSource(t, env.Store, "msg4", false)
+}
+
+func TestIncrementalWithHistoryRecoveryResumesPinnedCursorBeforeIncremental(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env, source, active := setupInterruptedHistoryRecoveryWithPrefixChange(t)
+	env.Syncer = New(env.Mock, env.Store, nil)
+
+	var recoveryNotices []bool
+	summary, err := env.Syncer.IncrementalWithHistoryRecovery(env.Context, source, func(resumed bool) {
+		recoveryNotices = append(recoveryNotices, resumed)
+	})
+	require.NoError(err, "IncrementalWithHistoryRecovery")
+	assert.Equal([]bool{true}, recoveryNotices, "retry announces the resumed recovery")
+	assert.True(summary.WasResumed, "recovery uses its saved page checkpoint")
+	assert.Equal(active.ID, summary.SyncRunID, "retry does not supersede the recovery run")
+	assertRawDataExists(t, env.Store, "arrived-before-resume")
+	refreshed, err := env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID")
+	assert.Equal("20000", refreshed.SyncCursor.String, "catch-up advances from the pinned cursor")
+}
+
+func TestFullRoutesPinnedHistoryRecoveryThroughCatchup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env, source, active := setupInterruptedHistoryRecoveryWithPrefixChange(t)
+	env.Syncer = New(env.Mock, env.Store, nil)
+
+	summary, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "Full")
+	assert.True(summary.WasResumed, "full routes through the marked recovery")
+	assert.Equal(active.ID, summary.SyncRunID, "full does not reinterpret or supersede the recovery run")
+	assertRawDataExists(t, env.Store, "arrived-before-resume")
+	refreshed, err := env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "GetSourceByID")
+	assert.Equal("20000", refreshed.SyncCursor.String, "full recovery catches up from the pinned cursor")
+}
+
+func setupInterruptedHistoryRecoveryWithPrefixChange(
+	t *testing.T,
+) (*TestEnv, *store.Source, *store.SyncRun) {
+	t.Helper()
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.HistoryID = 12345
+	seedPagedMessages(env, 4)
+	runFullSync(t, env)
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "GetSourceByIdentifier")
+
+	env.Mock.Profile.HistoryID = 15000
+	env.Mock.HistoryID = 15000
+	env.Syncer = New(&cancelOnSecondListAPI{MockAPI: env.Mock}, env.Store, nil)
+	_, err = env.Syncer.RecoverExpiredHistory(env.Context, source)
+	require.ErrorIs(err, context.Canceled, "interrupt recovery after its first page")
+	active, err := env.Store.GetActiveSync(source.ID)
+	require.NoError(err, "GetActiveSync")
+	assert.Equal("15000", active.CursorAfter.String, "recovery pins its handoff cursor before enumeration")
+
+	env.Mock.AddMessage("arrived-before-resume", testMIME(), []string{"INBOX"})
+	env.Mock.MessagePages = [][]string{
+		{"msg1", "msg2", "arrived-before-resume"},
+		{"msg3", "msg4"},
+	}
+	env.Mock.Profile.HistoryID = 20000
+	env.Mock.HistoryID = 20000
+	env.Mock.HistoryRecords = []gmail.HistoryRecord{historyAdded("arrived-before-resume")}
+	return env, source, active
+}
+
 func TestIncrementalSyncProfileError(t *testing.T) {
 	env := newTestEnv(t)
 	source := env.CreateSourceWithHistory(t, "12345")


### PR DESCRIPTION
## What changed

- Recover expired Gmail history from a complete source-scoped message snapshot, including spam and trash, and mark only missing source metadata as deleted while retaining archived message content.
- Reject filtered, limited, failed, or incomplete snapshots for absence-based reconciliation, and resume interrupted recovery without treating an ordinary partial full sync as authoritative.
- Pin the pre-enumeration history cursor and immediately catch up changes after the snapshot, using the same recovery path in the CLI and scheduled sync.

## Why

When Gmail expires a history cursor, the existing fallback can ingest messages that are still present but cannot repair stale source state for messages deleted during the lost interval. That leaves archived messages incorrectly marked as still present in Gmail and makes interrupted recovery vulnerable to skipping changes.

## Usage

No usage change.

Closes #680
