### PR TITLE
identity: add repair-identity command to confirm account identity and recompute is_from_me

### DIFF
--- a/cmd/msgvault/cmd/repair_identity.go
+++ b/cmd/msgvault/cmd/repair_identity.go
@@ -70,8 +70,9 @@ Examples:
 // repairIdentities confirms the own-address identity (and retro-attributes
 // is_from_me) for every source of sourceType whose resolved account address is
 // a valid email and is not already confirmed. When onlyIdentifier is non-empty,
-// only that source identifier is considered. Returns the number of sources
-// repaired and any identity-add failures after attempting every candidate.
+// only a matching source identifier or resolved account address is considered.
+// Returns the number of sources repaired and any identity-add failures after
+// attempting every candidate.
 func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.Writer) (int, error) {
 	sources, err := s.ListSources(sourceType)
 	if err != nil {
@@ -81,10 +82,12 @@ func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.
 	var failures []error
 	for _, src := range sources {
 		sourceIdentifier := strings.TrimSpace(src.Identifier)
-		if onlyIdentifier != "" && !strings.EqualFold(sourceIdentifier, onlyIdentifier) {
+		address := repairIdentityAddress(src)
+		if onlyIdentifier != "" &&
+			!strings.EqualFold(sourceIdentifier, onlyIdentifier) &&
+			!store.EqualIdentifier(address, onlyIdentifier) {
 			continue
 		}
-		address := repairIdentityAddress(src)
 		parsed, parseErr := mail.ParseAddress(address)
 		if parseErr != nil || parsed.Name != "" || !strings.EqualFold(parsed.Address, address) {
 			continue // not one plain email address; nothing to attribute against

--- a/cmd/msgvault/cmd/repair_identity.go
+++ b/cmd/msgvault/cmd/repair_identity.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/mail"
 	"strings"
 
 	"github.com/spf13/cobra"
+	imapclient "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -29,9 +31,9 @@ account's own address as a confirmed identity, which in the same transaction
 retro-attributes matching earlier messages (those the account sent) as
 is_from_me = 1.
 
-It is idempotent and safe: sources that already have a confirmed identity are
-skipped (re-adding an existing identity would not re-attribute), and only
-sources whose identifier looks like an email address are touched.
+It is idempotent and safe: a source is skipped when its account address is
+already confirmed, and only plain, valid email addresses are touched. Other
+confirmed aliases do not suppress repair of the account address.
 
 Examples:
   msgvault repair-identity                       # all Gmail accounts missing an identity
@@ -66,42 +68,71 @@ Examples:
 }
 
 // repairIdentities confirms the own-address identity (and retro-attributes
-// is_from_me) for every source of sourceType whose identifier is an email and
-// which has no confirmed identity yet. When onlyIdentifier is non-empty, only
-// that account is considered. Returns the number of sources repaired.
+// is_from_me) for every source of sourceType whose resolved account address is
+// a valid email and is not already confirmed. When onlyIdentifier is non-empty,
+// only that source identifier is considered. Returns the number of sources
+// repaired and any identity-add failures after attempting every candidate.
 func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.Writer) (int, error) {
 	sources, err := s.ListSources(sourceType)
 	if err != nil {
 		return 0, fmt.Errorf("list %s sources: %w", sourceType, err)
 	}
 	repaired := 0
+	var failures []error
 	for _, src := range sources {
-		id := strings.TrimSpace(src.Identifier)
-		if onlyIdentifier != "" && !strings.EqualFold(id, onlyIdentifier) {
+		sourceIdentifier := strings.TrimSpace(src.Identifier)
+		if onlyIdentifier != "" && !strings.EqualFold(sourceIdentifier, onlyIdentifier) {
 			continue
 		}
-		if !strings.Contains(id, "@") {
-			continue // not an email-shaped identifier; nothing to attribute against
+		address := repairIdentityAddress(src)
+		parsed, parseErr := mail.ParseAddress(address)
+		if parseErr != nil || parsed.Name != "" || !strings.EqualFold(parsed.Address, address) {
+			continue // not one plain email address; nothing to attribute against
 		}
 		existing, lerr := s.ListAccountIdentities(src.ID)
 		if lerr != nil {
-			return repaired, fmt.Errorf("list identities for %s: %w", id, lerr)
+			return repaired, fmt.Errorf("list identities for %s: %w", sourceIdentifier, lerr)
 		}
-		if len(existing) > 0 {
-			continue // already confirmed; AddAccountIdentity would not re-attribute
+		alreadyConfirmed := false
+		for _, identity := range existing {
+			if store.EqualIdentifier(identity.Address, address) {
+				alreadyConfirmed = true
+				break
+			}
+		}
+		if alreadyConfirmed {
+			continue // this account address is already confirmed
 		}
 		before := countFromMe(s, src.ID)
 		// AddAccountIdentity's insert hook retro-attributes matching messages in
 		// the same transaction (see store.addAccountIdentityContext).
-		if err := s.AddAccountIdentity(src.ID, id, "identity-repair"); err != nil {
-			_, _ = fmt.Fprintf(out, "  %s: FAILED: %v\n", id, err)
+		if err := s.AddAccountIdentity(src.ID, address, "identity-repair"); err != nil {
+			_, _ = fmt.Fprintf(out, "  %s: FAILED: %v\n", sourceIdentifier, err)
+			failures = append(failures, fmt.Errorf("add identity for %s: %w", sourceIdentifier, err))
 			continue
 		}
 		after := countFromMe(s, src.ID)
-		_, _ = fmt.Fprintf(out, "  %s: confirmed identity; is_from_me %d -> %d\n", id, before, after)
+		_, _ = fmt.Fprintf(out, "  %s: confirmed identity %s; is_from_me %d -> %d\n",
+			sourceIdentifier, address, before, after)
 		repaired++
 	}
-	return repaired, nil
+	return repaired, errors.Join(failures...)
+}
+
+func repairIdentityAddress(src *store.Source) string {
+	if src.SourceType != sourceTypeIMAP {
+		return strings.TrimSpace(src.Identifier)
+	}
+	if src.SyncConfig.Valid {
+		imapCfg, err := imapclient.ConfigFromJSON(src.SyncConfig.String)
+		if err == nil && strings.TrimSpace(imapCfg.Username) != "" {
+			return strings.TrimSpace(imapCfg.Username)
+		}
+	}
+	if src.DisplayName.Valid {
+		return strings.TrimSpace(src.DisplayName.String)
+	}
+	return ""
 }
 
 // countFromMe returns how many messages in a source are attributed to the

--- a/cmd/msgvault/cmd/repair_identity.go
+++ b/cmd/msgvault/cmd/repair_identity.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -54,7 +55,7 @@ Examples:
 			if len(args) == 1 {
 				only = strings.TrimSpace(args[0])
 			}
-			repaired, rerr := repairIdentities(s, repairIdentityType, only, cmd.OutOrStdout())
+			repaired, rerr := repairIdentities(cmd.Context(), s, repairIdentityType, only, cmd.OutOrStdout())
 			cacheErr := rebuildCacheAfterWrite(cfg.DatabaseDSN())
 			if rerr != nil {
 				return errors.Join(rerr, cacheErr)
@@ -71,16 +72,20 @@ Examples:
 // is_from_me) for every source of sourceType whose resolved account address is
 // a valid email and is not already confirmed. When onlyIdentifier is non-empty,
 // only a matching source identifier or resolved account address is considered.
-// Returns the number of sources repaired and any identity-add failures after
-// attempting every candidate.
-func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.Writer) (int, error) {
-	sources, err := s.ListSources(sourceType)
+// Cancellation stops before the next source and reaches each database call.
+// Returns the number of sources repaired and any failures encountered.
+func repairIdentities(ctx context.Context, s *store.Store, sourceType, onlyIdentifier string, out io.Writer) (int, error) {
+	sources, err := s.ListSourcesContext(ctx, sourceType)
 	if err != nil {
 		return 0, fmt.Errorf("list %s sources: %w", sourceType, err)
 	}
 	repaired := 0
 	var failures []error
 	for _, src := range sources {
+		if err := ctx.Err(); err != nil {
+			failures = append(failures, err)
+			break
+		}
 		sourceIdentifier := strings.TrimSpace(src.Identifier)
 		address := repairIdentityAddress(src)
 		if onlyIdentifier != "" &&
@@ -92,9 +97,11 @@ func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.
 		if parseErr != nil || parsed.Name != "" || !strings.EqualFold(parsed.Address, address) {
 			continue // not one plain email address; nothing to attribute against
 		}
-		existing, lerr := s.ListAccountIdentities(src.ID)
+		existing, lerr := s.ListAccountIdentitiesContext(ctx, src.ID)
 		if lerr != nil {
-			return repaired, fmt.Errorf("list identities for %s: %w", sourceIdentifier, lerr)
+			failures = append(failures,
+				fmt.Errorf("list identities for %s: %w", sourceIdentifier, lerr))
+			break
 		}
 		alreadyConfirmed := false
 		for _, identity := range existing {
@@ -106,15 +113,15 @@ func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.
 		if alreadyConfirmed {
 			continue // this account address is already confirmed
 		}
-		before := countFromMe(s, src.ID)
-		// AddAccountIdentity's insert hook retro-attributes matching messages in
-		// the same transaction (see store.addAccountIdentityContext).
-		if err := s.AddAccountIdentity(src.ID, address, "identity-repair"); err != nil {
+		before := countFromMe(ctx, s, src.ID)
+		// AddAccountIdentityContext's insert hook retro-attributes matching
+		// messages in the same transaction (see store.addAccountIdentityContext).
+		if err := s.AddAccountIdentityContext(ctx, src.ID, address, "identity-repair"); err != nil {
 			_, _ = fmt.Fprintf(out, "  %s: FAILED: %v\n", sourceIdentifier, err)
 			failures = append(failures, fmt.Errorf("add identity for %s: %w", sourceIdentifier, err))
 			continue
 		}
-		after := countFromMe(s, src.ID)
+		after := countFromMe(ctx, s, src.ID)
 		_, _ = fmt.Fprintf(out, "  %s: confirmed identity %s; is_from_me %d -> %d\n",
 			sourceIdentifier, address, before, after)
 		repaired++
@@ -140,9 +147,9 @@ func repairIdentityAddress(src *store.Source) string {
 
 // countFromMe returns how many messages in a source are attributed to the
 // account owner. Best-effort: a query error yields -1 (shown but non-fatal).
-func countFromMe(s *store.Store, sourceID int64) int {
+func countFromMe(ctx context.Context, s *store.Store, sourceID int64) int {
 	var n int
-	if err := s.DB().QueryRow(
+	if err := s.DB().QueryRowContext(ctx,
 		s.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ? AND is_from_me = 1`),
 		sourceID).Scan(&n); err != nil {
 		return -1

--- a/cmd/msgvault/cmd/repair_identity.go
+++ b/cmd/msgvault/cmd/repair_identity.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	repairIdentityType string
+)
+
+func newRepairIdentityCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repair-identity [identifier]",
+		Short: "Confirm account identities and recompute is_from_me on existing messages",
+		Long: `Confirm each account's own address as its identity and recompute the
+is_from_me attribution on messages already in the archive.
+
+Provider syncs (e.g. Gmail via a service account) can create a source without
+confirming its own address as an account identity. When that happens, no
+message is attributed to the account owner: is_from_me stays 0 for everything,
+so "what did this person send" cannot be answered. This command adds the
+account's own address as a confirmed identity, which in the same transaction
+retro-attributes matching earlier messages (those the account sent) as
+is_from_me = 1.
+
+It is idempotent and safe: sources that already have a confirmed identity are
+skipped (re-adding an existing identity would not re-attribute), and only
+sources whose identifier looks like an email address are touched.
+
+Examples:
+  msgvault repair-identity                       # all Gmail accounts missing an identity
+  msgvault repair-identity you@example.com       # one account
+  msgvault repair-identity --type imap`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+			s, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			only := ""
+			if len(args) == 1 {
+				only = strings.TrimSpace(args[0])
+			}
+			repaired, rerr := repairIdentities(s, repairIdentityType, only, cmd.OutOrStdout())
+			cacheErr := rebuildCacheAfterWrite(cfg.DatabaseDSN())
+			if rerr != nil {
+				return errors.Join(rerr, cacheErr)
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Repaired %d source(s).\n", repaired)
+			return cacheErr
+		},
+	}
+	cmd.Flags().StringVar(&repairIdentityType, "type", "gmail", "source type to repair")
+	return cmd
+}
+
+// repairIdentities confirms the own-address identity (and retro-attributes
+// is_from_me) for every source of sourceType whose identifier is an email and
+// which has no confirmed identity yet. When onlyIdentifier is non-empty, only
+// that account is considered. Returns the number of sources repaired.
+func repairIdentities(s *store.Store, sourceType, onlyIdentifier string, out io.Writer) (int, error) {
+	sources, err := s.ListSources(sourceType)
+	if err != nil {
+		return 0, fmt.Errorf("list %s sources: %w", sourceType, err)
+	}
+	repaired := 0
+	for _, src := range sources {
+		id := strings.TrimSpace(src.Identifier)
+		if onlyIdentifier != "" && !strings.EqualFold(id, onlyIdentifier) {
+			continue
+		}
+		if !strings.Contains(id, "@") {
+			continue // not an email-shaped identifier; nothing to attribute against
+		}
+		existing, lerr := s.ListAccountIdentities(src.ID)
+		if lerr != nil {
+			return repaired, fmt.Errorf("list identities for %s: %w", id, lerr)
+		}
+		if len(existing) > 0 {
+			continue // already confirmed; AddAccountIdentity would not re-attribute
+		}
+		before := countFromMe(s, src.ID)
+		// AddAccountIdentity's insert hook retro-attributes matching messages in
+		// the same transaction (see store.addAccountIdentityContext).
+		if err := s.AddAccountIdentity(src.ID, id, "identity-repair"); err != nil {
+			_, _ = fmt.Fprintf(out, "  %s: FAILED: %v\n", id, err)
+			continue
+		}
+		after := countFromMe(s, src.ID)
+		_, _ = fmt.Fprintf(out, "  %s: confirmed identity; is_from_me %d -> %d\n", id, before, after)
+		repaired++
+	}
+	return repaired, nil
+}
+
+// countFromMe returns how many messages in a source are attributed to the
+// account owner. Best-effort: a query error yields -1 (shown but non-fatal).
+func countFromMe(s *store.Store, sourceID int64) int {
+	var n int
+	if err := s.DB().QueryRow(
+		s.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ? AND is_from_me = 1`),
+		sourceID).Scan(&n); err != nil {
+		return -1
+	}
+	return n
+}
+
+func init() {
+	rootCmd.AddCommand(newRepairIdentityCmd())
+}

--- a/cmd/msgvault/cmd/repair_identity_test.go
+++ b/cmd/msgvault/cmd/repair_identity_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +33,7 @@ func TestRepairIdentities_Selection(t *testing.T) {
 	require.NoError(err)
 
 	var buf bytes.Buffer
-	n, err := repairIdentities(st, "gmail", "", &buf)
+	n, err := repairIdentities(t.Context(), st, "gmail", "", &buf)
 	require.NoError(err)
 	assert.Equal(1, n, "only the valid gmail address without an identity is repaired")
 
@@ -57,7 +59,7 @@ func TestRepairIdentities_Selection(t *testing.T) {
 
 	// Idempotent: a second run repairs nothing (all now confirmed).
 	buf.Reset()
-	n2, err := repairIdentities(st, "gmail", "", &buf)
+	n2, err := repairIdentities(t.Context(), st, "gmail", "", &buf)
 	require.NoError(err)
 	assert.Zero(n2, "re-running repairs nothing once identities are confirmed")
 }
@@ -73,7 +75,7 @@ func TestRepairIdentities_SingleTarget(t *testing.T) {
 	require.NoError(err)
 
 	var buf bytes.Buffer
-	n, err := repairIdentities(st, "gmail", "FRANK@example.com", &buf) // case-insensitive
+	n, err := repairIdentities(t.Context(), st, "gmail", "FRANK@example.com", &buf) // case-insensitive
 	require.NoError(err)
 	assert.Equal(1, n)
 
@@ -96,7 +98,7 @@ func TestRepairIdentities_IMAPUsesConfiguredUsername(t *testing.T) {
 	require.NoError(st.UpdateSourceSyncConfig(source.ID, configJSON))
 
 	var buf bytes.Buffer
-	repaired, err := repairIdentities(st, "imap", "", &buf)
+	repaired, err := repairIdentities(t.Context(), st, "imap", "", &buf)
 	require.NoError(err)
 	assert.Equal(1, repaired)
 
@@ -120,7 +122,7 @@ func TestRepairIdentities_IMAPTargetMatchesConfiguredUsername(t *testing.T) {
 	require.NoError(st.UpdateSourceSyncConfig(source.ID, configJSON))
 
 	var buf bytes.Buffer
-	repaired, err := repairIdentities(st, "imap", "OWNER@example.com", &buf)
+	repaired, err := repairIdentities(t.Context(), st, "imap", "OWNER@example.com", &buf)
 	require.NoError(err)
 	assert.Equal(1, repaired)
 
@@ -143,7 +145,7 @@ func TestRepairIdentities_SkipsOnlyMatchingIdentity(t *testing.T) {
 	require.NoError(st.AddAccountIdentity(matching.ID, "CONFIRMED@EXAMPLE.COM", "preexisting"))
 
 	var buf bytes.Buffer
-	repaired, err := repairIdentities(st, "gmail", "", &buf)
+	repaired, err := repairIdentities(t.Context(), st, "gmail", "", &buf)
 	require.NoError(err)
 	assert.Equal(1, repaired, "only the source missing its own address is repaired")
 
@@ -167,7 +169,7 @@ func TestRepairIdentities_ReturnsAddFailuresAfterRemainingSources(t *testing.T) 
 	installFailingRepairIdentityTrigger(t, st)
 
 	var buf bytes.Buffer
-	repaired, err := repairIdentities(st, "gmail", "", &buf)
+	repaired, err := repairIdentities(t.Context(), st, "gmail", "", &buf)
 	require.Error(err)
 	require.ErrorContains(err, "fail@example.com")
 	require.ErrorContains(err, "forced identity failure")
@@ -179,6 +181,41 @@ func TestRepairIdentities_ReturnsAddFailuresAfterRemainingSources(t *testing.T) 
 	succeededIdentities, listErr := st.ListAccountIdentities(succeeded.ID)
 	require.NoError(listErr)
 	assert.Len(succeededIdentities, 1)
+}
+
+func TestRepairIdentities_CancellationStopsBeforeNextSource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+
+	first, err := st.GetOrCreateSource("gmail", "a@example.com")
+	require.NoError(err)
+	second, err := st.GetOrCreateSource("gmail", "b@example.com")
+	require.NoError(err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	reader, writer := io.Pipe()
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		var firstByte [1]byte
+		_, _ = reader.Read(firstByte[:])
+		cancel()
+		_ = reader.CloseWithError(context.Canceled)
+	}()
+
+	repaired, err := repairIdentities(ctx, st, "gmail", "", writer)
+	_ = writer.Close()
+	<-readDone
+	require.ErrorIs(err, context.Canceled)
+	assert.Equal(1, repaired, "the completed source remains reported")
+
+	firstIdentities, listErr := st.ListAccountIdentities(first.ID)
+	require.NoError(listErr)
+	assert.Len(firstIdentities, 1)
+	secondIdentities, listErr := st.ListAccountIdentities(second.ID)
+	require.NoError(listErr)
+	assert.Empty(secondIdentities, "cancellation prevents the next source repair")
 }
 
 func installFailingRepairIdentityTrigger(t *testing.T, st *store.Store) {

--- a/cmd/msgvault/cmd/repair_identity_test.go
+++ b/cmd/msgvault/cmd/repair_identity_test.go
@@ -106,6 +106,30 @@ func TestRepairIdentities_IMAPUsesConfiguredUsername(t *testing.T) {
 	assert.Equal("owner@example.com", identities[0].Address)
 }
 
+func TestRepairIdentities_IMAPTargetMatchesConfiguredUsername(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	imapCfg := &imapclient.Config{
+		Host: "mail.example.com", Port: 993, TLS: true, Username: "owner@example.com",
+	}
+	source, err := st.GetOrCreateSource("imap", imapCfg.Identifier())
+	require.NoError(err)
+	configJSON, err := imapCfg.ToJSON()
+	require.NoError(err)
+	require.NoError(st.UpdateSourceSyncConfig(source.ID, configJSON))
+
+	var buf bytes.Buffer
+	repaired, err := repairIdentities(st, "imap", "OWNER@example.com", &buf)
+	require.NoError(err)
+	assert.Equal(1, repaired)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	require.Len(identities, 1)
+	assert.Equal("owner@example.com", identities[0].Address)
+}
+
 func TestRepairIdentities_SkipsOnlyMatchingIdentity(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/msgvault/cmd/repair_identity_test.go
+++ b/cmd/msgvault/cmd/repair_identity_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	imapclient "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
@@ -139,14 +140,7 @@ func TestRepairIdentities_ReturnsAddFailuresAfterRemainingSources(t *testing.T) 
 	require.NoError(err)
 	succeeded, err := st.GetOrCreateSource("gmail", "succeed@example.com")
 	require.NoError(err)
-	_, err = st.DB().Exec(`
-		CREATE TRIGGER fail_repair_identity
-		BEFORE INSERT ON account_identities
-		WHEN NEW.address = 'fail@example.com'
-		BEGIN
-			SELECT RAISE(FAIL, 'forced identity failure');
-		END`)
-	require.NoError(err)
+	installFailingRepairIdentityTrigger(t, st)
 
 	var buf bytes.Buffer
 	repaired, err := repairIdentities(st, "gmail", "", &buf)
@@ -161,4 +155,36 @@ func TestRepairIdentities_ReturnsAddFailuresAfterRemainingSources(t *testing.T) 
 	succeededIdentities, listErr := st.ListAccountIdentities(succeeded.ID)
 	require.NoError(listErr)
 	assert.Len(succeededIdentities, 1)
+}
+
+func installFailingRepairIdentityTrigger(t *testing.T, st *store.Store) {
+	t.Helper()
+
+	var err error
+	if st.IsPostgreSQL() {
+		_, err = st.DB().Exec(`
+			CREATE FUNCTION fail_repair_identity() RETURNS trigger
+			LANGUAGE plpgsql AS $$
+			BEGIN
+				IF NEW.address = 'fail@example.com' THEN
+					RAISE EXCEPTION 'forced identity failure';
+				END IF;
+				RETURN NEW;
+			END
+			$$;
+
+			CREATE TRIGGER fail_repair_identity
+			BEFORE INSERT ON account_identities
+			FOR EACH ROW EXECUTE FUNCTION fail_repair_identity()
+		`)
+	} else {
+		_, err = st.DB().Exec(`
+			CREATE TRIGGER fail_repair_identity
+			BEFORE INSERT ON account_identities
+			WHEN NEW.address = 'fail@example.com'
+			BEGIN
+				SELECT RAISE(FAIL, 'forced identity failure');
+			END`)
+	}
+	require.NoError(t, err)
 }

--- a/cmd/msgvault/cmd/repair_identity_test.go
+++ b/cmd/msgvault/cmd/repair_identity_test.go
@@ -6,66 +6,159 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	imapclient "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/testutil"
 )
 
 // repair-identity must confirm the own-address identity for exactly the
 // email-shaped, identity-less sources of the requested type, and be idempotent.
 func TestRepairIdentities_Selection(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 
 	a, err := st.GetOrCreateSource("gmail", "frank@example.com") // email, no identity -> repaired
-	require.NoError(t, err)
+	require.NoError(err)
 	b, err := st.GetOrCreateSource("gmail", "alice@example.com") // already confirmed -> skipped
-	require.NoError(t, err)
-	require.NoError(t, st.AddAccountIdentity(b.ID, "alice@example.com", "preexisting"))
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(b.ID, "alice@example.com", "preexisting"))
 	c, err := st.GetOrCreateSource("gmail", "notanemail") // non-email identifier -> skipped
-	require.NoError(t, err)
+	require.NoError(err)
 	d, err := st.GetOrCreateSource("imap", "bob@example.com") // wrong type -> skipped
-	require.NoError(t, err)
+	require.NoError(err)
+	e, err := st.GetOrCreateSource("gmail", "https://user@example.com/mail") // URL, not an email -> skipped
+	require.NoError(err)
 
 	var buf bytes.Buffer
 	n, err := repairIdentities(st, "gmail", "", &buf)
-	require.NoError(t, err)
-	assert.Equal(t, 1, n, "only the email-shaped gmail source without an identity is repaired")
+	require.NoError(err)
+	assert.Equal(1, n, "only the valid gmail address without an identity is repaired")
 
 	ai, err := st.ListAccountIdentities(a.ID)
-	require.NoError(t, err)
-	assert.Len(t, ai, 1, "frank gets his own address confirmed")
+	require.NoError(err)
+	assert.Len(ai, 1, "frank gets his own address confirmed")
 
 	ci, err := st.ListAccountIdentities(c.ID)
-	require.NoError(t, err)
-	assert.Empty(t, ci, "non-email identifier is left alone")
+	require.NoError(err)
+	assert.Empty(ci, "non-email identifier is left alone")
 
 	di, err := st.ListAccountIdentities(d.ID)
-	require.NoError(t, err)
-	assert.Empty(t, di, "imap source untouched when repairing gmail")
+	require.NoError(err)
+	assert.Empty(di, "imap source untouched when repairing gmail")
+
+	ei, err := st.ListAccountIdentities(e.ID)
+	require.NoError(err)
+	assert.Empty(ei, "URL identifier is not accepted as an email address")
 
 	bi, err := st.ListAccountIdentities(b.ID)
-	require.NoError(t, err)
-	assert.Len(t, bi, 1, "already-confirmed source is not doubled")
+	require.NoError(err)
+	assert.Len(bi, 1, "already-confirmed source is not doubled")
 
 	// Idempotent: a second run repairs nothing (all now confirmed).
 	buf.Reset()
 	n2, err := repairIdentities(st, "gmail", "", &buf)
-	require.NoError(t, err)
-	assert.Zero(t, n2, "re-running repairs nothing once identities are confirmed")
+	require.NoError(err)
+	assert.Zero(n2, "re-running repairs nothing once identities are confirmed")
 }
 
 // The onlyIdentifier argument scopes the repair to a single account.
 func TestRepairIdentities_SingleTarget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	a, err := st.GetOrCreateSource("gmail", "frank@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 	_, err = st.GetOrCreateSource("gmail", "carol@example.com")
-	require.NoError(t, err)
+	require.NoError(err)
 
 	var buf bytes.Buffer
 	n, err := repairIdentities(st, "gmail", "FRANK@example.com", &buf) // case-insensitive
-	require.NoError(t, err)
-	assert.Equal(t, 1, n)
+	require.NoError(err)
+	assert.Equal(1, n)
 
 	ai, err := st.ListAccountIdentities(a.ID)
-	require.NoError(t, err)
-	assert.Len(t, ai, 1, "only the targeted account is confirmed")
+	require.NoError(err)
+	assert.Len(ai, 1, "only the targeted account is confirmed")
+}
+
+func TestRepairIdentities_IMAPUsesConfiguredUsername(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	imapCfg := &imapclient.Config{
+		Host: "mail.example.com", Port: 993, TLS: true, Username: "owner@example.com",
+	}
+	source, err := st.GetOrCreateSource("imap", imapCfg.Identifier())
+	require.NoError(err)
+	configJSON, err := imapCfg.ToJSON()
+	require.NoError(err)
+	require.NoError(st.UpdateSourceSyncConfig(source.ID, configJSON))
+
+	var buf bytes.Buffer
+	repaired, err := repairIdentities(st, "imap", "", &buf)
+	require.NoError(err)
+	assert.Equal(1, repaired)
+
+	identities, err := st.ListAccountIdentities(source.ID)
+	require.NoError(err)
+	require.Len(identities, 1)
+	assert.Equal("owner@example.com", identities[0].Address)
+}
+
+func TestRepairIdentities_SkipsOnlyMatchingIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+
+	aliasOnly, err := st.GetOrCreateSource("gmail", "owner@example.com")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(aliasOnly.ID, "alias@example.com", "preexisting"))
+	matching, err := st.GetOrCreateSource("gmail", "confirmed@example.com")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(matching.ID, "CONFIRMED@EXAMPLE.COM", "preexisting"))
+
+	var buf bytes.Buffer
+	repaired, err := repairIdentities(st, "gmail", "", &buf)
+	require.NoError(err)
+	assert.Equal(1, repaired, "only the source missing its own address is repaired")
+
+	aliasIdentities, err := st.ListAccountIdentities(aliasOnly.ID)
+	require.NoError(err)
+	assert.Len(aliasIdentities, 2, "an unrelated alias must not suppress the account address")
+	matchingIdentities, err := st.ListAccountIdentities(matching.ID)
+	require.NoError(err)
+	assert.Len(matchingIdentities, 1, "case-equivalent account address is already confirmed")
+}
+
+func TestRepairIdentities_ReturnsAddFailuresAfterRemainingSources(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+
+	failed, err := st.GetOrCreateSource("gmail", "fail@example.com")
+	require.NoError(err)
+	succeeded, err := st.GetOrCreateSource("gmail", "succeed@example.com")
+	require.NoError(err)
+	_, err = st.DB().Exec(`
+		CREATE TRIGGER fail_repair_identity
+		BEFORE INSERT ON account_identities
+		WHEN NEW.address = 'fail@example.com'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced identity failure');
+		END`)
+	require.NoError(err)
+
+	var buf bytes.Buffer
+	repaired, err := repairIdentities(st, "gmail", "", &buf)
+	require.Error(err)
+	require.ErrorContains(err, "fail@example.com")
+	require.ErrorContains(err, "forced identity failure")
+	assert.Equal(1, repaired, "the later source is still repaired")
+
+	failedIdentities, listErr := st.ListAccountIdentities(failed.ID)
+	require.NoError(listErr)
+	assert.Empty(failedIdentities)
+	succeededIdentities, listErr := st.ListAccountIdentities(succeeded.ID)
+	require.NoError(listErr)
+	assert.Len(succeededIdentities, 1)
 }

--- a/cmd/msgvault/cmd/repair_identity_test.go
+++ b/cmd/msgvault/cmd/repair_identity_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// repair-identity must confirm the own-address identity for exactly the
+// email-shaped, identity-less sources of the requested type, and be idempotent.
+func TestRepairIdentities_Selection(t *testing.T) {
+	st := testutil.NewTestStore(t)
+
+	a, err := st.GetOrCreateSource("gmail", "frank@example.com") // email, no identity -> repaired
+	require.NoError(t, err)
+	b, err := st.GetOrCreateSource("gmail", "alice@example.com") // already confirmed -> skipped
+	require.NoError(t, err)
+	require.NoError(t, st.AddAccountIdentity(b.ID, "alice@example.com", "preexisting"))
+	c, err := st.GetOrCreateSource("gmail", "notanemail") // non-email identifier -> skipped
+	require.NoError(t, err)
+	d, err := st.GetOrCreateSource("imap", "bob@example.com") // wrong type -> skipped
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	n, err := repairIdentities(st, "gmail", "", &buf)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the email-shaped gmail source without an identity is repaired")
+
+	ai, err := st.ListAccountIdentities(a.ID)
+	require.NoError(t, err)
+	assert.Len(t, ai, 1, "frank gets his own address confirmed")
+
+	ci, err := st.ListAccountIdentities(c.ID)
+	require.NoError(t, err)
+	assert.Empty(t, ci, "non-email identifier is left alone")
+
+	di, err := st.ListAccountIdentities(d.ID)
+	require.NoError(t, err)
+	assert.Empty(t, di, "imap source untouched when repairing gmail")
+
+	bi, err := st.ListAccountIdentities(b.ID)
+	require.NoError(t, err)
+	assert.Len(t, bi, 1, "already-confirmed source is not doubled")
+
+	// Idempotent: a second run repairs nothing (all now confirmed).
+	buf.Reset()
+	n2, err := repairIdentities(st, "gmail", "", &buf)
+	require.NoError(t, err)
+	assert.Zero(t, n2, "re-running repairs nothing once identities are confirmed")
+}
+
+// The onlyIdentifier argument scopes the repair to a single account.
+func TestRepairIdentities_SingleTarget(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	a, err := st.GetOrCreateSource("gmail", "frank@example.com")
+	require.NoError(t, err)
+	_, err = st.GetOrCreateSource("gmail", "carol@example.com")
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	n, err := repairIdentities(st, "gmail", "FRANK@example.com", &buf) // case-insensitive
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	ai, err := st.ListAccountIdentities(a.ID)
+	require.NoError(t, err)
+	assert.Len(t, ai, 1, "only the targeted account is confirmed")
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1519,6 +1519,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"pack-attachments",
 		"purge-excluded-media",
 		"repair-dates",
+		"repair-identity",
 		"repack-attachments",
 		"remove-account",
 		"repair-derived",


### PR DESCRIPTION
What: adds a `repair-identity` CLI command that confirms each account's own address as a confirmed account identity and recomputes `is_from_me` on messages already in the archive.

Why: provider syncs (e.g. Gmail via a service account) can create a source without ever confirming its own address as an account identity. When that happens no message is attributed to the account owner — `is_from_me` stays 0 for every message — so "what did this account send" cannot be answered. Identity management already exists via the API/web UI, but there is no CLI/batch way to confirm an account's own address and repair attribution across sources.

How: confirming an identity already triggers `refreshSourceMessageAttribution` in the same transaction (existing store behavior), so the command calls `AddAccountIdentity(source, ownAddress)` for each in-scope source. Idempotent — sources that already have a confirmed identity are skipped, and only email-shaped identifiers are touched. Defaults to gmail sources; `--type` targets others; an optional identifier argument scopes to one account.

Usage:
```
msgvault repair-identity                 # all Gmail accounts missing an identity
msgvault repair-identity you@example.com # one account
msgvault repair-identity --type imap
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)