### PR TITLE
fix(mime): salvage headers after fatal parse

### DIFF
--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -34,14 +34,7 @@ func IngestRawMessage(
 	raw []byte, fallbackDate time.Time,
 	log *slog.Logger,
 ) error {
-	parsed, parseErr := mime.Parse(raw)
-	if parseErr != nil {
-		errMsg := textutil.FirstLine(parseErr.Error())
-		parsed = &mime.Message{
-			Subject:  "(MIME parse error)",
-			BodyText: fmt.Sprintf("[MIME parsing failed: %s]\n\nRaw MIME data is preserved in message_raw table.", errMsg),
-		}
-	}
+	parsed, _ := mime.ParseWithRecovery(raw, "(MIME parse error)")
 
 	subject := textutil.EnsureUTF8(parsed.Subject)
 	bodyText := textutil.EnsureUTF8(parsed.GetBodyText())

--- a/internal/importer/ingest_test.go
+++ b/internal/importer/ingest_test.go
@@ -125,6 +125,62 @@ func TestIngestRawMessage_SanitizesAddressFields(t *testing.T) {
 	require.NoError(rows2.Err(), "conversations rows")
 }
 
+func TestIngestRawMessage_SalvagesHeadersAfterFatalMIMEParse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(err, "open store")
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchema(), "init schema")
+
+	src, err := st.GetOrCreateSource("test", "owner@example.test")
+	require.NoError(err, "get/create source")
+	raw := []byte("From: Sender Example <sender@example.test>\r\n" +
+		"To: Owner Example <owner@example.test>\r\n" +
+		"Subject: Recovered import\r\n" +
+		"Date: Tue, 02 Jan 2024 15:04:05 +0000\r\n" +
+		"Message-ID: <recovered-import@example.test>\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart mixed; boundary=outer\r\n\r\n" +
+		"--outer\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--outer--\r\n")
+
+	err = IngestRawMessage(
+		context.Background(), st,
+		src.ID, "owner@example.test", "",
+		nil, "source-msg-recovery", "fakehash",
+		raw, time.Time{}, slog.Default(),
+	)
+	require.NoError(err, "IngestRawMessage")
+
+	var subject, body, sender string
+	var sentAt time.Time
+	err = st.DB().QueryRow(
+		`SELECT m.subject, mb.body_text, m.sent_at, p.email_address
+		 FROM messages m
+		 JOIN message_bodies mb ON mb.message_id = m.id
+		 JOIN participants p ON p.id = m.sender_id
+		 WHERE m.source_message_id = ?`,
+		"source-msg-recovery",
+	).Scan(&subject, &body, &sentAt, &sender)
+	require.NoError(err, "query recovered message")
+	assert.Equal("Recovered import", subject)
+	assert.Contains(body, "MIME parsing failed")
+	assert.Equal(time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC), sentAt.UTC())
+	assert.Equal("sender@example.test", sender)
+
+	var recipients int
+	err = st.DB().QueryRow(
+		`SELECT COUNT(*)
+		 FROM message_recipients mr
+		 JOIN messages m ON m.id = mr.message_id
+		 WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`,
+		"source-msg-recovery",
+	).Scan(&recipients)
+	require.NoError(err, "query recovered recipients")
+	assert.Equal(1, recipients)
+}
+
 func TestIngestRawMessage_InvalidUTF8_RecipientLinkage(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -156,9 +156,10 @@ func ParseWithRecovery(raw []byte, fallbackSubject string) (*Message, error) {
 func salvageHeaders(raw []byte) *Message {
 	headers := tokenizeHeaders(raw)
 	msg := &Message{
-		Subject:   decodeHeader(firstHeader(headers, "subject")),
-		MessageID: firstHeader(headers, "message-id"),
-		InReplyTo: firstHeader(headers, "in-reply-to"),
+		Subject:       decodeHeader(firstHeader(headers, "subject")),
+		ReceivedDates: ParseReceivedChain(headers["received"]),
+		MessageID:     firstHeader(headers, "message-id"),
+		InReplyTo:     firstHeader(headers, "in-reply-to"),
 	}
 
 	if dateHeader := firstHeader(headers, "date"); dateHeader != "" {

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -158,8 +158,8 @@ func salvageHeaders(raw []byte) *Message {
 	msg := &Message{
 		Subject:       decodeHeader(firstHeader(headers, "subject")),
 		ReceivedDates: ParseReceivedChain(headers["received"]),
-		MessageID:     firstHeader(headers, "message-id"),
-		InReplyTo:     firstHeader(headers, "in-reply-to"),
+		MessageID:     strings.ToValidUTF8(firstHeader(headers, "message-id"), "\uFFFD"),
+		InReplyTo:     strings.ToValidUTF8(firstHeader(headers, "in-reply-to"), "\uFFFD"),
 	}
 
 	if dateHeader := firstHeader(headers, "date"); dateHeader != "" {
@@ -171,7 +171,9 @@ func salvageHeaders(raw []byte) *Message {
 	msg.Cc = parseSalvagedAddressList(joinHeaders(headers, "cc"))
 	msg.Bcc = parseSalvagedAddressList(joinHeaders(headers, "bcc"))
 	msg.ReplyTo = parseSalvagedAddressList(joinHeaders(headers, "reply-to"))
-	msg.References = parseReferences(firstHeader(headers, "references"))
+	msg.References = parseReferences(strings.ToValidUTF8(
+		firstHeader(headers, "references"), "\uFFFD",
+	))
 	return msg
 }
 

--- a/internal/mime/parse.go
+++ b/internal/mime/parse.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"html"
+	stdmime "mime"
+	"net/mail"
 	"regexp"
 	"strings"
 	"time"
@@ -16,9 +18,10 @@ import (
 )
 
 const (
-	defaultContentType   = "text/plain"
-	fallbackContentType  = "application/octet-stream"
-	malformedContentType = "application/x-msgvault-malformed"
+	defaultContentType     = "text/plain"
+	fallbackContentType    = "application/octet-stream"
+	malformedContentType   = "application/x-msgvault-malformed"
+	maxRecoveryHeaderBytes = 256 * 1024
 )
 
 var envelopeParser = enmime.NewParser(
@@ -127,6 +130,157 @@ func Parse(raw []byte) (*Message, error) {
 	}
 
 	return msg, nil
+}
+
+// ParseWithRecovery parses a message and salvages its top-level headers when
+// malformed MIME structure prevents full envelope parsing. Body content and
+// attachments remain unavailable after a fatal parse error.
+func ParseWithRecovery(raw []byte, fallbackSubject string) (*Message, error) {
+	msg, err := Parse(raw)
+	if err == nil {
+		return msg, nil
+	}
+
+	msg = salvageHeaders(raw)
+	if msg.Subject == "" {
+		msg.Subject = fallbackSubject
+	}
+	errMsg, _, _ := strings.Cut(err.Error(), "\n")
+	msg.BodyText = fmt.Sprintf(
+		"[MIME parsing failed: %s]\n\nRaw MIME data is preserved in message_raw table.",
+		errMsg,
+	)
+	return msg, err
+}
+
+func salvageHeaders(raw []byte) *Message {
+	headers := tokenizeHeaders(raw)
+	msg := &Message{
+		Subject:   decodeHeader(firstHeader(headers, "subject")),
+		MessageID: firstHeader(headers, "message-id"),
+		InReplyTo: firstHeader(headers, "in-reply-to"),
+	}
+
+	if dateHeader := firstHeader(headers, "date"); dateHeader != "" {
+		msg.RawDateHeader = dateHeader
+		msg.Date = parseDate(dateHeader)
+	}
+	msg.From = parseSalvagedAddressList(joinHeaders(headers, "from"))
+	msg.To = parseSalvagedAddressList(joinHeaders(headers, "to"))
+	msg.Cc = parseSalvagedAddressList(joinHeaders(headers, "cc"))
+	msg.Bcc = parseSalvagedAddressList(joinHeaders(headers, "bcc"))
+	msg.ReplyTo = parseSalvagedAddressList(joinHeaders(headers, "reply-to"))
+	msg.References = parseReferences(firstHeader(headers, "references"))
+	return msg
+}
+
+func tokenizeHeaders(raw []byte) map[string][]string {
+	truncated := len(raw) > maxRecoveryHeaderBytes
+	if truncated {
+		raw = raw[:maxRecoveryHeaderBytes]
+	}
+
+	type header struct {
+		name  string
+		value []byte
+	}
+
+	var parsed []header
+	current := -1
+	for len(raw) > 0 {
+		lineEnd := bytes.IndexByte(raw, '\n')
+		var line []byte
+		if lineEnd < 0 {
+			if truncated {
+				break
+			}
+			line, raw = raw, nil
+		} else {
+			line, raw = raw[:lineEnd], raw[lineEnd+1:]
+		}
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		if len(bytes.TrimSpace(line)) == 0 {
+			break
+		}
+
+		if line[0] == ' ' || line[0] == '\t' {
+			if current >= 0 {
+				parsed[current].value = append(parsed[current].value, ' ')
+				parsed[current].value = append(parsed[current].value, bytes.TrimSpace(line)...)
+			}
+			continue
+		}
+
+		colon := bytes.IndexByte(line, ':')
+		if colon <= 0 || !validHeaderName(line[:colon]) {
+			current = -1
+			continue
+		}
+		current = len(parsed)
+		parsed = append(parsed, header{
+			name:  strings.ToLower(string(line[:colon])),
+			value: append([]byte(nil), bytes.TrimSpace(line[colon+1:])...),
+		})
+	}
+
+	headers := make(map[string][]string)
+	for _, header := range parsed {
+		headers[header.name] = append(headers[header.name], string(header.value))
+	}
+	return headers
+}
+
+func validHeaderName(name []byte) bool {
+	for _, b := range name {
+		if b < 33 || b > 126 || b == ':' {
+			return false
+		}
+	}
+	return len(name) > 0
+}
+
+func firstHeader(headers map[string][]string, name string) string {
+	values := headers[name]
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func joinHeaders(headers map[string][]string, name string) string {
+	return strings.Join(headers[name], ", ")
+}
+
+func decodeHeader(value string) string {
+	decoded, err := new(stdmime.WordDecoder).DecodeHeader(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func parseSalvagedAddressList(value string) []Address {
+	if value == "" {
+		return nil
+	}
+	list, err := mail.ParseAddressList(value)
+	if err != nil {
+		return fallbackAddressList(value)
+	}
+
+	addresses := make([]Address, 0, len(list))
+	for _, addr := range list {
+		if addr.Address == "" {
+			continue
+		}
+		email := strings.ToLower(addr.Address)
+		addresses = append(addresses, Address{
+			Name:   addr.Name,
+			Email:  email,
+			Domain: extractDomain(email),
+		})
+	}
+	return addresses
 }
 
 func parseMediaTypeLenient(value string) (

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -1,6 +1,7 @@
 package mime
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -165,6 +166,117 @@ func TestParse_InvalidMultipartContentTypeWithBoundaryRemainsFatal(t *testing.T)
 	msg, err := Parse(raw)
 	assert.Nil(t, msg)
 	require.ErrorContains(t, err, "expected slash after first token")
+}
+
+func TestParseWithRecovery_FatalMultipartSalvagesHeaders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	raw := []byte("From: Sender Example <sender@example.test>\r\n" +
+		"To: Recipient Example <recipient@example.test>\r\n" +
+		"Cc: Copy Example <copy@example.test>\r\n" +
+		"Subject: =?UTF-8?Q?Recovered_=E2=9C=93?=\r\n" +
+		"Date: Tue, 02 Jan 2024 15:04:05 +0000\r\n" +
+		"Message-ID: <message@example.test>\r\n" +
+		"In-Reply-To: <parent@example.test>\r\n" +
+		"References: <root@example.test>\r\n" +
+		"\t<parent@example.test>\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart mixed; boundary=outer\r\n\r\n" +
+		"--outer\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--outer--\r\n")
+
+	msg, err := ParseWithRecovery(raw, "snippet fallback")
+	require.ErrorContains(err, "expected slash after first token")
+	require.NotNil(msg)
+	assert.Equal("Recovered ✓", msg.Subject)
+	assert.Equal(time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC), msg.Date)
+	assert.Equal("Tue, 02 Jan 2024 15:04:05 +0000", msg.RawDateHeader)
+	assert.Equal([]Address{{
+		Name: "Sender Example", Email: "sender@example.test", Domain: "example.test",
+	}}, msg.From)
+	assert.Equal([]Address{{
+		Name: "Recipient Example", Email: "recipient@example.test", Domain: "example.test",
+	}}, msg.To)
+	assert.Equal([]Address{{
+		Name: "Copy Example", Email: "copy@example.test", Domain: "example.test",
+	}}, msg.Cc)
+	assert.Equal("<message@example.test>", msg.MessageID)
+	assert.Equal("<parent@example.test>", msg.InReplyTo)
+	assert.Equal([]string{"root@example.test", "parent@example.test"}, msg.References)
+	assert.Contains(msg.BodyText, "MIME parsing failed")
+	assert.Contains(msg.BodyText, "Raw MIME data is preserved")
+	assert.Empty(msg.BodyHTML)
+	assert.Empty(msg.Attachments)
+}
+
+func TestParseWithRecovery_UsesFallbackWithoutRecoverableHeaders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	msg, err := ParseWithRecovery(
+		[]byte("not valid mime at all - just garbage"),
+		"snippet fallback",
+	)
+
+	require.Error(err)
+	require.NotNil(msg)
+	assert.Equal("snippet fallback", msg.Subject)
+	assert.Empty(msg.From)
+	assert.True(msg.Date.IsZero())
+	assert.Contains(msg.BodyText, "MIME parsing failed")
+}
+
+func TestParseWithRecovery_DoesNotSalvageHeadersFromBody(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	raw := []byte("Content-Type: multipart mixed; boundary=outer\r\n\r\n" +
+		"Subject: body spoof\r\n" +
+		"From: body@example.test\r\n")
+
+	msg, err := ParseWithRecovery(raw, "snippet fallback")
+
+	require.Error(err)
+	require.NotNil(msg)
+	assert.Equal("snippet fallback", msg.Subject)
+	assert.Empty(msg.From)
+}
+
+func TestParseWithRecovery_SkipsMalformedTopLevelHeaderLine(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	raw := []byte("this is not a header\r\n" +
+		"From: sender@example.test\r\n" +
+		"Subject: recovered after malformed line\r\n\r\n" +
+		"body\r\n")
+
+	msg, err := ParseWithRecovery(raw, "snippet fallback")
+
+	require.Error(err)
+	require.NotNil(msg)
+	assert.Equal("recovered after malformed line", msg.Subject)
+	assert.Equal([]Address{{
+		Email: "sender@example.test", Domain: "example.test",
+	}}, msg.From)
+}
+
+func TestTokenizeHeaders_FoldedHeaderUsesBoundedAllocations(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var raw strings.Builder
+	raw.WriteString("References: <root@example.test>\r\n")
+	for range 4096 {
+		raw.WriteString("\t<next@example.test>\r\n")
+	}
+	raw.WriteString("\r\n")
+	rawBytes := []byte(raw.String())
+
+	headers := tokenizeHeaders(rawBytes)
+	require.Len(headers["references"], 1)
+	assert.Contains(headers["references"][0], "<root@example.test> <next@example.test>")
+
+	allocations := testing.AllocsPerRun(1, func() {
+		tokenizeHeaders(rawBytes)
+	})
+	assert.Less(allocations, 100.0)
 }
 
 // assertAddress checks that got has exactly wantLen elements and got[idx] has the expected email and (optionally) domain.

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -215,6 +215,23 @@ func TestParseWithRecovery_FatalMultipartSalvagesHeaders(t *testing.T) {
 	assert.Empty(msg.Attachments)
 }
 
+func TestParseWithRecovery_FatalMultipartSanitizesThreadingHeaders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	raw := []byte("Message-ID: <message-\xff@example.test>\r\n" +
+		"In-Reply-To: <parent-\xfe@example.test>\r\n" +
+		"References: <root-\xfd@example.test>\r\n" +
+		"Content-Type: multipart mixed; boundary=outer\r\n\r\n" +
+		"--outer--\r\n")
+
+	msg, err := ParseWithRecovery(raw, "snippet fallback")
+
+	require.ErrorContains(err, "expected slash after first token")
+	assert.Equal("<message-\uFFFD@example.test>", msg.MessageID)
+	assert.Equal("<parent-\uFFFD@example.test>", msg.InReplyTo)
+	assert.Equal([]string{"root-\uFFFD@example.test"}, msg.References)
+}
+
 func TestParseWithRecovery_UsesFallbackWithoutRecoverableHeaders(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -176,6 +176,8 @@ func TestParseWithRecovery_FatalMultipartSalvagesHeaders(t *testing.T) {
 		"Cc: Copy Example <copy@example.test>\r\n" +
 		"Subject: =?UTF-8?Q?Recovered_=E2=9C=93?=\r\n" +
 		"Date: Tue, 02 Jan 2024 15:04:05 +0000\r\n" +
+		"Received: from relay.example.test by mx.example.test; Wed, 03 Jan 2024 15:04:05 +0000\r\n" +
+		"Received: from sender.example.test by relay.example.test; Tue, 02 Jan 2024 15:04:05 +0000\r\n" +
 		"Message-ID: <message@example.test>\r\n" +
 		"In-Reply-To: <parent@example.test>\r\n" +
 		"References: <root@example.test>\r\n" +
@@ -191,6 +193,10 @@ func TestParseWithRecovery_FatalMultipartSalvagesHeaders(t *testing.T) {
 	assert.Equal("Recovered ✓", msg.Subject)
 	assert.Equal(time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC), msg.Date)
 	assert.Equal("Tue, 02 Jan 2024 15:04:05 +0000", msg.RawDateHeader)
+	assert.Equal([]time.Time{
+		time.Date(2024, 1, 3, 15, 4, 5, 0, time.UTC),
+		time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC),
+	}, msg.ReceivedDates)
 	assert.Equal([]Address{{
 		Name: "Sender Example", Email: "sender@example.test", Domain: "example.test",
 	}}, msg.From)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1261,20 +1261,16 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		}
 	}
 
-	// Parse MIME - on failure, store with placeholder body
+	// Parse MIME - on failure, salvage headers and store a placeholder body
 	// (threading override for IMAP happens after parsing below)
-	parsed, parseErr := mime.Parse(raw.Raw)
+	parsed, parseErr := mime.ParseWithRecovery(
+		raw.Raw,
+		extractSubjectFromSnippet(raw.Snippet),
+	)
 	if parseErr != nil {
 		// Extract just the first line of error (enmime includes full stack traces)
 		errMsg := textutil.FirstLine(parseErr.Error())
-
-		// Create placeholder message for MIME parse failures
-		// This preserves the raw data for potential future re-parsing
-		parsed = &mime.Message{
-			Subject:  extractSubjectFromSnippet(raw.Snippet),
-			BodyText: fmt.Sprintf("[MIME parsing failed: %s]\n\nRaw MIME data is preserved in message_raw table.", errMsg),
-		}
-		s.logger.Warn("MIME parse failed, storing with placeholder",
+		s.logger.Warn("MIME parse failed, storing partial message",
 			"id", raw.ID,
 			"error", errMsg)
 	}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2246,6 +2246,54 @@ func TestFullSyncWithMIMEParseError(t *testing.T) {
 	assertRawDataExists(t, env.Store, "msg-bad")
 }
 
+func TestFullSyncWithFatalMIMEParseSalvagesHeaders(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	raw := []byte("From: Sender Example <sender@example.test>\r\n" +
+		"To: Recipient Example <recipient@example.test>\r\n" +
+		"Subject: Recovered sync\r\n" +
+		"Date: Tue, 02 Jan 2024 15:04:05 +0000\r\n" +
+		"Message-ID: <recovered-sync@example.test>\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart mixed; boundary=outer\r\n\r\n" +
+		"--outer\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--outer--\r\n")
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 12345
+	env.Mock.AddMessage("msg-recovered", raw, []string{"INBOX"})
+
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1)), Errors: new(int64(0))})
+	assertBodyContains(t, env.Store, "msg-recovered", "MIME parsing failed")
+	assertRawDataExists(t, env.Store, "msg-recovered")
+
+	var subject, sender string
+	var sentAt time.Time
+	err := env.Store.DB().QueryRow(
+		`SELECT m.subject, m.sent_at, p.email_address
+		 FROM messages m
+		 JOIN participants p ON p.id = m.sender_id
+		 WHERE m.source_message_id = ?`,
+		"msg-recovered",
+	).Scan(&subject, &sentAt, &sender)
+	require.NoError(err, "query recovered message")
+	assert.Equal("Recovered sync", subject)
+	assert.Equal(time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC), sentAt.UTC())
+	assert.Equal("sender@example.test", sender)
+
+	var recipients int
+	err = env.Store.DB().QueryRow(
+		`SELECT COUNT(*)
+		 FROM message_recipients mr
+		 JOIN messages m ON m.id = mr.message_id
+		 WHERE m.source_message_id = ? AND mr.recipient_type = 'to'`,
+		"msg-recovered",
+	).Scan(&recipients)
+	require.NoError(err, "query recovered recipients")
+	assert.Equal(1, recipients)
+}
+
 func TestFullSyncMessageFetchError(t *testing.T) {
 	env := newTestEnv(t)
 	env.Mock.Profile.MessagesTotal = 2


### PR DESCRIPTION
## What changed

- Salvage bounded top-level message headers when malformed MIME structure prevents full envelope parsing.
- Use the same recovery path for imports and sync while preserving raw MIME and the parse-error body; broken body parts and attachments remain unavailable.
- Keep strict MIME parsing unchanged for validators, and keep the existing fallback subject when no useful headers can be recovered.

## Why

One malformed multipart declaration can currently replace an otherwise identifiable message with a generic MIME-error record. Recovering the intact subject, date, sender, recipients, and threading headers keeps those messages searchable and correctly grouped without pretending the broken body parsed successfully.

## Usage

No usage change.

Closes #507
