### PR TITLE
fix(vector): support embedding task prefixes

### DIFF
--- a/cmd/msgvault/cmd/embed_vector_test.go
+++ b/cmd/msgvault/cmd/embed_vector_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -292,6 +293,7 @@ func setupVectorFeaturesFixture(
 	dir := t.TempDir()
 	mainPath := filepath.Join(dir, "msgvault.db")
 	c := config.NewDefaultConfig()
+	c.HomeDir = dir
 	c.Data.DataDir = dir
 	c.Vector.Enabled = true
 	c.Vector.DBPath = filepath.Join(dir, "vectors.db")
@@ -307,12 +309,23 @@ func setupVectorFeaturesFixture(
 	for _, apply := range mutate {
 		apply(c)
 	}
+	require.NoError(t, c.Save())
 	withTestConfig(t, c)
 
 	s, err := store.Open(mainPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = s.Close() })
 	require.NoError(t, s.InitSchema())
+	if c.Vector.People.Enabled {
+		semanticProfile, err := c.Vector.SemanticPersonEmbeddingProfile()
+		require.NoError(t, err)
+		_, err = s.EnsurePersonSemanticEmbeddingProfile(t.Context(), semanticProfile)
+		require.NoError(t, err)
+		_, _, err = s.GrantPersonSemanticEmbeddingConsent(
+			t.Context(), semanticProfile.Fingerprint, "test",
+		)
+		require.NoError(t, err)
+	}
 	fingerprint := strings.Repeat("d", 64)
 	profile := store.DocumentExtractionProfile{
 		ID: "profile-" + fingerprint, Fingerprint: fingerprint, Provider: "synthetic",
@@ -369,6 +382,133 @@ func TestSetupVectorFeaturesDocumentClientRejectsCrossOriginRedirects(t *testing
 			assert.Zero(t, targetRequests.Load(), "attachment text must not reach the redirect target")
 		})
 	}
