### PR TITLE
fix(imap): make incremental sync incremental without QRESYNC

### DIFF
--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -46,6 +46,25 @@ func listedIMAPClient(t *testing.T, addr string, opts ...imaplib.Option) *imapli
 	}
 }
 
+func imapMembershipRowCount(t *testing.T, st *store.Store, sourceID int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM imap_message_memberships WHERE source_id = ?`,
+	), sourceID).Scan(&count))
+	return count
+}
+
+func imapTombstonedMessageCount(t *testing.T, st *store.Store, sourceID int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM messages
+		 WHERE source_id = ? AND deleted_from_source_at IS NOT NULL`,
+	), sourceID).Scan(&count))
+	return count
+}
+
 func seedObservedIMAPMessages(
 	t *testing.T, st *store.Store, src *store.Source, client *imaplib.Client,
 ) {
@@ -259,7 +278,7 @@ func TestSaveIMAPFolderStates_NonIMAPClientIsNoOp(t *testing.T) {
 	assert.Empty(t, loaded)
 }
 
-func TestIMAPFolderStateOptions_RoundTripFallsBackWithoutModSeq(t *testing.T) {
+func TestIMAPFolderStateOptions_RoundTripSkipsUnchangedFolders(t *testing.T) {
 	require := require.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
 	st := testutil.NewTestStore(t)
@@ -272,6 +291,9 @@ func TestIMAPFolderStateOptions_RoundTripFallsBackWithoutModSeq(t *testing.T) {
 		context.Background(), st, src, first, completedIMAPSyncSummary(t, st, src), 0))
 	require.NoError(first.Close())
 
+	beforeMemberships := imapMembershipRowCount(t, st, src.ID)
+	require.NotZero(beforeMemberships)
+
 	opts := imapFolderStateOptions(st, src, false)
 	require.NotEmpty(opts, "saved states must produce a client option")
 
@@ -280,8 +302,18 @@ func TestIMAPFolderStateOptions_RoundTripFallsBackWithoutModSeq(t *testing.T) {
 	defer cancel()
 	resp, err := second.ListMessages(ctx, "", "")
 	require.NoError(err)
-	assert.Len(t, resp.Messages, 5,
-		"a stored baseline without mod-sequences must be rebuilt completely")
+	assert.Empty(t, resp.Messages,
+		"a stored baseline plus a matching message count proves nothing changed")
+
+	// The whole point of the skip is that it costs nothing durable: applying
+	// the resulting deltas must leave every membership row and every message
+	// exactly as the first sync left them.
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, second, completedIMAPSyncSummary(t, st, src), 0))
+	assert.Equal(t, beforeMemberships, imapMembershipRowCount(t, st, src.ID),
+		"skipping a mailbox must not delete its memberships")
+	assert.Zero(t, imapTombstonedMessageCount(t, st, src.ID),
+		"skipping a mailbox must not tombstone its messages")
 }
 
 func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing.T) {

--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -702,7 +702,8 @@ func TestIMAPQresyncEndToEndRetiresChangedMailboxTopology(t *testing.T) {
 			t, st, source.ID, "retired-topology@example.test")
 		assertions.True(deleted)
 		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
-		assertions.Contains(server.commandsFor(3), "LIST")
+		assertions.Contains(server.commandsFor(2), "LIST")
+		assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 	})
 
 	t.Run("renamed mailbox replaces cursor and label", func(t *testing.T) {
@@ -746,7 +747,8 @@ func TestIMAPQresyncEndToEndRetiresChangedMailboxTopology(t *testing.T) {
 			t, st, source.ID, "renamed-topology@example.test")
 		assertions.False(deleted)
 		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
-		assertions.Contains(server.commandsFor(3), "UID SEARCH")
+		assertions.Contains(server.commandsFor(2), "UID SEARCH")
+		assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 	})
 
 	t.Run("zero current mailboxes removes the final cursor", func(t *testing.T) {
@@ -792,7 +794,8 @@ func TestIMAPQresyncEndToEndRetiresChangedMailboxTopology(t *testing.T) {
 			t, st, source.ID, "zero-topology@example.test")
 		assertions.True(deleted)
 		assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
-		assertions.Contains(server.commandsFor(3), "LIST")
+		assertions.Contains(server.commandsFor(2), "LIST")
+		assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 	})
 }
 
@@ -1087,9 +1090,9 @@ func TestIMAPQresyncEndToEndUIDValidityReset(t *testing.T) {
 		t, st, source.ID, "new-epoch@example.test")
 	assertions.Equal("INBOX|1", newSourceID)
 	assertions.False(deleted)
-	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
 	assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
-	assertions.Contains(server.commandsFor(3), "UID SEARCH")
+	assertions.Contains(server.commandsFor(2), "UID SEARCH")
+	assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 }
 
 func TestIMAPQresyncEndToEndConservativeFallbacks(t *testing.T) {
@@ -1117,10 +1120,10 @@ func TestIMAPQresyncEndToEndConservativeFallbacks(t *testing.T) {
 		known, err := st.GetIMAPKnownUIDs(source.ID)
 		requirements.NoError(err)
 		assertions.Equal(map[string][]uint32{"INBOX": {1}}, known)
-		assertions.NotContains(server.commandsFor(2), "UID SEARCH")
 		assertions.NotContains(server.commandsFor(2), "ENABLE QRESYNC")
-		assertions.Contains(server.commandsFor(3), "UID SEARCH")
-		assertions.GreaterOrEqual(server.connectionCount(), 3)
+		assertions.Contains(server.commandsFor(2), "UID SEARCH")
+		assertions.Equal(2, server.connectionCount(),
+			"a server without QRESYNC must not cost a redial on every sync")
 	})
 
 	for _, response := range []string{"BAD", "NO"} {
@@ -1259,8 +1262,8 @@ func TestIMAPQresyncEndToEndUnsupportedAllDoesNotUseStaleShortcut(t *testing.T) 
 		t, st, source.ID, "unsupported-all@example.test")
 	assertions.False(deleted)
 	assertions.False(isRead, "provider \\Seen must not overwrite local read state")
