### PR TITLE
feat(whatsapp): import Apple ChatStorage text

### DIFF
--- a/cmd/msgvault/cmd/import.go
+++ b/cmd/msgvault/cmd/import.go
@@ -25,12 +25,16 @@ var (
 )
 
 var importWhatsappCmd = &cobra.Command{
-	Use:   "import-whatsapp <msgstore.db>",
-	Short: "Import WhatsApp messages from decrypted backup",
-	Long: `Import messages from a decrypted WhatsApp msgstore.db backup.
+	Use:   "import-whatsapp <database>",
+	Short: "Import WhatsApp messages from an Android or Apple database",
+	Long: `Import messages from a decrypted Android msgstore.db backup or an
+Apple ChatStorage.sqlite database. Apple databases currently import text
+messages from direct and group chats. Reading the native macOS WhatsApp store
+may require Full Disk Access in System Settings > Privacy & Security.
 
 Examples:
   msgvault import-whatsapp --phone "+447700900000" /path/to/msgstore.db
+  msgvault import-whatsapp --phone "+447700900000" "$HOME/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite"
   msgvault import-whatsapp --phone "+447700900000" --contacts ~/contacts.vcf /path/to/msgstore.db
   msgvault import-whatsapp --phone "+447700900000" --media-dir /path/to/Media /path/to/msgstore.db`,
 	Args: cobra.ExactArgs(1),

--- a/internal/whatsapp/apple.go
+++ b/internal/whatsapp/apple.go
@@ -1,0 +1,712 @@
+package whatsapp
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const appleEpochOffset = int64(978307200)
+
+type appleChat struct {
+	RowID  int64
+	RawJID string
+	Name   string
+}
+
+type appleMessage struct {
+	RowID          int64               `json:"row_id"`
+	ChatRowID      int64               `json:"chat_row_id"`
+	StanzaID       string              `json:"stanza_id"`
+	FromMe         int                 `json:"from_me"`
+	MessageDate    appleTimestampValue `json:"message_date"`
+	Text           sql.NullString      `json:"text"`
+	MessageType    int                 `json:"message_type"`
+	FromJID        string              `json:"from_jid"`
+	GroupMemberJID string              `json:"group_member_jid"`
+	GroupContact   string              `json:"group_contact_name"`
+	GroupFirstName string              `json:"group_first_name"`
+}
+
+// appleTimestampValue accepts both numeric Core Data timestamp values and the
+// time.Time values returned by go-sqlite3 for columns declared TIMESTAMP.
+// time.Time.Unix recovers the original numeric seconds before the Apple epoch
+// offset is applied by appleMessageTimestamp.
+type appleTimestampValue struct {
+	Seconds float64 `json:"seconds"`
+	Valid   bool    `json:"valid"`
+}
+
+func (value *appleTimestampValue) Scan(source any) error {
+	switch typed := source.(type) {
+	case nil:
+		*value = appleTimestampValue{}
+		return nil
+	case time.Time:
+		value.Seconds = float64(typed.Unix()) +
+			float64(typed.Nanosecond())/float64(time.Second)
+		value.Valid = true
+		return nil
+	case int64:
+		value.Seconds = float64(typed)
+		value.Valid = true
+		return nil
+	case float64:
+		value.Seconds = typed
+		value.Valid = true
+		return nil
+	case []byte:
+		return value.scanString(string(typed))
+	case string:
+		return value.scanString(typed)
+	default:
+		return fmt.Errorf("unsupported Apple timestamp value %T", source)
+	}
+}
+
+func (value *appleTimestampValue) scanString(source string) error {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		*value = appleTimestampValue{}
+		return nil
+	}
+	seconds, err := strconv.ParseFloat(source, 64)
+	if err != nil {
+		return fmt.Errorf("parse Apple timestamp: %w", err)
+	}
+	value.Seconds = seconds
+	value.Valid = true
+	return nil
+}
+
+type appleGroupMember struct {
+	JID         string
+	ContactName string
+	FirstName   string
+	IsAdmin     bool
+}
+
+func (imp *Importer) importApple(
+	ctx context.Context,
+	db *sql.DB,
+	chatDBPath string,
+	opts ImportOptions,
+) (summary *ImportSummary, retErr error) {
+	startedAt := time.Now()
+	summary = &ImportSummary{}
+
+	source, err := imp.store.GetOrCreateSource("whatsapp", opts.Phone)
+	if err != nil {
+		return nil, fmt.Errorf("get or create source: %w", err)
+	}
+	if opts.DisplayName != "" {
+		_ = imp.store.UpdateSourceDisplayName(source.ID, opts.DisplayName)
+	}
+	summary.SourceID = source.ID
+
+	syncID, err := imp.store.StartSync(source.ID, "whatsapp_apple_import")
+	if err != nil {
+		return nil, fmt.Errorf("start sync: %w", err)
+	}
+	scoped := *imp
+	scoped.store = imp.store.ScopedToSync(source.ID, syncID)
+	imp = &scoped
+	defer func() {
+		if retErr != nil {
+			_ = imp.store.FailSync(syncID, retErr.Error())
+			return
+		}
+		if err := imp.store.CompleteSync(syncID, ""); err != nil {
+			retErr = fmt.Errorf("complete sync: %w", err)
+		}
+	}()
+
+	imp.progress.OnStart()
+
+	lidMap, err := loadAppleLIDMap(ctx, chatDBPath)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple LID mapping: %w", err)
+	}
+	duplicateStanzas, duplicateRows, err := fetchDuplicateAppleTextStanzas(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("find duplicate Apple stanza IDs: %w", err)
+	}
+	if duplicateRows > 0 {
+		summary.Errors++
+		imp.progress.OnError(fmt.Errorf(
+			"skipping %d Apple text messages whose stanza IDs are duplicated",
+			duplicateRows,
+		))
+	}
+
+	selfParticipantID, err := imp.store.EnsureParticipantByPhone(
+		opts.Phone, opts.DisplayName, "whatsapp",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("ensure self participant: %w", err)
+	}
+	participantIDs := map[string]int64{opts.Phone: selfParticipantID}
+	summary.Participants = 1
+
+	chats, err := fetchAppleChats(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Apple chats: %w", err)
+	}
+
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	totalLimit := int64(opts.Limit)
+	var totalAdded int64
+
+	for _, chat := range chats {
+		if err := ctx.Err(); err != nil {
+			return summary, err
+		}
+		if totalLimit > 0 && totalAdded >= totalLimit {
+			break
+		}
+		if !isImportableAppleChat(chat.RawJID) {
+			continue
+		}
+
+		canonicalChatJID := canonicalAppleJID(chat.RawJID, lidMap)
+		conversationType := "direct_chat"
+		conversationTitle := ""
+		if isAppleGroupJID(chat.RawJID) {
+			conversationType = "group_chat"
+			conversationTitle = chat.Name
+		}
+		conversationID, err := imp.store.EnsureConversationWithType(
+			source.ID, canonicalChatJID, conversationType, conversationTitle,
+		)
+		if err != nil {
+			return summary, fmt.Errorf("ensure Apple conversation: %w", err)
+		}
+		summary.ChatsProcessed++
+		imp.progress.OnChatStart(canonicalChatJID, appleChatTitle(chat, lidMap), 0)
+
+		if err := imp.store.EnsureConversationParticipant(
+			conversationID, selfParticipantID, "member",
+		); err != nil {
+			return summary, fmt.Errorf("add self to Apple conversation: %w", err)
+		}
+
+		if isAppleGroupJID(chat.RawJID) {
+			members, err := fetchAppleGroupMembers(ctx, db, chat.RowID)
+			if err != nil {
+				return summary, fmt.Errorf("fetch Apple group members: %w", err)
+			}
+			for _, member := range members {
+				phone := applePhoneForJID(member.JID, lidMap)
+				if phone == "" {
+					continue
+				}
+				participantID, err := ensureAppleParticipant(
+					imp.store, phone, firstNonEmptyApple(member.ContactName, member.FirstName),
+					participantIDs, summary,
+				)
+				if err != nil {
+					return summary, err
+				}
+				role := "member"
+				if member.IsAdmin {
+					role = "admin"
+				}
+				if err := imp.store.EnsureConversationParticipant(
+					conversationID, participantID, role,
+				); err != nil {
+					return summary, fmt.Errorf("add Apple group participant: %w", err)
+				}
+			}
+		} else if phone := applePhoneForJID(chat.RawJID, lidMap); phone != "" {
+			participantID, err := ensureAppleParticipant(
+				imp.store, phone, chat.Name, participantIDs, summary,
+			)
+			if err != nil {
+				return summary, err
+			}
+			if err := imp.store.EnsureConversationParticipant(
+				conversationID, participantID, "member",
+			); err != nil {
+				return summary, fmt.Errorf("add Apple direct participant: %w", err)
+			}
+		}
+
+		var afterRowID int64
+		var chatAdded int64
+		for {
+			if err := ctx.Err(); err != nil {
+				return summary, err
+			}
+			remaining := batchSize
+			if totalLimit > 0 {
+				left := totalLimit - totalAdded
+				if left <= 0 {
+					break
+				}
+				if left < int64(remaining) {
+					remaining = int(left)
+				}
+			}
+
+			messages, err := fetchAppleMessages(
+				ctx, db, chat.RowID, afterRowID, remaining,
+			)
+			if err != nil {
+				return summary, fmt.Errorf("fetch Apple messages: %w", err)
+			}
+			if len(messages) == 0 {
+				break
+			}
+
+			for _, sourceMessage := range messages {
+				afterRowID = sourceMessage.RowID
+				summary.MessagesProcessed++
+				if sourceMessage.MessageType != 0 ||
+					!sourceMessage.Text.Valid || strings.TrimSpace(sourceMessage.Text.String) == "" ||
+					strings.TrimSpace(sourceMessage.StanzaID) == "" {
+					summary.MessagesSkipped++
+					continue
+				}
+				if _, duplicate := duplicateStanzas[sourceMessage.StanzaID]; duplicate {
+					summary.MessagesSkipped++
+					continue
+				}
+
+				senderID, senderPhone, err := resolveAppleMessageSender(
+					imp.store, sourceMessage, chat, lidMap,
+					selfParticipantID, participantIDs, summary,
+				)
+				if err != nil {
+					return summary, err
+				}
+				if sourceMessage.FromMe != 0 {
+					senderPhone = opts.Phone
+				}
+				if senderID.Valid {
+					if err := imp.store.EnsureConversationParticipant(
+						conversationID, senderID.Int64, "member",
+					); err != nil {
+						return summary, fmt.Errorf("add Apple message sender: %w", err)
+					}
+				}
+
+				message := mapAppleMessage(
+					sourceMessage, conversationID, source.ID, senderID,
+				)
+				messageID, err := imp.store.UpsertMessage(&message)
+				if err != nil {
+					return summary, fmt.Errorf("upsert Apple message: %w", err)
+				}
+				if err := imp.store.UpsertMessageBody(
+					messageID, sourceMessage.Text, sql.NullString{},
+				); err != nil {
+					return summary, fmt.Errorf("store Apple message body: %w", err)
+				}
+				rawJSON, err := json.Marshal(sourceMessage)
+				if err != nil {
+					return summary, fmt.Errorf("encode Apple message raw data: %w", err)
+				}
+				if err := imp.store.UpsertMessageRawWithFormat(
+					messageID, rawJSON, "whatsapp_apple_json",
+				); err != nil {
+					return summary, fmt.Errorf("store Apple message raw data: %w", err)
+				}
+				if err := imp.store.UpsertFTS(
+					messageID, "", sourceMessage.Text.String, senderPhone, "", "",
+				); err != nil {
+					return summary, fmt.Errorf("index Apple message: %w", err)
+				}
+
+				summary.MessagesAdded++
+				chatAdded++
+				totalAdded++
+				if totalLimit > 0 && totalAdded >= totalLimit {
+					break
+				}
+			}
+
+			if err := imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+				MessagesProcessed: summary.MessagesProcessed,
+				MessagesAdded:     summary.MessagesAdded,
+			}); err != nil {
+				return summary, fmt.Errorf("checkpoint Apple import: %w", err)
+			}
+			imp.progress.OnProgress(
+				summary.MessagesProcessed,
+				summary.MessagesAdded,
+				summary.MessagesSkipped,
+			)
+
+			if len(messages) < remaining || (totalLimit > 0 && totalAdded >= totalLimit) {
+				break
+			}
+		}
+		imp.progress.OnChatComplete(canonicalChatJID, chatAdded)
+	}
+
+	if err := imp.store.RecomputeConversationStats(source.ID); err != nil {
+		return summary, fmt.Errorf("recompute Apple conversation stats: %w", err)
+	}
+	summary.Duration = time.Since(startedAt)
+	imp.progress.OnComplete(summary)
+	return summary, nil
+}
+
+func fetchAppleChats(ctx context.Context, db *sql.DB) ([]appleChat, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT Z_PK, COALESCE(ZCONTACTJID, ''), COALESCE(ZPARTNERNAME, '')
+		FROM ZWACHATSESSION
+		WHERE TRIM(COALESCE(ZCONTACTJID, '')) <> ''
+		ORDER BY COALESCE(ZLASTMESSAGEDATE, 0) DESC, Z_PK DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var chats []appleChat
+	for rows.Next() {
+		var chat appleChat
+		if err := rows.Scan(&chat.RowID, &chat.RawJID, &chat.Name); err != nil {
+			return nil, err
+		}
+		chats = append(chats, chat)
+	}
+	return chats, rows.Err()
+}
+
+func fetchAppleMessages(
+	ctx context.Context,
+	db *sql.DB,
+	chatRowID, afterRowID int64,
+	limit int,
+) ([]appleMessage, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT m.Z_PK, m.ZCHATSESSION, COALESCE(m.ZSTANZAID, ''),
+		       COALESCE(m.ZISFROMME, 0), m.ZMESSAGEDATE, m.ZTEXT,
+		       COALESCE(m.ZMESSAGETYPE, 0), COALESCE(m.ZFROMJID, ''),
+		       COALESCE(gm.ZMEMBERJID, ''), COALESCE(gm.ZCONTACTNAME, ''),
+		       COALESCE(gm.ZFIRSTNAME, '')
+		FROM ZWAMESSAGE m
+		LEFT JOIN ZWAGROUPMEMBER gm ON gm.Z_PK = m.ZGROUPMEMBER
+		WHERE m.ZCHATSESSION = ? AND m.Z_PK > ?
+		ORDER BY m.Z_PK ASC
+		LIMIT ?
+	`, chatRowID, afterRowID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var messages []appleMessage
+	for rows.Next() {
+		var message appleMessage
+		if err := rows.Scan(
+			&message.RowID, &message.ChatRowID, &message.StanzaID,
+			&message.FromMe, &message.MessageDate, &message.Text,
+			&message.MessageType, &message.FromJID,
+			&message.GroupMemberJID, &message.GroupContact,
+			&message.GroupFirstName,
+		); err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	return messages, rows.Err()
+}
+
+func fetchAppleGroupMembers(
+	ctx context.Context,
+	db *sql.DB,
+	chatRowID int64,
+) ([]appleGroupMember, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(ZMEMBERJID, ''), COALESCE(ZCONTACTNAME, ''),
+		       COALESCE(ZFIRSTNAME, ''), COALESCE(ZISADMIN, 0)
+		FROM ZWAGROUPMEMBER
+		WHERE ZCHATSESSION = ? AND TRIM(COALESCE(ZMEMBERJID, '')) <> ''
+		ORDER BY Z_PK ASC
+	`, chatRowID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var members []appleGroupMember
+	for rows.Next() {
+		var member appleGroupMember
+		var isAdmin int
+		if err := rows.Scan(
+			&member.JID, &member.ContactName, &member.FirstName, &isAdmin,
+		); err != nil {
+			return nil, err
+		}
+		member.IsAdmin = isAdmin != 0
+		members = append(members, member)
+	}
+	return members, rows.Err()
+}
+
+func fetchDuplicateAppleTextStanzas(
+	ctx context.Context,
+	db *sql.DB,
+) (map[string]struct{}, int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT m.ZSTANZAID, COUNT(*)
+		FROM ZWAMESSAGE m
+		JOIN ZWACHATSESSION c ON c.Z_PK = m.ZCHATSESSION
+		WHERE COALESCE(m.ZMESSAGETYPE, 0) = 0
+		  AND TRIM(COALESCE(m.ZSTANZAID, '')) <> ''
+		  AND TRIM(COALESCE(m.ZTEXT, '')) <> ''
+		  AND (
+		    LOWER(COALESCE(c.ZCONTACTJID, '')) LIKE '%@s.whatsapp.net'
+		    OR LOWER(COALESCE(c.ZCONTACTJID, '')) LIKE '%@lid'
+		    OR LOWER(COALESCE(c.ZCONTACTJID, '')) LIKE '%@g.us'
+		  )
+		GROUP BY m.ZSTANZAID
+		HAVING COUNT(*) > 1
+	`)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	duplicates := make(map[string]struct{})
+	var duplicateRows int64
+	for rows.Next() {
+		var stanzaID string
+		var count int64
+		if err := rows.Scan(&stanzaID, &count); err != nil {
+			return nil, 0, err
+		}
+		duplicates[stanzaID] = struct{}{}
+		duplicateRows += count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return duplicates, duplicateRows, nil
+}
+
+func loadAppleLIDMap(ctx context.Context, chatDBPath string) (map[string]string, error) {
+	lidPath := filepath.Join(filepath.Dir(chatDBPath), "LID.sqlite")
+	if _, err := os.Stat(lidPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+
+	db, err := openReadOnlyDatabase(ctx, lidPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	var tableCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'table' AND name = 'ZWAZACCOUNT'
+	`).Scan(&tableCount); err != nil {
+		return nil, err
+	}
+	if tableCount == 0 {
+		return map[string]string{}, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(ZIDENTIFIER, ''), COALESCE(ZPHONENUMBER, '')
+		FROM ZWAZACCOUNT
+		WHERE TRIM(COALESCE(ZIDENTIFIER, '')) <> ''
+		  AND TRIM(COALESCE(ZPHONENUMBER, '')) <> ''
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	mapping := make(map[string]string)
+	for rows.Next() {
+		var identifier, phoneValue string
+		if err := rows.Scan(&identifier, &phoneValue); err != nil {
+			return nil, err
+		}
+		phoneValue = strings.TrimSpace(phoneValue)
+		phone := normalizePhone(strings.TrimPrefix(phoneValue, "+"), "s.whatsapp.net")
+		if phone == "" {
+			continue
+		}
+		identifier = strings.ToLower(strings.TrimSpace(identifier))
+		mapping[identifier] = phone
+		mapping[strings.TrimSuffix(identifier, "@lid")] = phone
+	}
+	return mapping, rows.Err()
+}
+
+func resolveAppleMessageSender(
+	s *store.Store,
+	message appleMessage,
+	chat appleChat,
+	lidMap map[string]string,
+	selfParticipantID int64,
+	participantIDs map[string]int64,
+	summary *ImportSummary,
+) (sql.NullInt64, string, error) {
+	if message.FromMe != 0 {
+		return sql.NullInt64{Int64: selfParticipantID, Valid: true}, "", nil
+	}
+
+	jid := message.GroupMemberJID
+	name := firstNonEmptyApple(message.GroupContact, message.GroupFirstName)
+	if jid == "" && !isAppleGroupJID(chat.RawJID) {
+		jid = firstNonEmptyApple(message.FromJID, chat.RawJID)
+		name = firstNonEmptyApple(name, chat.Name)
+	}
+	phone := applePhoneForJID(jid, lidMap)
+	if phone == "" {
+		return sql.NullInt64{}, "", nil
+	}
+	participantID, err := ensureAppleParticipant(
+		s, phone, name, participantIDs, summary,
+	)
+	if err != nil {
+		return sql.NullInt64{}, "", err
+	}
+	return sql.NullInt64{Int64: participantID, Valid: true}, phone, nil
+}
+
+func ensureAppleParticipant(
+	s *store.Store,
+	phone, displayName string,
+	participantIDs map[string]int64,
+	summary *ImportSummary,
+) (int64, error) {
+	if participantID, ok := participantIDs[phone]; ok {
+		if displayName != "" {
+			if _, err := s.EnsureParticipantByPhone(phone, displayName, "whatsapp"); err != nil {
+				return 0, fmt.Errorf("update Apple participant: %w", err)
+			}
+		}
+		return participantID, nil
+	}
+	participantID, err := s.EnsureParticipantByPhone(phone, displayName, "whatsapp")
+	if err != nil {
+		return 0, fmt.Errorf("ensure Apple participant: %w", err)
+	}
+	participantIDs[phone] = participantID
+	summary.Participants++
+	return participantID, nil
+}
+
+func mapAppleMessage(
+	message appleMessage,
+	conversationID, sourceID int64,
+	senderID sql.NullInt64,
+) store.Message {
+	sentAt := appleMessageTimestamp(message.MessageDate)
+	return store.Message{
+		ConversationID:  conversationID,
+		SourceID:        sourceID,
+		SourceMessageID: message.StanzaID,
+		MessageType:     "whatsapp",
+		SentAt:          sentAt,
+		InternalDate:    sentAt,
+		SenderID:        senderID,
+		IsFromMe:        message.FromMe != 0,
+		Snippet:         appleMessageSnippet(message.Text),
+		SizeEstimate:    int64(len(message.Text.String)),
+		ArchivedAt:      time.Now(),
+	}
+}
+
+func appleMessageTimestamp(value appleTimestampValue) sql.NullTime {
+	if !value.Valid || value.Seconds <= 0 ||
+		math.IsNaN(value.Seconds) || math.IsInf(value.Seconds, 0) {
+		return sql.NullTime{}
+	}
+	seconds := math.Floor(value.Seconds)
+	nanoseconds := int64((value.Seconds - seconds) * float64(time.Second))
+	return sql.NullTime{
+		Time:  time.Unix(int64(seconds)+appleEpochOffset, nanoseconds).UTC(),
+		Valid: true,
+	}
+}
+
+func appleMessageSnippet(text sql.NullString) sql.NullString {
+	if !text.Valid || text.String == "" {
+		return sql.NullString{}
+	}
+	snippet := text.String
+	if utf8.RuneCountInString(snippet) > 100 {
+		snippet = string([]rune(snippet)[:100])
+	}
+	return sql.NullString{String: snippet, Valid: true}
+}
+
+func isImportableAppleChat(jid string) bool {
+	jid = strings.ToLower(strings.TrimSpace(jid))
+	return strings.HasSuffix(jid, "@s.whatsapp.net") ||
+		strings.HasSuffix(jid, "@lid") ||
+		strings.HasSuffix(jid, "@g.us")
+}
+
+func isAppleGroupJID(jid string) bool {
+	return strings.HasSuffix(strings.ToLower(strings.TrimSpace(jid)), "@g.us")
+}
+
+func applePhoneForJID(jid string, lidMap map[string]string) string {
+	jid = strings.ToLower(strings.TrimSpace(jid))
+	if jid == "" {
+		return ""
+	}
+	if strings.HasSuffix(jid, "@lid") {
+		if phone := lidMap[jid]; phone != "" {
+			return phone
+		}
+		return lidMap[strings.TrimSuffix(jid, "@lid")]
+	}
+	if !strings.HasSuffix(jid, "@s.whatsapp.net") {
+		return ""
+	}
+	return normalizePhone(strings.TrimSuffix(jid, "@s.whatsapp.net"), "s.whatsapp.net")
+}
+
+func canonicalAppleJID(jid string, lidMap map[string]string) string {
+	if phone := applePhoneForJID(jid, lidMap); phone != "" {
+		return strings.TrimPrefix(phone, "+") + "@s.whatsapp.net"
+	}
+	return strings.ToLower(strings.TrimSpace(jid))
+}
+
+func appleChatTitle(chat appleChat, lidMap map[string]string) string {
+	if chat.Name != "" {
+		return chat.Name
+	}
+	if phone := applePhoneForJID(chat.RawJID, lidMap); phone != "" {
+		return phone
+	}
+	return chat.RawJID
+}
+
+func firstNonEmptyApple(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -77,7 +77,7 @@ func TestOpenReadOnlyDatabase(t *testing.T) {
 	_, err = os.Stat(missingPath)
 	require.ErrorIs(err, os.ErrNotExist)
 
-	path := filepath.Join(t.TempDir(), "source ? data.sqlite")
+	path := filepath.Join(t.TempDir(), "source # data.sqlite")
 	createDSN, err := sqliteDatabaseDSN(path, "")
 	require.NoError(err)
 	db, err := sql.Open("sqlite3", createDSN)

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -1,0 +1,315 @@
+package whatsapp
+
+import (
+	"context"
+	"database/sql"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestDetectDatabaseKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		schema  string
+		want    databaseKind
+		wantErr string
+	}{
+		{
+			name: "Android",
+			schema: `
+				CREATE TABLE message (_id INTEGER);
+				CREATE TABLE jid (_id INTEGER);
+				CREATE TABLE chat (_id INTEGER);
+			`,
+			want: databaseKindAndroid,
+		},
+		{
+			name: "Apple",
+			schema: `
+				CREATE TABLE ZWAMESSAGE (Z_PK INTEGER);
+				CREATE TABLE ZWACHATSESSION (Z_PK INTEGER);
+			`,
+			want: databaseKindApple,
+		},
+		{
+			name:    "Unknown",
+			schema:  `CREATE TABLE unrelated (id INTEGER);`,
+			want:    databaseKindUnknown,
+			wantErr: "expected Android message/jid/chat tables or Apple",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := sql.Open("sqlite3", ":memory:")
+			require.NoError(t, err)
+			defer func() { require.NoError(t, db.Close()) }()
+			_, err = db.Exec(tt.schema)
+			require.NoError(t, err)
+
+			got, err := detectDatabaseKind(db)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestOpenReadOnlyDatabaseRejectsWrites(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "source ? data.sqlite")
+	createDSN := (&url.URL{Scheme: "file", OmitHost: true, Path: path}).String()
+	db, err := sql.Open("sqlite3", createDSN)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE source_rows (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	readOnly, err := openReadOnlyDatabase(context.Background(), path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, readOnly.Close()) }()
+
+	_, err = readOnly.Exec(`INSERT INTO source_rows (id) VALUES (1)`)
+	require.Error(t, err)
+}
+
+func TestImportAppleTextMessages(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	chatDBPath := createAppleChatFixture(t)
+	createAppleLIDFixture(t, filepath.Dir(chatDBPath))
+
+	st := testutil.NewTestStore(t)
+	importer := NewImporter(st, nil)
+	opts := ImportOptions{
+		Phone:       "+15555550100",
+		DisplayName: "Test Owner",
+		BatchSize:   2,
+	}
+
+	summary, err := importer.Import(context.Background(), chatDBPath, opts)
+	require.NoError(err)
+	assert.Equal(int64(3), summary.ChatsProcessed)
+	assert.Equal(int64(9), summary.MessagesProcessed)
+	assert.Equal(int64(4), summary.MessagesAdded)
+	assert.Equal(int64(5), summary.MessagesSkipped)
+	assert.Equal(int64(4), summary.Participants)
+	assert.Equal(int64(1), summary.Errors)
+
+	assertStoreCount(t, st.DB(), "messages", 4)
+	assertStoreCount(t, st.DB(), "conversations", 3)
+	assertStoreCount(t, st.DB(), "participants", 4)
+	assertStoreCount(t, st.DB(), "message_bodies", 4)
+	assertStoreCount(t, st.DB(), "message_raw", 4)
+
+	type conversationRecord struct {
+		kind  string
+		title sql.NullString
+	}
+	conversations := func() map[string]conversationRecord {
+		result := make(map[string]conversationRecord)
+		rows, err := st.DB().Query(`
+			SELECT source_conversation_id, conversation_type, title
+			FROM conversations
+		`)
+		require.NoError(err)
+		defer func() { require.NoError(rows.Close()) }()
+		for rows.Next() {
+			var sourceID, kind string
+			var title sql.NullString
+			require.NoError(rows.Scan(&sourceID, &kind, &title))
+			result[sourceID] = conversationRecord{kind: kind, title: title}
+		}
+		require.NoError(rows.Err())
+		return result
+	}()
+	assert.Equal("direct_chat", conversations["15555550101@s.whatsapp.net"].kind)
+	assert.Equal("direct_chat", conversations["15555550102@s.whatsapp.net"].kind)
+	assert.Equal("group_chat", conversations["120363000000000000@g.us"].kind)
+	assert.Equal("Test Group", conversations["120363000000000000@g.us"].title.String)
+
+	type messageRecord struct {
+		phone    sql.NullString
+		fromMe   bool
+		sentAt   sql.NullTime
+		bodyText string
+	}
+	messages := func() map[string]messageRecord {
+		result := make(map[string]messageRecord)
+		rows, err := st.DB().Query(`
+			SELECT m.source_message_id, p.phone_number, m.is_from_me, m.sent_at,
+			       COALESCE(mb.body_text, '')
+			FROM messages m
+			LEFT JOIN participants p ON p.id = m.sender_id
+			LEFT JOIN message_bodies mb ON mb.message_id = m.id
+		`)
+		require.NoError(err)
+		defer func() { require.NoError(rows.Close()) }()
+		for rows.Next() {
+			var sourceID string
+			var record messageRecord
+			require.NoError(rows.Scan(
+				&sourceID, &record.phone, &record.fromMe,
+				&record.sentAt, &record.bodyText,
+			))
+			result[sourceID] = record
+		}
+		require.NoError(rows.Err())
+		return result
+	}()
+
+	assert.Equal("+15555550101", messages["direct-in"].phone.String)
+	assert.False(messages["direct-in"].fromMe)
+	assert.Equal("+15555550100", messages["direct-out"].phone.String)
+	assert.True(messages["direct-out"].fromMe)
+	assert.Equal("+15555550103", messages["group-in"].phone.String)
+	assert.Equal("+15555550102", messages["lid-in"].phone.String)
+	assert.Equal("group prototype text", messages["group-in"].bodyText)
+	assert.Equal(
+		time.Unix(appleEpochOffset+700000000, 250000000).UTC(),
+		messages["direct-in"].sentAt.Time,
+	)
+
+	var rawFormats int
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(*) FROM message_raw WHERE raw_format = 'whatsapp_apple_json'
+	`).Scan(&rawFormats))
+	assert.Equal(4, rawFormats)
+
+	results, total, err := st.SearchMessages("group prototype", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal("group-in", results[0].SourceMessageID)
+
+	var adminRole string
+	require.NoError(st.DB().QueryRow(`
+		SELECT cp.role
+		FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE c.source_conversation_id = '120363000000000000@g.us'
+		  AND p.phone_number = '+15555550103'
+	`).Scan(&adminRole))
+	assert.Equal("admin", adminRole)
+
+	secondSummary, err := importer.Import(context.Background(), chatDBPath, opts)
+	require.NoError(err)
+	assert.Equal(int64(4), secondSummary.MessagesAdded)
+	assertStoreCount(t, st.DB(), "messages", 4)
+	assertStoreCount(t, st.DB(), "conversations", 3)
+	assertStoreCount(t, st.DB(), "message_bodies", 4)
+	assertStoreCount(t, st.DB(), "message_raw", 4)
+}
+
+func TestAppleMappingFallbacks(t *testing.T) {
+	assert.Empty(t, applePhoneForJID("999999999999999@lid", nil))
+	assert.Equal(t, "999999999999999@lid", canonicalAppleJID("999999999999999@lid", nil))
+	assert.False(t, isImportableAppleChat("status@broadcast"))
+	assert.False(t, isImportableAppleChat("123@newsletter"))
+
+	longText := sql.NullString{String: strings.Repeat("x", 101), Valid: true}
+	assert.Len(t, []rune(appleMessageSnippet(longText).String), 100)
+	assert.False(t, appleMessageTimestamp(appleTimestampValue{}).Valid)
+
+	var timestamp appleTimestampValue
+	require.NoError(t, timestamp.Scan(time.Unix(700000000, 250000000).UTC()))
+	assert.Equal(
+		t, time.Unix(appleEpochOffset+700000000, 250000000).UTC(),
+		appleMessageTimestamp(timestamp).Time,
+	)
+}
+
+func createAppleChatFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ChatStorage.sqlite")
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE ZWACHATSESSION (
+			Z_PK INTEGER PRIMARY KEY,
+			ZCONTACTJID TEXT,
+			ZPARTNERNAME TEXT,
+			ZSESSIONTYPE INTEGER,
+			ZLASTMESSAGEDATE TIMESTAMP
+		);
+		CREATE TABLE ZWAGROUPMEMBER (
+			Z_PK INTEGER PRIMARY KEY,
+			ZCHATSESSION INTEGER,
+			ZMEMBERJID TEXT,
+			ZCONTACTNAME TEXT,
+			ZFIRSTNAME TEXT,
+			ZISADMIN INTEGER
+		);
+		CREATE TABLE ZWAMESSAGE (
+			Z_PK INTEGER PRIMARY KEY,
+			ZCHATSESSION INTEGER,
+			ZGROUPMEMBER INTEGER,
+			ZSTANZAID TEXT,
+			ZISFROMME INTEGER,
+			ZMESSAGEDATE TIMESTAMP,
+			ZTEXT TEXT,
+			ZMESSAGETYPE INTEGER,
+			ZFROMJID TEXT
+		);
+
+		INSERT INTO ZWACHATSESSION VALUES
+			(1, '15555550101@s.whatsapp.net', 'Alice Test', 0, 700000002),
+			(2, '120363000000000000@g.us', 'Test Group', 1, 700000010),
+			(3, '999999999999999@lid', 'LID Test', 0, 700000020),
+			(4, 'status@broadcast', 'Status', 3, 700000030);
+
+		INSERT INTO ZWAGROUPMEMBER VALUES
+			(10, 2, '888888888888888@lid', 'Bob Test', 'Bob', 1);
+
+		INSERT INTO ZWAMESSAGE VALUES
+			(1, 1, NULL, 'direct-in', 0, 700000000.25, 'direct prototype text', 0, '15555550101@s.whatsapp.net'),
+			(2, 1, NULL, 'direct-out', 1, 700000001, 'outbound prototype text', 0, ''),
+			(3, 2, 10, 'group-in', 0, 700000002, 'group prototype text', 0, '120363000000000000@g.us'),
+			(4, 2, 10, 'group-image', 0, 700000003, 'image caption', 1, '120363000000000000@g.us'),
+			(5, 3, NULL, 'lid-in', 0, 700000004, 'lid prototype text', 0, '999999999999999@lid'),
+			(6, 4, NULL, 'status-text', 0, 700000005, 'ignored status text', 0, 'status@broadcast'),
+			(7, 1, NULL, 'duplicate-text', 0, 700000006, 'first duplicate', 0, '15555550101@s.whatsapp.net'),
+			(8, 2, 10, 'duplicate-text', 0, 700000007, 'second duplicate', 0, '120363000000000000@g.us'),
+			(9, 1, NULL, '   ', 0, 700000008, 'missing stanza', 0, '15555550101@s.whatsapp.net'),
+			(10, 1, NULL, 'empty-text', 0, 700000009, '   ', 0, '15555550101@s.whatsapp.net');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return path
+}
+
+func createAppleLIDFixture(t *testing.T, dir string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", filepath.Join(dir, "LID.sqlite"))
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE ZWAZACCOUNT (
+			ZIDENTIFIER TEXT,
+			ZPHONENUMBER TEXT
+		);
+		INSERT INTO ZWAZACCOUNT VALUES
+			('999999999999999@lid', '15555550102'),
+			('888888888888888@lid', '15555550103');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func assertStoreCount(t *testing.T, db *sql.DB, table string, want int) {
+	t.Helper()
+	var got int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM "+table).Scan(&got))
+	assert.Equal(t, want, got, table)
+}

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -49,38 +50,57 @@ func TestDetectDatabaseKind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
 			db, err := sql.Open("sqlite3", ":memory:")
-			require.NoError(t, err)
-			defer func() { require.NoError(t, db.Close()) }()
+			require.NoError(err)
+			defer func() { require.NoError(db.Close()) }()
 			_, err = db.Exec(tt.schema)
-			require.NoError(t, err)
+			require.NoError(err)
 
 			got, err := detectDatabaseKind(db)
 			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
+				require.ErrorContains(err, tt.wantErr)
 			} else {
-				require.NoError(t, err)
+				require.NoError(err)
 			}
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestOpenReadOnlyDatabaseRejectsWrites(t *testing.T) {
+func TestOpenReadOnlyDatabase(t *testing.T) {
+	require := require.New(t)
+
+	missingPath := filepath.Join(t.TempDir(), "missing.sqlite")
+	_, err := openReadOnlyDatabase(context.Background(), missingPath)
+	require.Error(err)
+	_, err = os.Stat(missingPath)
+	require.ErrorIs(err, os.ErrNotExist)
+
 	path := filepath.Join(t.TempDir(), "source ? data.sqlite")
 	createDSN := (&url.URL{Scheme: "file", OmitHost: true, Path: path}).String()
 	db, err := sql.Open("sqlite3", createDSN)
-	require.NoError(t, err)
-	_, err = db.Exec(`CREATE TABLE source_rows (id INTEGER PRIMARY KEY)`)
-	require.NoError(t, err)
-	require.NoError(t, db.Close())
+	require.NoError(err)
+	defer func() { require.NoError(db.Close()) }()
+	var journalMode string
+	require.NoError(db.QueryRow(`PRAGMA journal_mode=WAL`).Scan(&journalMode))
+	require.Equal("wal", strings.ToLower(journalMode))
+	_, err = db.Exec(`
+		CREATE TABLE source_rows (id INTEGER PRIMARY KEY);
+		INSERT INTO source_rows (id) VALUES (1);
+	`)
+	require.NoError(err)
 
 	readOnly, err := openReadOnlyDatabase(context.Background(), path)
-	require.NoError(t, err)
-	defer func() { require.NoError(t, readOnly.Close()) }()
+	require.NoError(err)
+	defer func() { require.NoError(readOnly.Close()) }()
+	var count int
+	require.NoError(readOnly.QueryRow(`SELECT COUNT(*) FROM source_rows`).Scan(&count))
+	assert.Equal(t, 1, count)
 
-	_, err = readOnly.Exec(`INSERT INTO source_rows (id) VALUES (1)`)
-	require.Error(t, err)
+	_, err = readOnly.Exec(`INSERT INTO source_rows (id) VALUES (2)`)
+	require.Error(err)
 }
 
 func TestImportAppleTextMessages(t *testing.T) {
@@ -178,7 +198,7 @@ func TestImportAppleTextMessages(t *testing.T) {
 	assert.Equal("group prototype text", messages["group-in"].bodyText)
 	assert.Equal(
 		time.Unix(appleEpochOffset+700000000, 250000000).UTC(),
-		messages["direct-in"].sentAt.Time,
+		messages["direct-in"].sentAt.Time.UTC(),
 	)
 
 	var rawFormats int
@@ -214,19 +234,21 @@ func TestImportAppleTextMessages(t *testing.T) {
 }
 
 func TestAppleMappingFallbacks(t *testing.T) {
-	assert.Empty(t, applePhoneForJID("999999999999999@lid", nil))
-	assert.Equal(t, "999999999999999@lid", canonicalAppleJID("999999999999999@lid", nil))
-	assert.False(t, isImportableAppleChat("status@broadcast"))
-	assert.False(t, isImportableAppleChat("123@newsletter"))
+	assert := assert.New(t)
+
+	assert.Empty(applePhoneForJID("999999999999999@lid", nil))
+	assert.Equal("999999999999999@lid", canonicalAppleJID("999999999999999@lid", nil))
+	assert.False(isImportableAppleChat("status@broadcast"))
+	assert.False(isImportableAppleChat("123@newsletter"))
 
 	longText := sql.NullString{String: strings.Repeat("x", 101), Valid: true}
-	assert.Len(t, []rune(appleMessageSnippet(longText).String), 100)
-	assert.False(t, appleMessageTimestamp(appleTimestampValue{}).Valid)
+	assert.Len([]rune(appleMessageSnippet(longText).String), 100)
+	assert.False(appleMessageTimestamp(appleTimestampValue{}).Valid)
 
 	var timestamp appleTimestampValue
 	require.NoError(t, timestamp.Scan(time.Unix(700000000, 250000000).UTC()))
 	assert.Equal(
-		t, time.Unix(appleEpochOffset+700000000, 250000000).UTC(),
+		time.Unix(appleEpochOffset+700000000, 250000000).UTC(),
 		appleMessageTimestamp(timestamp).Time,
 	)
 }

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -3,7 +3,6 @@ package whatsapp
 import (
 	"context"
 	"database/sql"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,7 +78,8 @@ func TestOpenReadOnlyDatabase(t *testing.T) {
 	require.ErrorIs(err, os.ErrNotExist)
 
 	path := filepath.Join(t.TempDir(), "source ? data.sqlite")
-	createDSN := (&url.URL{Scheme: "file", OmitHost: true, Path: path}).String()
+	createDSN, err := sqliteDatabaseDSN(path, "")
+	require.NoError(err)
 	db, err := sql.Open("sqlite3", createDSN)
 	require.NoError(err)
 	defer func() { require.NoError(db.Close()) }()

--- a/internal/whatsapp/database.go
+++ b/internal/whatsapp/database.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 )
 
 type databaseKind int
@@ -17,11 +18,15 @@ const (
 )
 
 func openReadOnlyDatabase(ctx context.Context, path string) (*sql.DB, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("stat database: %w", err)
+	}
+
 	dsn := (&url.URL{
 		Scheme:   "file",
 		OmitHost: true,
 		Path:     path,
-		RawQuery: "mode=ro&_busy_timeout=5000&_query_only=1",
+		RawQuery: "_busy_timeout=5000&_query_only=1",
 	}).String()
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/internal/whatsapp/database.go
+++ b/internal/whatsapp/database.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 type databaseKind int
@@ -22,12 +24,10 @@ func openReadOnlyDatabase(ctx context.Context, path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("stat database: %w", err)
 	}
 
-	dsn := (&url.URL{
-		Scheme:   "file",
-		OmitHost: true,
-		Path:     path,
-		RawQuery: "_busy_timeout=5000&_query_only=1",
-	}).String()
+	dsn, err := sqliteDatabaseDSN(path, "_busy_timeout=5000&_query_only=1")
+	if err != nil {
+		return nil, fmt.Errorf("resolve database path: %w", err)
+	}
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, err
@@ -39,6 +39,18 @@ func openReadOnlyDatabase(ctx context.Context, path string) (*sql.DB, error) {
 		return nil, err
 	}
 	return db, nil
+}
+
+func sqliteDatabaseDSN(path, rawQuery string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	uriPath := filepath.ToSlash(absPath)
+	if !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	return (&url.URL{Scheme: "file", Path: uriPath, RawQuery: rawQuery}).String(), nil
 }
 
 func detectDatabaseKind(db *sql.DB) (databaseKind, error) {

--- a/internal/whatsapp/database.go
+++ b/internal/whatsapp/database.go
@@ -1,0 +1,74 @@
+package whatsapp
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+type databaseKind int
+
+const (
+	databaseKindUnknown databaseKind = iota
+	databaseKindAndroid
+	databaseKindApple
+)
+
+func openReadOnlyDatabase(ctx context.Context, path string) (*sql.DB, error) {
+	dsn := (&url.URL{
+		Scheme:   "file",
+		OmitHost: true,
+		Path:     path,
+		RawQuery: "mode=ro&_busy_timeout=5000&_query_only=1",
+	}).String()
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func detectDatabaseKind(db *sql.DB) (databaseKind, error) {
+	rows, err := db.Query(`
+		SELECT name
+		FROM sqlite_master
+		WHERE type = 'table'
+		  AND name IN ('message', 'jid', 'chat', 'ZWAMESSAGE', 'ZWACHATSESSION')
+	`)
+	if err != nil {
+		return databaseKindUnknown, fmt.Errorf("inspect whatsapp database schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	tables := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return databaseKindUnknown, fmt.Errorf("scan whatsapp database table: %w", err)
+		}
+		tables[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return databaseKindUnknown, fmt.Errorf("iterate whatsapp database tables: %w", err)
+	}
+
+	switch {
+	case tables["message"] && tables["jid"] && tables["chat"]:
+		return databaseKindAndroid, nil
+	case tables["ZWAMESSAGE"] && tables["ZWACHATSESSION"]:
+		return databaseKindApple, nil
+	default:
+		return databaseKindUnknown, errors.New(
+			"not a valid WhatsApp database: expected Android message/jid/chat tables " +
+				"or Apple ZWAMESSAGE/ZWACHATSESSION tables",
+		)
+	}
+}

--- a/internal/whatsapp/importer.go
+++ b/internal/whatsapp/importer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +15,7 @@ import (
 	"go.kenn.io/msgvault/internal/store"
 )
 
-// Importer handles importing WhatsApp messages from a decrypted msgstore.db
-// into the msgvault store.
+// Importer handles importing WhatsApp messages into the msgvault store.
 type Importer struct {
 	store    *store.Store
 	progress ImportProgress
@@ -34,26 +32,27 @@ func NewImporter(s *store.Store, progress ImportProgress) *Importer {
 	}
 }
 
-// Import performs the full WhatsApp import from a decrypted msgstore.db.
+// Import detects the WhatsApp database schema and imports its messages.
 func (imp *Importer) Import(ctx context.Context, waDBPath string, opts ImportOptions) (*ImportSummary, error) {
 	startTime := time.Now()
 	summary := &ImportSummary{}
 
-	// Open WhatsApp DB read-only.
-	// Use file: URI to safely handle paths containing '?' or other special characters.
-	dsn := (&url.URL{
-		Scheme:   "file",
-		OmitHost: true,
-		Path:     waDBPath,
-		RawQuery: "mode=ro&_journal_mode=WAL&_busy_timeout=5000",
-	}).String()
-	waDB, err := sql.Open("sqlite3", dsn)
+	waDB, err := openReadOnlyDatabase(ctx, waDBPath)
 	if err != nil {
 		return nil, fmt.Errorf("open whatsapp db: %w", err)
 	}
 	defer func() { _ = waDB.Close() }()
 
-	// Verify it's a valid WhatsApp DB.
+	kind, err := detectDatabaseKind(waDB)
+	if err != nil {
+		return nil, err
+	}
+	if kind == databaseKindApple {
+		return imp.importApple(ctx, waDB, waDBPath, opts)
+	}
+
+	// Keep the detailed Android schema checks for compatibility with the
+	// existing importer error handling.
 	if err := verifyWhatsAppDB(waDB); err != nil {
 		return nil, err
 	}

--- a/internal/whatsapp/types.go
+++ b/internal/whatsapp/types.go
@@ -1,6 +1,5 @@
-// Package whatsapp provides import functionality for WhatsApp message backups.
-// It reads from a decrypted WhatsApp msgstore.db (SQLite) and maps messages
-// into the msgvault unified schema.
+// Package whatsapp imports WhatsApp messages from Android msgstore.db backups
+// and Apple ChatStorage.sqlite databases into the msgvault unified schema.
 package whatsapp
 
 import (


### PR DESCRIPTION
Addresses #370.

Generated using `gpt-5.6-sol max` + `codex-cli 0.150.1`. I have no experience with Go. Happy to share my Codex rollout in some secure way if that's useful.

---

Adds read-only import support for Apple WhatsApp `ChatStorage.sqlite` databases alongside existing Android `msgstore.db` support.

Apple databases are detected from their Core Data tables. The prototype imports non-empty text messages from direct and group chats, resolves LID identities when an adjacent `LID.sqlite` is available, preserves selected source rows as raw JSON, and indexes message text for search. SQLite is opened with `_query_only=1` after confirming the source exists, allowing SQLite to manage WAL sidecars. Ambiguous duplicate stanza IDs are reported and skipped rather than allowed to overwrite another message.

On macOS:

    msgvault import-whatsapp --phone "+15555550100" "$HOME/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite"

The native container may require Full Disk Access. Media, reactions, replies, status, broadcast, and newsletter messages remain out of scope for this prototype.
