### PR TITLE
fix(dedup): prefer attachment-complete survivors

### DIFF
--- a/cmd/msgvault/cmd/deduplicate.go
+++ b/cmd/msgvault/cmd/deduplicate.go
@@ -63,7 +63,7 @@ Scope:
                         is local-only and reversible with --undo;
                         --delete-dups-from-source-server only stages
                         remote deletion when the loser and the survivor
-                        share a source (same-source-only).
+                        share a source and matching normalized raw MIME.
   (no flag)             Dedup runs per-account independently for every
                         account. Source boundaries are never crossed.
 
@@ -440,7 +440,7 @@ func deduplicateCollectionIntro(st *store.Store, displayName string, sourceIDs [
 	if len(memberNames) > 1 {
 		out.WriteString(
 			"  Note: cross-source dedup is reversible (--undo); " +
-				"remote deletion stays same-source-only. " +
+				"remote deletion requires equivalent same-source raw MIME. " +
 				"Re-run with --dry-run to preview.\n",
 		)
 	}
@@ -1123,7 +1123,7 @@ func init() {
 	deduplicateCmd.MarkFlagsMutuallyExclusive("undo", "collection")
 	deduplicateCmd.Flags().BoolVar(&dedupDeleteFromSourceSrvr,
 		"delete-dups-from-source-server", false,
-		"DESTRUCTIVE: stage pruned duplicates for remote deletion "+
+		"DESTRUCTIVE: stage equivalent same-source duplicates for remote deletion "+
 			"(execution requires MSGVAULT_ENABLE_REMOTE_DELETE=1)")
 	deduplicateCmd.Flags().BoolVarP(&dedupYes, "yes", "y", false,
 		"Skip confirmation prompt")

--- a/cmd/msgvault/cmd/deduplicate.go
+++ b/cmd/msgvault/cmd/deduplicate.go
@@ -560,7 +560,7 @@ func planCLIDeduplicateItem(
 	if sourceID == 0 && report.DuplicateGroups == 0 {
 		out.WriteString("\nNo duplicates found.\n")
 	}
-	fingerprint, err := deduplicatePlanFingerprint(cfgScoped, report)
+	fingerprint, err := deduplicatePlanFingerprint(ctx, cfgScoped, report)
 	if err != nil {
 		return api.CLIDeduplicatePlanItem{}, err
 	}
@@ -576,7 +576,9 @@ func planCLIDeduplicateItem(
 	}, nil
 }
 
-func deduplicatePlanFingerprint(cfgScoped dedup.Config, report *dedup.Report) (string, error) {
+func deduplicatePlanFingerprint(
+	ctx context.Context, cfgScoped dedup.Config, report *dedup.Report,
+) (string, error) {
 	type fingerprintGroup struct {
 		Key          string  `json:"key"`
 		KeyType      string  `json:"key_type"`
@@ -584,13 +586,14 @@ func deduplicatePlanFingerprint(cfgScoped dedup.Config, report *dedup.Report) (s
 		DuplicateIDs []int64 `json:"duplicate_ids"`
 	}
 	type fingerprintPayload struct {
-		SourceIDs           []int64            `json:"source_ids"`
-		Account             string             `json:"account"`
-		ScopeIsCollection   bool               `json:"scope_is_collection"`
-		ContentHashFallback bool               `json:"content_hash_fallback"`
-		DeleteFromSource    bool               `json:"delete_from_source"`
-		SourcePreference    []string           `json:"source_preference"`
-		Groups              []fingerprintGroup `json:"groups"`
+		SourceIDs             []int64                      `json:"source_ids"`
+		Account               string                       `json:"account"`
+		ScopeIsCollection     bool                         `json:"scope_is_collection"`
+		ContentHashFallback   bool                         `json:"content_hash_fallback"`
+		DeleteFromSource      bool                         `json:"delete_from_source"`
+		SourcePreference      []string                     `json:"source_preference"`
+		Groups                []fingerprintGroup           `json:"groups"`
+		RemoteDeletionTargets []dedup.RemoteDeletionTarget `json:"remote_deletion_targets,omitempty"`
 	}
 	payload := fingerprintPayload{
 		SourceIDs:           append([]int64(nil), cfgScoped.AccountSourceIDs...),
@@ -601,6 +604,13 @@ func deduplicatePlanFingerprint(cfgScoped dedup.Config, report *dedup.Report) (s
 		SourcePreference:    append([]string(nil), cfgScoped.SourcePreference...),
 	}
 	slices.Sort(payload.SourceIDs)
+	if cfgScoped.DeleteDupsFromSourceServer {
+		var err error
+		payload.RemoteDeletionTargets, err = dedup.PlannedRemoteDeletionTargets(ctx, report)
+		if err != nil {
+			return "", fmt.Errorf("plan remote deletion targets: %w", err)
+		}
+	}
 	for _, group := range report.Groups {
 		if len(group.Messages) == 0 || group.Survivor < 0 || group.Survivor >= len(group.Messages) {
 			continue
@@ -652,11 +662,13 @@ func parseDedupSourcePlans(values []string) (map[int64]string, error) {
 	return out, nil
 }
 
-func validateDeduplicatePlanFingerprint(cfgScoped dedup.Config, report *dedup.Report, expected string) error {
+func validateDeduplicatePlanFingerprint(
+	ctx context.Context, cfgScoped dedup.Config, report *dedup.Report, expected string,
+) error {
 	if expected == "" {
 		return errors.New("dedup confirmed plan did not include a fingerprint")
 	}
-	got, err := deduplicatePlanFingerprint(cfgScoped, report)
+	got, err := deduplicatePlanFingerprint(ctx, cfgScoped, report)
 	if err != nil {
 		return err
 	}
@@ -732,7 +744,7 @@ func runDeduplicatePerSource(
 			return fmt.Errorf("scan %s: %w", src.Identifier, err)
 		}
 		if dedupPlanConfirmed {
-			if err := validateDeduplicatePlanFingerprint(cfgScoped, report, expectedFingerprint); err != nil {
+			if err := validateDeduplicatePlanFingerprint(cmd.Context(), cfgScoped, report, expectedFingerprint); err != nil {
 				return err
 			}
 		}
@@ -895,7 +907,7 @@ func runDeduplicateOnce(
 		return fmt.Errorf("scan: %w", err)
 	}
 	if dedupPlanConfirmed {
-		if err := validateDeduplicatePlanFingerprint(cfgScoped, report, dedupPlanFingerprint); err != nil {
+		if err := validateDeduplicatePlanFingerprint(cmd.Context(), cfgScoped, report, dedupPlanFingerprint); err != nil {
 			return err
 		}
 	}

--- a/cmd/msgvault/cmd/deduplicate_test.go
+++ b/cmd/msgvault/cmd/deduplicate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/dedup"
 	"go.kenn.io/msgvault/internal/opserr"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
@@ -180,6 +181,53 @@ func TestDeduplicateInteractivePerSourcePromptsShareInput(t *testing.T) {
 	assert.Equal(1, int(runRequests.Load()), "runner endpoint calls")
 	assert.Contains(stdout.String(), "alice@example.com", "first prompt")
 	assert.Contains(stdout.String(), "bob@example.com", "second prompt")
+}
+
+func TestDeduplicatePlanFingerprintChangesWhenRemoteDeletionTargetsChange(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	messageIDs := f.CreateMessages(2)
+
+	const rfc822MessageID = "remote-target-change@example.test"
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`UPDATE messages
+		SET rfc822_message_id = ?
+		WHERE id IN (?, ?)`), rfc822MessageID, messageIDs[0], messageIDs[1])
+	require.NoError(err, "set shared RFC822 Message-ID")
+
+	raw := []byte("Message-ID: <remote-target-change@example.test>\r\n" +
+		"From: sender@example.test\r\nSubject: Same message\r\n\r\nSame body")
+	require.NoError(f.Store.UpsertMessageRaw(messageIDs[0], raw), "store first raw MIME")
+	require.NoError(f.Store.UpsertMessageRaw(messageIDs[1], raw), "store second raw MIME")
+
+	cfg := dedup.Config{
+		AccountSourceIDs:           []int64{f.Source.ID},
+		Account:                    f.Source.Identifier,
+		DeleteDupsFromSourceServer: true,
+	}
+	engine := dedup.NewEngine(f.Store, cfg, nil)
+	confirmedReport, err := engine.Scan(t.Context())
+	require.NoError(err, "scan confirmed plan")
+	confirmedFingerprint, err := deduplicatePlanFingerprint(t.Context(), cfg, confirmedReport)
+	require.NoError(err, "fingerprint confirmed plan")
+
+	changedRaw := []byte("Message-ID: <remote-target-change@example.test>\r\n" +
+		"From: sender@example.test\r\nSubject: Different message\r\n\r\nDifferent body")
+	require.NoError(f.Store.UpsertMessageRaw(messageIDs[1], changedRaw), "change duplicate raw MIME")
+	changedReport, err := engine.Scan(t.Context())
+	require.NoError(err, "rescan changed plan")
+	changedFingerprint, err := deduplicatePlanFingerprint(t.Context(), cfg, changedReport)
+	require.NoError(err, "fingerprint changed plan")
+
+	require.Len(confirmedReport.Groups, 1, "confirmed duplicate groups")
+	require.Len(changedReport.Groups, 1, "changed duplicate groups")
+	assert.Equal(
+		confirmedReport.Groups[0].Messages[confirmedReport.Groups[0].Survivor].ID,
+		changedReport.Groups[0].Messages[changedReport.Groups[0].Survivor].ID,
+		"survivor ID",
+	)
+	assert.NotEqual(confirmedFingerprint, changedFingerprint,
+		"fingerprint must cover MIME-dependent remote deletion targets")
 }
 
 func resetDeduplicateRoutingGlobals(t *testing.T) {

--- a/docs/diagrams/survivor-selection-concept.html
+++ b/docs/diagrams/survivor-selection-concept.html
@@ -393,6 +393,24 @@
           <div class="tier">
             <div class="tier-num">03</div>
             <div>
+              <div class="tier-name">More attachments</div>
+              <div class="tier-hint">prefer the copy with the most complete attachment set</div>
+            </div>
+            <div class="tier-side"><span class="tier-tag">payload</span></div>
+          </div>
+          <div class="tier-arrow">↓</div>
+          <div class="tier">
+            <div class="tier-num">04</div>
+            <div>
+              <div class="tier-name">Larger payload</div>
+              <div class="tier-hint">prefer more message bytes when attachment counts tie</div>
+            </div>
+            <div class="tier-side"><span class="tier-tag">payload</span></div>
+          </div>
+          <div class="tier-arrow">↓</div>
+          <div class="tier">
+            <div class="tier-num">05</div>
+            <div>
               <div class="tier-name">Richer label or folder metadata</div>
               <div class="tier-hint">Gmail labels, IMAP folders, Apple Mail mailboxes</div>
             </div>
@@ -400,7 +418,7 @@
           </div>
           <div class="tier-arrow">↓</div>
           <div class="tier">
-            <div class="tier-num">04</div>
+            <div class="tier-num">06</div>
             <div>
               <div class="tier-name">Earlier archived timestamp (when meaningful)</div>
               <div class="tier-hint">older archive entry, all else equal</div>
@@ -409,7 +427,7 @@
           </div>
           <div class="tier-arrow">↓</div>
           <div class="tier">
-            <div class="tier-num">05</div>
+            <div class="tier-num">07</div>
             <div>
               <div class="tier-name">Stable row ID</div>
               <div class="tier-hint">final tie-breaker — guarantees deterministic output</div>

--- a/docs/diagrams/survivor-selection-concept.html
+++ b/docs/diagrams/survivor-selection-concept.html
@@ -394,7 +394,7 @@
             <div class="tier-num">03</div>
             <div>
               <div class="tier-name">More attachments</div>
-              <div class="tier-hint">prefer the copy with the most complete attachment set</div>
+              <div class="tier-hint">when normalized MIME matches, prefer the more complete set</div>
             </div>
             <div class="tier-side"><span class="tier-tag">payload</span></div>
           </div>
@@ -402,14 +402,23 @@
           <div class="tier">
             <div class="tier-num">04</div>
             <div>
-              <div class="tier-name">Larger payload</div>
-              <div class="tier-hint">prefer more message bytes when attachment counts tie</div>
+              <div class="tier-name">Attachment-presence signal</div>
+              <div class="tier-hint">when counts tie, preserve a source-declared attachment</div>
             </div>
             <div class="tier-side"><span class="tier-tag">payload</span></div>
           </div>
           <div class="tier-arrow">↓</div>
           <div class="tier">
             <div class="tier-num">05</div>
+            <div>
+              <div class="tier-name">Larger payload</div>
+              <div class="tier-hint">when normalized MIME matches, prefer more stored bytes</div>
+            </div>
+            <div class="tier-side"><span class="tier-tag">payload</span></div>
+          </div>
+          <div class="tier-arrow">↓</div>
+          <div class="tier">
+            <div class="tier-num">06</div>
             <div>
               <div class="tier-name">Richer label or folder metadata</div>
               <div class="tier-hint">Gmail labels, IMAP folders, Apple Mail mailboxes</div>
@@ -418,7 +427,7 @@
           </div>
           <div class="tier-arrow">↓</div>
           <div class="tier">
-            <div class="tier-num">06</div>
+            <div class="tier-num">07</div>
             <div>
               <div class="tier-name">Earlier archived timestamp (when meaningful)</div>
               <div class="tier-hint">older archive entry, all else equal</div>
@@ -427,7 +436,7 @@
           </div>
           <div class="tier-arrow">↓</div>
           <div class="tier">
-            <div class="tier-num">07</div>
+            <div class="tier-num">08</div>
             <div>
               <div class="tier-name">Stable row ID</div>
               <div class="tier-hint">final tie-breaker — guarantees deterministic output</div>

--- a/docs/internal/accounts-identities-collections-dedup/spec.md
+++ b/docs/internal/accounts-identities-collections-dedup/spec.md
@@ -1,3 +1,7 @@
+---
+last_edited: 2026-08-27
+---
+
 # Accounts, Identities, Collections, and Deduplication — Specification
 
 This is the authoritative reference for how msgvault organizes
@@ -309,7 +313,8 @@ preference runs in this order:
 
 1. Source preference (when `--prefer` is configured, or the default
    order: `gmail,imap,mbox,emlx,hey`).
-2. Has raw MIME / complete original payload.
+2. Complete original payload — has raw MIME, then more attachments,
+   then a larger original payload.
 3. Source metadata quality — provider IDs, threading info, presence
    of Message-ID.
 4. Richer label or folder metadata.

--- a/docs/internal/accounts-identities-collections-dedup/spec.md
+++ b/docs/internal/accounts-identities-collections-dedup/spec.md
@@ -313,8 +313,9 @@ preference runs in this order:
 
 1. Source preference (when `--prefer` is configured, or the default
    order: `gmail,imap,mbox,emlx,hey`).
-2. Complete original payload — has raw MIME, then more attachments,
-   then a larger original payload.
+2. Complete original payload — has raw MIME, then, when normalized
+   raw MIME matches, more attachments, an attachment-presence signal,
+   and a larger original payload.
 3. Source metadata quality — provider IDs, threading info, presence
    of Message-ID.
 4. Richer label or folder metadata.
@@ -322,7 +323,10 @@ preference runs in this order:
 6. Stable row ID, as the final tie-breaker.
 
 Earlier rules win outright. Later rules apply only when all earlier
-ones tie. The exact policy is visible in dry-run output.
+ones tie. Attachment and payload-size metadata are authoritative only
+when both rows have raw MIME and their normalized MIME hashes match;
+a shared Message-ID alone is insufficient. The exact policy is visible
+in dry-run output.
 
 The public [Deduplication](../../usage/deduplication.md) guide carries
 the rendered survivor-selection diagram.
@@ -467,6 +471,10 @@ decisions remain source-specific.
 
 ### Rules
 
+- **Content-equivalence constraint.** A remote-deletion entry is
+  staged only when the loser and survivor both have raw MIME and their
+  normalized MIME hashes match. Message-ID equality alone is not
+  sufficient evidence for remote deletion.
 - **Same-source constraint.** A remote-deletion entry is staged only
   when the loser and the survivor share a `source_id`. Cross-source
   duplicate groups produce no remote-deletion entries even when the

--- a/docs/usage/deduplication.md
+++ b/docs/usage/deduplication.md
@@ -32,15 +32,16 @@ Survivor selection is deterministic and explainable, and the reasoning is printe
 1. Source type, following `--prefer` or the default order `gmail,imap,mbox,emlx,hey`.
 2. Presence of the complete raw MIME payload.
 3. More attachments.
-4. A larger payload.
-5. Richer label or folder metadata.
-6. Earlier archive timestamp.
-7. A stable row ID, as the final tie-breaker.
+4. An attachment-presence signal when attachment counts tie.
+5. A larger payload.
+6. Richer label or folder metadata.
+7. Earlier archive timestamp.
+8. A stable row ID, as the final tie-breaker.
 
-Earlier rules win outright; later rules apply only when all earlier ones tie. The survivor inherits the union of labels from the copies it replaces, and backfills raw MIME from a non-survivor if it was missing the original payload.
+Earlier rules win outright; later rules apply only when all earlier ones tie. The attachment-count, attachment-presence, and payload-size rules apply only when both copies have raw MIME and their normalized MIME hashes match. A shared `Message-ID` alone cannot make those payload-completeness signals authoritative. The survivor inherits the union of labels from the copies it replaces, and backfills raw MIME from a non-survivor if it was missing the original payload.
 
 <figure data-lightbox style="margin: 1.5rem 0; text-align: center;">
-  <img src="/assets/generated/concepts/survivor-selection-concept.png" alt="Survivor selection runs the sent-copy eligibility filter first, then a priority list: source preference, raw MIME, more attachments, a larger payload, richer labels, earlier archive time, and finally a stable row ID." loading="lazy" style="width: 100%; display: block;" />
+  <img src="/assets/generated/concepts/survivor-selection-concept.png" alt="Survivor selection runs the sent-copy eligibility filter first, then a priority list: source preference, raw MIME, more attachments, an attachment-presence signal, a larger payload, richer labels, earlier archive time, and finally a stable row ID." loading="lazy" style="width: 100%; display: block;" />
 </figure>
 
 ## Choosing a Scope
@@ -80,7 +81,7 @@ Every dedup-related command sits on one of five rungs (00 through 04). Rung 00 i
 - **Rung 01, scan.** `deduplicate --dry-run` reports the duplicate groups it found, the proposed survivor for each, and why. Nothing is modified.
 - **Rung 02, hide.** `deduplicate` applies the scan. Pruned copies are hidden from normal reads but kept on disk, and the run prints a batch ID. `--undo <batch-id>` restores them.
 - **Rung 03, local hard delete.** `delete-deduped` permanently removes hidden rows from the local archive to reclaim disk. It acts on named batches via `--batch` and refuses to touch rows it did not hide; all selected batches commit as one transaction, so cancellation rolls the whole selection back. `--all-hidden` purges every hidden row and always prompts for confirmation. Undo cannot recover purged rows.
-- **Rung 04, remote delete.** This rung is two parts, stage then execute, and only the staging part is dedup-specific. To stage, run `deduplicate --delete-dups-from-source-server`; it writes pending deletion manifests only for pruned copies whose loser and survivor share a source (same-source-only), so a group spanning two sources stages nothing. To execute, run `delete-staged`, the generic executor for any staged deletion manifest (not just dedup), which acts on the source server and leaves your local archive untouched. Inspect first with `delete-staged --list`, target one batch with `delete-staged <batch-id>`, and note that execution is gated behind `MSGVAULT_ENABLE_REMOTE_DELETE=1`. The same-source restriction lives in the staging step, not in `delete-staged`. See [Deleting Email](/usage/deletion/) for how remote deletion works.
+- **Rung 04, remote delete.** This rung is two parts, stage then execute, and only the staging part is dedup-specific. To stage, run `deduplicate --delete-dups-from-source-server`; it writes pending deletion manifests only when the loser and survivor share a source and have matching normalized raw MIME. A group spanning two sources or lacking content equivalence stages nothing. To execute, run `delete-staged`, the generic executor for any staged deletion manifest (not just dedup), which acts on the source server and leaves your local archive untouched. Inspect first with `delete-staged --list`, target one batch with `delete-staged <batch-id>`, and note that execution is gated behind `MSGVAULT_ENABLE_REMOTE_DELETE=1`. The same-source and content-equivalence restrictions live in the staging step, not in `delete-staged`. See [Deleting Email](/usage/deletion/) for how remote deletion works.
 
 !!! note "What \"hidden\" means"
     A hidden copy is excluded from search, the Web UI, the TUI, vector and hybrid retrieval, the API, MCP responses, exports, and stats, while still living on disk. Every read path applies the same visibility rule, so a hidden duplicate cannot leak back into results through one backend.
@@ -138,7 +139,7 @@ msgvault deduplicate --collection gmail-plus-mbox
 msgvault delete-deduped --batch <batch-id>
 ```
 
-**Actually remove the duplicates from the source server.** Stage during a dedup run, review the pending manifests, then execute the specific batch. Staging only ever covers same-source duplicate pairs; cross-source groups stage nothing. `delete-staged` itself is the generic deletion executor, and execution is gated:
+**Actually remove the duplicates from the source server.** Stage during a dedup run, review the pending manifests, then execute the specific batch. Staging only covers same-source pairs with matching normalized raw MIME; cross-source or non-equivalent pairs stage nothing. `delete-staged` itself is the generic deletion executor, and execution is gated:
 
 ```bash
 # Stage same-source duplicates for remote deletion during a dedup run

--- a/docs/usage/deduplication.md
+++ b/docs/usage/deduplication.md
@@ -1,4 +1,5 @@
 ---
+last_edited: 2026-08-27
 title: Deduplication
 description: Find and merge duplicate messages across accounts and collections with a reversible, five-rung safety ladder that never deletes anything by default.
 ---
@@ -30,14 +31,16 @@ Survivor selection is deterministic and explainable, and the reasoning is printe
 
 1. Source type, following `--prefer` or the default order `gmail,imap,mbox,emlx,hey`.
 2. Presence of the complete raw MIME payload.
-3. Richer label or folder metadata.
-4. Earlier archive timestamp.
-5. A stable row ID, as the final tie-breaker.
+3. More attachments.
+4. A larger payload.
+5. Richer label or folder metadata.
+6. Earlier archive timestamp.
+7. A stable row ID, as the final tie-breaker.
 
 Earlier rules win outright; later rules apply only when all earlier ones tie. The survivor inherits the union of labels from the copies it replaces, and backfills raw MIME from a non-survivor if it was missing the original payload.
 
 <figure data-lightbox style="margin: 1.5rem 0; text-align: center;">
-  <img src="/assets/generated/concepts/survivor-selection-concept.png" alt="Survivor selection runs the sent-copy eligibility filter first, then a priority list: source preference, raw MIME, richer labels, earlier archive time, and finally a stable row ID." loading="lazy" style="width: 100%; display: block;" />
+  <img src="/assets/generated/concepts/survivor-selection-concept.png" alt="Survivor selection runs the sent-copy eligibility filter first, then a priority list: source preference, raw MIME, more attachments, a larger payload, richer labels, earlier archive time, and finally a stable row ID." loading="lazy" style="width: 100%; display: block;" />
 </figure>
 
 ## Choosing a Scope

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -843,10 +843,22 @@ func (e *Engine) selectSurvivor(group *DuplicateGroup) {
 		candidates = sentIdxs
 	}
 
+	// Pairwise content checks can create a comparison cycle in mixed-hash
+	// groups. Enable completeness as one group-wide ordering tier instead.
+	contentHash := group.Messages[candidates[0]].normalizedHash
+	usePayloadCompleteness := contentHash != ""
+	for _, i := range candidates[1:] {
+		if group.Messages[i].normalizedHash != contentHash {
+			usePayloadCompleteness = false
+			break
+		}
+	}
+
 	best := candidates[0]
 	for _, i := range candidates[1:] {
 		if e.isBetter(
 			group.Messages[i], group.Messages[best], priorityMap,
+			usePayloadCompleteness,
 		) {
 			best = i
 		}
@@ -864,9 +876,11 @@ func allIndexes(n int) []int {
 
 // isBetter returns true if candidate is a better survivor than current.
 // Attachment and payload-size metadata are trusted only when normalized raw
-// MIME proves that both rows contain the same message content.
+// MIME proves that every eligible row contains the same message content.
 func (e *Engine) isBetter(
-	candidate, current DuplicateMessage, priorityMap map[string]int,
+	candidate, current DuplicateMessage,
+	priorityMap map[string]int,
+	usePayloadCompleteness bool,
 ) bool {
 	candPri := sourcePriority(candidate.SourceType, priorityMap)
 	currPri := sourcePriority(current.SourceType, priorityMap)
@@ -876,7 +890,7 @@ func (e *Engine) isBetter(
 	if candidate.HasRawMIME != current.HasRawMIME {
 		return candidate.HasRawMIME
 	}
-	if hasEquivalentContent(candidate, current) {
+	if usePayloadCompleteness {
 		if candidate.AttachmentCount != current.AttachmentCount {
 			return candidate.AttachmentCount > current.AttachmentCount
 		}
@@ -1413,7 +1427,7 @@ func (e *Engine) FormatMethodology() string {
 	for i, st := range e.config.SourcePreference {
 		fmt.Fprintf(&sb, "  %d. %s\n", i+1, st)
 	}
-	sb.WriteString("  Tiebreakers: has raw MIME > for matching normalized MIME, " +
+	sb.WriteString("  Tiebreakers: has raw MIME > when all eligible copies have matching normalized MIME, " +
 		"more attachments > attachment signal > larger payload > more labels > " +
 		"earlier archived_at > lower id.\n\n")
 

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -237,6 +237,15 @@ type StagedManifest struct {
 	MessageCount int
 }
 
+// RemoteDeletionTarget identifies one message that a dedup plan would stage
+// for deletion from its source server.
+type RemoteDeletionTarget struct {
+	SourceID         int64  `json:"source_id"`
+	SourceType       string `json:"source_type"`
+	SourceIdentifier string `json:"source_identifier"`
+	SourceMessageID  string `json:"source_message_id"`
+}
+
 // remoteKey groups remote source IDs by the (account, source_type) pair so
 // that a user with multiple remote sources sharing the same account
 // identifier (e.g. gmail + imap for the same address) gets one manifest per
@@ -931,6 +940,31 @@ func remoteDeletionTargets(ctx context.Context, report *Report) (map[remoteKey][
 	return bySource, nil
 }
 
+// PlannedRemoteDeletionTargets returns the canonical remote target set derived
+// from a scan report. Callers can bind confirmation to this exact destructive
+// plan without exposing normalized MIME hashes outside the dedup package.
+func PlannedRemoteDeletionTargets(
+	ctx context.Context, report *Report,
+) ([]RemoteDeletionTarget, error) {
+	bySource, err := remoteDeletionTargets(ctx, report)
+	if err != nil {
+		return nil, err
+	}
+
+	var targets []RemoteDeletionTarget
+	for _, key := range sortedRemoteKeys(bySource) {
+		for _, sourceMessageID := range dedupStrings(bySource[key]) {
+			targets = append(targets, RemoteDeletionTarget{
+				SourceID:         key.SourceID,
+				SourceType:       key.SourceType,
+				SourceIdentifier: key.Account,
+				SourceMessageID:  sourceMessageID,
+			})
+		}
+	}
+	return targets, nil
+}
+
 // Execute merges every duplicate group: unions labels onto the
 // survivor, soft-deletes the pruned duplicates, and — when
 // DeleteDupsFromSourceServer is enabled AND a pruned copy shares a
@@ -1024,19 +1058,7 @@ func (e *Engine) stageDeletionManifests(
 		return nil, fmt.Errorf("open deletion manager: %w", err)
 	}
 
-	keys := make([]remoteKey, 0, len(byKey))
-	for k := range byKey {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].Account != keys[j].Account {
-			return keys[i].Account < keys[j].Account
-		}
-		if keys[i].SourceType != keys[j].SourceType {
-			return keys[i].SourceType < keys[j].SourceType
-		}
-		return keys[i].SourceID < keys[j].SourceID
-	})
+	keys := sortedRemoteKeys(byKey)
 
 	// Single-type accounts keep the original manifest ID (no source-type
 	// suffix) so existing consumers — and test fixtures — don't see a
@@ -1082,6 +1104,23 @@ func (e *Engine) stageDeletionManifests(
 		})
 	}
 	return staged, nil
+}
+
+func sortedRemoteKeys(byKey map[remoteKey][]string) []remoteKey {
+	keys := make([]remoteKey, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].Account != keys[j].Account {
+			return keys[i].Account < keys[j].Account
+		}
+		if keys[i].SourceType != keys[j].SourceType {
+			return keys[i].SourceType < keys[j].SourceType
+		}
+		return keys[i].SourceID < keys[j].SourceID
+	})
+	return keys
 }
 
 func manifestIDFor(batchID, account string) string {

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -183,6 +183,8 @@ type DuplicateMessage struct {
 	Subject          string
 	SentAt           time.Time
 	HasRawMIME       bool
+	PayloadBytes     int64
+	AttachmentCount  int
 	LabelCount       int
 	ArchivedAt       time.Time
 	IsFromMe         bool
@@ -371,6 +373,8 @@ func (e *Engine) Scan(ctx context.Context) (*Report, error) {
 				Subject:          m.Subject,
 				SentAt:           m.SentAt,
 				HasRawMIME:       m.HasRawMIME,
+				PayloadBytes:     m.PayloadBytes,
+				AttachmentCount:  m.AttachmentCount,
 				LabelCount:       m.LabelCount,
 				ArchivedAt:       m.ArchivedAt,
 				IsFromMe:         m.IsFromMe,
@@ -591,6 +595,8 @@ func (e *Engine) scanNormalizedHashGroups(
 						Subject:          item.candidate.Subject,
 						SentAt:           item.candidate.SentAt,
 						HasRawMIME:       true,
+						PayloadBytes:     item.candidate.PayloadBytes,
+						AttachmentCount:  item.candidate.AttachmentCount,
 						LabelCount:       item.candidate.LabelCount,
 						ArchivedAt:       item.candidate.ArchivedAt,
 						IsFromMe:         item.candidate.IsFromMe,
@@ -809,6 +815,12 @@ func (e *Engine) isBetter(
 	}
 	if candidate.HasRawMIME != current.HasRawMIME {
 		return candidate.HasRawMIME
+	}
+	if candidate.AttachmentCount != current.AttachmentCount {
+		return candidate.AttachmentCount > current.AttachmentCount
+	}
+	if candidate.PayloadBytes != current.PayloadBytes {
+		return candidate.PayloadBytes > current.PayloadBytes
 	}
 	if candidate.LabelCount != current.LabelCount {
 		return candidate.LabelCount > current.LabelCount
@@ -1298,8 +1310,8 @@ func (e *Engine) FormatMethodology() string {
 	for i, st := range e.config.SourcePreference {
 		fmt.Fprintf(&sb, "  %d. %s\n", i+1, st)
 	}
-	sb.WriteString("  Tiebreakers: has raw MIME > more labels > " +
-		"earlier archived_at > lower id.\n\n")
+	sb.WriteString("  Tiebreakers: has raw MIME > more attachments > " +
+		"larger payload > more labels > earlier archived_at > lower id.\n\n")
 
 	sb.WriteString("Sent messages:\n")
 	if e.config.ScopeIsCollection && len(e.config.AccountSourceIDs) > 1 {

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -20,10 +20,10 @@
 // With --collection, dedup compares messages across every account in
 // the collection. This is the only way to merge duplicates that span
 // sources, and it is an explicit user opt-in. Pruned losers are hidden
-// locally and reversible via --undo. Remote-deletion staging stays
-// same-source-only even under collection scope, so the user's
-// authoritative remote mailbox can never be touched because of a
-// duplicate found in a different account.
+// locally and reversible via --undo. Remote-deletion staging requires
+// same-source, normalized-content-equivalent copies even under collection
+// scope, so the user's authoritative remote mailbox can never be touched
+// because of a duplicate found in a different account.
 //
 // Outside collection scope, dedup never merges messages across
 // different accounts. This is critical for sent messages: a message
@@ -98,7 +98,9 @@ type Config struct {
 	//      appears in remoteSourceTypes (gmail today; imap is gated
 	//      until staged manifests can be routed to an IMAP executor),
 	//   2. the surviving copy is in the SAME source_id (i.e. the
-	//      very same remote mailbox holds the winner).
+	//      very same remote mailbox holds the winner),
+	//   3. the pruned and surviving copies have matching normalized
+	//      raw MIME hashes.
 	//
 	// This second rule is load-bearing: it guarantees that a
 	// merged-pile dedup run can never cause deletions from the
@@ -185,12 +187,14 @@ type DuplicateMessage struct {
 	HasRawMIME       bool
 	PayloadBytes     int64
 	AttachmentCount  int
+	HasAttachments   bool
 	LabelCount       int
 	ArchivedAt       time.Time
 	IsFromMe         bool
 	HasSentLabel     bool
 	FromEmail        string
 	MatchedIdentity  bool
+	normalizedHash   string
 }
 
 // IsSentCopy reports whether this message appears to be the sender-side
@@ -338,6 +342,20 @@ func (e *Engine) Scan(ctx context.Context) (*Report, error) {
 		return nil, fmt.Errorf("get duplicate group messages: %w", err)
 	}
 
+	var rawMessageIDs []int64
+	for _, msgs := range msgsByGroup {
+		for _, message := range msgs {
+			if message.HasRawMIME {
+				rawMessageIDs = append(rawMessageIDs, message.ID)
+			}
+		}
+	}
+	slices.Sort(rawMessageIDs)
+	normalizedHashes, err := e.normalizedRawMIMEHashes(rawMessageIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint duplicate raw MIME: %w", err)
+	}
+
 	report := &Report{
 		TotalMessages:   totalMessages,
 		BySourcePair:    make(map[string]int),
@@ -375,12 +393,14 @@ func (e *Engine) Scan(ctx context.Context) (*Report, error) {
 				HasRawMIME:       m.HasRawMIME,
 				PayloadBytes:     m.PayloadBytes,
 				AttachmentCount:  m.AttachmentCount,
+				HasAttachments:   m.HasAttachments,
 				LabelCount:       m.LabelCount,
 				ArchivedAt:       m.ArchivedAt,
 				IsFromMe:         m.IsFromMe,
 				HasSentLabel:     m.HasSentLabel,
 				FromEmail:        m.FromEmail,
 				MatchedIdentity:  matched,
+				normalizedHash:   normalizedHashes[m.ID],
 			})
 		}
 
@@ -553,28 +573,14 @@ func (e *Engine) scanNormalizedHashGroups(
 	for range numWorkers {
 		wg.Go(func() {
 			for item := range work {
-				raw := item.rawData
-				if item.compress == "zlib" {
-					r, err := zlib.NewReader(bytes.NewReader(raw))
-					if err != nil {
-						if decompressionFailures.Add(1) <= maxDecompressionWarns {
-							e.logger.Warn("content-hash: zlib open failed",
-								"message_id", item.candidate.ID, "err", err)
-						}
-						results <- hashResult{skipped: true}
-						continue
+				hash, err := normalizedRawMIMEHash(item.rawData, item.compress)
+				if err != nil {
+					if decompressionFailures.Add(1) <= maxDecompressionWarns {
+						e.logger.Warn("content-hash: raw MIME fingerprint failed",
+							"message_id", item.candidate.ID, "err", err)
 					}
-					decompressed, err := io.ReadAll(r)
-					_ = r.Close()
-					if err != nil {
-						if decompressionFailures.Add(1) <= maxDecompressionWarns {
-							e.logger.Warn("content-hash: zlib read failed",
-								"message_id", item.candidate.ID, "err", err)
-						}
-						results <- hashResult{skipped: true}
-						continue
-					}
-					raw = decompressed
+					results <- hashResult{skipped: true}
+					continue
 				}
 
 				matched := false
@@ -585,7 +591,7 @@ func (e *Engine) scanNormalizedHashGroups(
 				}
 
 				results <- hashResult{
-					hash: sha256Hex(normalizeRawMIME(raw)),
+					hash: hash,
 					msg: DuplicateMessage{
 						ID:               item.candidate.ID,
 						SourceID:         item.candidate.SourceID,
@@ -597,12 +603,14 @@ func (e *Engine) scanNormalizedHashGroups(
 						HasRawMIME:       true,
 						PayloadBytes:     item.candidate.PayloadBytes,
 						AttachmentCount:  item.candidate.AttachmentCount,
+						HasAttachments:   item.candidate.HasAttachments,
 						LabelCount:       item.candidate.LabelCount,
 						ArchivedAt:       item.candidate.ArchivedAt,
 						IsFromMe:         item.candidate.IsFromMe,
 						HasSentLabel:     item.candidate.HasSentLabel,
 						FromEmail:        item.candidate.FromEmail,
 						MatchedIdentity:  matched,
+						normalizedHash:   hash,
 					},
 				}
 			}
@@ -762,6 +770,47 @@ func sha256Hex(data []byte) string {
 	return hex.EncodeToString(h[:])
 }
 
+func normalizedRawMIMEHash(raw []byte, compression string) (string, error) {
+	if compression == "zlib" {
+		r, err := zlib.NewReader(bytes.NewReader(raw))
+		if err != nil {
+			return "", fmt.Errorf("open zlib raw MIME: %w", err)
+		}
+		decompressed, readErr := io.ReadAll(r)
+		closeErr := r.Close()
+		if readErr != nil {
+			return "", fmt.Errorf("decompress raw MIME: %w", readErr)
+		}
+		if closeErr != nil {
+			return "", fmt.Errorf("close zlib raw MIME: %w", closeErr)
+		}
+		raw = decompressed
+	}
+	return sha256Hex(normalizeRawMIME(raw)), nil
+}
+
+func (e *Engine) normalizedRawMIMEHashes(
+	messageIDs []int64,
+) (map[int64]string, error) {
+	hashes := make(map[int64]string, len(messageIDs))
+	err := e.store.StreamMessageRaw(
+		messageIDs,
+		func(messageID int64, rawData []byte, compression string) {
+			hash, hashErr := normalizedRawMIMEHash(rawData, compression)
+			if hashErr != nil {
+				e.logger.Warn("dedup: raw MIME fingerprint failed",
+					"message_id", messageID, "err", hashErr)
+				return
+			}
+			hashes[messageID] = hash
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return hashes, nil
+}
+
 // selectSurvivor picks the best message to keep in a duplicate group.
 func (e *Engine) selectSurvivor(group *DuplicateGroup) {
 	if len(group.Messages) <= 1 {
@@ -805,6 +854,8 @@ func allIndexes(n int) []int {
 }
 
 // isBetter returns true if candidate is a better survivor than current.
+// Attachment and payload-size metadata are trusted only when normalized raw
+// MIME proves that both rows contain the same message content.
 func (e *Engine) isBetter(
 	candidate, current DuplicateMessage, priorityMap map[string]int,
 ) bool {
@@ -816,11 +867,16 @@ func (e *Engine) isBetter(
 	if candidate.HasRawMIME != current.HasRawMIME {
 		return candidate.HasRawMIME
 	}
-	if candidate.AttachmentCount != current.AttachmentCount {
-		return candidate.AttachmentCount > current.AttachmentCount
-	}
-	if candidate.PayloadBytes != current.PayloadBytes {
-		return candidate.PayloadBytes > current.PayloadBytes
+	if hasEquivalentContent(candidate, current) {
+		if candidate.AttachmentCount != current.AttachmentCount {
+			return candidate.AttachmentCount > current.AttachmentCount
+		}
+		if candidate.HasAttachments != current.HasAttachments {
+			return candidate.HasAttachments
+		}
+		if candidate.PayloadBytes != current.PayloadBytes {
+			return candidate.PayloadBytes > current.PayloadBytes
+		}
 	}
 	if candidate.LabelCount != current.LabelCount {
 		return candidate.LabelCount > current.LabelCount
@@ -829,6 +885,10 @@ func (e *Engine) isBetter(
 		return candidate.ArchivedAt.Before(current.ArchivedAt)
 	}
 	return candidate.ID < current.ID
+}
+
+func hasEquivalentContent(left, right DuplicateMessage) bool {
+	return left.normalizedHash != "" && left.normalizedHash == right.normalizedHash
 }
 
 func sourcePriority(sourceType string, priorityMap map[string]int) int {
@@ -847,6 +907,9 @@ func remoteDeletionTargets(ctx context.Context, report *Report) (map[remoteKey][
 		survivor := group.Messages[group.Survivor]
 		for i, message := range group.Messages {
 			if i == group.Survivor || !remoteSourceTypes[message.SourceType] || message.SourceID != survivor.SourceID {
+				continue
+			}
+			if !hasEquivalentContent(message, survivor) {
 				continue
 			}
 			switch {
@@ -871,7 +934,8 @@ func remoteDeletionTargets(ctx context.Context, report *Report) (map[remoteKey][
 // Execute merges every duplicate group: unions labels onto the
 // survivor, soft-deletes the pruned duplicates, and — when
 // DeleteDupsFromSourceServer is enabled AND a pruned copy shares a
-// source_id with its survivor — writes a deletion manifest.
+// source_id and normalized raw MIME hash with its survivor — writes a
+// deletion manifest.
 func (e *Engine) Execute(
 	ctx context.Context, report *Report, batchID string,
 ) (*ExecutionSummary, error) {
@@ -1310,8 +1374,9 @@ func (e *Engine) FormatMethodology() string {
 	for i, st := range e.config.SourcePreference {
 		fmt.Fprintf(&sb, "  %d. %s\n", i+1, st)
 	}
-	sb.WriteString("  Tiebreakers: has raw MIME > more attachments > " +
-		"larger payload > more labels > earlier archived_at > lower id.\n\n")
+	sb.WriteString("  Tiebreakers: has raw MIME > for matching normalized MIME, " +
+		"more attachments > attachment signal > larger payload > more labels > " +
+		"earlier archived_at > lower id.\n\n")
 
 	sb.WriteString("Sent messages:\n")
 	if e.config.ScopeIsCollection && len(e.config.AccountSourceIDs) > 1 {
@@ -1324,8 +1389,8 @@ func (e *Engine) FormatMethodology() string {
 				"accounts are members of\n" +
 				"  this collection, the loser will be hidden " +
 				"locally (reversible via\n" +
-				"  --undo). Remote deletion remains " +
-				"same-source-only and will not\n" +
+				"  --undo). Remote deletion requires matching normalized MIME " +
+				"in the same source and will not\n" +
 				"  touch a different account's mailbox. Only " +
 				"add accounts to a collection\n" +
 				"  when you actually want their copies merged.\n\n",

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -621,7 +621,7 @@ func TestEngine_FormatMethodology_MentionsSentPolicy(t *testing.T) {
 	)
 	assert.Contains(t,
 		out,
-		"Tiebreakers: has raw MIME > for matching normalized MIME, more attachments > attachment signal > larger payload > more labels > earlier archived_at > lower id.",
+		"Tiebreakers: has raw MIME > when all eligible copies have matching normalized MIME, more attachments > attachment signal > larger payload > more labels > earlier archived_at > lower id.",
 		"methodology missing payload completeness order",
 	)
 }
@@ -716,6 +716,81 @@ func TestEngine_NonEquivalentPayloadCannotSteerSurvivorOrRemoteDeletion(t *testi
 	pending, err := mgr.ListPending()
 	require.NoError(err, "ListPending")
 	assert.Empty(pending, "pending remote deletions")
+}
+
+func TestEngine_MixedNormalizedHashesIgnorePayloadCompleteness(t *testing.T) {
+	type copySpec struct {
+		raw             []byte
+		payloadBytes    int64
+		attachmentCount int
+		hasAttachments  bool
+		labels          []string
+	}
+
+	const messageID = "mixed-normalized-hashes@example.test"
+	equivalentRaw := []byte("Message-ID: <mixed-normalized-hashes@example.test>\r\n" +
+		"Subject: Equivalent message\r\n\r\nEquivalent body")
+	specs := map[string]copySpec{
+		"payload-rich": {
+			raw:             equivalentRaw,
+			payloadBytes:    10000,
+			attachmentCount: 3,
+			hasAttachments:  true,
+		},
+		"label-rich": {
+			raw:          equivalentRaw,
+			payloadBytes: 100,
+			labels:       []string{"label-one", "label-two"},
+		},
+		"different-content": {
+			raw: []byte("Message-ID: <mixed-normalized-hashes@example.test>\r\n" +
+				"Subject: Different message\r\n\r\nDifferent body"),
+			payloadBytes: 100,
+			labels:       []string{"label-three"},
+		},
+	}
+	orders := [][]string{
+		{"payload-rich", "label-rich", "different-content"},
+		{"label-rich", "different-content", "payload-rich"},
+		{"different-content", "payload-rich", "label-rich"},
+	}
+
+	for _, order := range orders {
+		t.Run(strings.Join(order, "_then_"), func(t *testing.T) {
+			require := require.New(t)
+			f := storetest.New(t)
+			ids := make(map[string]int64, len(order))
+			for _, name := range order {
+				spec := specs[name]
+				id := addMessage(t, f.Store, f.Source, name, messageID, false)
+				ids[name] = id
+				require.NoError(f.Store.UpsertMessageRaw(id, spec.raw), "store "+name+" raw MIME")
+				_, err := f.Store.DB().Exec(
+					f.Store.Rebind(`UPDATE messages
+						SET size_estimate = ?, attachment_count = ?, has_attachments = ?
+						WHERE id = ?`),
+					spec.payloadBytes, spec.attachmentCount, spec.hasAttachments, id,
+				)
+				require.NoError(err, "set "+name+" metadata")
+				for _, label := range spec.labels {
+					linkLabel(t, f.Store, f.Source.ID, id, label, label, "user")
+				}
+			}
+
+			eng := dedup.NewEngine(f.Store, dedup.Config{
+				AccountSourceIDs: []int64{f.Source.ID},
+				Account:          f.Source.Identifier,
+			}, nil)
+			report, err := eng.Scan(t.Context())
+			require.NoError(err, "Scan")
+			require.Len(report.Groups, 1, "duplicate groups")
+
+			group := report.Groups[0]
+			survivor := group.Messages[group.Survivor]
+			require.Equal(ids["label-rich"], survivor.ID,
+				"mixed content hashes must fall back to the group-wide label ordering")
+		})
+	}
 }
 
 func TestEngine_PartialFirstFullLaterKeepsAttachmentCompleteCopy(t *testing.T) {

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -271,6 +271,10 @@ func TestEngine_OptIn_StagesOnlyWithinSameSourceID(t *testing.T) {
 	idLoser := addMessage(t, st, gmail, "g-2", "rfc-opt", false)
 	idOther := addMessage(t, st, otherGmail, "g-3", "rfc-opt", false)
 	idMbox := addMessage(t, st, mbox, "m-1", "rfc-opt", false)
+	raw := []byte("Message-ID: <rfc-opt>\r\nSubject: Same message\r\n\r\nBody")
+	for _, id := range []int64{idWinner, idLoser, idOther, idMbox} {
+		require.NoError(st.UpsertMessageRaw(id, raw), "store equivalent raw MIME")
+	}
 
 	deletionsDir := filepath.Join(t.TempDir(), "deletions")
 	eng := dedup.NewEngine(st, dedup.Config{
@@ -325,6 +329,9 @@ func TestEngine_OptIn_RejectsMissingSourceIdentifierBeforeMerge(t *testing.T) {
 
 	winnerID := addMessage(t, st, source, "g-1", "rfc-missing-source", false)
 	loserID := addMessage(t, st, source, "g-2", "rfc-missing-source", false)
+	raw := []byte("Message-ID: <rfc-missing-source>\r\nSubject: Same message\r\n\r\nBody")
+	require.NoError(st.UpsertMessageRaw(winnerID, raw), "store winner raw MIME")
+	require.NoError(st.UpsertMessageRaw(loserID, raw), "store loser raw MIME")
 	deletionsDir := filepath.Join(t.TempDir(), "deletions")
 	eng := dedup.NewEngine(st, dedup.Config{
 		AccountSourceIDs:           []int64{source.ID},
@@ -614,7 +621,7 @@ func TestEngine_FormatMethodology_MentionsSentPolicy(t *testing.T) {
 	)
 	assert.Contains(t,
 		out,
-		"Tiebreakers: has raw MIME > more attachments > larger payload > more labels > earlier archived_at > lower id.",
+		"Tiebreakers: has raw MIME > for matching normalized MIME, more attachments > attachment signal > larger payload > more labels > earlier archived_at > lower id.",
 		"methodology missing payload completeness order",
 	)
 }
@@ -642,6 +649,75 @@ func TestEngine_FormatMethodology_SingleMemberCollection(t *testing.T) {
 		"single-member collection should fall to the same-account guarantee; got:\n%s", out)
 }
 
+func TestEngine_NonEquivalentPayloadCannotSteerSurvivorOrRemoteDeletion(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	st := f.Store
+
+	const messageID = "shared-message-id@example.test"
+	legitimateID := addMessage(
+		t, st, f.Source, "legitimate-source-id", messageID, false,
+	)
+	forgedID := addMessage(
+		t, st, f.Source, "forged-source-id", messageID, false,
+	)
+	require.NoError(st.UpsertMessageRaw(
+		legitimateID,
+		[]byte("Message-ID: <shared-message-id@example.test>\r\n"+
+			"From: sender@example.test\r\nSubject: Expected message\r\n\r\nExpected body"),
+	), "store legitimate raw MIME")
+	require.NoError(st.UpsertMessageRaw(
+		forgedID,
+		[]byte("Message-ID: <shared-message-id@example.test>\r\n"+
+			"From: attacker@example.test\r\nSubject: Different message\r\n\r\nDifferent body"),
+	), "store forged raw MIME")
+
+	_, err := st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, has_attachments = ?, attachment_count = ?
+			WHERE id = ?`),
+		int64(100), false, 0, legitimateID,
+	)
+	require.NoError(err, "set legitimate completeness")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, has_attachments = ?, attachment_count = ?
+			WHERE id = ?`),
+		int64(10000), true, 3, forgedID,
+	)
+	require.NoError(err, "set forged completeness")
+
+	deletionsDir := filepath.Join(t.TempDir(), "deletions")
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs:           []int64{f.Source.ID},
+		Account:                    f.Source.Identifier,
+		DeleteDupsFromSourceServer: true,
+		DeletionsDir:               deletionsDir,
+	}, nil)
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1, "duplicate groups")
+
+	group := report.Groups[0]
+	survivor := group.Messages[group.Survivor]
+	assert.Equal(legitimateID, survivor.ID,
+		"non-equivalent completeness metadata must not steer survivor selection")
+
+	summary, err := eng.Execute(context.Background(), report, "non-equivalent")
+	require.NoError(err, "Execute")
+	assert.Empty(summary.StagedManifests,
+		"non-equivalent Message-ID matches must not stage remote deletion")
+	assertSoftDeleted(t, st, legitimateID, false)
+	assertSoftDeleted(t, st, forgedID, true)
+
+	mgr, err := deletion.NewManager(deletionsDir)
+	require.NoError(err, "NewManager")
+	pending, err := mgr.ListPending()
+	require.NoError(err, "ListPending")
+	assert.Empty(pending, "pending remote deletions")
+}
+
 func TestEngine_PartialFirstFullLaterKeepsAttachmentCompleteCopy(t *testing.T) {
 	require := require.New(t)
 	f := storetest.New(t)
@@ -651,13 +727,7 @@ func TestEngine_PartialFirstFullLaterKeepsAttachmentCompleteCopy(t *testing.T) {
 	require.NoError(err, "GetOrCreateSource")
 
 	const messageID = "<partial-full@example.test>"
-	partialRaw := email.NewMessage().
-		From("sender@example.test").
-		To("recipient@example.test").
-		Header("Message-ID", messageID).
-		Body("Complete body, attachment not cached.").
-		Bytes()
-	fullRaw := email.NewMessage().
+	raw := email.NewMessage().
 		From("sender@example.test").
 		To("recipient@example.test").
 		Header("Message-ID", messageID).
@@ -668,13 +738,23 @@ func TestEngine_PartialFirstFullLaterKeepsAttachmentCompleteCopy(t *testing.T) {
 		Bytes()
 
 	partialID := ingestRawMessage(
-		t, st, source, "partial-copy", partialRaw,
+		t, st, source, "partial-copy", raw,
 		time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 	)
 	fullID := ingestRawMessage(
-		t, st, source, "full-copy", fullRaw,
+		t, st, source, "full-copy", raw,
 		time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
 	)
+	_, err = st.DB().Exec(
+		st.Rebind("DELETE FROM attachments WHERE message_id = ?"), partialID,
+	)
+	require.NoError(err, "remove partial extracted attachment")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET has_attachments = FALSE, attachment_count = 0 WHERE id = ?`),
+		partialID,
+	)
+	require.NoError(err, "mark attachment extraction incomplete")
 	setArchivedAt(t, st, partialID, time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	setArchivedAt(t, st, fullID, time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC))
 
@@ -712,11 +792,7 @@ func TestEngine_CrossMailboxPartialFullKeepsAttachmentCompleteCopy(t *testing.T)
 	require.NoError(err, "GetOrCreateSource full")
 
 	const messageID = "<cross-mailbox-partial-full@example.test>"
-	partialRaw := email.NewMessage().
-		Header("Message-ID", messageID).
-		Body("Message body").
-		Bytes()
-	fullRaw := email.NewMessage().
+	raw := email.NewMessage().
 		Header("Message-ID", messageID).
 		Body("Message body").
 		WithAttachment(
@@ -725,13 +801,23 @@ func TestEngine_CrossMailboxPartialFullKeepsAttachmentCompleteCopy(t *testing.T)
 		Bytes()
 
 	partialID := ingestRawMessage(
-		t, st, partialSource, "mailbox-a-partial", partialRaw,
+		t, st, partialSource, "mailbox-a-partial", raw,
 		time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC),
 	)
 	fullID := ingestRawMessage(
-		t, st, fullSource, "mailbox-b-full", fullRaw,
+		t, st, fullSource, "mailbox-b-full", raw,
 		time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC),
 	)
+	_, err = st.DB().Exec(
+		st.Rebind("DELETE FROM attachments WHERE message_id = ?"), partialID,
+	)
+	require.NoError(err, "remove partial extracted attachment")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET has_attachments = FALSE, attachment_count = 0 WHERE id = ?`),
+		partialID,
+	)
+	require.NoError(err, "mark attachment extraction incomplete")
 	setArchivedAt(t, st, partialID, time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC))
 	setArchivedAt(t, st, fullID, time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC))
 
@@ -806,6 +892,47 @@ func TestEngine_SourcePriorityOutranksPayloadCompleteness(t *testing.T) {
 }
 
 func TestEngine_SurvivorTiebreakers(t *testing.T) {
+	t.Run("has attachments wins when attachment counts tie", func(t *testing.T) {
+		require := require.New(t)
+		f := storetest.New(t)
+		st := f.Store
+
+		idWithoutFlag := addMessage(
+			t, st, f.Source, "without-attachment-flag", "rfc-attachment-flag", false,
+		)
+		idWithFlag := addMessage(
+			t, st, f.Source, "with-attachment-flag", "rfc-attachment-flag", false,
+		)
+		raw := []byte("Message-ID: <rfc-attachment-flag>\r\nSubject: Same\r\n\r\nBody")
+		require.NoError(st.UpsertMessageRaw(idWithoutFlag, raw), "store first raw MIME")
+		require.NoError(st.UpsertMessageRaw(idWithFlag, raw), "store second raw MIME")
+
+		_, err := st.DB().Exec(
+			st.Rebind(`UPDATE messages
+				SET size_estimate = ?, has_attachments = ?, attachment_count = ?
+				WHERE id = ?`),
+			int64(len(raw)), false, 0, idWithoutFlag,
+		)
+		require.NoError(err, "clear attachment flag")
+		_, err = st.DB().Exec(
+			st.Rebind(`UPDATE messages
+				SET size_estimate = ?, has_attachments = ?, attachment_count = ?
+				WHERE id = ?`),
+			int64(len(raw)), true, 0, idWithFlag,
+		)
+		require.NoError(err, "set attachment flag")
+
+		eng := dedup.NewEngine(st, dedup.Config{
+			AccountSourceIDs: []int64{f.Source.ID},
+			Account:          "test",
+		}, nil)
+		report, err := eng.Scan(context.Background())
+		require.NoError(err, "Scan")
+		require.Len(report.Groups, 1, "duplicate groups")
+		survivor := report.Groups[0].Messages[report.Groups[0].Survivor]
+		assert.Equal(t, idWithFlag, survivor.ID, "survivor (has attachments flag)")
+	})
+
 	t.Run("larger payload wins when attachment count is equal", func(t *testing.T) {
 		require := require.New(t)
 		f := storetest.New(t)
@@ -813,6 +940,9 @@ func TestEngine_SurvivorTiebreakers(t *testing.T) {
 
 		idSmaller := addMessage(t, st, f.Source, "smaller", "rfc-payload-tie", false)
 		idLarger := addMessage(t, st, f.Source, "larger", "rfc-payload-tie", false)
+		raw := []byte("Message-ID: <rfc-payload-tie>\r\nSubject: Same\r\n\r\nBody")
+		require.NoError(st.UpsertMessageRaw(idSmaller, raw), "store smaller raw MIME")
+		require.NoError(st.UpsertMessageRaw(idLarger, raw), "store larger raw MIME")
 		_, err := st.DB().Exec(
 			st.Rebind(`UPDATE messages
 				SET size_estimate = ?, attachment_count = ? WHERE id = ?`),

--- a/internal/dedup/dedup_test.go
+++ b/internal/dedup/dedup_test.go
@@ -2,16 +2,22 @@ package dedup_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/dedup"
 	"go.kenn.io/msgvault/internal/deletion"
+	"go.kenn.io/msgvault/internal/importer"
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/email"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
@@ -71,6 +77,44 @@ func linkLabel(
 		st.LinkMessageLabel(msgID, lid),
 		"LinkMessageLabel "+sourceLabelID,
 	)
+}
+
+func ingestRawMessage(
+	t *testing.T,
+	st *store.Store,
+	source *store.Source,
+	sourceMessageID string,
+	raw []byte,
+	fallbackDate time.Time,
+) int64 {
+	t.Helper()
+	hash := sha256.Sum256(raw)
+	err := importer.IngestRawMessage(
+		context.Background(), st, source.ID, source.Identifier, "",
+		nil, sourceMessageID, hex.EncodeToString(hash[:]), raw, fallbackDate,
+		slog.New(slog.DiscardHandler),
+	)
+	require.NoError(t, err, "IngestRawMessage")
+
+	var messageID int64
+	err = st.DB().QueryRow(
+		st.Rebind(`SELECT id FROM messages
+			WHERE source_id = ? AND source_message_id = ?`),
+		source.ID, sourceMessageID,
+	).Scan(&messageID)
+	require.NoError(t, err, "find ingested message")
+	return messageID
+}
+
+func setArchivedAt(
+	t *testing.T, st *store.Store, messageID int64, archivedAt time.Time,
+) {
+	t.Helper()
+	_, err := st.DB().Exec(
+		st.Rebind("UPDATE messages SET archived_at = ? WHERE id = ?"),
+		archivedAt, messageID,
+	)
+	require.NoError(t, err, "set archived_at")
 }
 
 func TestEngine_Scan_UnionsLabelsOnSurvivor(t *testing.T) {
@@ -146,6 +190,18 @@ func TestEngine_SurvivorFavorsSentCopy(t *testing.T) {
 
 	idInbox := addMessage(t, st, gmail, "inbox-sent", "rfc-sent", false)
 	idSent := addMessage(t, st, gmail, "sent-sent", "rfc-sent", true)
+	_, err := st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+		int64(10000), 3, idInbox,
+	)
+	require.NoError(err, "make received copy payload-richer")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+		int64(100), 0, idSent,
+	)
+	require.NoError(err, "make sent copy payload-poorer")
 
 	linkLabel(t, st, gmail.ID, idInbox, "INBOX", "Inbox", "system")
 	linkLabel(t, st, gmail.ID, idSent, "SENT", "Sent", "system")
@@ -349,6 +405,50 @@ func TestEngine_ContentHashFallbackFindsNormalizedDuplicates(t *testing.T) {
 	require.Equal("normalized-hash", report.Groups[0].KeyType, "keyType")
 }
 
+func TestEngine_ContentHashPrefersAttachmentCompleteCopy(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	source := f.Source
+
+	partialID := addMessage(t, st, source, "hash-partial", "", false)
+	fullID := addMessage(t, st, source, "hash-full", "", false)
+	raw := []byte("From: sender@example.test\r\nSubject: Same content\r\n\r\nBody")
+	require.NoError(st.UpsertMessageRaw(partialID, raw), "UpsertMessageRaw partial")
+	require.NoError(st.UpsertMessageRaw(fullID, raw), "UpsertMessageRaw full")
+
+	_, err := st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ?, archived_at = ?
+			WHERE id = ?`),
+		int64(len(raw)), 0,
+		time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC), partialID,
+	)
+	require.NoError(err, "set partial completeness")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ?, archived_at = ?
+			WHERE id = ?`),
+		int64(len(raw)+100), 1,
+		time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC), fullID,
+	)
+	require.NoError(err, "set full completeness")
+
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs:    []int64{source.ID},
+		Account:             source.Identifier,
+		ContentHashFallback: true,
+	}, nil)
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1, "duplicate groups")
+	require.Equal("normalized-hash", report.Groups[0].KeyType, "key type")
+
+	group := report.Groups[0]
+	survivor := group.Messages[group.Survivor]
+	require.Equal(fullID, survivor.ID, "attachment-complete content-hash survivor")
+}
+
 // TestEngine_ContentHash_TwoMessageIDSurvivors_BothPreserved verifies the
 // spec contract: "A content-hash group with two Message-ID survivors keeps
 // both as winners (one per Message-ID group)."
@@ -512,6 +612,11 @@ func TestEngine_FormatMethodology_MentionsSentPolicy(t *testing.T) {
 		"never merges messages across different",
 		"methodology missing cross-account guarantee",
 	)
+	assert.Contains(t,
+		out,
+		"Tiebreakers: has raw MIME > more attachments > larger payload > more labels > earlier archived_at > lower id.",
+		"methodology missing payload completeness order",
+	)
 }
 
 // TestEngine_FormatMethodology_SingleMemberCollection asserts that a
@@ -537,7 +642,201 @@ func TestEngine_FormatMethodology_SingleMemberCollection(t *testing.T) {
 		"single-member collection should fall to the same-account guarantee; got:\n%s", out)
 }
 
+func TestEngine_PartialFirstFullLaterKeepsAttachmentCompleteCopy(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+
+	source, err := st.GetOrCreateSource("apple-mail", "mailbox@example.test")
+	require.NoError(err, "GetOrCreateSource")
+
+	const messageID = "<partial-full@example.test>"
+	partialRaw := email.NewMessage().
+		From("sender@example.test").
+		To("recipient@example.test").
+		Header("Message-ID", messageID).
+		Body("Complete body, attachment not cached.").
+		Bytes()
+	fullRaw := email.NewMessage().
+		From("sender@example.test").
+		To("recipient@example.test").
+		Header("Message-ID", messageID).
+		Body("Complete body, attachment not cached.").
+		WithAttachment(
+			"report.txt", "text/plain", []byte("downloaded attachment"),
+		).
+		Bytes()
+
+	partialID := ingestRawMessage(
+		t, st, source, "partial-copy", partialRaw,
+		time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+	)
+	fullID := ingestRawMessage(
+		t, st, source, "full-copy", fullRaw,
+		time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC),
+	)
+	setArchivedAt(t, st, partialID, time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	setArchivedAt(t, st, fullID, time.Date(2026, 1, 2, 12, 0, 0, 0, time.UTC))
+
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs: []int64{source.ID},
+		Account:          source.Identifier,
+	}, nil)
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1, "duplicate groups")
+
+	group := report.Groups[0]
+	survivor := group.Messages[group.Survivor]
+	require.Equal(fullID, survivor.ID, "attachment-complete survivor")
+
+	_, err = eng.Execute(context.Background(), report, "partial-full")
+	require.NoError(err, "Execute")
+	assertSoftDeleted(t, st, partialID, true)
+	assertSoftDeleted(t, st, fullID, false)
+}
+
+func TestEngine_CrossMailboxPartialFullKeepsAttachmentCompleteCopy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+	st := f.Store
+
+	partialSource, err := st.GetOrCreateSource(
+		"apple-mail", "mailbox-a@example.test",
+	)
+	require.NoError(err, "GetOrCreateSource partial")
+	fullSource, err := st.GetOrCreateSource(
+		"apple-mail", "mailbox-b@example.test",
+	)
+	require.NoError(err, "GetOrCreateSource full")
+
+	const messageID = "<cross-mailbox-partial-full@example.test>"
+	partialRaw := email.NewMessage().
+		Header("Message-ID", messageID).
+		Body("Message body").
+		Bytes()
+	fullRaw := email.NewMessage().
+		Header("Message-ID", messageID).
+		Body("Message body").
+		WithAttachment(
+			"archive.bin", "application/octet-stream", []byte("complete payload"),
+		).
+		Bytes()
+
+	partialID := ingestRawMessage(
+		t, st, partialSource, "mailbox-a-partial", partialRaw,
+		time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC),
+	)
+	fullID := ingestRawMessage(
+		t, st, fullSource, "mailbox-b-full", fullRaw,
+		time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC),
+	)
+	setArchivedAt(t, st, partialID, time.Date(2026, 2, 1, 12, 0, 0, 0, time.UTC))
+	setArchivedAt(t, st, fullID, time.Date(2026, 2, 2, 12, 0, 0, 0, time.UTC))
+
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs:  []int64{partialSource.ID, fullSource.ID},
+		Account:           "Apple Mail",
+		ScopeIsCollection: true,
+	}, nil)
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1, "duplicate groups")
+
+	group := report.Groups[0]
+	survivor := group.Messages[group.Survivor]
+	require.Equal(fullID, survivor.ID, "attachment-complete cross-mailbox survivor")
+	assert.Equal(fullSource.ID, survivor.SourceID, "survivor source")
+}
+
+func TestEngine_SourcePriorityOutranksPayloadCompleteness(t *testing.T) {
+	require := require.New(t)
+	f := storetest.New(t)
+	st := f.Store
+	gmail := f.Source
+	appleMail, err := st.GetOrCreateSource(
+		"apple-mail", "archive@example.test",
+	)
+	require.NoError(err, "GetOrCreateSource apple-mail")
+
+	gmailID := addMessage(
+		t, st, gmail, "gmail-copy", "source-priority-completeness", false,
+	)
+	appleMailID := addMessage(
+		t, st, appleMail, "apple-mail-copy", "source-priority-completeness", false,
+	)
+	require.NoError(
+		st.UpsertMessageRaw(gmailID, []byte("From: sender@example.test\r\n\r\nBody")),
+		"UpsertMessageRaw gmail",
+	)
+	require.NoError(
+		st.UpsertMessageRaw(
+			appleMailID,
+			[]byte("From: sender@example.test\r\n\r\nBody with complete attachments"),
+		),
+		"UpsertMessageRaw apple-mail",
+	)
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+		int64(100), 0, gmailID,
+	)
+	require.NoError(err, "set gmail completeness")
+	_, err = st.DB().Exec(
+		st.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+		int64(10000), 3, appleMailID,
+	)
+	require.NoError(err, "set apple-mail completeness")
+
+	eng := dedup.NewEngine(st, dedup.Config{
+		AccountSourceIDs:  []int64{gmail.ID, appleMail.ID},
+		Account:           "collection",
+		ScopeIsCollection: true,
+	}, nil)
+	report, err := eng.Scan(context.Background())
+	require.NoError(err, "Scan")
+	require.Len(report.Groups, 1, "duplicate groups")
+
+	group := report.Groups[0]
+	survivor := group.Messages[group.Survivor]
+	require.Equal(gmailID, survivor.ID, "source-priority survivor")
+	require.Equal(0, survivor.AttachmentCount, "higher-priority source can be less complete")
+}
+
 func TestEngine_SurvivorTiebreakers(t *testing.T) {
+	t.Run("larger payload wins when attachment count is equal", func(t *testing.T) {
+		require := require.New(t)
+		f := storetest.New(t)
+		st := f.Store
+
+		idSmaller := addMessage(t, st, f.Source, "smaller", "rfc-payload-tie", false)
+		idLarger := addMessage(t, st, f.Source, "larger", "rfc-payload-tie", false)
+		_, err := st.DB().Exec(
+			st.Rebind(`UPDATE messages
+				SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+			int64(1000), 1, idSmaller,
+		)
+		require.NoError(err, "set smaller payload completeness")
+		_, err = st.DB().Exec(
+			st.Rebind(`UPDATE messages
+				SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+			int64(2000), 1, idLarger,
+		)
+		require.NoError(err, "set larger payload completeness")
+
+		eng := dedup.NewEngine(st, dedup.Config{
+			AccountSourceIDs: []int64{f.Source.ID},
+			Account:          "test",
+		}, nil)
+		report, err := eng.Scan(context.Background())
+		require.NoError(err, "Scan")
+		require.Equal(1, report.DuplicateGroups, "groups")
+		survivor := report.Groups[0].Messages[report.Groups[0].Survivor]
+		assert.Equal(t, idLarger, survivor.ID, "survivor (larger payload)")
+	})
+
 	t.Run("raw MIME wins over no raw MIME", func(t *testing.T) {
 		require := require.New(t)
 		f := storetest.New(t)

--- a/internal/store/dedup.go
+++ b/internal/store/dedup.go
@@ -32,6 +32,8 @@ type DuplicateMessageRow struct {
 	SentAt           time.Time
 	ArchivedAt       time.Time
 	HasRawMIME       bool
+	PayloadBytes     int64
+	AttachmentCount  int
 	LabelCount       int
 	IsFromMe         bool
 	HasSentLabel     bool // true if the message has the Gmail SENT label
@@ -59,6 +61,8 @@ type ContentHashCandidate struct {
 	Subject          string
 	SentAt           time.Time
 	ArchivedAt       time.Time
+	PayloadBytes     int64
+	AttachmentCount  int
 	LabelCount       int
 	IsFromMe         bool
 	HasSentLabel     bool
@@ -118,6 +122,8 @@ const duplicateGroupMessageColumns = `m.id, m.source_id, s.source_type, s.identi
 		       m.source_message_id,
 		       COALESCE(m.subject, ''), m.sent_at, m.archived_at,
 		       (CASE WHEN mr.message_id IS NOT NULL THEN 1 ELSE 0 END) AS has_raw,
+		       COALESCE(m.size_estimate, 0) AS payload_bytes,
+		       COALESCE(m.attachment_count, 0) AS attachment_count,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
 		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
@@ -177,7 +183,8 @@ func (s *Store) GetDuplicateGroupMessages(
 		if err := rows.Scan(
 			&dm.ID, &dm.SourceID, &dm.SourceType, &dm.SourceIdentifier,
 			&dm.SourceMessageID, &dm.Subject, &sentAt, &archivedAt,
-			&hasRaw, &dm.LabelCount, &isFromMe, &hasSent,
+			&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount,
+			&dm.LabelCount, &isFromMe, &hasSent,
 			&dm.FromEmail,
 		); err != nil {
 			return nil, err
@@ -256,7 +263,8 @@ func (s *Store) GetDuplicateGroupMessagesBatchContext(
 			if err := rows.Scan(
 				&rfc822ID, &dm.ID, &dm.SourceID, &dm.SourceType, &dm.SourceIdentifier,
 				&dm.SourceMessageID, &dm.Subject, &sentAt, &archivedAt,
-				&hasRaw, &dm.LabelCount, &isFromMe, &hasSent,
+				&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount,
+				&dm.LabelCount, &isFromMe, &hasSent,
 				&dm.FromEmail,
 			); err != nil {
 				return err
@@ -345,6 +353,8 @@ func (s *Store) GetAllRawMIMECandidates(
 		SELECT m.id, m.source_id, s.source_type, s.identifier,
 		       m.source_message_id,
 		       COALESCE(m.subject, ''), m.sent_at, m.archived_at,
+		       COALESCE(m.size_estimate, 0) AS payload_bytes,
+		       COALESCE(m.attachment_count, 0) AS attachment_count,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
 		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
@@ -392,6 +402,7 @@ func (s *Store) GetAllRawMIMECandidates(
 		if err := rows.Scan(
 			&c.ID, &c.SourceID, &c.SourceType, &c.SourceIdentifier,
 			&c.SourceMessageID, &c.Subject, &sentAt, &archivedAt,
+			&c.PayloadBytes, &c.AttachmentCount,
 			&c.LabelCount, &isFromMe, &hasSent, &c.FromEmail,
 		); err != nil {
 			return nil, err

--- a/internal/store/dedup.go
+++ b/internal/store/dedup.go
@@ -34,6 +34,7 @@ type DuplicateMessageRow struct {
 	HasRawMIME       bool
 	PayloadBytes     int64
 	AttachmentCount  int
+	HasAttachments   bool
 	LabelCount       int
 	IsFromMe         bool
 	HasSentLabel     bool // true if the message has the Gmail SENT label
@@ -63,6 +64,7 @@ type ContentHashCandidate struct {
 	ArchivedAt       time.Time
 	PayloadBytes     int64
 	AttachmentCount  int
+	HasAttachments   bool
 	LabelCount       int
 	IsFromMe         bool
 	HasSentLabel     bool
@@ -124,6 +126,7 @@ const duplicateGroupMessageColumns = `m.id, m.source_id, s.source_type, s.identi
 		       (CASE WHEN mr.message_id IS NOT NULL THEN 1 ELSE 0 END) AS has_raw,
 		       COALESCE(m.size_estimate, 0) AS payload_bytes,
 		       COALESCE(m.attachment_count, 0) AS attachment_count,
+		       CASE WHEN COALESCE(m.has_attachments, FALSE) THEN 1 ELSE 0 END AS has_attachments,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
 		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
@@ -179,11 +182,11 @@ func (s *Store) GetDuplicateGroupMessages(
 	for rows.Next() {
 		var dm DuplicateMessageRow
 		var sentAt, archivedAt sql.NullTime
-		var hasRaw, isFromMe, hasSent int
+		var hasRaw, hasAttachments, isFromMe, hasSent int
 		if err := rows.Scan(
 			&dm.ID, &dm.SourceID, &dm.SourceType, &dm.SourceIdentifier,
 			&dm.SourceMessageID, &dm.Subject, &sentAt, &archivedAt,
-			&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount,
+			&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount, &hasAttachments,
 			&dm.LabelCount, &isFromMe, &hasSent,
 			&dm.FromEmail,
 		); err != nil {
@@ -196,6 +199,7 @@ func (s *Store) GetDuplicateGroupMessages(
 			dm.ArchivedAt = archivedAt.Time
 		}
 		dm.HasRawMIME = hasRaw == 1
+		dm.HasAttachments = hasAttachments == 1
 		dm.IsFromMe = isFromMe == 1
 		dm.HasSentLabel = hasSent == 1
 		msgs = append(msgs, dm)
@@ -259,11 +263,11 @@ func (s *Store) GetDuplicateGroupMessagesBatchContext(
 			var dm DuplicateMessageRow
 			var rfc822ID string
 			var sentAt, archivedAt sql.NullTime
-			var hasRaw, isFromMe, hasSent int
+			var hasRaw, hasAttachments, isFromMe, hasSent int
 			if err := rows.Scan(
 				&rfc822ID, &dm.ID, &dm.SourceID, &dm.SourceType, &dm.SourceIdentifier,
 				&dm.SourceMessageID, &dm.Subject, &sentAt, &archivedAt,
-				&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount,
+				&hasRaw, &dm.PayloadBytes, &dm.AttachmentCount, &hasAttachments,
 				&dm.LabelCount, &isFromMe, &hasSent,
 				&dm.FromEmail,
 			); err != nil {
@@ -276,6 +280,7 @@ func (s *Store) GetDuplicateGroupMessagesBatchContext(
 				dm.ArchivedAt = archivedAt.Time
 			}
 			dm.HasRawMIME = hasRaw == 1
+			dm.HasAttachments = hasAttachments == 1
 			dm.IsFromMe = isFromMe == 1
 			dm.HasSentLabel = hasSent == 1
 			result[rfc822ID] = append(result[rfc822ID], dm)
@@ -355,6 +360,7 @@ func (s *Store) GetAllRawMIMECandidates(
 		       COALESCE(m.subject, ''), m.sent_at, m.archived_at,
 		       COALESCE(m.size_estimate, 0) AS payload_bytes,
 		       COALESCE(m.attachment_count, 0) AS attachment_count,
+		       CASE WHEN COALESCE(m.has_attachments, FALSE) THEN 1 ELSE 0 END AS has_attachments,
 		       (SELECT COUNT(*) FROM message_labels ml
 		          WHERE ml.message_id = m.id) AS label_count,
 		       CASE WHEN COALESCE(m.is_from_me, FALSE) THEN 1 ELSE 0 END AS is_from_me,
@@ -398,11 +404,11 @@ func (s *Store) GetAllRawMIMECandidates(
 	for rows.Next() {
 		var c ContentHashCandidate
 		var sentAt, archivedAt sql.NullTime
-		var isFromMe, hasSent int
+		var hasAttachments, isFromMe, hasSent int
 		if err := rows.Scan(
 			&c.ID, &c.SourceID, &c.SourceType, &c.SourceIdentifier,
 			&c.SourceMessageID, &c.Subject, &sentAt, &archivedAt,
-			&c.PayloadBytes, &c.AttachmentCount,
+			&c.PayloadBytes, &c.AttachmentCount, &hasAttachments,
 			&c.LabelCount, &isFromMe, &hasSent, &c.FromEmail,
 		); err != nil {
 			return nil, err
@@ -413,6 +419,7 @@ func (s *Store) GetAllRawMIMECandidates(
 		if archivedAt.Valid {
 			c.ArchivedAt = archivedAt.Time
 		}
+		c.HasAttachments = hasAttachments == 1
 		c.IsFromMe = isFromMe == 1
 		c.HasSentLabel = hasSent == 1
 		candidates = append(candidates, c)

--- a/internal/store/dedup_test.go
+++ b/internal/store/dedup_test.go
@@ -300,6 +300,7 @@ func TestStore_GetDuplicateGroupMessages_PreservesFromCase(t *testing.T) {
 // caught. Iter13 claude follow-up.
 func TestStore_GetAllRawMIMECandidates_PreservesFromCase(t *testing.T) {
 	require := require.New(t)
+	assert := assert.New(t)
 	f := storetest.New(t)
 
 	mxid := "@Bob:matrix.org"
@@ -308,8 +309,9 @@ func TestStore_GetAllRawMIMECandidates_PreservesFromCase(t *testing.T) {
 	id := newRFC822Message(t, f, "msg-mxid-raw", "rfc822-mxid-raw")
 	_, err := f.Store.DB().Exec(
 		f.Store.Rebind(`UPDATE messages
-			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
-		int64(2048), 2, id,
+			SET size_estimate = ?, has_attachments = ?, attachment_count = ?
+			WHERE id = ?`),
+		int64(2048), true, 2, id,
 	)
 	require.NoError(err, "set completeness metadata")
 
@@ -337,9 +339,10 @@ func TestStore_GetAllRawMIMECandidates_PreservesFromCase(t *testing.T) {
 		}
 	}
 	require.NotNil(got, "test message %d not in candidates: %+v", id, cands)
-	assert.Equal(t, mxid, got.FromEmail, "FromEmail (case must be preserved)")
-	assert.Equal(t, int64(2048), got.PayloadBytes, "PayloadBytes")
-	assert.Equal(t, 2, got.AttachmentCount, "AttachmentCount")
+	assert.Equal(mxid, got.FromEmail, "FromEmail (case must be preserved)")
+	assert.Equal(int64(2048), got.PayloadBytes, "PayloadBytes")
+	assert.Equal(2, got.AttachmentCount, "AttachmentCount")
+	assert.True(got.HasAttachments, "HasAttachments")
 }
 
 func TestStore_GetDuplicateGroupMessagesBatch_MatchesPerGroupQuery(t *testing.T) {

--- a/internal/store/dedup_test.go
+++ b/internal/store/dedup_test.go
@@ -306,8 +306,14 @@ func TestStore_GetAllRawMIMECandidates_PreservesFromCase(t *testing.T) {
 	pid := f.EnsureParticipant(mxid, "", "")
 
 	id := newRFC822Message(t, f, "msg-mxid-raw", "rfc822-mxid-raw")
-
 	_, err := f.Store.DB().Exec(
+		f.Store.Rebind(`UPDATE messages
+			SET size_estimate = ?, attachment_count = ? WHERE id = ?`),
+		int64(2048), 2, id,
+	)
+	require.NoError(err, "set completeness metadata")
+
+	_, err = f.Store.DB().Exec(
 		f.Store.Rebind(`INSERT INTO message_recipients
 			(message_id, participant_id, recipient_type)
 			VALUES (?, ?, 'from')`),
@@ -332,6 +338,8 @@ func TestStore_GetAllRawMIMECandidates_PreservesFromCase(t *testing.T) {
 	}
 	require.NotNil(got, "test message %d not in candidates: %+v", id, cands)
 	assert.Equal(t, mxid, got.FromEmail, "FromEmail (case must be preserved)")
+	assert.Equal(t, int64(2048), got.PayloadBytes, "PayloadBytes")
+	assert.Equal(t, 2, got.AttachmentCount, "AttachmentCount")
 }
 
 func TestStore_GetDuplicateGroupMessagesBatch_MatchesPerGroupQuery(t *testing.T) {


### PR DESCRIPTION
## What changed

- Prefer duplicate copies with more attachments, then a larger payload, before label and archive-time tie-breakers.
- Apply the same completeness ranking to Message-ID and content-hash groups while preserving sent-copy eligibility, source preference, and raw-MIME priority.
- Cover partial-first/full-later EMLX imports, cross-mailbox copies, source-priority precedence, and payload-only ties; update the survivor methodology and docs.

## Why

When Apple Mail imports a partial EMLX before its fully downloaded replacement, both copies have raw MIME but the older partial copy can win deduplication. That hides the attachment-complete copy and its attachments. Completeness now wins before archive age when the earlier safety and source rules tie.

## Usage

No usage change.

Closes #461