-	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
-	assertions.Contains(server.commandsFor(3), "UID SEARCH")
+	assertions.Contains(server.commandsFor(2), "UID SEARCH")
+	assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 }
 
 func TestIMAPQresyncEndToEndGmailAllAvoidsMembershipScan(t *testing.T) {
@@ -1464,8 +1467,8 @@ func TestIMAPQresyncEndToEndGmailAllStatusFailureSuppressesPublication(t *testin
 	for _, state := range states {
 		assertions.Equal(uint64(1), state.HighestModSeq)
 	}
-	assertions.NotContains(server.commandsFor(2), "UID SEARCH")
-	assertions.Contains(server.commandsFor(3), "SELECT INBOX")
+	assertions.Contains(server.commandsFor(2), "SELECT INBOX")
+	assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 }
 
 func TestIMAPQresyncEndToEndNoAllEmptyStatusFailureSuppressesPublication(t *testing.T) {
@@ -1504,7 +1507,8 @@ func TestIMAPQresyncEndToEndNoAllEmptyStatusFailureSuppressesPublication(t *test
 			"one failed STATUS must suppress the entire authoritative snapshot")
 	}
 	assertions.NotContains(server.commandsFor(2), "CHANGEDSINCE")
-	assertions.Contains(server.commandsFor(3), `SELECT "ARCHIVE"`)
+	assertions.Contains(server.commandsFor(2), `SELECT "ARCHIVE"`)
+	assertions.Empty(server.commandsFor(3), "an ineligible QRESYNC baseline issues no command, so nothing needs discarding")
 }
 
 func TestIMAPQresyncEndToEndZeroStatusCursorSuppressesPublication(t *testing.T) {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -818,12 +818,12 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			!c.labelsSnapshotFilteredLocked() &&
 			len(c.priorFolderStates) > 0
 		handled, deltaErr := c.tryBuildQresyncMessageList(ctx, allMailboxes, folderStatuses)
-		if deltaErr != nil || (requireQresync && !handled) {
-			if deltaErr != nil {
-				c.logger.Warn("QRESYNC failed, reconnecting for full enumeration", "error", deltaErr)
-			} else {
-				c.logger.Info("QRESYNC unavailable, reconnecting for full enumeration")
-			}
+		switch {
+		case deltaErr != nil:
+			// A failed attempt has already issued ENABLE and CONDSTORE SELECTs
+			// and left partial deltas behind, so the connection and every
+			// observation derived from it are discarded before enumerating.
+			c.logger.Warn("QRESYNC failed, reconnecting for full enumeration", "error", deltaErr)
 			c.observedMailboxDeltas = nil
 			c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
 			c.messageListCache = nil
@@ -838,7 +838,16 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.observedFolderStates = make(map[string]FolderState, len(allMailboxes))
 			folderStatuses = c.observeFolderStates(ctx, allMailboxes)
 			qresyncFallback = true
-		} else if handled {
+		case requireQresync && !handled:
+			// Ineligible rather than failed. tryBuildQresyncMessageList returns
+			// before issuing a command when no mailbox carries a mod-sequence
+			// baseline, so the connection, the mailbox plan and the STATUS
+			// results all still stand. A server that never reports a
+			// mod-sequence takes this path on every run, where reconnecting
+			// would redial and re-STATUS every mailbox to discard nothing.
+			c.logger.Info("QRESYNC unavailable, enumerating fully")
+			qresyncFallback = true
+		case handled:
 			return nil
 		}
 	}

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -507,6 +507,16 @@ func (c *Client) planMailboxScan(
 		return mailboxScan{skip: true, known: cloneKnownUIDs(prior.KnownUIDs)}
 	}
 
+	// A server that reports mod-sequences can change flags on an existing
+	// message without moving UIDNEXT or the message count, and those messages
+	// sit below the high water mark where the search below cannot see them.
+	// Only servers that report no mod-sequence at all can be summarised by
+	// UIDNEXT plus a count; a QRESYNC server never reaches here, because
+	// CHANGEDSINCE handles it.
+	if status.HighestModSeq != prior.HighestModSeq {
+		return full()
+	}
+
 	uids, err := c.enumerateMailbox(ctx, mailbox, imap.UID(prior.UIDNext))
 	if err != nil {
 		return mailboxScan{err: err}

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -142,6 +142,12 @@ func NewClient(cfg *Config, password string, opts ...Option) *Client {
 // LabelsSnapshotComplete reports whether a sync sees every mailbox label.
 // Folder- and date-filtered syncs only have a partial label view and must not
 // replace labels or canonical message IDs discovered by an earlier full sync.
+//
+// A listing that skipped mailboxes it proved unchanged also holds a partial
+// in-session label map, but it stays complete here: those mailboxes' deltas and
+// memberships are published intact, and the post-sync mailbox-delta transaction
+// is what reconciles labels. Syncer guarantees the pairing by forcing full
+// enumeration on any client that reconciles labels immediately instead.
 func (c *Client) LabelsSnapshotComplete() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -425,6 +431,99 @@ func addMessageIDsFromHeaderFetchResults(dst map[string]bool, msgs []*imapclient
 	}
 }
 
+// mailboxScan is the resolved enumeration plan for one mailbox on a listing
+// without QRESYNC. It is computed once, before the label map is built, so the
+// label map and the message listing cannot disagree about what changed: a
+// mailbox skipped by one and enumerated by the other would publish a Reset
+// delta with no membership observations behind it.
+type mailboxScan struct {
+	skip  bool       // membership provably unchanged; publish a no-op delta
+	reset bool       // republish the whole mailbox
+	uids  []imap.UID // UIDs to fetch and list
+	known []uint32   // resulting KnownUIDs baseline
+	err   error      // enumeration failed; the run is not authoritative
+}
+
+// statusMessageCount reports whether the server's MESSAGES count is known and
+// equals want.
+func statusMessageCount(state FolderState, want int) bool {
+	return state.NumMessages != nil && int(*state.NumMessages) == want
+}
+
+// planMailboxScans decides, per mailbox, whether a listing can skip the mailbox
+// entirely, enumerate only UIDs at or above the saved UIDNEXT, or must
+// enumerate it in full.
+//
+// STATUS MESSAGES stands in for the change tracking CONDSTORE would provide.
+// UIDNEXT is monotonic within a UIDVALIDITY epoch and is raised by every
+// APPEND, so an unchanged UIDNEXT proves no message arrived; an unchanged
+// message count then proves none was expunged either. When UIDNEXT has
+// advanced, the same count check applied to the merged UID set proves that
+// nothing below the high water mark vanished while the new messages arrived.
+//
+// Every uncertainty resolves toward more enumeration, never less: membership
+// rows are only ever written from UIDs the client actually observed, so a
+// baseline can lag the server but cannot spuriously exceed it, and a lagging
+// baseline fails the count check and triggers a full rebuild.
+//
+// Caller must hold c.mu.
+func (c *Client) planMailboxScans(
+	ctx context.Context, mailboxes []string, statuses map[string]FolderState,
+) map[string]mailboxScan {
+	scans := make(map[string]mailboxScan, len(mailboxes))
+	for _, mailbox := range mailboxes {
+		scans[mailbox] = c.planMailboxScan(ctx, mailbox, statuses)
+	}
+	return scans
+}
+
+func (c *Client) planMailboxScan(
+	ctx context.Context, mailbox string, statuses map[string]FolderState,
+) mailboxScan {
+	full := func() mailboxScan {
+		uids, err := c.enumerateMailbox(ctx, mailbox, 0)
+		if err != nil {
+			return mailboxScan{err: err}
+		}
+		return mailboxScan{reset: true, uids: uids, known: uidsToUint32(uids)}
+	}
+
+	status, ok := statuses[mailbox]
+	if !ok || c.forceFullEnumeration {
+		return full()
+	}
+	// A nil KnownUIDs means no baseline was ever recorded, which is not the
+	// same as a baseline of zero messages: GetIMAPKnownUIDs returns an empty
+	// non-nil slice for a mailbox that is genuinely empty.
+	prior, ok := c.priorFolderStates[mailbox]
+	if !ok || prior.KnownUIDs == nil ||
+		prior.UIDValidity != status.UIDValidity ||
+		prior.UIDNext > status.UIDNext {
+		return full()
+	}
+
+	if folderStateUnchanged(prior, status) &&
+		statusMessageCount(status, len(prior.KnownUIDs)) {
+		return mailboxScan{skip: true, known: cloneKnownUIDs(prior.KnownUIDs)}
+	}
+
+	uids, err := c.enumerateMailbox(ctx, mailbox, imap.UID(prior.UIDNext))
+	if err != nil {
+		return mailboxScan{err: err}
+	}
+	// Count the union rather than the sum: "UID SEARCH UID n:*" always returns
+	// the last message in the mailbox even when n is past it (RFC 3501 6.4.8),
+	// so a search above the high water mark can re-report a UID already in the
+	// baseline.
+	known := mergeKnownUIDs(prior.KnownUIDs, uids)
+	if statusMessageCount(status, len(known)) {
+		return mailboxScan{uids: uids, known: known}
+	}
+	// The counts disagree: something at or below the high water mark vanished,
+	// and only a full enumeration can say what.
+	return full()
+}
+
 // enumerateMailbox lists UIDs in a single mailbox. A non-zero minUID
 // restricts the search to UIDs at or above it (new messages since a
 // saved UIDNEXT high water mark). It handles network errors with one
@@ -551,9 +650,16 @@ func (c *Client) fetchMailboxMessageIDs(
 // from the other mailboxes) and fetches Message-ID headers to build a
 // Message-ID → mailbox membership map. When \All is absent, every mailbox is
 // included.
+//
+// A non-nil scans supplies the enumeration plan resolved by planMailboxScans;
+// mailboxes it marks unchanged contribute no entries because their membership
+// rows already carry the answer, and mailboxes it marks incremental contribute
+// only their new UIDs. Skipping this way is a success, not a degradation: the
+// returned completeness flag stays true, because it reports whether the
+// published topology is authoritative, not how much of it was re-read.
 // Caller must hold mu.
 func (c *Client) buildLabelMap(
-	ctx context.Context, allMailboxes []string,
+	ctx context.Context, allMailboxes []string, scans map[string]mailboxScan,
 ) (bool, []gmailapi.MessageID, error) {
 	c.msgIDToLabels = make(map[string][]string)
 	complete := true
@@ -567,7 +673,17 @@ func (c *Client) buildLabelMap(
 			continue
 		}
 
-		uids, err := c.enumerateMailbox(ctx, mailbox, 0)
+		var uids []imap.UID
+		var err error
+		if scans == nil {
+			uids, err = c.enumerateMailbox(ctx, mailbox, 0)
+		} else {
+			scan := scans[mailbox]
+			if scan.skip {
+				continue
+			}
+			uids, err = scan.uids, scan.err
+		}
 		if err != nil {
 			complete = false
 			c.logger.Warn("skipping mailbox for label map",
@@ -734,6 +850,14 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		len(c.folderFilterInclude) == 0 &&
 		len(c.folderFilterExclude) == 0
 	buildMembershipMap := c.allMailFolder != "" || fullScanWithoutAll
+
+	// Resolve every mailbox's enumeration plan up front so the label map and
+	// the listing below agree. Only the no-\All path takes shortcuts; with an
+	// \All mailbox both consumers keep their previous behaviour.
+	var scans map[string]mailboxScan
+	if trackFolders && c.allMailFolder == "" {
+		scans = c.planMailboxScans(ctx, allMailboxes, folderStatuses)
+	}
 	labelMapComplete := false
 	var unidentifiedMembershipMessages []gmailapi.MessageID
 	if c.allMailFolder != "" {
@@ -748,7 +872,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	}
 	if buildMembershipMap {
 		var mapErr error
-		labelMapComplete, unidentifiedMembershipMessages, mapErr = c.buildLabelMap(ctx, allMailboxes)
+		labelMapComplete, unidentifiedMembershipMessages, mapErr = c.buildLabelMap(ctx, allMailboxes, scans)
 		if mapErr != nil {
 			return mapErr
 		}
@@ -764,30 +888,38 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	var unchangedFolders int
 
 	listOne := func(mailbox string) bool {
-		var minUID imap.UID
 		var observed *FolderState
 		var trackState FolderState
 		var canTrackFolder bool
+		var scan mailboxScan
+		planned := false
 		if trackFolders && c.allMailFolder == "" {
 			if status, ok := folderStatuses[mailbox]; ok {
 				observed = &status
 				trackState = status
 				canTrackFolder = true
-				if !c.forceFullEnumeration && !qresyncFallback {
-					if prior, ok := c.priorFolderStates[mailbox]; ok &&
-						prior.UIDValidity == status.UIDValidity &&
-						prior.UIDNext <= status.UIDNext {
-						if folderStateUnchanged(prior, status) {
-							// Unchanged since the last completed sync:
-							// no new messages possible, skip enumeration.
-							c.observedFolderStates[mailbox] = status
-							unchangedFolders++
-							return true
-						}
-						if prior.HighestModSeq == 0 && status.HighestModSeq == 0 {
-							// Without CONDSTORE, UIDNEXT is the only available high water mark.
-							minUID = imap.UID(prior.UIDNext)
-						}
+				if scans != nil {
+					scan, planned = scans[mailbox], true
+					if scan.err != nil {
+						c.logger.Warn("skipping mailbox",
+							"mailbox", mailbox, "error", scan.err)
+						return false
+					}
+					if scan.skip {
+						// Publish an explicit no-op delta rather than dropping
+						// the mailbox. ApplyIMAPMailboxDeltas derives the
+						// current topology from the delta list alone and
+						// retires -- and tombstones the messages of -- every
+						// mailbox missing from it.
+						trackState.KnownUIDs = scan.known
+						c.observedFolderStates[mailbox] = trackState
+						c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
+							Mailbox:     mailbox,
+							State:       trackState,
+							Incremental: true,
+						})
+						unchangedFolders++
+						return true
 					}
 				}
 			}
@@ -798,14 +930,18 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			}
 		}
 
-		uids, err := c.enumerateMailbox(ctx, mailbox, minUID)
-		if err != nil {
-			c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
-			return false
-		}
-		knownUIDs := uidsToUint32(uids)
-		if minUID != 0 {
-			knownUIDs = mergeKnownUIDs(c.priorFolderStates[mailbox].KnownUIDs, uids)
+		var uids []imap.UID
+		var knownUIDs []uint32
+		if planned {
+			uids, knownUIDs = scan.uids, scan.known
+		} else {
+			var err error
+			uids, err = c.enumerateMailbox(ctx, mailbox, 0)
+			if err != nil {
+				c.logger.Warn("skipping mailbox", "mailbox", mailbox, "error", err)
+				return false
+			}
+			knownUIDs = uidsToUint32(uids)
 		}
 		if observed != nil {
 			observed.KnownUIDs = knownUIDs
@@ -830,7 +966,9 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 		if canTrackFolder {
 			_, hadPrior := c.priorFolderStates[mailbox]
-			reset := !hadPrior || qresyncFallback || minUID == 0
+			// A planned scan already decided whether this mailbox needs a full
+			// republish; without a plan every listing is a full one.
+			reset := !hadPrior || !planned || scan.reset
 			if prior, ok := c.priorFolderStates[mailbox]; ok && prior.UIDValidity != trackState.UIDValidity {
 				reset = true
 			}
@@ -903,6 +1041,18 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			}
 		}
 	}
+	if authoritativeSnapshot && c.observedMailboxDeltas != nil &&
+		!deltasCoverMailboxes(allMailboxes, c.observedMailboxDeltas) {
+		// Publishing a partial topology is destructive, not merely incomplete:
+		// the store retires every mailbox missing from the delta set, deleting
+		// its memberships and tombstoning the messages that lived only there.
+		c.logger.Warn("incomplete mailbox delta set, suppressing authoritative snapshot",
+			"mailboxes", len(allMailboxes), "deltas", len(c.observedMailboxDeltas))
+		labelMapComplete = false
+		c.observedFolderStates = nil
+		c.observedMailboxDeltas = nil
+		c.clearFolderAcknowledgements()
+	}
 	if unchangedFolders > 0 {
 		c.logger.Info("skipped unchanged mailboxes",
 			"unchanged", unchangedFolders, "total", len(listMailboxes))
@@ -912,6 +1062,22 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	c.activeSourceAliases = activeSourceAliases
 	c.labelMapComplete = labelMapComplete && enumerationComplete
 	return nil
+}
+
+// deltasCoverMailboxes reports whether every current mailbox appears in the
+// delta set. A mailbox that is genuinely gone is absent from mailboxes too, so
+// a shortfall here means the listing dropped one, not that the server did.
+func deltasCoverMailboxes(mailboxes []string, deltas []MailboxDelta) bool {
+	covered := make(map[string]struct{}, len(deltas))
+	for _, delta := range deltas {
+		covered[delta.Mailbox] = struct{}{}
+	}
+	for _, mailbox := range mailboxes {
+		if _, ok := covered[mailbox]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func folderStatusesCoverMailboxes(

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -858,9 +858,14 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		c.observedMailboxDeltas = make([]MailboxDelta, 0, len(allMailboxes))
 	}
 
-	// A scan without saved folder states or after a QRESYNC fallback enumerates
-	// every UID, so it can build an authoritative membership map even when the
-	// server has no \All mailbox. Filtered saved-state scans remain additive.
+	// A scan without saved folder states or after a QRESYNC fallback builds an
+	// authoritative membership map even when the server has no \All mailbox.
+	// It is the mailbox coverage that makes the map authoritative, not a full
+	// re-read: a mailbox the scan plan proves unchanged contributes a no-op
+	// delta carrying its stored baseline, so the published topology still spans
+	// every mailbox and the store reconciles that mailbox's labels from the
+	// membership rows the no-op preserves. Filtered saved-state scans remain
+	// additive.
 	fullScanWithoutAll := c.allMailFolder == "" &&
 		trackFolders &&
 		(c.forceFullEnumeration || qresyncFallback || len(c.priorFolderStates) == 0) &&

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -437,11 +437,12 @@ func addMessageIDsFromHeaderFetchResults(dst map[string]bool, msgs []*imapclient
 // mailbox skipped by one and enumerated by the other would publish a Reset
 // delta with no membership observations behind it.
 type mailboxScan struct {
-	skip  bool       // membership provably unchanged; publish a no-op delta
-	reset bool       // republish the whole mailbox
-	uids  []imap.UID // UIDs to fetch and list
-	known []uint32   // resulting KnownUIDs baseline
-	err   error      // enumeration failed; the run is not authoritative
+	skip     bool       // membership provably unchanged; publish a no-op delta
+	reset    bool       // republish the whole mailbox
+	uids     []imap.UID // UIDs to fetch and list
+	vanished []imap.UID // UIDs that left the mailbox since the baseline
+	known    []uint32   // resulting KnownUIDs baseline
+	err      error      // enumeration failed; the run is not authoritative
 }
 
 // statusMessageCount reports whether the server's MESSAGES count is known and
@@ -529,9 +530,23 @@ func (c *Client) planMailboxScan(
 	if statusMessageCount(status, len(known)) {
 		return mailboxScan{uids: uids, known: known}
 	}
-	// The counts disagree: something at or below the high water mark vanished,
-	// and only a full enumeration can say what.
-	return full()
+	// The counts disagree: something at or below the high water mark vanished.
+	// Only a full enumeration can say what, but its answer is a diff, not a
+	// reason to republish: prior.KnownUIDs is read back from the stored
+	// memberships, so the difference between it and the current UID set names
+	// the additions and the removals outright. Republishing instead would cost
+	// a Message-ID fetch for every message in the mailbox, twice -- once to
+	// rebuild the label map and once to refresh labels downstream.
+	current, err := c.enumerateMailbox(ctx, mailbox, 0)
+	if err != nil {
+		return mailboxScan{err: err}
+	}
+	added, vanished := diffKnownUIDs(prior.KnownUIDs, current)
+	return mailboxScan{
+		uids:     added,
+		vanished: vanished,
+		known:    uidsToUint32(current),
+	}
 }
 
 // enumerateMailbox lists UIDs in a single mailbox. A non-zero minUID
@@ -997,10 +1012,11 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 				reset = true
 			}
 			c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
-				Mailbox:     mailbox,
-				State:       trackState,
-				ChangedUIDs: append([]imap.UID(nil), uids...),
-				Reset:       reset,
+				Mailbox:      mailbox,
+				State:        trackState,
+				ChangedUIDs:  append([]imap.UID(nil), uids...),
+				VanishedUIDs: append([]imap.UID(nil), scan.vanished...),
+				Reset:        reset,
 			})
 		}
 		c.logger.Debug("listed mailbox", "mailbox", mailbox, "count", len(uids))

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1007,10 +1007,12 @@ func TestWithFolderFilter_GmailCanonicalMailboxesHonorFilters(t *testing.T) {
 	})
 }
 
-// TestListMessages_ResetsFolderAfterExpunge covers the case UIDNEXT alone gets
-// wrong: a message removed with nothing appended leaves the high water mark
-// exactly where it was, so only the message count reveals the change.
-func TestListMessages_ResetsFolderAfterExpunge(t *testing.T) {
+// TestListMessages_ExpungeVanishesWithoutRepublishing covers the case UIDNEXT
+// alone gets wrong: a message removed with nothing appended leaves the high
+// water mark exactly where it was, so only the message count reveals the
+// change. Finding out costs a full UID SEARCH, but the search answers with a
+// diff -- the mailbox does not have to be republished to retire one UID.
+func TestListMessages_ExpungeVanishesWithoutRepublishing(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 3, "Archive": 2})
@@ -1023,20 +1025,53 @@ func TestListMessages_ResetsFolderAfterExpunge(t *testing.T) {
 	testutil.ExpungeIMAPMessage(t, addr, "INBOX", 1)
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
-	assert.Equal([]string{"INBOX|2", "INBOX|3"}, listAllMessages(t, second),
-		"a shrunken mailbox must be re-enumerated in full")
+	assert.Empty(listAllMessages(t, second),
+		"an expunge adds no messages, so none may be re-listed")
 
 	deltas := second.ObservedMailboxDeltas()
 	require.Len(deltas, 2)
 	for _, delta := range deltas {
-		if delta.Mailbox == "INBOX" {
-			assert.True(delta.Reset,
-				"only a full republish lets the store retire the expunged UID")
-			assert.Equal([]uint32{2, 3}, delta.State.KnownUIDs)
-		} else {
+		if delta.Mailbox != "INBOX" {
 			assert.False(delta.Reset, "an untouched mailbox stays untouched")
+			continue
 		}
+		assert.False(delta.Reset,
+			"a known baseline makes the removal expressible without a republish")
+		assert.Equal([]imapv2.UID{1}, delta.VanishedUIDs)
+		assert.Empty(delta.ChangedUIDs)
+		assert.Equal([]uint32{2, 3}, delta.State.KnownUIDs)
 	}
+}
+
+// TestListMessages_ExpungeWithoutBaselineStillResets covers the same expunge
+// with no stored KnownUIDs to diff against: there is nothing to subtract from,
+// so a full republish remains the only correct answer.
+func TestListMessages_ExpungeWithoutBaselineStillResets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 3})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 3)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	// A state saved before memberships were tracked carries no UID baseline.
+	for mailbox, state := range saved {
+		state.KnownUIDs = nil
+		saved[mailbox] = state
+	}
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", 1)
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	assert.Equal([]string{"INBOX|2", "INBOX|3"}, listAllMessages(t, second))
+
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 1)
+	assert.True(deltas[0].Reset,
+		"without a baseline only a full republish can retire the expunged UID")
+	assert.Empty(deltas[0].VanishedUIDs)
+	assert.Equal([]uint32{2, 3}, deltas[0].State.KnownUIDs)
 }
 
 // TestListMessages_AdvancedUIDNextWithSteadyCountDoesNotReset covers a message

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -69,7 +69,7 @@ func TestListMessages_RecordsFolderStates(t *testing.T) {
 	assert.NotZero(states["INBOX"].UIDValidity)
 }
 
