### PR TITLE
fix(imap): reconnect when the label-map SELECT hits a dead connection

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -629,7 +629,19 @@ func (c *Client) fetchMailboxMessageIDs(
 	}
 
 	if err := c.selectMailbox(mailbox); err != nil {
-		return nil, nil, err
+		if !isNetworkError(err) {
+			return nil, nil, err
+		}
+		c.logger.Warn("network error selecting mailbox for label map, reconnecting",
+			"mailbox", mailbox, "error", err)
+		if reconErr := c.reconnect(ctx); reconErr != nil {
+			return nil, nil, fmt.Errorf(
+				"reconnect failed building label map for %q: %w",
+				mailbox, reconErr)
+		}
+		if err := c.selectMailbox(mailbox); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	result := make(map[string]bool, len(uids))

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1151,3 +1151,32 @@ func TestListMessages_LimitedSyncDisablesFolderSkipping(t *testing.T) {
 	assert.Len(listAllMessages(t, second), 5,
 		"a limited sync must not take folder shortcuts")
 }
+
+func TestLabelMapSelectReconnectsAfterDroppedConnection(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"INBOX":   0,
+		"Archive": 0,
+	})
+	const messageID = "label-map-reconnect@example.com"
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", messageID)
+	client := newTestClient(t, addr)
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	require.NoError(client.connect(ctx))
+	require.NoError(client.selectMailbox("INBOX"))
+	// Drop the connection the way a mid-run server disconnect does, leaving the
+	// client holding a dead socket it has not noticed yet.
+	require.NoError(client.conn.Close())
+
+	labels, unidentified, err := client.fetchMailboxMessageIDs(
+		ctx, "Archive", []imapv2.UID{1})
+
+	require.NoError(err,
+		"a dropped connection must not fail the label map, which discards the run")
+	assert.Equal(map[string]bool{messageID: true}, labels)
+	assert.Empty(unidentified)
+}


### PR DESCRIPTION
Closes #709

Building the IMAP label map now reconnects when SELECT fails on a dropped
connection, the way every other mailbox selection in the package already does.
A SELECT that the server refuses still fails at once.

Without this, one dropped connection left the label map incomplete. An
incomplete label map makes the whole run discard its folder states, mailbox
deltas and acknowledgements. The run then publishes nothing, and the next run
starts from the same baseline.

On a 96,000-message Microsoft 365 account, two runs in a row discarded a
finished enumeration this way, about three hours of work, before a third run
kept its connection and published.

No configuration or usage changes.