+}
+
+func TestSetupVectorFeatures_AppliesOpenAIEmbeddingPrefixes(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	maxChunk := strings.Repeat("x", 2000)
+	var calls [][]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Input []string `json:"input"`
+		}
+		if !check.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			return
+		}
+		calls = append(calls, request.Input)
+		data := make([]map[string]any, len(request.Input))
+		for i := range request.Input {
+			data[i] = map[string]any{
+				"embedding": []float32{1, 2, 3, 4},
+				"index":     i,
+			}
+		}
+		check.NoError(json.NewEncoder(w).Encode(map[string]any{"data": data}))
+	}))
+	t.Cleanup(server.Close)
+	vf := setupVectorFeaturesFixture(t, vector.APIFormatOpenAI, false, func(c *config.Config) {
+		c.Vector.Embeddings.Endpoint = server.URL
+		c.Vector.Embeddings.MaxInputChars = len(maxChunk)
+		c.Vector.Embeddings.DocumentPrefix = "search_document: "
+		c.Vector.Embeddings.QueryPrefix = "search_query: "
+		c.Vector.People = vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		}
+	})
+
+	_, err := vf.SemanticClient.EmbedDocuments(t.Context(), []vector.DocumentInput{
+		{Chunks: []string{"first chunk", "second chunk"}},
+	})
+	must.NoError(err)
+	_, err = vf.DocumentQueryClient.EmbedQuery(t.Context(), "document query")
+	must.NoError(err)
+	_, err = vf.HybridEngine.EmbedQuery(t.Context(), "message query")
+	must.NoError(err)
+	_, err = vf.PersonQueryClient.EmbedQuery(t.Context(), "person query")
+	must.NoError(err)
+	_, err = vf.SemanticClient.EmbedDocuments(t.Context(), []vector.DocumentInput{
+		{Chunks: []string{maxChunk}},
+	})
+	must.NoError(err)
+
+	check.Equal([][]string{
+		{"search_document: first chunk", "search_document: second chunk"},
+		{"search_query: document query"},
+		{"search_query: message query"},
+		{"search_query: person query"},
+		{"search_document: " + maxChunk},
+	}, calls)
+	must.Len(calls, 5)
+	must.Len(calls[4], 1)
+	check.Len(calls[4][0], len(maxChunk)+len("search_document: "))
+}
+
+func TestSetupVectorFeatures_AppliesVoyageEmbeddingPrefixes(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	maxChunk := strings.Repeat("x", 2000)
+	type voyageCall struct {
+		Inputs    [][]string `json:"inputs"`
+		InputType string     `json:"input_type"`
+	}
+	var calls []voyageCall
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request voyageCall
+		if !check.NoError(json.NewDecoder(r.Body).Decode(&request)) {
+			return
+		}
+		calls = append(calls, request)
+		outer := make([]map[string]any, len(request.Inputs))
+		for i, chunks := range request.Inputs {
+			inner := make([]map[string]any, len(chunks))
+			for j := range chunks {
+				inner[j] = map[string]any{
+					"embedding": []float32{1, 2, 3, 4},
+					"index":     j,
+				}
+			}
+			outer[i] = map[string]any{"data": inner, "index": i}
+		}
+		check.NoError(json.NewEncoder(w).Encode(map[string]any{"data": outer}))
+	}))
+	t.Cleanup(server.Close)
+	vf := setupVectorFeaturesFixture(t, vector.APIFormatVoyageContextual, false, func(c *config.Config) {
+		c.Vector.Embeddings.Endpoint = server.URL
+		c.Vector.Embeddings.MaxInputChars = len(maxChunk)
+		c.Vector.Embeddings.DocumentPrefix = "search_document: "
+		c.Vector.Embeddings.QueryPrefix = "search_query: "
+		c.Vector.People = vector.PeopleConfig{
+			Enabled: true, RetentionPosture: "zero_data_retention", TrainingPosture: "no_training",
+		}
+	})
+
+	_, err := vf.SemanticClient.EmbedDocuments(t.Context(), []vector.DocumentInput{
+		{Chunks: []string{"first chunk", "second chunk"}},
+	})
+	must.NoError(err)
+	_, err = vf.DocumentQueryClient.EmbedQuery(t.Context(), "document query")
+	must.NoError(err)
+	_, err = vf.HybridEngine.EmbedQuery(t.Context(), "message query")
+	must.NoError(err)
+	_, err = vf.PersonQueryClient.EmbedQuery(t.Context(), "person query")
+	must.NoError(err)
+	_, err = vf.SemanticClient.EmbedDocuments(t.Context(), []vector.DocumentInput{
+		{Chunks: []string{maxChunk}},
+	})
+	must.NoError(err)
+
+	check.Equal([]voyageCall{
+		{InputType: "document", Inputs: [][]string{{"search_document: first chunk", "search_document: second chunk"}}},
+		{InputType: "query", Inputs: [][]string{{"search_query: document query"}}},
+		{InputType: "query", Inputs: [][]string{{"search_query: message query"}}},
+		{InputType: "query", Inputs: [][]string{{"search_query: person query"}}},
+		{InputType: "document", Inputs: [][]string{{"search_document: " + maxChunk}}},
+	}, calls)
+	must.Len(calls, 5)
+	must.Len(calls[4].Inputs, 1)
+	must.Len(calls[4].Inputs[0], 1)
+	check.Len(calls[4].Inputs[0][0], len(maxChunk)+len("search_document: "))
 }
 
 func TestSetupVectorFeatures_SelectsRunnerByAPIFormat(t *testing.T) {

--- a/cmd/msgvault/cmd/remove_account.go
+++ b/cmd/msgvault/cmd/remove_account.go
@@ -31,6 +31,11 @@ const (
 // before the lock-held cache rebuild.
 var removeAccountAfterCascadeHook func()
 
+// removeAccountBeforeDiscordLifecycleLockHook lets tests observe that store
+// initialization has finished before the Discord credential lifecycle lock is
+// acquired.
+var removeAccountBeforeDiscordLifecycleLockHook func()
+
 func newRemoveAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   removeAccountCommandName + " [account]",
@@ -204,6 +209,9 @@ func runRemoveAccountLocal(cmd *cobra.Command, args []string) error {
 	)
 	if source.SourceType == sourceTypeDiscord {
 		discordTokens := discord.NewTokenManager(cfg.TokensDir())
+		if removeAccountBeforeDiscordLifecycleLockHook != nil {
+			removeAccountBeforeDiscordLifecycleLockHook()
+		}
 		removeErr = discordTokens.WithLifecycleLock(func() error {
 			lockedSource, lookupErr := s.GetSourceByID(source.ID)
 			if lookupErr != nil {

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -1310,6 +1310,12 @@ func TestDiscordAddLifecycleBlocksFinalCredentialRemovalUntilGuildRegistration(t
 		require.FailNow("timed out waiting for Discord credential save")
 	}
 
+	removeReachedLifecycleLock := make(chan struct{})
+	removeAccountBeforeDiscordLifecycleLockHook = func() {
+		close(removeReachedLifecycleLock)
+	}
+	t.Cleanup(func() { removeAccountBeforeDiscordLifecycleLockHook = nil })
+
 	removeDone := make(chan error, 1)
 	go func() {
 		root := newTestRootCmd()
@@ -1317,6 +1323,13 @@ func TestDiscordAddLifecycleBlocksFinalCredentialRemovalUntilGuildRegistration(t
 		root.SetArgs([]string{"remove-account", first.Identifier, "--yes", "--type", sourceTypeDiscord})
 		removeDone <- root.Execute()
 	}()
+	select {
+	case <-removeReachedLifecycleLock:
+	case err := <-removeDone:
+		require.FailNow("removal ended before reaching Discord lifecycle lock", "error: %v", err)
+	case <-time.After(5 * time.Second):
+		require.FailNow("timed out waiting for removal to reach Discord lifecycle lock")
+	}
 	select {
 	case err := <-removeDone:
 		require.FailNow("removal bypassed Discord lifecycle lock", "error: %v", err)

--- a/cmd/msgvault/cmd/serve_vector.go
+++ b/cmd/msgvault/cmd/serve_vector.go
@@ -248,6 +248,8 @@ func newEmbeddingRuntime(vectorCfg vector.Config, deps embeddingRuntimeDeps) (*e
 			Endpoint: vectorCfg.Embeddings.Endpoint, APIKey: vectorCfg.Embeddings.APIKey(),
 			Model: vectorCfg.Embeddings.Model, Dimension: vectorCfg.Embeddings.Dimension,
 			Timeout: vectorCfg.Embeddings.Timeout, MaxRetries: vectorCfg.Embeddings.MaxRetries,
+			DocumentPrefix: vectorCfg.Embeddings.DocumentPrefix,
+			QueryPrefix:    vectorCfg.Embeddings.QueryPrefix,
 		}
 		messageClient := embed.NewClient(clientConfig)
 		documentClientConfig := clientConfig
@@ -292,6 +294,8 @@ func newEmbeddingRuntime(vectorCfg vector.Config, deps embeddingRuntimeDeps) (*e
 			Endpoint: vectorCfg.Embeddings.Endpoint, APIKey: vectorCfg.Embeddings.APIKey(),
 			Model: vectorCfg.Embeddings.Model, Dimension: vectorCfg.Embeddings.Dimension,
 			Timeout: vectorCfg.Embeddings.Timeout, MaxRetries: vectorCfg.Embeddings.MaxRetries,
+			DocumentPrefix: vectorCfg.Embeddings.DocumentPrefix,
+			QueryPrefix:    vectorCfg.Embeddings.QueryPrefix,
 			Limits: embed.RequestLimits{MaxDocuments: vectorCfg.Embeddings.BatchSize,
 				MaxChunks: 16_000, MaxUTF8Bytes: contextualDocumentUTF8Limit},
 		}
@@ -307,16 +311,18 @@ func newEmbeddingRuntime(vectorCfg vector.Config, deps embeddingRuntimeDeps) (*e
 		clientConfig.BeforeRequest = personGate.Check
 		personClient := embed.NewVoyageClient(clientConfig)
 		policy := embed.AssemblyPolicy{
-			MaxChunkRunes:        vectorCfg.Embeddings.MaxInputChars,
-			MaxDocumentUTF8Bytes: contextualDocumentUTF8Limit,
-			Preprocess:           embeddingPreprocessConfig(vectorCfg),
+			MaxChunkRunes:           vectorCfg.Embeddings.MaxInputChars,
+			MaxDocumentUTF8Bytes:    contextualDocumentUTF8Limit,
+			DocumentPrefixUTF8Bytes: len(vectorCfg.Embeddings.DocumentPrefix),
+			Preprocess:              embeddingPreprocessConfig(vectorCfg),
 		}
 		assembler := embed.CompositeAssembler{Policy: policy, Chat: embed.ChatWindowAssembler{Policy: policy}}
 		messageWorker := embed.NewContextWorker(embed.ContextWorkerDeps{
 			Backend: deps.Backend, Publisher: publisher, Store: deps.Store,
 			Assembler: assembler, Client: messageClient, BuildScope: vectorCfg.Embed.Scope.BuildScope(),
-			ChangeBatchSize:    vectorCfg.Embeddings.BatchSize,
-			ReconcileBatchSize: vectorCfg.Embeddings.BatchSize,
+			ChangeBatchSize:         vectorCfg.Embeddings.BatchSize,
+			ReconcileBatchSize:      vectorCfg.Embeddings.BatchSize,
+			DocumentPrefixUTF8Bytes: len(vectorCfg.Embeddings.DocumentPrefix),
 		})
 		personWorker := embed.NewPersonWorker(embed.PersonWorkerDeps{
 			Store: deps.Store, Backend: personBackend, Client: personClient,
@@ -544,6 +550,7 @@ func setupVectorFeatures(ctx context.Context, mainStore *store.Store, mainPath s
 		features.Convergence = runtime.Convergence
 		features.SemanticClient = runtime.SemanticClient
 		features.DocumentQueryClient = runtime.QuerySemanticClient
+		features.PersonQueryClient = runtime.PersonQueryClient
 		features.HybridEngine = hybrid.NewEngine(backend, mainDB, runtime.QueryClient, hybrid.Config{
 			ExpectedFingerprint: vecCfg.GenerationFingerprint(),
 			RRFK:                vecCfg.Search.RRFK,

--- a/cmd/msgvault/cmd/vector_features.go
+++ b/cmd/msgvault/cmd/vector_features.go
@@ -51,6 +51,7 @@ type vectorFeatures struct {
 	DocumentSearch      *vectordocument.SearchService
 	SemanticClient      embed.SemanticClient
 	DocumentQueryClient embed.SemanticClient
+	PersonQueryClient   personsearch.QueryEmbedder
 	Cfg                 vector.Config
 	Visual              *visualFeatures
 	// Close releases the backend's resources: on SQLite it closes the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,8 @@ backend = "sqlite-vec"
 endpoint = "http://localhost:11434/v1"
 model = "nomic-embed-text"
 dimension = 768
+document_prefix = "search_document: "
+query_prefix = "search_query: "
 eta_window = 10
 
 [vector.preprocess]
@@ -685,6 +687,8 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `endpoint` | (required) | HTTP(S) base URL for an OpenAI-compatible embeddings API. msgvault appends `/embeddings` (for example, set `http://localhost:11434/v1`, not `.../embeddings`). |
 | `model` | (required) | Model name to pass in each request (e.g., `nomic-embed-text`). |
 | `dimension` | (required) | Vector dimension. Must match the model's output dimension. |
+| `document_prefix` | `""` | Model-specific instruction prepended to every document chunk after chunking (for example, `"search_document: "` for `nomic-embed-text`). The prefix does not reduce `max_input_chars`; maximum 4096 UTF-8 bytes. |
+| `query_prefix` | `""` | Model-specific instruction prepended to every vector-search query (for example, `"search_query: "` for `nomic-embed-text`); maximum 4096 UTF-8 bytes. |
 | `api_key_env` | — | Name of an environment variable containing the API key. Omit for anonymous endpoints. |
 | `batch_size` | `32` | Embedding inputs per HTTP call. Long messages can contribute multiple chunk inputs. |
 | `timeout` | `30s` | Per-request timeout. |
@@ -692,7 +696,7 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `max_input_chars` | `32768` | Character cap per embedding chunk. Set below your model's context window (e.g., `2000` for Ollama's default `nomic-embed-text`). |
 | `eta_window` | `10` | Number of recent progress samples used for ETA smoothing. |
 
-The index generation fingerprint includes the model, dimension, preprocessing settings, `max_input_chars`, embedding policy, and scope. Changing those settings triggers a stale-index error on the next vector/hybrid query. For an existing account-scoped generation built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon; otherwise run `msgvault embeddings build --full-rebuild`.
+The index generation fingerprint includes the model, dimension, document and query prefixes, preprocessing settings, `max_input_chars`, embedding policy, and scope. Changing those settings triggers a stale-index error on the next vector/hybrid query. For an existing account-scoped generation built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon; otherwise run `msgvault embeddings build --full-rebuild`.
 
 #### `[vector.preprocess]`
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -112,6 +112,8 @@ endpoint = "http://tailnet-host:11434/v1"
 api_key_env = "OLLAMA_API_KEY"           # optional; omit for anonymous endpoints
 model = "nomic-embed-text"
 dimension = 768
+document_prefix = "search_document: "  # required by nomic-embed-text
+query_prefix = "search_query: "        # required by nomic-embed-text
 batch_size = 32                          # embeddings per HTTP call
 timeout = "30s"
 max_retries = 3
@@ -166,11 +168,27 @@ backend = "pgvector"
 endpoint = "http://localhost:11434/v1"
 model = "nomic-embed-text"
 dimension = 768
+document_prefix = "search_document: "
+query_prefix = "search_query: "
 ```
 
 pgvector embeddings live in the PostgreSQL database. `db_path` and
 `vectors.db` apply only to the SQLite sqlite-vec backend. See
 [PostgreSQL Backend](/architecture/postgresql/) for database setup.
+
+### Model task prefixes
+
+Some embedding models require different task instructions for indexed
+documents and search queries. The `nomic-embed-text` examples above use
+its required retrieval prefixes. Set `document_prefix` and `query_prefix`
+to the values required by your model, or leave them empty for models that
+do not use instructions.
+
+msgvault prepends `document_prefix` to every chunk after chunking and
+`query_prefix` to every vector-search query. Prefix characters do not
+reduce the `max_input_chars` content budget. Changing either prefix marks
+the existing vector generation stale so prefixed queries cannot be mixed
+with an index built from unprefixed documents.
 
 ### Matching `max_input_chars` to your embedder's context window
 
@@ -463,7 +481,7 @@ filtering.
 
 ## Model Rotation
 
-To switch models, dimensions, preprocessing settings, or
+To switch models, dimensions, task prefixes, preprocessing settings, or
 `max_input_chars`, update your config, then run:
 
 ```bash
@@ -472,7 +490,7 @@ msgvault embeddings build --full-rebuild --yes
 
 This builds a new generation with the new fingerprint and activates
 it atomically when the build completes. The fingerprint includes the
-model, dimension, preprocessing policy, `max_input_chars`, and
+model, dimension, task prefixes, preprocessing policy, `max_input_chars`, and
 embedding output policy. While the rebuild is in flight,
 `mode=vector` and `mode=hybrid` return `index_stale` (the
 previously-active generation no longer matches the configured
@@ -494,7 +512,7 @@ body keywords.
 | Error | Meaning | Recovery |
 |---|---|---|
 | `vector_not_enabled` | The server or MCP process did not wire a vector backend, usually because `[vector] enabled = false`. | Set `enabled = true`, configure `[vector.embeddings]`, and start with a build that includes the needed backend (`sqlite_vec` or `pgvector`). |
-| `index_stale` | Active generation's fingerprint does not match the current embedding settings: model, dimension, preprocessing policy, `max_input_chars`, output policy, or scope. | For an existing account-scoped index built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon. Otherwise run `msgvault embeddings build --full-rebuild --yes`. |
+| `index_stale` | Active generation's fingerprint does not match the current embedding settings: model, dimension, task prefixes, preprocessing policy, `max_input_chars`, output policy, or scope. | For an existing account-scoped index built with CLI flags, set matching `[vector.embed.scope].accounts` and restart the daemon. Otherwise run `msgvault embeddings build --full-rebuild --yes`. |
 | `index_building` | No active generation yet; one is being built. | Finish running `msgvault embeddings build`, wait for the scheduler, or use the appropriate non-vector fallback. |
 | `missing_free_text` | `mode=vector` or `mode=hybrid` used with a filter-only query (no free text to embed). | Add free-text terms to `q`, or use the appropriate non-vector fallback. |
 | `index_scope_mismatch` | The active vector generation was built for selected message types and the query is unscoped or asks for a type outside that scope. | Add a compatible `message_type` filter, use the appropriate non-vector fallback, or rebuild an unscoped generation. |

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -110,6 +110,8 @@ var settingsCatalog = []settingDefinition{
 	testableStringSetting("vector.embeddings.endpoint", "search", func(c *config.Config) string { return c.Vector.Embeddings.Endpoint }),
 	localOnlyStringSetting("vector.embeddings.api_key_env", "search", func(c *config.Config) string { return c.Vector.Embeddings.APIKeyEnv }),
 	stringSetting("vector.embeddings.model", "search", nil, func(c *config.Config) string { return c.Vector.Embeddings.Model }),
+	stringSetting("vector.embeddings.document_prefix", "search", nil, func(c *config.Config) string { return c.Vector.Embeddings.DocumentPrefix }),
+	stringSetting("vector.embeddings.query_prefix", "search", nil, func(c *config.Config) string { return c.Vector.Embeddings.QueryPrefix }),
 	intSetting("vector.embeddings.dimension", "search", func(c *config.Config) int { return c.Vector.Embeddings.Dimension }),
 	intSetting("vector.embeddings.batch_size", "search", func(c *config.Config) int { return c.Vector.Embeddings.BatchSize }),
 	intSetting("vector.embeddings.max_retries", "search", func(c *config.Config) int { return c.Vector.Embeddings.MaxRetries }),

--- a/internal/api/settings_test.go
+++ b/internal/api/settings_test.go
@@ -27,6 +27,7 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 	require := require.New(t)
 	srv, _ := newSettingsTestServer(t, "# keep\n[web]\ntheme = \"dark\"\n"+
 		"[server]\napi_key = \"test-api-key\"\n"+
+		"[vector.embeddings]\ndocument_prefix = \"search_document: \"\nquery_prefix = \"search_query: \"\n"+
 		"[integrations.tasks]\napi_key = \"task-secret\"\n"+
 		"[unsupported]\nprivate_value = \"must-not-leak\"\n")
 	resp := performSettingsRequest(t, srv, http.MethodGet, settingsPath, nil, "", "test-api-key")
@@ -47,6 +48,12 @@ func TestGetSettingsUsesAllowlistETagAndSecretStates(t *testing.T) {
 	require.NotNil(byKey["vector.embeddings.api_format"].Value.String)
 	assert.Equal("openai", *byKey["vector.embeddings.api_format"].Value.String)
 	assert.Equal([]string{"openai", "voyage-contextual"}, byKey["vector.embeddings.api_format"].Options)
+	require.NotNil(byKey["vector.embeddings.document_prefix"].Value)
+	require.NotNil(byKey["vector.embeddings.document_prefix"].Value.String)
+	assert.Equal("search_document: ", *byKey["vector.embeddings.document_prefix"].Value.String)
+	require.NotNil(byKey["vector.embeddings.query_prefix"].Value)
+	require.NotNil(byKey["vector.embeddings.query_prefix"].Value.String)
+	assert.Equal("search_query: ", *byKey["vector.embeddings.query_prefix"].Value.String)
 	require.NotNil(byKey["vector.people.enabled"].Value)
 	require.NotNil(byKey["vector.people.enabled"].Value.Boolean)
 	assert.False(*byKey["vector.people.enabled"].Value.Boolean)

--- a/internal/vector/config.go
+++ b/internal/vector/config.go
@@ -27,6 +27,10 @@ const (
 	APIFormatVoyageContextual EmbeddingAPIFormat = "voyage-contextual"
 	// contextPolicyVersion identifies the contextual document assembly policy.
 	contextPolicyVersion = 2
+	// Task prefixes are short provider instructions, not document content.
+	// Bounding them prevents one prefix from exhausting contextual request
+	// budgets before any source text can be assembled.
+	maxEmbeddingTaskPrefixUTF8Bytes = 4096
 )
 
 // preprocessVersion identifies the embed/preprocess.go implementation
@@ -182,16 +186,18 @@ func (m MultimodalConfig) APIKey() string {
 // EmbeddingsConfig configures the external embedding endpoint used to convert
 // message text into vectors.
 type EmbeddingsConfig struct {
-	APIFormat     EmbeddingAPIFormat `toml:"api_format"`
-	Endpoint      string             `toml:"endpoint"`
-	APIKeyEnv     string             `toml:"api_key_env"`
-	Model         string             `toml:"model"`
-	Dimension     int                `toml:"dimension"`
-	BatchSize     int                `toml:"batch_size"`
-	Timeout       time.Duration      `toml:"timeout"`
-	MaxRetries    int                `toml:"max_retries"`
-	MaxInputChars int                `toml:"max_input_chars"`
-	ETAWindow     int                `toml:"eta_window"`
+	APIFormat      EmbeddingAPIFormat `toml:"api_format"`
+	Endpoint       string             `toml:"endpoint"`
+	APIKeyEnv      string             `toml:"api_key_env"`
+	Model          string             `toml:"model"`
+	DocumentPrefix string             `toml:"document_prefix"`
+	QueryPrefix    string             `toml:"query_prefix"`
+	Dimension      int                `toml:"dimension"`
+	BatchSize      int                `toml:"batch_size"`
+	Timeout        time.Duration      `toml:"timeout"`
+	MaxRetries     int                `toml:"max_retries"`
+	MaxInputChars  int                `toml:"max_input_chars"`
+	ETAWindow      int                `toml:"eta_window"`
 }
 
 // EffectiveAPIFormat returns the configured API format, defaulting to the
@@ -226,6 +232,14 @@ func (e EmbeddingsConfig) Validate() error {
 	}
 	if e.Model == "" {
 		return fmt.Errorf("vector.embeddings.model: required (the index generation fingerprint is %q, which is ambiguous without a model name)", e.Fingerprint())
+	}
+	if len(e.DocumentPrefix) > maxEmbeddingTaskPrefixUTF8Bytes {
+		return fmt.Errorf("vector.embeddings.document_prefix: must be at most %d UTF-8 bytes, got %d",
+			maxEmbeddingTaskPrefixUTF8Bytes, len(e.DocumentPrefix))
+	}
+	if len(e.QueryPrefix) > maxEmbeddingTaskPrefixUTF8Bytes {
+		return fmt.Errorf("vector.embeddings.query_prefix: must be at most %d UTF-8 bytes, got %d",
+			maxEmbeddingTaskPrefixUTF8Bytes, len(e.QueryPrefix))
 	}
 	if e.Dimension <= 0 {
 		return fmt.Errorf("vector.embeddings.dimension: must be positive, got %d", e.Dimension)
@@ -421,6 +435,7 @@ func (e EmbeddingsConfig) Fingerprint() string {
 // GenerationFingerprint returns the full identifier used to compare an
 // index generation against the configured policy. Format:
 // "<model>:<dimension>:<preprocess>:c<max_input_chars>:e<embed_policy>".
+// Non-empty document or query prefixes add a hashed ":t<digest>" segment.
 // Contextual generations add
 // ":avoyage-contextual:v<context_policy_version>" before any scope segment.
 // Every segment is derived from the effective config (or a code-level
@@ -451,6 +466,9 @@ func (c *Config) GenerationFingerprint() string {
 	fp := fmt.Sprintf("%s:%s:c%d:e%d",
 		c.Embeddings.Fingerprint(), c.Preprocess.Fingerprint(), c.Embeddings.MaxInputChars,
 		embedPolicyVersion)
+	if taskPrefixFingerprint := c.Embeddings.TaskPrefixFingerprint(); taskPrefixFingerprint != "" {
+		fp += ":t" + taskPrefixFingerprint
+	}
 	if c.Embeddings.EffectiveAPIFormat() == APIFormatVoyageContextual {
 		fp = fmt.Sprintf("%s:a%s:v%d", fp, APIFormatVoyageContextual, contextPolicyVersion)
 	}
@@ -458,6 +476,19 @@ func (c *Config) GenerationFingerprint() string {
 		fp = fmt.Sprintf("%s:s%s", fp, scopeFP)
 	}
 	return fp
+}
+
+// TaskPrefixFingerprint identifies document/query task-prefix policy without
+// exposing configured prefix text. Empty policy deliberately has no identity
+// so existing generation fingerprints retain their exact legacy bytes.
+func (e EmbeddingsConfig) TaskPrefixFingerprint() string {
+	if e.DocumentPrefix == "" && e.QueryPrefix == "" {
+		return ""
+	}
+	encoded := fmt.Sprintf("embedding-prefix-v1:%d:%s:%d:%s",
+		len(e.DocumentPrefix), e.DocumentPrefix, len(e.QueryPrefix), e.QueryPrefix)
+	digest := sha256.Sum256([]byte(encoded))
+	return hex.EncodeToString(digest[:])
 }
 
 // AnyLaneEnabled reports whether either the ordinary text-vector lane or the

--- a/internal/vector/config_test.go
+++ b/internal/vector/config_test.go
@@ -82,6 +82,16 @@ func TestConfig_Validate(t *testing.T) {
 		{"UnknownBackend", func(c *Config) { c.Backend = "mystery" }, "backend"},
 		{"ZeroBatch", func(c *Config) { c.Embeddings.BatchSize = 0 }, "batch_size"},
 		{"MissingModel", func(c *Config) { c.Embeddings.Model = "" }, "model"},
+		{"DocumentPrefixTooLarge", func(c *Config) {
+			c.Embeddings.DocumentPrefix = strings.Repeat("x", maxEmbeddingTaskPrefixUTF8Bytes+1)
+		}, "document_prefix"},
+		{"QueryPrefixTooLarge", func(c *Config) {
+			c.Embeddings.QueryPrefix = strings.Repeat("x", maxEmbeddingTaskPrefixUTF8Bytes+1)
+		}, "query_prefix"},
+		{"PrefixLimitOK", func(c *Config) {
+			c.Embeddings.DocumentPrefix = strings.Repeat("x", maxEmbeddingTaskPrefixUTF8Bytes)
+			c.Embeddings.QueryPrefix = strings.Repeat("x", maxEmbeddingTaskPrefixUTF8Bytes)
+		}, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -453,6 +463,48 @@ func TestConfig_GenerationFingerprint_IncludesMaxInputChars(t *testing.T) {
 	zeroed.Embeddings.MaxInputChars = 0
 	assert.NotEqual(t, baseline, zeroed.GenerationFingerprint(),
 		"GenerationFingerprint should change when MaxInputChars goes 6000→0")
+}
+
+func TestConfig_GenerationFingerprint_IncludesEmbeddingPrefixes(t *testing.T) {
+	check := assert.New(t)
+	const base = `
+[embeddings]
+model = "nomic-embed-text"
+dimension = 768
+max_input_chars = 2000
+`
+	decode := func(t *testing.T, suffix string) Config {
+		t.Helper()
+		var cfg Config
+		_, err := toml.Decode(base+suffix, &cfg)
+		require.NoError(t, err)
+		return cfg
+	}
+
+	unprefixed := decode(t, "")
+	documentPrefixed := decode(t, `document_prefix = "search_document: "`)
+	queryPrefixed := decode(t, `query_prefix = "search_query: "`)
+	bothPrefixed := decode(t, `
+document_prefix = "search_document: "
+query_prefix = "search_query: "
+`)
+
+	check.NotEqual(unprefixed.GenerationFingerprint(), documentPrefixed.GenerationFingerprint())
+	check.NotEqual(unprefixed.GenerationFingerprint(), queryPrefixed.GenerationFingerprint())
+	check.NotEqual(documentPrefixed.GenerationFingerprint(), bothPrefixed.GenerationFingerprint())
+	check.NotEqual(queryPrefixed.GenerationFingerprint(), bothPrefixed.GenerationFingerprint())
+}
+
+func TestConfig_GenerationFingerprint_EmbeddingPrefixEncodingIsUnambiguous(t *testing.T) {
+	left := Config{Embeddings: EmbeddingsConfig{
+		Model: "m", Dimension: 8, MaxInputChars: 2000,
+		DocumentPrefix: "a\x1fb", QueryPrefix: "c",
+	}}
+	right := left
+	right.Embeddings.DocumentPrefix = "a"
+	right.Embeddings.QueryPrefix = "b\x1fc"
+
+	assert.NotEqual(t, left.GenerationFingerprint(), right.GenerationFingerprint())
 }
 
 // TestConfig_GenerationFingerprint_IncludesEmbedPolicyVersion pins the

--- a/internal/vector/document/model.go
+++ b/internal/vector/document/model.go
@@ -108,13 +108,15 @@ func Fingerprint(extractionProfileID string, cfg vector.Config) (string, error) 
 		return "", fmt.Errorf("fingerprint document vector space: %w", err)
 	}
 	payload := struct {
-		Version             int    `json:"version"`
-		ExtractionProfileID string `json:"extraction_profile_id"`
-		RecipeFingerprint   string `json:"recipe_fingerprint"`
-		VectorSpace         string `json:"vector_space_fingerprint"`
+		Version               int    `json:"version"`
+		ExtractionProfileID   string `json:"extraction_profile_id"`
+		RecipeFingerprint     string `json:"recipe_fingerprint"`
+		VectorSpace           string `json:"vector_space_fingerprint"`
+		TaskPrefixFingerprint string `json:"task_prefix_fingerprint,omitempty"`
 	}{
 		Version: 1, ExtractionProfileID: extractionProfileID,
 		RecipeFingerprint: recipe.Fingerprint(), VectorSpace: spaceFingerprint,
+		TaskPrefixFingerprint: cfg.Embeddings.TaskPrefixFingerprint(),
 	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/vector/document/model_test.go
+++ b/internal/vector/document/model_test.go
@@ -16,14 +16,16 @@ func requireFingerprint(t *testing.T, extractionProfileID string, config vector.
 }
 
 func TestFingerprintBindsDocumentExtractionAndEmbeddingPolicy(t *testing.T) {
+	check := assert.New(t)
 	config := vector.Config{Embeddings: vector.EmbeddingsConfig{
 		Endpoint:  "https://embeddings.example.test/v1",
 		APIFormat: vector.APIFormatOpenAI, Model: "embed-v1", Dimension: 768, MaxInputChars: 8192,
 	}}
 
 	baseline := requireFingerprint(t, "extract-v1", config)
-	assert.Regexp(t, "^[0-9a-f]{64}$", baseline)
-	assert.Equal(t, baseline, requireFingerprint(t, "extract-v1", config))
+	check.Regexp("^[0-9a-f]{64}$", baseline)
+	check.Equal("9e8ac42634c6e981a20950e20f612f4bf692dd460a07491643e2cb5853278f64", baseline)
+	check.Equal(baseline, requireFingerprint(t, "extract-v1", config))
 
 	tests := []struct {
 		name   string
@@ -34,15 +36,17 @@ func TestFingerprintBindsDocumentExtractionAndEmbeddingPolicy(t *testing.T) {
 		{name: "model", mutate: func(c *vector.Config) { c.Embeddings.Model = "embed-v2" }},
 		{name: "dimension", mutate: func(c *vector.Config) { c.Embeddings.Dimension++ }},
 		{name: "max input chars", mutate: func(c *vector.Config) { c.Embeddings.MaxInputChars++ }},
+		{name: "document prefix", mutate: func(c *vector.Config) { c.Embeddings.DocumentPrefix = "search_document: " }},
+		{name: "query prefix", mutate: func(c *vector.Config) { c.Embeddings.QueryPrefix = "search_query: " }},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			changed := config
 			test.mutate(&changed)
-			assert.NotEqual(t, baseline, requireFingerprint(t, "extract-v1", changed))
+			assert.New(t).NotEqual(baseline, requireFingerprint(t, "extract-v1", changed))
 		})
 	}
-	assert.NotEqual(t, baseline, requireFingerprint(t, "extract-v2", config))
+	check.NotEqual(baseline, requireFingerprint(t, "extract-v2", config))
 }
 
 func TestFingerprintExcludesMessageCorpusAndCredentials(t *testing.T) {

--- a/internal/vector/embed/assemble.go
+++ b/internal/vector/embed/assemble.go
@@ -27,11 +27,12 @@ var ErrSourceSnapshotClosed = errors.New("embedding source snapshot is closed")
 // activation-path filter; it is evaluated before an ordinary or meeting
 // document is rendered.
 type AssemblyPolicy struct {
-	MaxChunkRunes        int
-	MaxDocumentUTF8Bytes int
-	ChatGap              time.Duration
-	Preprocess           PreprocessConfig
-	SkipMessage          func(AssemblyMessage) bool
+	MaxChunkRunes           int
+	MaxDocumentUTF8Bytes    int
+	DocumentPrefixUTF8Bytes int
+	ChatGap                 time.Duration
+	Preprocess              PreprocessConfig
+	SkipMessage             func(AssemblyMessage) bool
 }
 
 // AssemblyMessage is the source row used by the deterministic assemblers.
@@ -757,7 +758,8 @@ func assembleOrdinaryDocument(row AssemblyMessage, policy AssemblyPolicy) (Docum
 			Truncated:   bodyTruncated || tailDropped,
 		})
 	}
-	chunks = limitOwnedChunksToRequest(chunks, policy.MaxDocumentUTF8Bytes, defaultVoyageRequestLimits.MaxChunks)
+	chunks = limitOwnedChunksToRequest(chunks, policy.MaxDocumentUTF8Bytes,
+		defaultVoyageRequestLimits.MaxChunks, policy.DocumentPrefixUTF8Bytes)
 	if len(chunks) == 0 {
 		return Document{}, false
 	}
@@ -775,7 +777,7 @@ func assembleOrdinaryDocument(row AssemblyMessage, policy AssemblyPolicy) (Docum
 // accounting used by PackDocuments. It preserves a prefix of the source,
 // marks the final retained chunk truncated, and never splits one document
 // across provider requests.
-func limitOwnedChunksToRequest(chunks []OwnedChunk, maxBytes, maxChunks int) []OwnedChunk {
+func limitOwnedChunksToRequest(chunks []OwnedChunk, maxBytes, maxChunks, documentPrefixBytes int) []OwnedChunk {
 	if len(chunks) == 0 || (maxBytes <= 0 && maxChunks <= 0) {
 		return chunks
 	}
@@ -792,7 +794,8 @@ func limitOwnedChunksToRequest(chunks []OwnedChunk, maxBytes, maxChunks int) []O
 			out = append(out, chunk)
 			continue
 		}
-		textBudget := remaining - voyagePromptReserveUTF8BytesPerChunk
+		chunkReserve := voyagePromptReserveUTF8BytesPerChunk + max(0, documentPrefixBytes)
+		textBudget := remaining - chunkReserve
 		if textBudget <= 0 {
 			dropped = true
 			break
@@ -810,7 +813,7 @@ func limitOwnedChunksToRequest(chunks []OwnedChunk, maxBytes, maxChunks int) []O
 			break
 		}
 		out = append(out, chunk)
-		remaining -= len(chunk.Text) + voyagePromptReserveUTF8BytesPerChunk
+		remaining -= len(chunk.Text) + chunkReserve
 	}
 	if dropped && len(out) > 0 {
 		out[len(out)-1].Truncated = true
@@ -863,6 +866,9 @@ func documentRevision(kind string, row AssemblyMessage, policy AssemblyPolicy, c
 	h := sha256.New()
 	_, _ = fmt.Fprintf(h, "%s\x00%d\x00%d\x00%s\x00%d\x00%d\x00", kind, row.ID,
 		row.ConversationID, row.MessageType, policy.MaxChunkRunes, policy.MaxDocumentUTF8Bytes)
+	if policy.DocumentPrefixUTF8Bytes > 0 {
+		_, _ = fmt.Fprintf(h, "document-prefix-bytes:%d\x00", policy.DocumentPrefixUTF8Bytes)
+	}
 	for _, chunk := range chunks {
 		_, _ = fmt.Fprintf(h, "%d\x00%d\x00%d\x00%d\x00%d\x00%t\x00%s\x00",
 			chunk.MessageID, chunk.ChunkIndex, chunk.SourceCharStart, chunk.SourceCharEnd,

--- a/internal/vector/embed/assemble_chat.go
+++ b/internal/vector/embed/assemble_chat.go
@@ -163,7 +163,9 @@ func (a ChatWindowAssembler) sessionize(
 	currentBytes := 0
 	for _, member := range members {
 		header := chatHeader(conversation, member.row.SentAt, includeMutableMetadata)
-		memberBytes := chatMemberEmbeddingBytes(header, member, includeMutableMetadata)
+		memberBytes := chatMemberEmbeddingBytes(
+			header, member, includeMutableMetadata, a.Policy.DocumentPrefixUTF8Bytes,
+		)
 		split := false
 		if len(current) != 0 {
 			previous := current[len(current)-1]
@@ -211,7 +213,8 @@ func (a ChatWindowAssembler) document(
 			})
 		}
 	}
-	chunks = limitOwnedChunksToRequest(chunks, a.Policy.MaxDocumentUTF8Bytes, defaultVoyageRequestLimits.MaxChunks)
+	chunks = limitOwnedChunksToRequest(chunks, a.Policy.MaxDocumentUTF8Bytes,
+		defaultVoyageRequestLimits.MaxChunks, a.Policy.DocumentPrefixUTF8Bytes)
 	key := "chat:" + strconv.FormatInt(conversation.ID, 10) + ":" +
 		chatDocumentPolicyVersion + ":" + strconv.FormatInt(anchor.ID, 10)
 	metadataVersion := conversation.MetadataVersion
@@ -271,10 +274,13 @@ func contextualChatText(
 	return header + "\n\n" + sender + " (" + timestamp + "): " + source
 }
 
-func chatMemberEmbeddingBytes(header string, member chatMember, includeMutableMetadata bool) int {
+func chatMemberEmbeddingBytes(
+	header string, member chatMember, includeMutableMetadata bool, documentPrefixBytes int,
+) int {
 	total := 0
 	for _, span := range member.chunks {
-		total += len(contextualChatText(header, member.row, span.Text, includeMutableMetadata)) + voyagePromptReserveUTF8BytesPerChunk
+		total += len(contextualChatText(header, member.row, span.Text, includeMutableMetadata)) +
+			voyagePromptReserveUTF8BytesPerChunk + max(0, documentPrefixBytes)
 	}
 	return total
 }

--- a/internal/vector/embed/assemble_meeting.go
+++ b/internal/vector/embed/assemble_meeting.go
@@ -66,7 +66,8 @@ func AssembleMeetingDocument(row AssemblyMessage, policy AssemblyPolicy) (Docume
 		chunks[i].ChunkIndex = i
 		chunks[i].Truncated = chunks[i].Truncated || bodyTruncated
 	}
-	chunks = limitOwnedChunksToRequest(chunks, policy.MaxDocumentUTF8Bytes, defaultVoyageRequestLimits.MaxChunks)
+	chunks = limitOwnedChunksToRequest(chunks, policy.MaxDocumentUTF8Bytes,
+		defaultVoyageRequestLimits.MaxChunks, policy.DocumentPrefixUTF8Bytes)
 	key := "meeting:" + strconv.FormatInt(row.ID, 10)
 	return Document{
 		Key: key, Kind: "meeting-transcript", ScopeKey: key,

--- a/internal/vector/embed/assemble_test.go
+++ b/internal/vector/embed/assemble_test.go
@@ -2,7 +2,9 @@ package embed
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
@@ -34,6 +36,66 @@ func TestAssembleOrdinaryDocument_AlwaysFitsContextualRequestBudget(t *testing.T
 	})
 	require.NoError(err)
 	assert.True(t, doc.Chunks[len(doc.Chunks)-1].Truncated)
+}
+
+func TestAssembleOrdinaryDocument_ReservesDocumentPrefixBytes(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	const prefix = "search_document: "
+	policy := AssemblyPolicy{
+		MaxChunkRunes: 128, MaxDocumentUTF8Bytes: 220,
+		DocumentPrefixUTF8Bytes: len(prefix),
+	}
+	doc, ok := assembleOrdinaryDocument(AssemblyMessage{
+		ID: 1, ConversationID: 2, MessageType: "email",
+		Body: strings.Repeat("🙂", 128), LastModified: "v1",
+	}, policy)
+	must.True(ok)
+	must.NotEmpty(doc.Chunks)
+
+	input := DocumentInput{Chunks: make([]string, len(doc.Chunks))}
+	for i, chunk := range doc.Chunks {
+		input.Chunks[i] = prefix + chunk.Text
+	}
+	_, err := PackDocuments([]DocumentInput{input}, RequestLimits{
+		MaxDocuments: 1, MaxChunks: 16_000, MaxUTF8Bytes: policy.MaxDocumentUTF8Bytes,
+	})
+
+	must.NoError(err)
+	check.True(doc.Chunks[len(doc.Chunks)-1].Truncated)
+}
+
+func TestAssembleOrdinaryDocument_EmptyPrefixPreservesLegacyRevision(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	row := AssemblyMessage{
+		ID: 1, ConversationID: 2, MessageType: "email", Subject: "subject",
+		Body: "short body", LastModified: "v1",
+	}
+	policy := AssemblyPolicy{MaxChunkRunes: 128, MaxDocumentUTF8Bytes: 220}
+	legacy, ok := assembleOrdinaryDocument(row, policy)
+	must.True(ok)
+	check.Equal(legacyDocumentRevision("ordinary", row, policy, legacy.Chunks), legacy.Revision)
+
+	prefixedPolicy := policy
+	prefixedPolicy.DocumentPrefixUTF8Bytes = len("search_document: ")
+	prefixed, ok := assembleOrdinaryDocument(row, prefixedPolicy)
+	must.True(ok)
+	check.NotEqual(legacy.Revision, prefixed.Revision)
+}
+
+func legacyDocumentRevision(
+	kind string, row AssemblyMessage, policy AssemblyPolicy, chunks []OwnedChunk,
+) string {
+	h := sha256.New()
+	_, _ = fmt.Fprintf(h, "%s\x00%d\x00%d\x00%s\x00%d\x00%d\x00", kind, row.ID,
+		row.ConversationID, row.MessageType, policy.MaxChunkRunes, policy.MaxDocumentUTF8Bytes)
+	for _, chunk := range chunks {
+		_, _ = fmt.Fprintf(h, "%d\x00%d\x00%d\x00%d\x00%d\x00%t\x00%s\x00",
+			chunk.MessageID, chunk.ChunkIndex, chunk.SourceCharStart, chunk.SourceCharEnd,
+			chunk.SourceBasis, chunk.Truncated, chunk.Text)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 type chatAssemblerStub struct{}

--- a/internal/vector/embed/client.go
+++ b/internal/vector/embed/client.go
@@ -35,6 +35,10 @@ type Config struct {
 	APIKey string
 	// Model is the model name passed in the request body.
 	Model string
+	// DocumentPrefix is prepended to every document chunk before it is sent.
+	DocumentPrefix string
+	// QueryPrefix is prepended to every query before it is sent.
+	QueryPrefix string
 	// Dimension is the expected vector dimension. Responses whose vectors
 	// differ are rejected with an error.
 	Dimension int
@@ -84,7 +88,8 @@ type embeddingResponse struct {
 	Model string `json:"model"`
 }
 
-// Embed returns one vector per input, in input order. Empty input is a no-op
+// Embed embeds document chunks and returns one vector per input, in input order.
+// DocumentPrefix is applied independently to every input. Empty input is a no-op
 // and returns (nil, nil) without making an HTTP call. Every returned vector
 // is verified to match cfg.Dimension. Transient errors — 5xx responses, 429
 // Too Many Requests, network failures, and body-read / decode hiccups — are
@@ -92,6 +97,10 @@ type embeddingResponse struct {
 // 429 response's Retry-After header (when present and parseable) overrides
 // the backoff for that attempt. Other 4xx responses fail immediately.
 func (c *Client) Embed(ctx context.Context, inputs []string) ([][]float32, error) {
+	return c.embed(ctx, prependPrefix(inputs, c.cfg.DocumentPrefix))
+}
+
+func (c *Client) embed(ctx context.Context, inputs []string) ([][]float32, error) {
 	if len(inputs) == 0 {
 		return nil, nil
 	}
@@ -149,7 +158,7 @@ func (c *Client) Embed(ctx context.Context, inputs []string) ([][]float32, error
 
 // EmbedQuery embeds one query and returns its single vector.
 func (c *Client) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
-	vecs, err := c.Embed(ctx, []string{text})
+	vecs, err := c.embed(ctx, prependPrefix([]string{text}, c.cfg.QueryPrefix))
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +176,7 @@ func (c *Client) EmbedDocuments(ctx context.Context, documents []DocumentInput) 
 		inputs = append(inputs, document.Chunks...)
 	}
 
-	vecs, err := c.Embed(ctx, inputs)
+	vecs, err := c.embed(ctx, prependPrefix(inputs, c.cfg.DocumentPrefix))
 	if err != nil {
 		return nil, err
 	}
@@ -183,6 +192,17 @@ func (c *Client) EmbedDocuments(ctx context.Context, documents []DocumentInput) 
 		offset = next
 	}
 	return documentVecs, nil
+}
+
+func prependPrefix(inputs []string, prefix string) []string {
+	if prefix == "" || len(inputs) == 0 {
+		return inputs
+	}
+	prefixed := make([]string, len(inputs))
+	for i, input := range inputs {
+		prefixed[i] = prefix + input
+	}
+	return prefixed
 }
 
 // doOnce performs a single HTTP request. A returned *retryError signals the

--- a/internal/vector/embed/client_test.go
+++ b/internal/vector/embed/client_test.go
@@ -107,6 +107,41 @@ func TestClient_EmbedQueryUsesSingleInput(t *testing.T) {
 	assert.Equal(t, []float32{1}, got)
 }
 
+func TestClient_AppliesEmbeddingPrefixesByRole(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	var calls [][]string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := decodeRequest(t, r)
+		calls = append(calls, request.Input)
+		vectors := make([][]float32, len(request.Input))
+		for i := range vectors {
+			vectors[i] = []float32{float32(i + 1)}
+		}
+		writeEmbeddings(t, w, vectors)
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(Config{
+		Endpoint: server.URL, Model: "test-model", Dimension: 1,
+		DocumentPrefix: "search_document: ", QueryPrefix: "search_query: ",
+	})
+
+	_, err := client.EmbedDocuments(t.Context(), []DocumentInput{
+		{Chunks: []string{"first chunk", "second chunk"}},
+	})
+	must.NoError(err)
+	_, err = client.EmbedQuery(t.Context(), "find this")
+	must.NoError(err)
+	_, err = client.Embed(t.Context(), []string{"legacy worker chunk"})
+	must.NoError(err)
+
+	check.Equal([][]string{
+		{"search_document: first chunk", "search_document: second chunk"},
+		{"search_query: find this"},
+		{"search_document: legacy worker chunk"},
+	}, calls)
+}
+
 // TestClientBeforeRequestFencesEveryRetryAttempt catches a consent check that
 // runs once around the logical embedding operation instead of immediately
 // before every real HTTP attempt. Query retries are included because curated

--- a/internal/vector/embed/context_worker.go
+++ b/internal/vector/embed/context_worker.go
@@ -54,10 +54,11 @@ type ContextWorkerDeps struct {
 	Client     SemanticClient
 	BuildScope vector.BuildScope
 
-	ChangeBatchSize    int
-	ReconcileBatchSize int
-	MaxRunUTF8Bytes    int
-	Hooks              ContextWorkerHooks
+	ChangeBatchSize         int
+	ReconcileBatchSize      int
+	MaxRunUTF8Bytes         int
+	DocumentPrefixUTF8Bytes int
+	Hooks                   ContextWorkerHooks
 }
 
 // ContextConvergence is the durable state Task 10 can use for activation and
@@ -712,7 +713,7 @@ func (w *ContextWorker) publishPreparedScopes(ctx context.Context, gen vector.Ge
 			for chunkIndex, chunk := range doc.Chunks {
 				input.Chunks[chunkIndex] = chunk.Text
 			}
-			scopeBytes += documentInputUTF8Bytes(input)
+			scopeBytes += documentInputUTF8Bytes(input, w.deps.DocumentPrefixUTF8Bytes)
 		}
 		// Assembly and source reads consume bounded work even when durable
 		// vectors can be preserved or a scope now needs only a tombstone.
@@ -1019,10 +1020,10 @@ func successfulPreparedDocuments(plan preparedScopePublication) ([]Document, [][
 	return documents, vectors, preserved
 }
 
-func documentInputUTF8Bytes(input DocumentInput) int {
+func documentInputUTF8Bytes(input DocumentInput, documentPrefixBytes int) int {
 	total := 0
 	for _, chunk := range input.Chunks {
-		total += len(chunk) + voyagePromptReserveUTF8BytesPerChunk
+		total += len(chunk) + voyagePromptReserveUTF8BytesPerChunk + max(0, documentPrefixBytes)
 	}
 	return total
 }

--- a/internal/vector/embed/context_worker_test.go
+++ b/internal/vector/embed/context_worker_test.go
@@ -767,7 +767,7 @@ func TestContextWorker_MetadataFanoutBudgetsPreservedScopes(t *testing.T) {
 	for i, chunk := range documents[0].Chunks {
 		input.Chunks[i] = chunk.Text
 	}
-	f.worker.deps.MaxRunUTF8Bytes = documentInputUTF8Bytes(input)
+	f.worker.deps.MaxRunUTF8Bytes = documentInputUTF8Bytes(input, 0)
 	counted.calls = 0
 	counted.selectors = make(map[AffectedScope]int)
 	beforeDocuments := f.client.Documents()
@@ -792,6 +792,14 @@ func TestContextWorker_MetadataFanoutBudgetsPreservedScopes(t *testing.T) {
 		selector := chatDayContextScope(f.chatID, start.AddDate(0, 0, day)).selector
 		assert.Positive(t, counted.selectors[selector])
 	}
+}
+
+func TestDocumentInputUTF8BytesIncludesDocumentPrefixPerChunk(t *testing.T) {
+	input := DocumentInput{Chunks: []string{"first", "second"}}
+	withoutPrefix := documentInputUTF8Bytes(input, 0)
+
+	assert.Equal(t, withoutPrefix+2*len("search_document: "),
+		documentInputUTF8Bytes(input, len("search_document: ")))
 }
 
 func TestContextWorker_MetadataFanoutUsesBoundedResumablePages(t *testing.T) {
@@ -1100,7 +1108,7 @@ func TestContextWorker_MetadataFanoutHonorsPerRunByteBudgetAndResumes(t *testing
 	for i, chunk := range documents[0].Chunks {
 		input.Chunks[i] = chunk.Text
 	}
-	f.worker.deps.MaxRunUTF8Bytes = documentInputUTF8Bytes(input)
+	f.worker.deps.MaxRunUTF8Bytes = documentInputUTF8Bytes(input, 0)
 	counted.calls = 0
 	counted.selectors = make(map[AffectedScope]int)
 	for run := 1; run <= 5; run++ {

--- a/internal/vector/embed/voyage.go
+++ b/internal/vector/embed/voyage.go
@@ -23,6 +23,10 @@ type VoyageConfig struct {
 	Timeout    time.Duration
 	MaxRetries int
 	Limits     RequestLimits
+	// DocumentPrefix is prepended to every document chunk before packing.
+	DocumentPrefix string
+	// QueryPrefix is prepended to the query before packing.
+	QueryPrefix string
 	// BeforeRequest reauthorizes each concrete HTTP attempt. A returned error
 	// is propagated without retrying. Nil leaves the client ungated.
 	BeforeRequest BeforeRequestFunc
@@ -79,7 +83,9 @@ type voyageResponse struct {
 
 // EmbedQuery embeds one independent query with Voyage's query role.
 func (c *VoyageClient) EmbedQuery(ctx context.Context, text string) ([]float32, error) {
-	batches, err := PackDocuments([]DocumentInput{{Chunks: []string{text}}}, c.cfg.Limits)
+	batches, err := PackDocuments([]DocumentInput{{
+		Chunks: prependPrefix([]string{text}, c.cfg.QueryPrefix),
+	}}, c.cfg.Limits)
 	if err != nil {
 		return nil, fmt.Errorf("embed query: %w", err)
 	}
@@ -102,7 +108,7 @@ func (c *VoyageClient) EmbedDocuments(ctx context.Context, documents []DocumentI
 	if len(documents) == 0 {
 		return nil, nil
 	}
-	batches, err := PackDocuments(documents, c.cfg.Limits)
+	batches, err := PackDocuments(prependDocumentPrefix(documents, c.cfg.DocumentPrefix), c.cfg.Limits)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +122,17 @@ func (c *VoyageClient) EmbedDocuments(ctx context.Context, documents []DocumentI
 		results = append(results, batchResults...)
 	}
 	return results, nil
+}
+
+func prependDocumentPrefix(documents []DocumentInput, prefix string) []DocumentInput {
+	if prefix == "" || len(documents) == 0 {
+		return documents
+	}
+	prefixed := make([]DocumentInput, len(documents))
+	for i, document := range documents {
+		prefixed[i].Chunks = prependPrefix(document.Chunks, prefix)
+	}
+	return prefixed
 }
 
 func documentInputs(documents []DocumentInput) [][]string {

--- a/internal/vector/embed/voyage_test.go
+++ b/internal/vector/embed/voyage_test.go
@@ -717,6 +717,35 @@ func TestVoyageClient_EmbedQueryUsesQueryRole(t *testing.T) {
 	assert.Equal([]float32{1, 1, 1, 1}, got)
 }
 
+func TestVoyageClient_AppliesEmbeddingPrefixesByRole(t *testing.T) {
+	check := assert.New(t)
+	must := require.New(t)
+	var captured []capturedVoyageRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := decodeVoyageRequest(t, r)
+		captured = append(captured, request)
+		writeVoyageResponse(t, w, sequentialVoyageResults(request.Inputs))
+	}))
+	t.Cleanup(server.Close)
+	client := newVoyageClient(server.URL, func(cfg *embed.VoyageConfig) {
+		cfg.DocumentPrefix = "search_document: "
+		cfg.QueryPrefix = "search_query: "
+	})
+
+	_, err := client.EmbedDocuments(t.Context(), []embed.DocumentInput{
+		{Chunks: []string{"first chunk", "second chunk"}},
+	})
+	must.NoError(err)
+	_, err = client.EmbedQuery(t.Context(), "find this")
+	must.NoError(err)
+
+	must.Len(captured, 2)
+	check.Equal("document", captured[0].InputType)
+	check.Equal([][]string{{"search_document: first chunk", "search_document: second chunk"}}, captured[0].Inputs)
+	check.Equal("query", captured[1].InputType)
+	check.Equal([][]string{{"search_query: find this"}}, captured[1].Inputs)
+}
+
 func TestVoyageClient_RejectsDuplicateOuterIndex(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeVoyageResponse(t, w, []voyageResponseResult{

--- a/web/src/lib/settings/catalog.test.ts
+++ b/web/src/lib/settings/catalog.test.ts
@@ -16,6 +16,8 @@ describe('settings catalog', () => {
       'openai',
       'voyage-contextual'
     ]);
+    expect(settingsCatalog['vector.embeddings.document_prefix'].description).toContain('document chunk');
+    expect(settingsCatalog['vector.embeddings.query_prefix'].description).toContain('search query');
     expect(settingsCatalog['vector.embed.scope.accounts'].group).toBe('search');
     expect(settingsCatalog['vector.multimodal.enabled'].group).toBe('search');
     expect(settingsCatalog['vector.multimodal.provider'].options).toEqual(['voyage']);

--- a/web/src/lib/settings/catalog.ts
+++ b/web/src/lib/settings/catalog.ts
@@ -72,6 +72,8 @@ export const settingsCatalog: Record<string, CatalogEntry> = {
   }),
   'vector.embeddings.api_key_env': entry('search', 'Embedding key environment variable', 'Environment variable containing the endpoint key.'),
   'vector.embeddings.model': entry('search', 'Embedding model', 'Model identifier used to build an index generation.'),
+  'vector.embeddings.document_prefix': entry('search', 'Document task prefix', 'Text prepended to every document chunk.'),
+  'vector.embeddings.query_prefix': entry('search', 'Query task prefix', 'Text prepended to every vector search query.'),
   'vector.embeddings.dimension': entry('search', 'Embedding dimension', 'Vector dimension returned by the model.'),
   'vector.embeddings.batch_size': entry('search', 'Embedding batch size', 'Items sent per embedding request.'),
   'vector.embeddings.max_retries': entry('search', 'Embedding retries', 'Maximum transient request retries.'),


### PR DESCRIPTION
## What changed

- Add `document_prefix` and `query_prefix` to `[vector.embeddings]`, including the Settings UI, for OpenAI-compatible and Voyage contextual providers.
- Apply the document prefix to every message, person, and attachment chunk after chunking, and apply the query prefix to every vector-search query without reducing `max_input_chars`.
- Bind both prefixes to message, person, and attachment generation identities while preserving exact legacy fingerprints and document revisions when both values are empty.
- Keep Voyage request and run budgets prefix-aware, and reject task prefixes larger than 4096 UTF-8 bytes instead of allowing an empty contextual index.

## Why

Models such as `nomic-embed-text` require different task instructions for indexed documents and search queries. Without role-aware prefixes, msgvault cannot configure those models correctly and can compare query vectors against documents embedded for the wrong task.

## Usage

```toml
[vector.embeddings]
model = "nomic-embed-text"
document_prefix = "search_document: "
query_prefix = "search_query: "
```

Leave both values empty for models that do not use task instructions. Changing either value makes the current vector generation stale; rebuild it with `msgvault embeddings build --full-rebuild --yes`.

Closes #673