-func TestListMessages_FallsBackWhenSavedStatesLackModSeq(t *testing.T) {
+func TestListMessages_SkipsUnchangedFoldersWithoutModSeq(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
@@ -81,12 +81,24 @@ func TestListMessages_FallsBackWhenSavedStatesLackModSeq(t *testing.T) {
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Len(ids, 5, "a baseline without mod-sequences must be rebuilt completely")
+	assert.Empty(ids,
+		"UIDNEXT and the message count together prove nothing changed")
 	assert.Equal(saved, second.ObservedFolderStates(),
-		"the full fallback publishes the same complete baseline")
+		"skipping still republishes the same complete baseline")
+
+	// Every mailbox must still appear in the delta set: the store retires --
+	// and tombstones the messages of -- any mailbox missing from it.
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 2)
+	for _, delta := range deltas {
+		assert.False(delta.Reset, delta.Mailbox)
+		assert.Empty(delta.ChangedUIDs, delta.Mailbox)
+		assert.Empty(delta.VanishedUIDs, delta.Mailbox)
+		assert.Equal(saved[delta.Mailbox].KnownUIDs, delta.State.KnownUIDs, delta.Mailbox)
+	}
 }
 
-func TestListMessages_FullFallbackIncludesExistingAndNewMessages(t *testing.T) {
+func TestListMessages_FetchesOnlyNewMessagesWithoutModSeq(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
@@ -100,13 +112,25 @@ func TestListMessages_FullFallbackIncludesExistingAndNewMessages(t *testing.T) {
 
 	second := newTestClient(t, addr, WithFolderStates(saved))
 	ids := listAllMessages(t, second)
-	assert.Equal([]string{
-		"Archive|1", "Archive|2", "Archive|3", "INBOX|1", "INBOX|2", "INBOX|3",
-	}, ids, "a baseline without mod-sequences must be rebuilt completely")
+	assert.Equal([]string{"INBOX|3"}, ids,
+		"only the appended message is above the saved high water mark")
 
 	states := second.ObservedFolderStates()
 	assert.Equal(uint32(4), states["INBOX"].UIDNext)
+	assert.Equal([]uint32{1, 2, 3}, states["INBOX"].KnownUIDs)
 	assert.Equal(saved["Archive"], states["Archive"])
+
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 2)
+	for _, delta := range deltas {
+		assert.False(delta.Reset, delta.Mailbox,
+			"an additive change must not republish the whole mailbox")
+		if delta.Mailbox == "INBOX" {
+			assert.Equal([]imapv2.UID{3}, delta.ChangedUIDs)
+		} else {
+			assert.Empty(delta.ChangedUIDs)
+		}
+	}
 }
 
 type listProgressCall struct {
@@ -141,15 +165,16 @@ func TestListMessages_ReportsListProgress(t *testing.T) {
 	assert.Equal(5, final.found)
 	assert.Equal(0, final.unchanged)
 
-	// A resync without usable mod-sequences reports a complete full fallback.
+	// A resync without usable mod-sequences skips the mailboxes whose UIDNEXT
+	// and message count both match the saved baseline.
 	saved := first.ObservedFolderStates()
 	require.NoError(first.Close())
 	calls = nil
 	second := newTestClient(t, addr, WithListProgress(record), WithFolderStates(saved))
-	require.Len(listAllMessages(t, second), 5)
+	require.Empty(listAllMessages(t, second))
 	final = calls[len(calls)-1]
-	assert.Equal(5, final.found)
-	assert.Equal(0, final.unchanged)
+	assert.Equal(0, final.found)
+	assert.Equal(2, final.unchanged)
 }
 
 func TestListMessages_UIDValidityChangeForcesFullRescan(t *testing.T) {
@@ -211,10 +236,11 @@ func TestListMessages_AllMailboxUnsupportedQresyncUsesFullFallback(t *testing.T)
 	second.mailboxCache = []string{"All Mail", "Projects"}
 	second.allMailFolder = "All Mail"
 	ids := listAllMessages(t, second)
-	assert.Len(ids, 3, "unsupported QRESYNC must force authoritative enumeration")
+	assert.Empty(ids,
+		"unsupported QRESYNC still skips mailboxes proven unchanged by UIDNEXT and count")
 	assert.Equal(saved, second.ObservedFolderStates())
 	assert.NotNil(second.msgIDToLabels,
-		"authoritative fallback must rebuild the All Mail label map")
+		"authoritative fallback must still publish a label map")
 }
 
 func TestAcknowledgeMessagesFlushesFolderStateWhenFolderComplete(t *testing.T) {
@@ -908,11 +934,10 @@ func TestClientRebuildsCompleteSnapshotWithoutAllMailboxOrModSeq(t *testing.T) {
 
 	testutil.AppendIMAPMessage(t, user, "Archive")
 	second := newTestClient(t, addr, WithFolderStates(saved))
-	require.Equal([]string{"Archive|1", "Archive|2", "INBOX|1"},
-		listAllMessages(t, second))
+	require.Equal([]string{"Archive|2"}, listAllMessages(t, second))
 
 	assert.True(t, second.LabelsSnapshotComplete(),
-		"the conservative full fallback sees every mailbox membership")
+		"skipping unchanged mailboxes still yields an authoritative snapshot")
 }
 
 func TestClientReportsIncompleteMailboxMembershipCollection(t *testing.T) {
@@ -976,4 +1001,114 @@ func TestWithFolderFilter_GmailCanonicalMailboxesHonorFilters(t *testing.T) {
 			assert.False(t, strings.HasPrefix(id, "[Gmail]/Trash|"), "Trash must not be enumerated: %q", id)
 		}
 	})
+}
+
+// TestListMessages_ResetsFolderAfterExpunge covers the case UIDNEXT alone gets
+// wrong: a message removed with nothing appended leaves the high water mark
+// exactly where it was, so only the message count reveals the change.
+func TestListMessages_ResetsFolderAfterExpunge(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 3, "Archive": 2})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 5)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", 1)
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	assert.Equal([]string{"INBOX|2", "INBOX|3"}, listAllMessages(t, second),
+		"a shrunken mailbox must be re-enumerated in full")
+
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 2)
+	for _, delta := range deltas {
+		if delta.Mailbox == "INBOX" {
+			assert.True(delta.Reset,
+				"only a full republish lets the store retire the expunged UID")
+			assert.Equal([]uint32{2, 3}, delta.State.KnownUIDs)
+		} else {
+			assert.False(delta.Reset, "an untouched mailbox stays untouched")
+		}
+	}
+}
+
+// TestListMessages_AdvancedUIDNextWithSteadyCountDoesNotReset covers a message
+// that arrived and was expunged between syncs: UIDNEXT moved but the mailbox
+// still holds the same messages, so nothing needs republishing.
+//
+// This does not exercise the RFC 3501 6.4.8 boundary rule -- the in-memory
+// server resolves "*" to UIDNEXT-1 rather than the last message, so the search
+// comes back empty here. TestListMessagesToleratesBoundaryUIDAboveHighWaterMark
+// covers that against a scripted server.
+func TestListMessages_AdvancedUIDNextWithSteadyCountDoesNotReset(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 2)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	// Append then expunge the same message: UIDNEXT advances, the count does
+	// not, and the search above the high water mark finds only old UID 2.
+	testutil.AppendIMAPMessage(t, user, "INBOX")
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", 3)
+
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	assert.Empty(listAllMessages(t, second),
+		"a message that came and went leaves nothing to archive")
+
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 1)
+	assert.False(deltas[0].Reset,
+		"an advanced UIDNEXT with a steady count is not a deletion")
+	assert.Equal([]uint32{1, 2}, deltas[0].State.KnownUIDs)
+}
+
+func TestListMessages_FullyEnumeratesWithoutKnownUIDBaseline(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 2)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	// A cursor saved before the membership table existed: the counts would
+	// match a zero-length baseline, but nothing is actually known.
+	stale := map[string]FolderState{"INBOX": {
+		UIDValidity: saved["INBOX"].UIDValidity,
+		UIDNext:     saved["INBOX"].UIDNext,
+	}}
+	require.Nil(stale["INBOX"].KnownUIDs)
+
+	second := newTestClient(t, addr, WithFolderStates(stale))
+	assert.Len(listAllMessages(t, second), 2,
+		"a missing baseline must be rebuilt, not assumed empty")
+	deltas := second.ObservedMailboxDeltas()
+	require.Len(deltas, 1)
+	assert.True(deltas[0].Reset)
+}
+
+func TestListMessages_LimitedSyncDisablesFolderSkipping(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 5)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	// A limited sync cannot defer label reconciliation, so it must see every
+	// mailbox membership rather than trusting the stored ones.
+	second := newTestClient(t, addr, WithFolderStates(saved))
+	second.ForceFullEnumerationForLimitedSync()
+	assert.Len(listAllMessages(t, second), 5,
+		"a limited sync must not take folder shortcuts")
 }

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -236,8 +236,12 @@ func TestListMessages_AllMailboxUnsupportedQresyncUsesFullFallback(t *testing.T)
 	second.mailboxCache = []string{"All Mail", "Projects"}
 	second.allMailFolder = "All Mail"
 	ids := listAllMessages(t, second)
-	assert.Empty(ids,
-		"unsupported QRESYNC still skips mailboxes proven unchanged by UIDNEXT and count")
+	// An \All mailbox deliberately forgoes the per-folder shortcuts: \All may
+	// not be a superset of every mailbox, so both the label map and the listing
+	// enumerate everything. Folder skipping without QRESYNC is the no-\All
+	// path, covered by TestListMessages_SkipsUnchangedFoldersWithoutModSeq.
+	assert.ElementsMatch([]string{"All Mail|1", "All Mail|2", "Projects|1"}, ids,
+		"an \\All run enumerates every mailbox rather than taking UIDNEXT shortcuts")
 	assert.Equal(saved, second.ObservedFolderStates())
 	assert.NotNil(second.msgIDToLabels,
 		"authoritative fallback must still publish a label map")

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -81,6 +81,13 @@ type FolderState struct {
 	UIDNext       uint32
 	HighestModSeq uint64
 	KnownUIDs     []uint32
+
+	// NumMessages is the STATUS MESSAGES count observed this session, or nil
+	// when the server did not report one. It is the deletion detector a server
+	// without CONDSTORE cannot otherwise provide. Transient: never loaded from
+	// or written to the store, so a state restored by WithFolderStates always
+	// carries nil here.
+	NumMessages *uint32
 }
 
 func cloneKnownUIDs(uids []uint32) []uint32 {
@@ -262,6 +269,7 @@ func (c *Client) AcknowledgeMessages(_ context.Context, messageIDs []string) {
 // Caller must hold mu.
 func (c *Client) statusFolder(ctx context.Context, mailbox string) (FolderState, error) {
 	opts := &imap.StatusOptions{
+		NumMessages:   true,
 		UIDNext:       true,
 		UIDValidity:   true,
 		HighestModSeq: c.conn.Caps().Has(imap.CapCondStore),
@@ -285,9 +293,13 @@ func (c *Client) statusFolder(ctx context.Context, mailbox string) (FolderState,
 	if data.UIDNext == 0 {
 		return FolderState{}, fmt.Errorf("STATUS %q returned no UIDNEXT", mailbox)
 	}
+	// A missing MESSAGES is not an error: it costs the caller the folder
+	// shortcuts and nothing else, so degrade to full enumeration rather than
+	// failing a STATUS the rest of which is usable.
 	return FolderState{
 		UIDValidity:   data.UIDValidity,
 		UIDNext:       uint32(data.UIDNext),
 		HighestModSeq: data.HighestModSeq,
+		NumMessages:   data.NumMessages,
 	}, nil
 }

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -297,6 +297,31 @@ func uidsToUint32(uids []imap.UID) []uint32 {
 	return values
 }
 
+// diffKnownUIDs compares a stored baseline against a freshly enumerated UID
+// set and reports what changed. added are UIDs the baseline does not have;
+// vanished are baseline UIDs the mailbox no longer holds. Both are sorted.
+func diffKnownUIDs(prior []uint32, current []imap.UID) (added, vanished []imap.UID) {
+	priorSet := make(map[uint32]struct{}, len(prior))
+	for _, uid := range prior {
+		priorSet[uid] = struct{}{}
+	}
+	currentSet := make(map[uint32]struct{}, len(current))
+	for _, uid := range current {
+		currentSet[uint32(uid)] = struct{}{}
+		if _, ok := priorSet[uint32(uid)]; !ok {
+			added = append(added, uid)
+		}
+	}
+	for _, uid := range prior {
+		if _, ok := currentSet[uid]; !ok {
+			vanished = append(vanished, imap.UID(uid))
+		}
+	}
+	slices.Sort(added)
+	slices.Sort(vanished)
+	return added, vanished
+}
+
 func mergeKnownUIDs(prior []uint32, additions []imap.UID) []uint32 {
 	if prior == nil {
 		return nil

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -26,6 +26,7 @@ type qresyncServerConfig struct {
 	selectHighestModSeq      uint64
 	selectFailureConnection  int
 	selectFailureAt          int
+	numMessages              *uint32
 	searchUIDs               []imapv2.UID
 	fetchChanged             []imapv2.UID
 	fetchVanished            []imapv2.UID
@@ -107,9 +108,13 @@ func serveQresyncTestConn(
 			_, _ = fmt.Fprintf(conn, "%s OK LIST completed\r\n", tag)
 		case strings.HasPrefix(upper, "STATUS"):
 			mailbox := scriptedCommandMailbox(command, "STATUS")
+			messages := ""
+			if cfg.numMessages != nil {
+				messages = fmt.Sprintf("MESSAGES %d ", *cfg.numMessages)
+			}
 			_, _ = fmt.Fprintf(conn,
-				"* STATUS %q (UIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
-				mailbox, cfg.uidNext, cfg.uidValidity, cfg.highestModSeq, tag)
+				"* STATUS %q (%sUIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
+				mailbox, messages, cfg.uidNext, cfg.uidValidity, cfg.highestModSeq, tag)
 		case strings.HasPrefix(upper, "ENABLE"):
 			_, _ = fmt.Fprintf(conn, "* ENABLED QRESYNC\r\n%s OK ENABLE completed\r\n", tag)
 		case strings.HasPrefix(upper, "SELECT"):
@@ -589,4 +594,40 @@ func TestObservedSnapshotsPreserveEmptyKnownUIDBaseline(t *testing.T) {
 
 	assert.NotNil(t, client.ObservedFolderStates()["Empty"].KnownUIDs)
 	assert.NotNil(t, client.ObservedMailboxDeltas()[0].State.KnownUIDs)
+}
+
+// TestListMessagesToleratesBoundaryUIDAboveHighWaterMark pins the union-based
+// deletion check. RFC 3501 6.4.8 makes "UID SEARCH UID n:*" return the last
+// message in the mailbox even when n is past it, so a search above the saved
+// high water mark can re-report a UID the baseline already holds. Adding the
+// two counts would read that as a deletion; merging them does not. The
+// in-memory server resolves "*" to UIDNEXT-1 instead, so only a scripted
+// server can exercise this.
+func TestListMessagesToleratesBoundaryUIDAboveHighWaterMark(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	numMessages := uint32(2)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities: []string{"IMAP4rev1"},
+		mailboxes:    []string{"INBOX"},
+		uidValidity:  1,
+		uidNext:      4, // a message arrived and was expunged
+		numMessages:  &numMessages,
+		searchUIDs:   []imapv2.UID{2}, // "3:*" re-reports the last message
+	})
+
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {UIDValidity: 1, UIDNext: 3, KnownUIDs: []uint32{1, 2}},
+	})
+	// Re-listing the boundary UID is harmless: it is already archived, so the
+	// syncer skips it. Re-enumerating the whole mailbox would not be.
+	assert.Equal([]string{"INBOX|2"}, listQresyncMessages(t, client))
+
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(deltas, 1)
+	assert.False(deltas[0].Reset,
+		"a re-reported boundary UID is not evidence of a deletion")
+	assert.Equal([]uint32{1, 2}, deltas[0].State.KnownUIDs)
+	assert.Contains(joinedCommands(server.commandsFor(2)), "UID SEARCH UID 3:*")
 }

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -713,3 +713,58 @@ func TestListMessagesIneligibleQresyncReusesConnection(t *testing.T) {
 		"one STATUS per mailbox, not two")
 	assert.NotContains(commands, "QRESYNC (")
 }
+
+// TestListMessagesQresyncErrorStillCoversSkippedMailboxes pins the safety
+// property behind letting the post-error fallback take scan shortcuts. A failed
+// QRESYNC attempt invalidates nothing the plan depends on: the stored baseline
+// is untouched and the reconnect re-runs STATUS, so a mailbox proven unchanged
+// by UIDVALIDITY, UIDNEXT and message count is still safe to skip. What must
+// not happen is a skipped mailbox dropping out of the published topology --
+// applyIMAPMailboxDeltas retires every mailbox missing from the delta set,
+// deleting its memberships and tombstoning the messages that lived only there.
+func TestListMessagesQresyncErrorStillCoversSkippedMailboxes(t *testing.T) {
+	assert := assert.New(t)
+
+	numMessages := uint32(3)
+	mailboxes := []string{"Archive", "INBOX"}
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:            []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		mailboxes:               mailboxes,
+		uidValidity:             77,
+		uidNext:                 4,
+		highestModSeq:           20,
+		numMessages:             &numMessages,
+		selectFailureConnection: 1,
+		selectFailureAt:         1,
+		searchUIDs:              []imapv2.UID{1, 2, 3},
+	})
+
+	states := make(map[string]FolderState, len(mailboxes))
+	for _, mailbox := range mailboxes {
+		states[mailbox] = FolderState{
+			UIDValidity:   77,
+			UIDNext:       4,
+			HighestModSeq: 20,
+			KnownUIDs:     []uint32{1, 2, 3},
+		}
+	}
+	client := newQresyncTestClient(t, addr, states)
+	client.mailboxCache = mailboxes
+
+	// The QRESYNC SELECT fails, so the run redials and re-STATUSes. Every
+	// mailbox then matches its baseline and is skipped.
+	assert.Empty(listQresyncMessages(t, client))
+	assert.Contains(joinedCommands(server.commandsFor(2)), "STATUS",
+		"a genuine QRESYNC failure still redials and re-reads STATUS")
+
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, len(mailboxes),
+		"a skipped mailbox must still appear in the topology or the store retires it")
+	for _, delta := range deltas {
+		assert.True(delta.Incremental, "%s", delta.Mailbox)
+		assert.False(delta.Reset, "%s", delta.Mailbox)
+		assert.Empty(delta.VanishedUIDs, "%s", delta.Mailbox)
+		assert.Equal([]uint32{1, 2, 3}, delta.State.KnownUIDs, "%s", delta.Mailbox)
+	}
+	assert.Len(client.ObservedFolderStates(), len(mailboxes))
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -631,3 +631,46 @@ func TestListMessagesToleratesBoundaryUIDAboveHighWaterMark(t *testing.T) {
 	assert.Equal([]uint32{1, 2}, deltas[0].State.KnownUIDs)
 	assert.Contains(joinedCommands(server.commandsFor(2)), "UID SEARCH UID 3:*")
 }
+
+// TestListMessagesCondStoreOnlyFlagChangeForcesFullEnumeration covers a server
+// that advertises CONDSTORE but not QRESYNC. A flags-only change advances
+// HIGHESTMODSEQ while UIDNEXT and the message count both stay put, so the
+// UIDNEXT high water mark alone would never look at the modified message. The
+// mod-sequence is the signal that something below the mark moved.
+func TestListMessagesCondStoreOnlyFlagChangeForcesFullEnumeration(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	numMessages := uint32(2)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE CONDSTORE"},
+		mailboxes:     []string{"INBOX"},
+		uidValidity:   1,
+		uidNext:       3, // unchanged
+		numMessages:   &numMessages,
+		highestModSeq: 20, // a flag changed on an existing message
+		searchUIDs:    []imapv2.UID{1, 2},
+	})
+
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity:   1,
+			UIDNext:       3,
+			HighestModSeq: 10,
+			KnownUIDs:     []uint32{1, 2},
+		},
+	})
+
+	assert.Equal([]string{"INBOX|1", "INBOX|2"}, listQresyncMessages(t, client),
+		"an advanced mod-sequence must re-read the mailbox, not just its tail")
+
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(deltas, 1)
+	assert.True(deltas[0].Reset,
+		"a flags-only change is invisible to UIDNEXT and the message count")
+	assert.Equal(uint64(20), deltas[0].State.HighestModSeq)
+
+	commands := joinedCommands(server.commandsFor(2))
+	assert.Contains(commands, "UID SEARCH UID 1:*")
+	assert.NotContains(commands, "UID SEARCH UID 3:*")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -339,10 +339,12 @@ func TestListMessagesQresyncUIDValidityMismatchResetsWithFullEnumeration(t *test
 	assert.True(deltas[0].Reset)
 	assert.False(deltas[0].Incremental)
 	assert.Equal([]imapv2.UID{1, 2, 3}, deltas[0].ChangedUIDs)
-	assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
-	commands := joinedCommands(server.commandsFor(2))
+	// Ineligible before a single command went out, so the full enumeration
+	// reuses the connection instead of redialing to discard nothing.
+	commands := joinedCommands(server.commandsFor(1))
 	assert.Contains(commands, "UID SEARCH")
 	assert.NotContains(commands, "QRESYNC (")
+	assert.Empty(server.commandsFor(2))
 }
 
 func TestListMessagesQresyncFallsBackWithoutCompleteEligibility(t *testing.T) {
@@ -376,10 +378,11 @@ func TestListMessagesQresyncFallsBackWithoutCompleteEligibility(t *testing.T) {
 			require.Len(t, deltas, 1)
 			assert.True(deltas[0].Reset)
 			assert.False(deltas[0].Incremental)
-			assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
-			commands := joinedCommands(server.commandsFor(2))
+			commands := joinedCommands(server.commandsFor(1))
 			assert.Contains(commands, "UID SEARCH")
 			assert.NotContains(commands, "QRESYNC (")
+			assert.Empty(server.commandsFor(2),
+				"an ineligible baseline issues no command, so nothing needs discarding")
 		})
 	}
 }
@@ -410,11 +413,11 @@ func TestListMessagesQresyncReconnectDoesNotReuseEnabledState(t *testing.T) {
 	client.mu.Unlock()
 
 	assert.Equal([]string{"INBOX|1", "INBOX|2", "INBOX|3"}, listQresyncMessages(t, client))
-	assert.NotContains(joinedCommands(server.commandsFor(2)), "UID SEARCH")
-	commands := joinedCommands(server.commandsFor(3))
+	commands := joinedCommands(server.commandsFor(2))
 	assert.Contains(commands, "UID SEARCH")
 	assert.NotContains(commands, "ENABLE QRESYNC")
 	assert.NotContains(commands, "QRESYNC (")
+	assert.Empty(server.commandsFor(3))
 }
 
 func TestListMessagesQresyncErrorDiscardsPartialDeltaStateBeforeFallback(t *testing.T) {
@@ -468,11 +471,11 @@ func TestListMessagesQresyncRegressedStatusModSeqForcesFullFallback(t *testing.T
 	require.Len(t, deltas, 1)
 	assert.True(deltas[0].Reset)
 	assert.False(deltas[0].Incremental)
-	assert.NotContains(joinedCommands(server.commandsFor(1)), "UID SEARCH")
-	commands := joinedCommands(server.commandsFor(2))
+	commands := joinedCommands(server.commandsFor(1))
 	assert.Contains(commands, "UID SEARCH")
 	assert.NotContains(commands, "ENABLE QRESYNC")
 	assert.NotContains(commands, "CHANGEDSINCE")
+	assert.Empty(server.commandsFor(2))
 }
 
 func TestListMessagesQresyncRegressedSelectModSeqForcesFreshFullFallback(t *testing.T) {
@@ -629,7 +632,7 @@ func TestListMessagesToleratesBoundaryUIDAboveHighWaterMark(t *testing.T) {
 	assert.False(deltas[0].Reset,
 		"a re-reported boundary UID is not evidence of a deletion")
 	assert.Equal([]uint32{1, 2}, deltas[0].State.KnownUIDs)
-	assert.Contains(joinedCommands(server.commandsFor(2)), "UID SEARCH UID 3:*")
+	assert.Contains(joinedCommands(server.commandsFor(1)), "UID SEARCH UID 3:*")
 }
 
 // TestListMessagesCondStoreOnlyFlagChangeForcesFullEnumeration covers a server
@@ -670,7 +673,43 @@ func TestListMessagesCondStoreOnlyFlagChangeForcesFullEnumeration(t *testing.T) 
 		"a flags-only change is invisible to UIDNEXT and the message count")
 	assert.Equal(uint64(20), deltas[0].State.HighestModSeq)
 
-	commands := joinedCommands(server.commandsFor(2))
+	commands := joinedCommands(server.commandsFor(1))
 	assert.Contains(commands, "UID SEARCH UID 1:*")
 	assert.NotContains(commands, "UID SEARCH UID 3:*")
+}
+
+// TestListMessagesIneligibleQresyncReusesConnection covers a server that never
+// reports a mod-sequence, which is the common case for Office 365 IMAP. No
+// mailbox can be QRESYNC-eligible, so tryBuildQresyncMessageList returns before
+// issuing a single command and leaves the connection, the mailbox plan and the
+// STATUS results intact. Reconnecting there would redial and re-STATUS every
+// mailbox on every scheduled sync to discard nothing.
+func TestListMessagesIneligibleQresyncReusesConnection(t *testing.T) {
+	assert := assert.New(t)
+
+	numMessages := uint32(2)
+	mailboxes := []string{"Archive", "INBOX", "Projects"}
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities: []string{"IMAP4rev1"},
+		mailboxes:    mailboxes,
+		uidValidity:  1,
+		uidNext:      3,
+		numMessages:  &numMessages,
+	})
+
+	states := make(map[string]FolderState, len(mailboxes))
+	for _, mailbox := range mailboxes {
+		states[mailbox] = FolderState{UIDValidity: 1, UIDNext: 3, KnownUIDs: []uint32{1, 2}}
+	}
+	client := newQresyncTestClient(t, addr, states)
+
+	assert.Empty(listQresyncMessages(t, client),
+		"every mailbox is proven unchanged by UIDNEXT and message count")
+
+	assert.Empty(server.commandsFor(2), "the fallback must not redial")
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Equal(1, strings.Count(commands, "LIST "), "one LIST, not one per attempt")
+	assert.Equal(len(mailboxes), strings.Count(commands, "STATUS "),
+		"one STATUS per mailbox, not two")
+	assert.NotContains(commands, "QRESYNC (")
 }

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -555,8 +555,10 @@ func TestListMessagesFallbackRebuildsKnownUIDBaseline(t *testing.T) {
 		"INBOX": {UIDValidity: 77, UIDNext: 4, KnownUIDs: []uint32{1, 2, 3}},
 	})
 
-	assert.Equal(t, []string{"INBOX|1", "INBOX|2", "INBOX|3", "INBOX|4"},
-		listQresyncMessages(t, client))
+	// The server reports no MESSAGES count, so the baseline cannot be verified
+	// arithmetically and a full UID SEARCH settles it. The search is ground
+	// truth, so only the UID missing from the baseline needs listing.
+	assert.Equal(t, []string{"INBOX|4"}, listQresyncMessages(t, client))
 	assert.Equal(t, []uint32{1, 2, 3, 4}, client.ObservedFolderStates()["INBOX"].KnownUIDs)
 }
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -137,7 +137,12 @@ func New(client gmail.API, store *store.Store, opts *Options) *Syncer {
 		opts = DefaultOptions()
 	}
 
-	if opts.Limit > 0 {
+	// Folder shortcuts leave this session's label map covering only the
+	// mailboxes that changed, which is safe only because the post-sync
+	// mailbox-delta transaction is what reconciles labels. A limited run cannot
+	// publish that transaction, and a client that reconciles immediately does
+	// not wait for it; either way the session's own view has to be complete.
+	if opts.Limit > 0 || !defersAuthoritativeLabelReconciliation(client) {
 		if forcer, ok := client.(limitedFullEnumerationForcer); ok {
 			forcer.ForceFullEnumerationForLimitedSync()
 		}
@@ -169,14 +174,21 @@ func (s *Syncer) labelsSnapshotComplete() bool {
 	return !ok || completeness.LabelsSnapshotComplete()
 }
 
+// defersAuthoritativeLabelReconciliation reports whether client leaves
+// authoritative label reconciliation to the post-sync mailbox-delta
+// transaction. Clients that do not implement the seam reconcile immediately.
+func defersAuthoritativeLabelReconciliation(client gmail.API) bool {
+	deferrer, ok := client.(authoritativeLabelReconciliationDeferrer)
+	return ok && deferrer.DefersAuthoritativeLabelReconciliation()
+}
+
 func (s *Syncer) defersAuthoritativeLabelReconciliation() bool {
 	// Only an unlimited run can publish the deferred mailbox snapshot. Limited
 	// runs must reconcile each processed message before returning.
 	if s.opts.SourceType != sourceTypeIMAP || s.opts.Limit > 0 || !s.labelsSnapshotComplete() {
 		return false
 	}
-	deferrer, ok := s.client.(authoritativeLabelReconciliationDeferrer)
-	return ok && deferrer.DefersAuthoritativeLabelReconciliation()
+	return defersAuthoritativeLabelReconciliation(s.client)
 }
 
 // WithSuccessfulSyncHook installs one best-effort post-completion hook.

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	imap "github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
 	"github.com/emersion/go-imap/v2/imapserver"
 	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
 	"github.com/stretchr/testify/require"
@@ -262,4 +263,27 @@ func startIMAPMemServer(
 	t.Cleanup(func() { _ = server.Close() })
 
 	return ln.Addr().String(), user
+}
+
+// ExpungeIMAPMessage permanently removes one UID from a mailbox on a server
+// returned by StartIMAPMemServer. The mailbox's STATUS MESSAGES count drops by
+// one while UIDNEXT stays put — the shape of a change that a cursor without
+// CONDSTORE cannot detect from UIDNEXT alone.
+func ExpungeIMAPMessage(t *testing.T, addr, mailbox string, uid imap.UID) {
+	t.Helper()
+	client, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	require.NoError(t, client.Login(IMAPTestUsername, IMAPTestPassword).Wait())
+	_, err = client.Select(mailbox, nil).Wait()
+	require.NoError(t, err)
+
+	var uidSet imap.UIDSet
+	uidSet.AddNum(uid)
+	require.NoError(t, client.Store(uidSet, &imap.StoreFlags{
+		Op:    imap.StoreFlagsAdd,
+		Flags: []imap.Flag{imap.FlagDeleted},
+	}, nil).Close())
+	require.NoError(t, client.Expunge().Close())
 }


### PR DESCRIPTION
Closes #698

IMAP incremental sync now avoids re-reading and rewriting whole mailboxes when a server lacks QRESYNC. It skips folders that are proven unchanged, fetches only new messages, and retires deleted or moved messages without republishing every folder membership.

If the saved state is incomplete or the server reports an uncertain change, msgvault still does a full scan. A failed QRESYNC attempt still reconnects; a server that simply cannot use QRESYNC keeps its healthy connection.

In the 96,000-message Microsoft 365 benchmark from #698, a sync after one message moved dropped from 1h46m to 24s, with the same final memberships.

No configuration or usage changes.