### PR TITLE
[IMAP] treat a message expunged mid-run as handled, not failed

### DIFF
--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -559,20 +559,24 @@ func syncedIMAPClient(
 	return client, results
 }
 
-// TestSaveIMAPFolderStates_RepublishMissingUIDRecoversNextRun measures what
-// treating an omitted UID as gone costs on a republish, rather than arguing
-// about it.
+// TestSaveIMAPFolderStates_RepublishGoneUIDRecoversByMessageCount measures
+// what a confirmed-gone UID costs a republish. The server here leaves the UID
+// out of every response, including the recheck, so this is a message that
+// really did leave the mailbox.
 //
 // A republish keeps only what the run read: ApplyIMAPMailboxDeltas answers a
 // Reset delta by deleting every membership row for the mailbox and
-// re-inserting the observations. A live UID the server failed to return is
-// therefore deleted, and tombstoned when that was its last mailbox.
+// re-inserting the observations. The UID is therefore deleted, and tombstoned
+// when that was its last mailbox.
 //
-// This test does not claim the reading is right. It pins the bound: the cost
-// is one cycle, the message row is never deleted, and the next run restores
-// both the membership and the message. If run three ever fails, the reading is
-// not reversible and the sentinel needs a revalidating fetch behind it.
-func TestSaveIMAPFolderStates_RepublishMissingUIDRecoversNextRun(t *testing.T) {
+// **The recovery asserted here is the message-count check, and it does not
+// exist on every path.** planMailboxScan reconciles a mailbox by comparing the
+// server's MESSAGES count against the saved UID list, and it runs only when
+// the account is not using QRESYNC -- paths B and C of the sync. A QRESYNC
+// account advances HIGHESTMODSEQ instead and never revisits the mailbox on its
+// own. That gap is why an omission is rechecked before it is believed, and
+// TestOmittedUIDIsRecheckedBeforeItCountsAsGone covers the recheck itself.
+func TestSaveIMAPFolderStates_RepublishGoneUIDRecoversByMessageCount(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := context.Background()

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -476,16 +476,17 @@ func TestApplyIMAPMailboxDeltas_ConvertsObservationsAndVanishedUIDs(t *testing.T
 // enumeration and fetch as handled, so the run finishes without errors and
 // reaches this commit. Nothing ingested that message, so its enumeration
 // observation would find no message row to resolve and would roll back every
-// mailbox cursor in the source — the outcome the fix exists to prevent.
+// mailbox cursor in the source.
 func TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists(t *testing.T) {
 	require := require.New(t)
-	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+	addr, _, hideUID := testutil.StartIMAPMemServerWithMissingUID(
+		t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+	hideUID()
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
 
 	client := listedIMAPClient(t, addr)
-	testutil.ExpungeIMAPMessage(t, addr, "INBOX", imapapi.UID(2))
 	results, err := client.GetMessageLabelsBatch(
 		context.Background(), []string{"INBOX|1", "INBOX|2"})
 	require.NoError(err)
@@ -494,7 +495,7 @@ func TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists(t *testing.T) {
 	require.ErrorIs(results[1].Err, gmail.ErrMessageGone)
 
 	// Only the survivor was ingested, which is what the run itself would have
-	// stored: the expunged message was acknowledged, never fetched.
+	// stored: the message that left the mailbox was acknowledged, never fetched.
 	seedIMAPMessage(t, st, src, "INBOX|1", "")
 
 	require.NoError(saveIMAPFolderStates(
@@ -504,4 +505,24 @@ func TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists(t *testing.T) {
 	require.NoError(err)
 	require.Contains(loaded, "INBOX")
 	assert.Equal(t, []uint32{1}, loaded["INBOX"].KnownUIDs)
+}
+
+// TestSaveIMAPFolderStates_LiveMessageWithoutHeadersBlocksPersistence is the
+// other side of that line. The server returned the UID, so the message is
+// still in the mailbox and only its headers are missing. Acknowledging it
+// would drop a live message from the authoritative snapshot, so it stays a
+// fetch error and the commit does not run.
+func TestSaveIMAPFolderStates_LiveMessageWithoutHeadersBlocksPersistence(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+	client := listedIMAPClient(t, addr)
+	// The in-memory server answers a FETCH of a UID expunged by another
+	// session with an empty body rather than leaving it out of the response.
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", imapapi.UID(2))
+	results, err := client.GetMessageLabelsBatch(
+		context.Background(), []string{"INBOX|1", "INBOX|2"})
+	require.NoError(err)
+	require.Len(results, 2)
+	require.Error(results[1].Err)
+	assert.NotErrorIs(t, results[1].Err, gmail.ErrMessageGone)
 }

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -481,7 +481,7 @@ func TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists(t *testing.T) {
 	require := require.New(t)
 	addr, _, hideUID := testutil.StartIMAPMemServerWithMissingUID(
 		t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
-	hideUID()
+	hideUID(true)
 	st := testutil.NewTestStore(t)
 	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
 	require.NoError(err)
@@ -525,4 +525,117 @@ func TestSaveIMAPFolderStates_LiveMessageWithoutHeadersBlocksPersistence(t *test
 	require.Len(results, 2)
 	require.Error(results[1].Err)
 	assert.NotErrorIs(t, results[1].Err, gmail.ErrMessageGone)
+}
+
+// syncedIMAPClient enumerates the server the way a run does and refreshes the
+// labels of every message it listed, so the client ends holding the membership
+// observations the commit will publish.
+func syncedIMAPClient(
+	t *testing.T, addr string, opts ...imaplib.Option,
+) (*imaplib.Client, []gmail.MessageLabelsBatchResult) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := listedIMAPClient(t, addr, opts...)
+	var ids []string
+	pageToken := ""
+	for {
+		resp, err := client.ListMessages(ctx, "", pageToken)
+		require.NoError(t, err)
+		for _, msg := range resp.Messages {
+			ids = append(ids, msg.ID)
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	if len(ids) == 0 {
+		return client, nil
+	}
+	results, err := client.GetMessageLabelsBatch(ctx, ids)
+	require.NoError(t, err)
+	return client, results
+}
+
+// TestSaveIMAPFolderStates_RepublishMissingUIDRecoversNextRun measures what
+// treating an omitted UID as gone costs on a republish, rather than arguing
+// about it.
+//
+// A republish keeps only what the run read: ApplyIMAPMailboxDeltas answers a
+// Reset delta by deleting every membership row for the mailbox and
+// re-inserting the observations. A live UID the server failed to return is
+// therefore deleted, and tombstoned when that was its last mailbox.
+//
+// This test does not claim the reading is right. It pins the bound: the cost
+// is one cycle, the message row is never deleted, and the next run restores
+// both the membership and the message. If run three ever fails, the reading is
+// not reversible and the sentinel needs a revalidating fetch behind it.
+func TestSaveIMAPFolderStates_RepublishMissingUIDRecoversNextRun(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := context.Background()
+	addr, _, hideUID := testutil.StartIMAPMemServerWithMissingUID(
+		t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	// Run one: the healthy baseline. No saved state, so the mailbox is
+	// republished and both messages are stored.
+	first, firstLabels := syncedIMAPClient(t, addr)
+	require.Len(firstLabels, 2)
+	require.NoError(firstLabels[0].Err)
+	require.NoError(firstLabels[1].Err)
+	seedObservedIMAPMessages(t, st, src, first)
+	require.NoError(saveIMAPFolderStates(
+		ctx, st, src, first, completedIMAPSyncSummary(t, st, src), 0))
+	require.NoError(first.Close())
+	require.Equal(2, imapMembershipRowCount(t, st, src.ID))
+	require.Zero(imapTombstonedMessageCount(t, st, src.ID))
+
+	// Run two: another republish, with the server leaving UID 2 out of every
+	// FETCH response. The run treats it as gone and finishes without errors,
+	// so the commit proceeds -- which on main it never did.
+	hideUID(true)
+	second, secondLabels := syncedIMAPClient(t, addr)
+	require.Len(secondLabels, 2)
+	require.ErrorIs(secondLabels[1].Err, gmail.ErrMessageGone)
+	seedObservedIMAPMessages(t, st, src, second)
+	require.NoError(saveIMAPFolderStates(
+		ctx, st, src, second, completedIMAPSyncSummary(t, st, src), 0))
+	require.NoError(second.Close())
+
+	assert.Equal(1, imapMembershipRowCount(t, st, src.ID),
+		"a republish deletes the membership of a UID it did not read back")
+	assert.Equal(1, imapTombstonedMessageCount(t, st, src.ID),
+		"losing its last mailbox tombstones the message -- this is the cost")
+
+	// Run three: the server stops hiding the UID. The saved baseline is one
+	// row short of the server's message count, so the mailbox cannot be
+	// skipped, and reading it again restores both the membership and the
+	// message.
+	hideUID(false)
+	third, thirdLabels := syncedIMAPClient(t, addr, imapFolderStateOptions(st, src, false)...)
+	// The recovery is the count check, not another republish. The saved
+	// baseline holds one UID and the server reports two, so the mailbox is
+	// read again and the one missing UID is diffed back in.
+	thirdDeltas := third.ObservedMailboxDeltas()
+	require.Len(thirdDeltas, 1)
+	assert.False(thirdDeltas[0].Reset,
+		"the mailbox recovers by diff, not by republishing it again")
+	assert.Equal([]imapapi.UID{2}, thirdDeltas[0].ChangedUIDs)
+	seedObservedIMAPMessages(t, st, src, third)
+	require.NoError(saveIMAPFolderStates(
+		ctx, st, src, third, completedIMAPSyncSummary(t, st, src), 0))
+	require.NoError(third.Close())
+	for _, result := range thirdLabels {
+		require.NoError(result.Err)
+	}
+
+	assert.Equal(2, imapMembershipRowCount(t, st, src.ID),
+		"the next run must read the mailbox again and restore the membership")
+	assert.Zero(imapTombstonedMessageCount(t, st, src.ID),
+		"a message that regains a mailbox must lose its tombstone")
 }

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -470,3 +470,38 @@ func TestApplyIMAPMailboxDeltas_ConvertsObservationsAndVanishedUIDs(t *testing.T
 		Mailbox: "INBOX", UIDValidity: 17, UIDNext: 4, HighestModSeq: 101,
 	}}, states)
 }
+
+// TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists is the durable half
+// of the expunge race. The sync treats a message that left the mailbox between
+// enumeration and fetch as handled, so the run finishes without errors and
+// reaches this commit. Nothing ingested that message, so its enumeration
+// observation would find no message row to resolve and would roll back every
+// mailbox cursor in the source — the outcome the fix exists to prevent.
+func TestSaveIMAPFolderStates_MessageGoneMidRunStillPersists(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "imap://alice@example.com")
+	require.NoError(err)
+
+	client := listedIMAPClient(t, addr)
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", imapapi.UID(2))
+	results, err := client.GetMessageLabelsBatch(
+		context.Background(), []string{"INBOX|1", "INBOX|2"})
+	require.NoError(err)
+	require.Len(results, 2)
+	require.NoError(results[0].Err)
+	require.ErrorIs(results[1].Err, gmail.ErrMessageGone)
+
+	// Only the survivor was ingested, which is what the run itself would have
+	// stored: the expunged message was acknowledged, never fetched.
+	seedIMAPMessage(t, st, src, "INBOX|1", "")
+
+	require.NoError(saveIMAPFolderStates(
+		context.Background(), st, src, client, completedIMAPSyncSummary(t, st, src), 0))
+
+	loaded, err := loadIMAPFolderStates(st, src.ID)
+	require.NoError(err)
+	require.Contains(loaded, "INBOX")
+	assert.Equal(t, []uint32{1}, loaded["INBOX"].KnownUIDs)
+}

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -3,6 +3,7 @@ package gmail
 
 import (
 	"context"
+	"errors"
 
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -124,6 +125,13 @@ type RawMessageBatchResult struct {
 	Message *RawMessage
 	Err     error
 }
+
+// ErrMessageGone reports that a message listed earlier in the run was gone from
+// the mailbox when the run tried to fetch it. It is an ordinary race with the
+// mail server, not a failure: the message was moved or deleted, and deletion
+// detection retires it. A batch result carrying this error is handled, not
+// failed.
+var ErrMessageGone = errors.New("message no longer present in the mailbox")
 
 // MessageLabelsBatchResult is one per-message result from a batch label fetch.
 // LabelIDs is nil when the fetch failed; Err preserves the per-message cause.

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -108,7 +108,7 @@ func (c *Client) applyFetchResults(
 	mailbox string,
 	chunk []batchFetchItem,
 	msgs []*imapclient.FetchMessageBuffer,
-) {
+) []batchFetchItem {
 	seenReturnedUIDs := make(map[imap.UID]bool, len(msgs))
 	for _, msgBuf := range msgs {
 		idx, ok := uidToIdx[msgBuf.UID]
@@ -193,15 +193,16 @@ func (c *Client) applyFetchResults(
 		results[idx].Err = nil
 	}
 
+	var omitted []batchFetchItem
 	for _, item := range chunk {
 		if seenReturnedUIDs[item.uid] {
 			continue
 		}
 		if results[item.idx].Message == nil && results[item.idx].Err == nil {
-			results[item.idx].Err = errIMAPFetchResultMissing
-			c.forgetMembershipLocked(mailbox, item.uid)
+			omitted = append(omitted, item)
 		}
 	}
+	return omitted
 }
 
 // batchMailboxOrder returns the mailboxes sorted by name, except that
@@ -326,9 +327,53 @@ func (c *Client) fetchMailboxBatch(
 			return nil
 		}
 
-		c.applyFetchResults(results, uidToIdx, mailbox, chunk, msgs)
+		omitted := c.applyFetchResults(results, uidToIdx, mailbox, chunk, msgs)
+		if len(omitted) > 0 {
+			omitted = c.recheckOmittedRaw(
+				ctx, results, uidToIdx, mailbox, omitted, fetchOpts)
+		}
+		for _, item := range omitted {
+			results[item.idx].Err = errIMAPFetchResultMissing
+			c.forgetMembershipLocked(mailbox, item.uid)
+		}
 	}
 	return nil
+}
+
+// recheckOmittedRaw re-asks the server for the UIDs a chunk's FETCH response
+// left out, and returns the ones it leaves out a second time.
+//
+// A UID missing from a FETCH response is not an expunge notice. The server can
+// drop a UID for its own reasons, and believing the first omission loses the
+// message outright on a QRESYNC account: the run acknowledges the UID, stores
+// no membership for it, and still advances HIGHESTMODSEQ, so no later
+// CHANGEDSINCE fetch has any reason to report it. Only the paths that
+// reconcile a mailbox by message count recover on their own.
+//
+// The recheck costs one extra FETCH for a chunk that had an omission, and
+// nothing at all for a chunk that did not. When the recheck itself fails
+// nothing was learned, so the UIDs are recorded as fetch errors rather than
+// absences, which holds the commit back instead of acting on a guess.
+func (c *Client) recheckOmittedRaw(
+	ctx context.Context,
+	results []gmailapi.RawMessageBatchResult,
+	uidToIdx map[imap.UID]int,
+	mailbox string,
+	omitted []batchFetchItem,
+	fetchOpts *imap.FetchOptions,
+) []batchFetchItem {
+	var uidSet imap.UIDSet
+	for _, item := range omitted {
+		uidSet.AddNum(item.uid)
+	}
+	msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	if err != nil {
+		c.logger.Warn("could not recheck UIDs missing from a FETCH response",
+			"mailbox", mailbox, "uids", len(omitted), "error", err)
+		markRawBatchError(results, omitted, err)
+		return nil
+	}
+	return c.applyFetchResults(results, uidToIdx, mailbox, omitted, msgs)
 }
 
 // GetMessagesRawBatchWithErrors fetches multiple messages, grouping by mailbox for efficiency.
@@ -402,7 +447,7 @@ func (c *Client) applyLabelFetchResults(
 	mailbox string,
 	chunk []batchFetchItem,
 	msgs []*imapclient.FetchMessageBuffer,
-) {
+) []batchFetchItem {
 	seenUIDs := make(map[imap.UID]bool, len(msgs))
 	for _, msgBuf := range msgs {
 		idx, ok := uidToIdx[msgBuf.UID]
@@ -410,7 +455,9 @@ func (c *Client) applyLabelFetchResults(
 			continue
 		}
 		seenUIDs[msgBuf.UID] = true
-		if len(msgBuf.BodySection) == 0 {
+		// An empty section is as unreadable as an absent one, and the UID was
+		// returned either way, so this is a fetch failure and not an absence.
+		if len(msgBuf.BodySection) == 0 || len(msgBuf.BodySection[0].Bytes) == 0 {
 			results[idx].Err = errIMAPLabelBodyMissing
 			continue
 		}
@@ -422,12 +469,13 @@ func (c *Client) applyLabelFetchResults(
 		results[idx].Err = nil
 	}
 
+	var omitted []batchFetchItem
 	for _, item := range chunk {
 		if !seenUIDs[item.uid] && results[item.idx].Err == nil {
-			results[item.idx].Err = errIMAPFetchResultMissing
-			c.forgetMembershipLocked(mailbox, item.uid)
+			omitted = append(omitted, item)
 		}
 	}
+	return omitted
 }
 
 func (c *Client) selectLabelBatchMailbox(
@@ -492,9 +540,41 @@ func (c *Client) fetchMailboxLabelBatch(
 			markLabelBatchError(results, items[end:], errIMAPSkippedAfterChunkFailed)
 			return nil
 		}
-		c.applyLabelFetchResults(results, uidToIdx, mailbox, chunk, msgs)
+		omitted := c.applyLabelFetchResults(results, uidToIdx, mailbox, chunk, msgs)
+		if len(omitted) > 0 {
+			omitted = c.recheckOmittedLabels(
+				ctx, results, uidToIdx, mailbox, omitted, fetchOpts)
+		}
+		for _, item := range omitted {
+			results[item.idx].Err = errIMAPFetchResultMissing
+			c.forgetMembershipLocked(mailbox, item.uid)
+		}
 	}
 	return nil
+}
+
+// recheckOmittedLabels is recheckOmittedRaw for the label fetch. See that
+// function for why one omission is not enough to call a message gone.
+func (c *Client) recheckOmittedLabels(
+	ctx context.Context,
+	results []gmailapi.MessageLabelsBatchResult,
+	uidToIdx map[imap.UID]int,
+	mailbox string,
+	omitted []batchFetchItem,
+	fetchOpts *imap.FetchOptions,
+) []batchFetchItem {
+	var uidSet imap.UIDSet
+	for _, item := range omitted {
+		uidSet.AddNum(item.uid)
+	}
+	msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	if err != nil {
+		c.logger.Warn("could not recheck UIDs missing from a label FETCH response",
+			"mailbox", mailbox, "uids", len(omitted), "error", err)
+		markLabelBatchError(results, omitted, err)
+		return nil
+	}
+	return c.applyLabelFetchResults(results, uidToIdx, mailbox, omitted, msgs)
 }
 
 // GetMessageLabelsBatch fetches only the Message-ID header needed to recover

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -563,8 +563,10 @@ func (c *Client) sourceMessageMetadata(
 			"source message validation returned %d results", len(results))
 	}
 	if results[0].Err != nil {
-		if errors.Is(results[0].Err, errIMAPFetchResultMissing) ||
-			errors.Is(results[0].Err, errIMAPLabelBodyMissing) {
+		// Only an absent UID is definitive absence. A returned UID whose
+		// headers are missing is a live message, and reporting it as absent
+		// would let SourceMessageMatches conclude a mismatch and rekey it.
+		if errors.Is(results[0].Err, errIMAPFetchResultMissing) {
 			return "", false, nil
 		}
 		return "", false, results[0].Err

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -191,6 +191,7 @@ func (c *Client) applyFetchResults(
 		}
 		if results[item.idx].Message == nil && results[item.idx].Err == nil {
 			results[item.idx].Err = errIMAPFetchResultMissing
+			c.forgetMembershipLocked(mailbox, item.uid)
 		}
 	}
 }
@@ -403,6 +404,7 @@ func (c *Client) applyLabelFetchResults(
 		seenUIDs[msgBuf.UID] = true
 		if len(msgBuf.BodySection) == 0 {
 			results[idx].Err = errIMAPFetchResultMissing
+			c.forgetMembershipLocked(mailbox, msgBuf.UID)
 			continue
 		}
 		rfc822MessageID := rawMIMEMessageID(msgBuf.BodySection[0].Bytes)
@@ -416,6 +418,7 @@ func (c *Client) applyLabelFetchResults(
 	for _, item := range chunk {
 		if !seenUIDs[item.uid] && results[item.idx].Err == nil {
 			results[item.idx].Err = errIMAPFetchResultMissing
+			c.forgetMembershipLocked(mailbox, item.uid)
 		}
 	}
 }

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -18,7 +18,8 @@ import (
 )
 
 var errIMAPRawBodyMissing = errors.New("IMAP fetch result did not include raw body")
-var errIMAPFetchResultMissing = errors.New("IMAP fetch result missing from response")
+var errIMAPFetchResultMissing = fmt.Errorf(
+	"IMAP fetch result missing from response: %w", gmailapi.ErrMessageGone)
 var errIMAPSkippedAfterChunkFailed = errors.New("IMAP fetch skipped after earlier chunk failure")
 
 type batchFetchItem struct {

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -329,8 +329,12 @@ func (c *Client) fetchMailboxBatch(
 
 		omitted := c.applyFetchResults(results, uidToIdx, mailbox, chunk, msgs)
 		if len(omitted) > 0 {
-			omitted = c.recheckOmittedRaw(
+			var fatalErr error
+			omitted, fatalErr = c.recheckOmittedRaw(
 				ctx, results, uidToIdx, mailbox, omitted, fetchOpts)
+			if fatalErr != nil {
+				return fatalErr
+			}
 		}
 		for _, item := range omitted {
 			results[item.idx].Err = errIMAPFetchResultMissing
@@ -361,19 +365,25 @@ func (c *Client) recheckOmittedRaw(
 	mailbox string,
 	omitted []batchFetchItem,
 	fetchOpts *imap.FetchOptions,
-) []batchFetchItem {
+) ([]batchFetchItem, error) {
 	var uidSet imap.UIDSet
 	for _, item := range omitted {
 		uidSet.AddNum(item.uid)
 	}
-	msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	msgs, fatal, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	if fatal {
+		// The reconnect failed, so there is no connection left to run the next
+		// chunk on. The batch has to end here, exactly as it does when the
+		// first fetch of a chunk hits this.
+		return nil, err
+	}
 	if err != nil {
 		c.logger.Warn("could not recheck UIDs missing from a FETCH response",
 			"mailbox", mailbox, "uids", len(omitted), "error", err)
 		markRawBatchError(results, omitted, err)
-		return nil
+		return nil, nil
 	}
-	return c.applyFetchResults(results, uidToIdx, mailbox, omitted, msgs)
+	return c.applyFetchResults(results, uidToIdx, mailbox, omitted, msgs), nil
 }
 
 // GetMessagesRawBatchWithErrors fetches multiple messages, grouping by mailbox for efficiency.
@@ -542,8 +552,12 @@ func (c *Client) fetchMailboxLabelBatch(
 		}
 		omitted := c.applyLabelFetchResults(results, uidToIdx, mailbox, chunk, msgs)
 		if len(omitted) > 0 {
-			omitted = c.recheckOmittedLabels(
+			var fatalErr error
+			omitted, fatalErr = c.recheckOmittedLabels(
 				ctx, results, uidToIdx, mailbox, omitted, fetchOpts)
+			if fatalErr != nil {
+				return fatalErr
+			}
 		}
 		for _, item := range omitted {
 			results[item.idx].Err = errIMAPFetchResultMissing
@@ -562,19 +576,22 @@ func (c *Client) recheckOmittedLabels(
 	mailbox string,
 	omitted []batchFetchItem,
 	fetchOpts *imap.FetchOptions,
-) []batchFetchItem {
+) ([]batchFetchItem, error) {
 	var uidSet imap.UIDSet
 	for _, item := range omitted {
 		uidSet.AddNum(item.uid)
 	}
-	msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	msgs, fatal, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
+	if fatal {
+		return nil, err
+	}
 	if err != nil {
 		c.logger.Warn("could not recheck UIDs missing from a label FETCH response",
 			"mailbox", mailbox, "uids", len(omitted), "error", err)
 		markLabelBatchError(results, omitted, err)
-		return nil
+		return nil, nil
 	}
-	return c.applyLabelFetchResults(results, uidToIdx, mailbox, omitted, msgs)
+	return c.applyLabelFetchResults(results, uidToIdx, mailbox, omitted, msgs), nil
 }
 
 // GetMessageLabelsBatch fetches only the Message-ID header needed to recover

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -20,6 +20,14 @@ import (
 var errIMAPRawBodyMissing = errors.New("IMAP fetch result did not include raw body")
 var errIMAPFetchResultMissing = fmt.Errorf(
 	"IMAP fetch result missing from response: %w", gmailapi.ErrMessageGone)
+
+// errIMAPLabelBodyMissing is the label-fetch counterpart of
+// errIMAPRawBodyMissing. The server returned the UID, so the message is still
+// in the mailbox and only its headers are missing. That is a fetch failure,
+// not the expunge race, and it must not reach gmailapi.ErrMessageGone: a run
+// that acknowledged it would drop a live message from an authoritative
+// snapshot.
+var errIMAPLabelBodyMissing = errors.New("IMAP fetch result did not include message headers")
 var errIMAPSkippedAfterChunkFailed = errors.New("IMAP fetch skipped after earlier chunk failure")
 
 type batchFetchItem struct {
@@ -403,8 +411,7 @@ func (c *Client) applyLabelFetchResults(
 		}
 		seenUIDs[msgBuf.UID] = true
 		if len(msgBuf.BodySection) == 0 {
-			results[idx].Err = errIMAPFetchResultMissing
-			c.forgetMembershipLocked(mailbox, msgBuf.UID)
+			results[idx].Err = errIMAPLabelBodyMissing
 			continue
 		}
 		rfc822MessageID := rawMIMEMessageID(msgBuf.BodySection[0].Bytes)
@@ -556,7 +563,8 @@ func (c *Client) sourceMessageMetadata(
 			"source message validation returned %d results", len(results))
 	}
 	if results[0].Err != nil {
-		if errors.Is(results[0].Err, errIMAPFetchResultMissing) {
+		if errors.Is(results[0].Err, errIMAPFetchResultMissing) ||
+			errors.Is(results[0].Err, errIMAPLabelBodyMissing) {
 			return "", false, nil
 		}
 		return "", false, results[0].Err

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -819,3 +819,31 @@ func observedUIDs(c *Client) []uint32 {
 	}
 	return uids
 }
+
+// TestReturnedUIDWithoutHeadersKeepsMembershipObservation is the other side of
+// TestMissingUIDDropsEarlierMembershipObservation. The server returned the
+// UID, so the message is still in the mailbox. Classifying that as gone would
+// let the run acknowledge a live message and drop its observation, and a
+// mailbox that resets its memberships would then delete the row and tombstone
+// the message.
+func TestReturnedUIDWithoutHeadersKeepsMembershipObservation(t *testing.T) {
+	c := Client{observedMemberships: []MembershipObservation{
+		{Mailbox: "Archive", UID: 10, SourceMessageID: "Archive|10"},
+	}}
+	results := newLabelBatchResults([]string{"Archive|10"})
+	msgs := []*imapclient.FetchMessageBuffer{
+		{UID: imapapi.UID(10), Envelope: &imapapi.Envelope{MessageID: "message-10"}},
+	}
+
+	c.applyLabelFetchResults(
+		results,
+		map[imapapi.UID]int{imapapi.UID(10): 0},
+		"Archive",
+		[]batchFetchItem{{idx: 0, uid: imapapi.UID(10)}},
+		msgs,
+	)
+
+	require.ErrorIs(t, results[0].Err, errIMAPLabelBodyMissing)
+	require.NotErrorIs(t, results[0].Err, gmailapi.ErrMessageGone)
+	assert.Contains(t, observedUIDs(&c), uint32(10))
+}

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -476,12 +476,15 @@ func TestApplyLabelFetchResultsMarksOnlyMissingUID(t *testing.T) {
 	}
 
 	var c Client
-	c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+	omitted := c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
 
 	assert.Equal([]string{"Archive"}, results[0].LabelIDs)
 	require.NoError(results[0].Err)
 	assert.Nil(results[1].LabelIDs)
-	require.ErrorIs(results[1].Err, errIMAPFetchResultMissing)
+	// The omission is reported, not acted on. Calling it gone is the caller's
+	// decision, and only after the server has been asked a second time.
+	assert.Equal([]batchFetchItem{{idx: 1, uid: imapapi.UID(11)}}, omitted)
+	require.NoError(results[1].Err)
 }
 
 func TestApplyFetchResultsMarksMissingUIDs(t *testing.T) {
@@ -501,14 +504,15 @@ func TestApplyFetchResultsMarksMissingUIDs(t *testing.T) {
 	}
 
 	var c Client
-	c.applyFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+	omitted := c.applyFetchResults(results, uidToIdx, "Archive", chunk, msgs)
 
 	require.NotNil(results[0].Message)
 	assert.Equal("Archive|10", results[0].Message.ID)
 	assert.Equal([]byte("raw-10"), results[0].Message.Raw)
 	require.NoError(results[0].Err)
 	assert.Nil(results[1].Message)
-	require.ErrorIs(results[1].Err, errIMAPFetchResultMissing)
+	assert.Equal([]batchFetchItem{{idx: 1, uid: imapapi.UID(11)}}, omitted)
+	require.NoError(results[1].Err)
 }
 
 func TestApplyFetchResultsMarksMissingRawBody(t *testing.T) {
@@ -759,11 +763,32 @@ func startMalformedEnvelopeIMAPServer(t *testing.T, raw []byte) (string, <-chan 
 	return listener.Addr().String(), fetchCommand
 }
 
+// markConfirmedGone is what the chunk loops do once a second FETCH has also
+// left a UID out. It is inlined here so these tests cover the same end state
+// they covered before the recheck moved the decision out of the apply step.
+func markConfirmedGone(
+	c *Client,
+	raw []gmailapi.RawMessageBatchResult,
+	labels []gmailapi.MessageLabelsBatchResult,
+	mailbox string,
+	omitted []batchFetchItem,
+) {
+	for _, item := range omitted {
+		if raw != nil {
+			raw[item.idx].Err = errIMAPFetchResultMissing
+		}
+		if labels != nil {
+			labels[item.idx].Err = errIMAPFetchResultMissing
+		}
+		c.forgetMembershipLocked(mailbox, item.uid)
+	}
+}
+
 // TestMissingUIDDropsEarlierMembershipObservation covers the observation the
-// label map records during enumeration. When the message is expunged before
-// the run fetches it, the fetch reports it gone and the run acknowledges it,
-// so nothing ingests the message. The stale observation must not survive to
-// the durable commit, which would find no message row to map it to.
+// label map records during enumeration. When a message is confirmed gone --
+// left out of a FETCH response and then left out of the recheck -- nothing
+// ingests it, so the stale observation must not survive to the durable commit,
+// which would find no message row to map it to.
 func TestMissingUIDDropsEarlierMembershipObservation(t *testing.T) {
 	enumerated := func() []MembershipObservation {
 		return []MembershipObservation{
@@ -787,7 +812,8 @@ func TestMissingUIDDropsEarlierMembershipObservation(t *testing.T) {
 			fetchMessageBuffer("message-10", []byte("raw-10")),
 		}
 
-		c.applyFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+		omitted := c.applyFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+		markConfirmedGone(&c, results, nil, "Archive", omitted)
 
 		require.ErrorIs(t, results[1].Err, errIMAPFetchResultMissing)
 		assert.NotContains(t, observedUIDs(&c), uint32(11))
@@ -804,7 +830,8 @@ func TestMissingUIDDropsEarlierMembershipObservation(t *testing.T) {
 			),
 		}
 
-		c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+		omitted := c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+		markConfirmedGone(&c, nil, results, "Archive", omitted)
 
 		require.ErrorIs(t, results[1].Err, errIMAPFetchResultMissing)
 		assert.NotContains(t, observedUIDs(&c), uint32(11))
@@ -846,4 +873,54 @@ func TestReturnedUIDWithoutHeadersKeepsMembershipObservation(t *testing.T) {
 	require.ErrorIs(t, results[0].Err, errIMAPLabelBodyMissing)
 	require.NotErrorIs(t, results[0].Err, gmailapi.ErrMessageGone)
 	assert.Contains(t, observedUIDs(&c), uint32(10))
+}
+
+// TestOmittedUIDIsRecheckedBeforeItCountsAsGone is the reason the recheck
+// exists. The server drops one live UID from the first FETCH response and
+// returns it on the next, which is a response the server got wrong rather than
+// a message that left the mailbox.
+//
+// Believing the first omission loses the message on a QRESYNC account: the run
+// acknowledges the UID, stores no membership for it, and still advances
+// HIGHESTMODSEQ, so no later CHANGEDSINCE fetch reports it again. Only the
+// paths that reconcile a mailbox by message count recover on their own, so the
+// omission must not be believed the first time on any path.
+func TestOmittedUIDIsRecheckedBeforeItCountsAsGone(t *testing.T) {
+	t.Run("label fetch", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		addr, _ := testutil.StartIMAPMemServerOmittingUIDOnce(
+			t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+		client := newTestClient(t, addr)
+
+		results, err := client.GetMessageLabelsBatch(
+			t.Context(), []string{"INBOX|1", "INBOX|2"})
+
+		require.NoError(err)
+		require.Len(results, 2)
+		require.NoError(results[0].Err)
+		require.NoError(results[1].Err,
+			"a UID the server returns on the recheck is a live message")
+		assert.Contains(observedUIDs(client), uint32(2),
+			"a rechecked message keeps the membership the commit publishes")
+	})
+
+	t.Run("raw fetch", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		addr, _ := testutil.StartIMAPMemServerOmittingUIDOnce(
+			t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+		client := newTestClient(t, addr)
+
+		results, err := client.GetMessagesRawBatchWithErrors(
+			t.Context(), []string{"INBOX|1", "INBOX|2"})
+
+		require.NoError(err)
+		require.Len(results, 2)
+		require.NoError(results[0].Err)
+		require.NoError(results[1].Err,
+			"a UID the server returns on the recheck is a live message")
+		require.NotNil(results[1].Message)
+		assert.Contains(observedUIDs(client), uint32(2))
+	})
 }

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -758,3 +758,64 @@ func startMalformedEnvelopeIMAPServer(t *testing.T, raw []byte) (string, <-chan 
 	}()
 	return listener.Addr().String(), fetchCommand
 }
+
+// TestMissingUIDDropsEarlierMembershipObservation covers the observation the
+// label map records during enumeration. When the message is expunged before
+// the run fetches it, the fetch reports it gone and the run acknowledges it,
+// so nothing ingests the message. The stale observation must not survive to
+// the durable commit, which would find no message row to map it to.
+func TestMissingUIDDropsEarlierMembershipObservation(t *testing.T) {
+	enumerated := func() []MembershipObservation {
+		return []MembershipObservation{
+			{Mailbox: "Archive", UID: 10, SourceMessageID: "Archive|10"},
+			{Mailbox: "Archive", UID: 11, SourceMessageID: "Archive|11"},
+		}
+	}
+	uidToIdx := map[imapapi.UID]int{
+		imapapi.UID(10): 0,
+		imapapi.UID(11): 1,
+	}
+	chunk := []batchFetchItem{
+		{idx: 0, uid: imapapi.UID(10)},
+		{idx: 1, uid: imapapi.UID(11)},
+	}
+
+	t.Run("raw fetch", func(t *testing.T) {
+		c := Client{observedMemberships: enumerated()}
+		results := newRawBatchResults([]string{"Archive|10", "Archive|11"})
+		msgs := []*imapclient.FetchMessageBuffer{
+			fetchMessageBuffer("message-10", []byte("raw-10")),
+		}
+
+		c.applyFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+
+		require.ErrorIs(t, results[1].Err, errIMAPFetchResultMissing)
+		assert.NotContains(t, observedUIDs(&c), uint32(11))
+		assert.Contains(t, observedUIDs(&c), uint32(10))
+	})
+
+	t.Run("label fetch", func(t *testing.T) {
+		c := Client{observedMemberships: enumerated()}
+		results := newLabelBatchResults([]string{"Archive|10", "Archive|11"})
+		msgs := []*imapclient.FetchMessageBuffer{
+			fetchMessageBuffer(
+				"message-10",
+				[]byte("Message-ID: <message-10@example.com>\r\n\r\n"),
+			),
+		}
+
+		c.applyLabelFetchResults(results, uidToIdx, "Archive", chunk, msgs)
+
+		require.ErrorIs(t, results[1].Err, errIMAPFetchResultMissing)
+		assert.NotContains(t, observedUIDs(&c), uint32(11))
+		assert.Contains(t, observedUIDs(&c), uint32(10))
+	})
+}
+
+func observedUIDs(c *Client) []uint32 {
+	uids := make([]uint32, 0, len(c.observedMemberships))
+	for _, observation := range c.observedMemberships {
+		uids = append(uids, observation.UID)
+	}
+	return uids
+}

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -924,3 +924,68 @@ func TestOmittedUIDIsRecheckedBeforeItCountsAsGone(t *testing.T) {
 		assert.Contains(observedUIDs(client), uint32(2))
 	})
 }
+
+// startOmitThenDieIMAPServer answers one FETCH with a response that leaves
+// uid out, then stops serving and closes its listener. The recheck that
+// follows therefore hits a dead socket and cannot reconnect.
+func startOmitThenDieIMAPServer(t *testing.T, uid imapapi.UID) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.WriteString(conn, "* OK [CAPABILITY IMAP4rev1] synthetic server ready\r\n")
+		reader := bufio.NewReader(conn)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				return
+			}
+			tag, command, _ := strings.Cut(strings.TrimSpace(line), " ")
+			upper := strings.ToUpper(command)
+			switch {
+			case strings.HasPrefix(upper, "LOGIN"):
+				_, _ = fmt.Fprintf(conn, "%s OK LOGIN completed\r\n", tag)
+			case strings.HasPrefix(upper, "SELECT"):
+				_, _ = io.WriteString(conn,
+					"* FLAGS (\\Seen)\r\n* 2 EXISTS\r\n* OK [UIDVALIDITY 1]\r\n* OK [UIDNEXT 3]\r\n")
+				_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
+			case strings.HasPrefix(upper, "UID FETCH"):
+				// Answer with every requested UID except the one under test,
+				// then refuse to serve anything further.
+				_, _ = fmt.Fprintf(conn,
+					"* 1 FETCH (UID %d FLAGS () INTERNALDATE \"01-Jan-2026 00:00:00 +0000\" "+
+						"RFC822.SIZE 5 BODY[] {5}\r\nhello)\r\n", uid-1)
+				_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
+				_ = listener.Close()
+				return
+			default:
+				_, _ = fmt.Fprintf(conn, "%s BAD unsupported synthetic command\r\n", tag)
+			}
+		}
+	}()
+	return addr
+}
+
+// TestRecheckReconnectFailureEndsTheBatch covers the invariant the recheck must
+// not break. fetchChunk reports a failed reconnect as fatal, and a fatal
+// failure has already cleared c.conn, so the batch cannot continue: the next
+// chunk would dereference a nil connection. The recheck has to propagate that
+// the way the first fetch of a chunk already does.
+func TestRecheckReconnectFailureEndsTheBatch(t *testing.T) {
+	require := require.New(t)
+	addr := startOmitThenDieIMAPServer(t, imapapi.UID(2))
+	client := newTestClient(t, addr)
+
+	_, err := client.GetMessagesRawBatchWithErrors(
+		t.Context(), []string{"INBOX|1", "INBOX|2"})
+
+	require.Error(err, "a failed reconnect during the recheck must end the batch")
+}

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1197,3 +1197,24 @@ func TestLabelMapSelectReconnectsAfterDroppedConnection(t *testing.T) {
 	assert.Equal(map[string]bool{messageID: true}, labels)
 	assert.Empty(unidentified)
 }
+
+// TestSourceMessageExistsIsNotDefiniteWhenHeadersMissing pins the boundary of
+// "definitive absence". Only a UID the server leaves out of the response is
+// absent. A UID it returns without headers is a live message, and reporting it
+// as absent lets SourceMessageMatches conclude a mismatch and rekey it.
+func TestSourceMessageExistsIsNotDefiniteWhenHeadersMissing(t *testing.T) {
+	require := require.New(t)
+	addr, _ := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2})
+	client := newTestClient(t, addr)
+
+	// Select INBOX first. The in-memory server then answers a FETCH of a UID
+	// another session expunged with an empty body, rather than leaving it out.
+	exists, err := client.SourceMessageExists(context.Background(), "INBOX|1")
+	require.NoError(err)
+	require.True(exists)
+	testutil.ExpungeIMAPMessage(t, addr, "INBOX", imapv2.UID(2))
+
+	_, err = client.SourceMessageExists(context.Background(), "INBOX|2")
+	require.Error(err, "a live message without headers is not definitive absence")
+	require.NotErrorIs(err, errIMAPFetchResultMissing)
+}

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -75,6 +75,22 @@ func (c *Client) recordMembershipLocked(
 	})
 }
 
+// forgetMembershipLocked drops any observation of one mailbox UID recorded
+// earlier in the run. A UID the server leaves out of a FETCH response is gone
+// from the mailbox, and the run treats that as handled rather than failed. Its
+// observation must not reach the durable commit: nothing ingested the message,
+// so membership resolution finds no row to map it to and rolls back every
+// mailbox cursor in the source. Deletion detection retires the stored
+// membership on the next run.
+func (c *Client) forgetMembershipLocked(mailbox string, uid imap.UID) {
+	c.observedMemberships = slices.DeleteFunc(
+		c.observedMemberships,
+		func(observation MembershipObservation) bool {
+			return observation.Mailbox == mailbox && observation.UID == uint32(uid)
+		},
+	)
+}
+
 // FolderState is the change-detection state of one mailbox.
 type FolderState struct {
 	UIDValidity   uint32

--- a/internal/sync/item_errors.go
+++ b/internal/sync/item_errors.go
@@ -16,6 +16,7 @@ const (
 	syncItemKindBatchFetchError = "batch_fetch_error"
 	syncItemKindFetchError      = "fetch_error"
 	syncItemKindGmailNotFound   = "gmail_not_found"
+	syncItemKindMessageGone     = "message_gone"
 	syncItemKindIngestError     = "ingest_error"
 	syncItemKindDeleteError     = "delete_error"
 )
@@ -56,6 +57,22 @@ func (s *Syncer) getMessagesRawBatchWithDiagnostics(ctx context.Context, message
 func isGmailNotFound(err error) bool {
 	var notFound *gmail.NotFoundError
 	return errors.As(err, &notFound)
+}
+
+// messageGoneKind reports whether the source no longer holds the message, and
+// the sync-item kind that records why. A Gmail 404 and an IMAP UID expunged
+// between enumeration and fetch mean the same thing to the run: the message was
+// handled, not failed. Both must be acknowledged, or the folder they belong to
+// never saves its high water mark.
+func messageGoneKind(err error) (string, bool) {
+	switch {
+	case isGmailNotFound(err):
+		return syncItemKindGmailNotFound, true
+	case errors.Is(err, gmail.ErrMessageGone):
+		return syncItemKindMessageGone, true
+	default:
+		return "", false
+	}
 }
 
 func syncItemErrorMessage(err error, fallback string) string {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -561,6 +561,13 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 				continue
 			}
 			labelResult := labelResults[i]
+			if errors.Is(labelResult.Err, gmail.ErrMessageGone) {
+				// The message left the mailbox mid-run. Deletion detection
+				// retires it; acknowledging here is what lets the folder keep
+				// its high water mark instead of re-enumerating next run.
+				result.acknowledged = append(result.acknowledged, sourceMessageID)
+				continue
+			}
 			if labelResult.Err != nil {
 				s.logger.Warn("failed to fetch message labels",
 					"id", sourceMessageID, "error", labelResult.Err)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -565,6 +565,8 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 				// The message left the mailbox mid-run. Deletion detection
 				// retires it; acknowledging here is what lets the folder keep
 				// its high water mark instead of re-enumerating next run.
+				s.logger.Debug("skipping message expunged before label fetch",
+					"id", sourceMessageID)
 				result.acknowledged = append(result.acknowledged, sourceMessageID)
 				continue
 			}
@@ -691,9 +693,9 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 				inconclusiveRefreshes[sourceMessageID]
 			raw := fetch.Message
 			if raw == nil {
-				if isGmailNotFound(fetch.Err) {
+				if kind, gone := messageGoneKind(fetch.Err); gone {
 					s.logger.Debug("skipping message deleted before fetch", "id", sourceMessageID)
-					s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
+					s.recordSyncItem(syncID, sourceMessageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, kind, fetch.Err)
 					if !alreadyExists {
 						result.skipped++
 					}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4595,61 +4595,6 @@ func TestIncrementalSyncLabelRemovedWithMissingRaw(t *testing.T) {
 	assertMessageHasLabel(t, env.Store, "msg1", "INBOX")
 }
 
-// expungeBeforeLabelsIMAPClient removes one message from the server the first
-// time the run fetches labels, reproducing the ordinary race where a message
-// leaves the mailbox between enumeration and the label FETCH.
-type expungeBeforeLabelsIMAPClient struct {
-	*immediateLabelIMAPClient
-
-	t       *testing.T
-	addr    string
-	mailbox string
-	uid     imapv2.UID
-	done    bool
-}
-
-func (c *expungeBeforeLabelsIMAPClient) GetMessageLabelsBatch(
-	ctx context.Context, messageIDs []string,
-) ([]gmail.MessageLabelsBatchResult, error) {
-	if !c.done {
-		c.done = true
-		testutil.ExpungeIMAPMessage(c.t, c.addr, c.mailbox, c.uid)
-	}
-	return c.immediateLabelIMAPClient.GetMessageLabelsBatch(ctx, messageIDs)
-}
-
-// rawGoneIMAPClient reports one message as gone from the source on the raw
-// fetch, the shape internal/imap produces when a UID it enumerated is absent
-// from the FETCH response (batch_fetch.go, errIMAPFetchResultMissing, whose
-// wrapping of gmail.ErrMessageGone internal/imap's own tests pin).
-//
-// The in-memory server cannot produce that shape: it answers a FETCH of an
-// expunged UID with an empty body, which is errIMAPRawBodyMissing — a
-// different condition, and deliberately still an error. So the vanished result
-// is substituted here and the rest of the run stays real.
-type rawGoneIMAPClient struct {
-	*immediateLabelIMAPClient
-
-	goneID string
-}
-
-func (c *rawGoneIMAPClient) GetMessagesRawBatchWithErrors(
-	ctx context.Context, messageIDs []string,
-) ([]gmail.RawMessageBatchResult, error) {
-	results, err := c.immediateLabelIMAPClient.GetMessagesRawBatchWithErrors(ctx, messageIDs)
-	if err != nil {
-		return results, err
-	}
-	for i := range results {
-		if results[i].ID == c.goneID || messageIDs[i] == c.goneID {
-			results[i].Message = nil
-			results[i].Err = fmt.Errorf(
-				"IMAP fetch result missing from response: %w", gmail.ErrMessageGone)
-		}
-	}
-	return results, nil
-}
-
 func TestIMAPMessageGoneBeforeRawFetchStillSavesFolderState(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -4657,43 +4602,32 @@ func TestIMAPMessageGoneBeforeRawFetchStillSavesFolderState(t *testing.T) {
 	opts := DefaultOptions()
 	opts.SourceType = sourceTypeIMAP
 
-	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
-		"Archive": 0,
-		"INBOX":   0,
-	})
+	// UID 2 is enumerated but never fetchable, so the run reaches its body
+	// fetch and the server leaves it out of the response.
+	addr, user, hideUID := testutil.StartIMAPMemServerWithMissingUID(
+		t, map[string]int{"Archive": 0, "INBOX": 0}, "Archive", imapv2.UID(2))
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
-
-	firstClient := newSyncTestIMAPClient(t, addr)
-	env.Syncer = New(firstClient, env.Store, opts)
-	summary := runFullSync(t, env)
-	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
-	saved := firstClient.ObservedFolderStates()
-	require.NotEmpty(saved)
-	require.NoError(firstClient.Close())
-
-	// UID 2 is new, so the second run fetches its body rather than its labels.
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "vanished@example.com")
+	hideUID()
 
 	acknowledged := make(map[string]imapclient.FolderState)
-	secondClient := &rawGoneIMAPClient{
-		immediateLabelIMAPClient: newSyncTestIMAPClient(
-			t, addr,
-			imapclient.WithFolderStates(saved),
-			imapclient.WithFolderStateSave(
-				func(mailbox string, state imapclient.FolderState) {
-					acknowledged[mailbox] = state
-				},
-			),
+	client := newSyncTestIMAPClient(
+		t, addr,
+		imapclient.WithFolderStateSave(
+			func(mailbox string, state imapclient.FolderState) {
+				acknowledged[mailbox] = state
+			},
 		),
-		goneID: "Archive|2",
-	}
-	env.Syncer = New(secondClient, env.Store, opts)
-	summary = runFullSync(t, env)
+	)
+	env.Syncer = New(client, env.Store, opts)
+	summary := runFullSync(t, env)
 
 	assert.Equal(int64(0), summary.Errors,
 		"a message that left the mailbox before its body fetch is a race, not an error")
 	assert.Contains(acknowledged, "Archive",
 		"a message gone before its body fetch must not hold back the high water mark")
+	assertMessageCount(t, env.Store, 1)
+	require.NoError(client.Close())
 }
 
 func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
@@ -4703,10 +4637,8 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 	opts := DefaultOptions()
 	opts.SourceType = sourceTypeIMAP
 
-	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
-		"Archive": 0,
-		"INBOX":   0,
-	})
+	addr, user, hideUID := testutil.StartIMAPMemServerWithMissingUID(
+		t, map[string]int{"Archive": 0, "INBOX": 0}, "Archive", imapv2.UID(1))
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "expunged@example.com")
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
 
@@ -4716,24 +4648,19 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
 	require.NoError(firstClient.Close())
 
-	// No saved folder state, so the second run enumerates Archive in full and
-	// refreshes the labels of both stored messages. UID 1 disappears while it
-	// does so.
+	// Both messages are archived, so the second run refreshes their labels
+	// rather than fetching bodies. UID 1 leaves the mailbox before it does so.
+	hideUID()
+
 	acknowledged := make(map[string]imapclient.FolderState)
-	secondClient := &expungeBeforeLabelsIMAPClient{
-		immediateLabelIMAPClient: newSyncTestIMAPClient(
-			t, addr,
-			imapclient.WithFolderStateSave(
-				func(mailbox string, state imapclient.FolderState) {
-					acknowledged[mailbox] = state
-				},
-			),
+	secondClient := newSyncTestIMAPClient(
+		t, addr,
+		imapclient.WithFolderStateSave(
+			func(mailbox string, state imapclient.FolderState) {
+				acknowledged[mailbox] = state
+			},
 		),
-		t:       t,
-		addr:    addr,
-		mailbox: "Archive",
-		uid:     imapv2.UID(1),
-	}
+	)
 	env.Syncer = New(secondClient, env.Store, opts)
 	summary = runFullSync(t, env)
 
@@ -4741,4 +4668,5 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 		"a message that left the mailbox mid-run is a race, not a fetch error")
 	assert.Contains(acknowledged, "Archive",
 		"an expunged message must not hold back the mailbox high water mark")
+	require.NoError(secondClient.Close())
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4608,7 +4608,7 @@ func TestIMAPMessageGoneBeforeRawFetchStillSavesFolderState(t *testing.T) {
 		t, map[string]int{"Archive": 0, "INBOX": 0}, "Archive", imapv2.UID(2))
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
 	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "vanished@example.com")
-	hideUID()
+	hideUID(true)
 
 	acknowledged := make(map[string]imapclient.FolderState)
 	client := newSyncTestIMAPClient(
@@ -4650,7 +4650,7 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 
 	// Both messages are archived, so the second run refreshes their labels
 	// rather than fetching bodies. UID 1 leaves the mailbox before it does so.
-	hideUID()
+	hideUID(true)
 
 	acknowledged := make(map[string]imapclient.FolderState)
 	secondClient := newSyncTestIMAPClient(
@@ -4668,5 +4668,45 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 		"a message that left the mailbox mid-run is a race, not a fetch error")
 	assert.Contains(acknowledged, "Archive",
 		"an expunged message must not hold back the mailbox high water mark")
+	require.NoError(secondClient.Close())
+}
+
+// TestIMAPMessageMissingFromFetchIsRecoveredNextRun bounds what an omitted UID
+// costs. Treating it as gone is a guess about a live server, so the guess must
+// not be durable: the UID never enters the saved UID set, the mailbox no
+// longer matches its message count, and the next run enumerates it and
+// archives the message.
+func TestIMAPMessageMissingFromFetchIsRecoveredNextRun(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user, setUIDHidden := testutil.StartIMAPMemServerWithMissingUID(
+		t, map[string]int{"Archive": 0, "INBOX": 0}, "Archive", imapv2.UID(2))
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "omitted@example.com")
+
+	setUIDHidden(true)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assert.Equal(int64(0), summary.Errors)
+	assertMessageCount(t, env.Store, 1)
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.Close())
+
+	// The server stops hiding the UID. The saved state never recorded it, so
+	// the mailbox is not provably unchanged and the run reads it again.
+	setUIDHidden(false)
+	secondClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderStates(saved))
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+
+	assert.Equal(int64(0), summary.Errors)
+	assertMessageCount(t, env.Store, 2)
 	require.NoError(secondClient.Close())
 }

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4594,3 +4594,73 @@ func TestIncrementalSyncLabelRemovedWithMissingRaw(t *testing.T) {
 	assertMessageNotHasLabel(t, env.Store, "msg1", "STARRED")
 	assertMessageHasLabel(t, env.Store, "msg1", "INBOX")
 }
+
+// expungeBeforeLabelsIMAPClient removes one message from the server the first
+// time the run fetches labels, reproducing the ordinary race where a message
+// leaves the mailbox between enumeration and the label FETCH.
+type expungeBeforeLabelsIMAPClient struct {
+	*immediateLabelIMAPClient
+
+	t       *testing.T
+	addr    string
+	mailbox string
+	uid     imapv2.UID
+	done    bool
+}
+
+func (c *expungeBeforeLabelsIMAPClient) GetMessageLabelsBatch(
+	ctx context.Context, messageIDs []string,
+) ([]gmail.MessageLabelsBatchResult, error) {
+	if !c.done {
+		c.done = true
+		testutil.ExpungeIMAPMessage(c.t, c.addr, c.mailbox, c.uid)
+	}
+	return c.immediateLabelIMAPClient.GetMessageLabelsBatch(ctx, messageIDs)
+}
+
+func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "expunged@example.com")
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(2))})
+	require.NoError(firstClient.Close())
+
+	// No saved folder state, so the second run enumerates Archive in full and
+	// refreshes the labels of both stored messages. UID 1 disappears while it
+	// does so.
+	acknowledged := make(map[string]imapclient.FolderState)
+	secondClient := &expungeBeforeLabelsIMAPClient{
+		immediateLabelIMAPClient: newSyncTestIMAPClient(
+			t, addr,
+			imapclient.WithFolderStateSave(
+				func(mailbox string, state imapclient.FolderState) {
+					acknowledged[mailbox] = state
+				},
+			),
+		),
+		t:       t,
+		addr:    addr,
+		mailbox: "Archive",
+		uid:     imapv2.UID(1),
+	}
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+
+	assert.Equal(int64(0), summary.Errors,
+		"a message that left the mailbox mid-run is a race, not a fetch error")
+	assert.Contains(acknowledged, "Archive",
+		"an expunged message must not hold back the mailbox high water mark")
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4618,6 +4618,84 @@ func (c *expungeBeforeLabelsIMAPClient) GetMessageLabelsBatch(
 	return c.immediateLabelIMAPClient.GetMessageLabelsBatch(ctx, messageIDs)
 }
 
+// rawGoneIMAPClient reports one message as gone from the source on the raw
+// fetch, the shape internal/imap produces when a UID it enumerated is absent
+// from the FETCH response (batch_fetch.go, errIMAPFetchResultMissing, whose
+// wrapping of gmail.ErrMessageGone internal/imap's own tests pin).
+//
+// The in-memory server cannot produce that shape: it answers a FETCH of an
+// expunged UID with an empty body, which is errIMAPRawBodyMissing — a
+// different condition, and deliberately still an error. So the vanished result
+// is substituted here and the rest of the run stays real.
+type rawGoneIMAPClient struct {
+	*immediateLabelIMAPClient
+
+	goneID string
+}
+
+func (c *rawGoneIMAPClient) GetMessagesRawBatchWithErrors(
+	ctx context.Context, messageIDs []string,
+) ([]gmail.RawMessageBatchResult, error) {
+	results, err := c.immediateLabelIMAPClient.GetMessagesRawBatchWithErrors(ctx, messageIDs)
+	if err != nil {
+		return results, err
+	}
+	for i := range results {
+		if results[i].ID == c.goneID || messageIDs[i] == c.goneID {
+			results[i].Message = nil
+			results[i].Err = fmt.Errorf(
+				"IMAP fetch result missing from response: %w", gmail.ErrMessageGone)
+		}
+	}
+	return results, nil
+}
+
+func TestIMAPMessageGoneBeforeRawFetchStillSavesFolderState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Archive": 0,
+		"INBOX":   0,
+	})
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "survivor@example.com")
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	saved := firstClient.ObservedFolderStates()
+	require.NotEmpty(saved)
+	require.NoError(firstClient.Close())
+
+	// UID 2 is new, so the second run fetches its body rather than its labels.
+	testutil.AppendIMAPMessageWithMessageID(t, user, "Archive", "vanished@example.com")
+
+	acknowledged := make(map[string]imapclient.FolderState)
+	secondClient := &rawGoneIMAPClient{
+		immediateLabelIMAPClient: newSyncTestIMAPClient(
+			t, addr,
+			imapclient.WithFolderStates(saved),
+			imapclient.WithFolderStateSave(
+				func(mailbox string, state imapclient.FolderState) {
+					acknowledged[mailbox] = state
+				},
+			),
+		),
+		goneID: "Archive|2",
+	}
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+
+	assert.Equal(int64(0), summary.Errors,
+		"a message that left the mailbox before its body fetch is a race, not an error")
+	assert.Contains(acknowledged, "Archive",
+		"a message gone before its body fetch must not hold back the high water mark")
+}
+
 func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4671,12 +4671,16 @@ func TestIMAPExpungeDuringRunStillSavesFolderState(t *testing.T) {
 	require.NoError(secondClient.Close())
 }
 
-// TestIMAPMessageMissingFromFetchIsRecoveredNextRun bounds what an omitted UID
-// costs. Treating it as gone is a guess about a live server, so the guess must
-// not be durable: the UID never enters the saved UID set, the mailbox no
+// TestIMAPGoneUIDIsArchivedOnceTheServerReturnsIt bounds what a confirmed-gone
+// UID costs. The server hides it from every response here, including the
+// recheck, so the run is right to treat it as gone -- but the verdict must
+// still not be durable. The UID never enters the saved UID set, the mailbox no
 // longer matches its message count, and the next run enumerates it and
 // archives the message.
-func TestIMAPMessageMissingFromFetchIsRecoveredNextRun(t *testing.T) {
+//
+// The message-count recovery this asserts belongs to the non-QRESYNC paths.
+// See TestSaveIMAPFolderStates_RepublishGoneUIDRecoversByMessageCount.
+func TestIMAPGoneUIDIsArchivedOnceTheServerReturnsIt(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	env := newTestEnv(t)

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -178,19 +178,19 @@ func (s *missingUIDSession) Fetch(
 // SEARCH still report it, so a run enumerates the UID and then cannot fetch
 // it. That is the expunge race as a real server presents it.
 //
-// The returned function starts hiding the UID. Call it between two runs to
-// make a message disappear after it was already archived.
+// The returned function sets whether the UID is hidden. Call it between two
+// runs to make a message disappear, or to bring it back.
 func StartIMAPMemServerWithMissingUID(
 	t *testing.T,
 	messagesPerMailbox map[string]int,
 	mailbox string,
 	uid imap.UID,
-) (string, *imapmemserver.User, func()) {
+) (string, *imapmemserver.User, func(hidden bool)) {
 	t.Helper()
 	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
 	addr, user := startIMAPMemServer(
 		t, messagesPerMailbox, nil, "", 0, "", config)
-	return addr, user, func() { config.hidden.Store(true) }
+	return addr, user, func(hidden bool) { config.hidden.Store(hidden) }
 }
 
 // AppendIMAPMessage appends one synthetic RFC822 message to a mailbox

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -107,6 +108,91 @@ func (s *specialUseSession) List(
 	return nil
 }
 
+// missingUIDSession leaves one UID out of every FETCH response for one
+// mailbox, the way a real server answers a FETCH for a message another session
+// expunged. The in-memory server cannot produce that shape on its own: it
+// still returns the UID, with an empty body, which is a live message whose
+// headers are missing rather than a message that left the mailbox.
+type missingUIDSession struct {
+	imapserver.Session
+
+	config   *missingUIDConfig
+	selected string
+}
+
+// missingUIDConfig is shared by every session the server opens, so the UID can
+// be hidden after one run has already fetched it.
+type missingUIDConfig struct {
+	mailbox string
+	uid     imap.UID
+	hidden  atomic.Bool
+}
+
+func (s *missingUIDSession) Select(
+	mailbox string,
+	options *imap.SelectOptions,
+) (*imap.SelectData, error) {
+	data, err := s.Session.Select(mailbox, options)
+	if err != nil {
+		return nil, fmt.Errorf("select %q: %w", mailbox, err)
+	}
+	s.selected = mailbox
+	return data, nil
+}
+
+func (s *missingUIDSession) Fetch(
+	w *imapserver.FetchWriter,
+	numSet imap.NumSet,
+	options *imap.FetchOptions,
+) error {
+	fetch := func(set imap.NumSet) error {
+		if err := s.Session.Fetch(w, set, options); err != nil {
+			return fmt.Errorf("fetch %q: %w", s.selected, err)
+		}
+		return nil
+	}
+	uidSet, ok := numSet.(imap.UIDSet)
+	if !ok || !s.config.hidden.Load() ||
+		s.selected != s.config.mailbox || !uidSet.Contains(s.config.uid) {
+		return fetch(numSet)
+	}
+	uids, static := uidSet.Nums()
+	if !static {
+		return fetch(numSet)
+	}
+	kept := make([]imap.UID, 0, len(uids))
+	for _, uid := range uids {
+		if uid != s.config.uid {
+			kept = append(kept, uid)
+		}
+	}
+	if len(kept) == 0 {
+		// Every requested UID is gone, so the response carries no messages.
+		return nil
+	}
+	return fetch(imap.UIDSetNum(kept...))
+}
+
+// StartIMAPMemServerWithMissingUID runs an in-memory IMAP server that can
+// leave one UID out of every FETCH response for one mailbox. LIST, STATUS and
+// SEARCH still report it, so a run enumerates the UID and then cannot fetch
+// it. That is the expunge race as a real server presents it.
+//
+// The returned function starts hiding the UID. Call it between two runs to
+// make a message disappear after it was already archived.
+func StartIMAPMemServerWithMissingUID(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	mailbox string,
+	uid imap.UID,
+) (string, *imapmemserver.User, func()) {
+	t.Helper()
+	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
+	addr, user := startIMAPMemServer(
+		t, messagesPerMailbox, nil, "", 0, "", config)
+	return addr, user, func() { config.hidden.Store(true) }
+}
+
 // AppendIMAPMessage appends one synthetic RFC822 message to a mailbox
 // of an in-memory IMAP test user.
 func AppendIMAPMessage(t *testing.T, user *imapmemserver.User, mailbox string) {
@@ -169,7 +255,7 @@ func AppendIMAPMessageWithMessageID(
 // down via t.Cleanup.
 func StartIMAPMemServer(t *testing.T, messagesPerMailbox map[string]int) (string, *imapmemserver.User) {
 	t.Helper()
-	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0, "")
+	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0, "", nil)
 }
 
 // StartIMAPMemServerWithSpecialUse runs an in-memory IMAP server whose LIST
@@ -180,7 +266,7 @@ func StartIMAPMemServerWithSpecialUse(
 	specialUse map[string][]imap.MailboxAttr,
 ) (string, *imapmemserver.User) {
 	t.Helper()
-	return startIMAPMemServer(t, messagesPerMailbox, specialUse, "", 0, "")
+	return startIMAPMemServer(t, messagesPerMailbox, specialUse, "", 0, "", nil)
 }
 
 // StartIMAPMemServerWithStatusError runs an in-memory IMAP server that rejects
@@ -193,7 +279,7 @@ func StartIMAPMemServerWithStatusError(
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	return startIMAPMemServer(
-		t, messagesPerMailbox, specialUse, "", 0, statusErrorMailbox)
+		t, messagesPerMailbox, specialUse, "", 0, statusErrorMailbox, nil)
 }
 
 // StartIMAPMemServerWithSelectError runs an in-memory IMAP server that rejects
@@ -206,7 +292,7 @@ func StartIMAPMemServerWithSelectError(
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	return startIMAPMemServer(
-		t, messagesPerMailbox, specialUse, selectErrorMailbox, -1, "")
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, -1, "", nil)
 }
 
 // StartIMAPMemServerWithOneShotSelectError runs an in-memory IMAP server that
@@ -219,7 +305,7 @@ func StartIMAPMemServerWithOneShotSelectError(
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	return startIMAPMemServer(
-		t, messagesPerMailbox, specialUse, selectErrorMailbox, 1, "")
+		t, messagesPerMailbox, specialUse, selectErrorMailbox, 1, "", nil)
 }
 
 func startIMAPMemServer(
@@ -229,6 +315,7 @@ func startIMAPMemServer(
 	selectErrorMailbox string,
 	selectErrorCount int,
 	statusErrorMailbox string,
+	missingUID *missingUIDConfig,
 ) (string, *imapmemserver.User) {
 	t.Helper()
 	user := imapmemserver.NewUser(IMAPTestUsername, IMAPTestPassword)
@@ -267,6 +354,9 @@ func startIMAPMemServer(
 					Session: session,
 					mailbox: statusErrorMailbox,
 				}
+			}
+			if missingUID != nil {
+				session = &missingUIDSession{Session: session, config: missingUID}
 			}
 			return session, nil, nil
 		},

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -125,7 +125,26 @@ type missingUIDSession struct {
 type missingUIDConfig struct {
 	mailbox string
 	uid     imap.UID
-	hidden  atomic.Bool
+	// hideRemaining is negative to hide the UID from every FETCH, zero to hide
+	// it from none, and positive to hide it from that many more responses.
+	hideRemaining atomic.Int64
+}
+
+// takeHide reports whether this FETCH response must leave the UID out, and
+// spends one of a limited budget when the budget is what allows it.
+func (c *missingUIDConfig) takeHide() bool {
+	for {
+		remaining := c.hideRemaining.Load()
+		if remaining == 0 {
+			return false
+		}
+		if remaining < 0 {
+			return true
+		}
+		if c.hideRemaining.CompareAndSwap(remaining, remaining-1) {
+			return true
+		}
+	}
 }
 
 func (s *missingUIDSession) Select(
@@ -152,12 +171,16 @@ func (s *missingUIDSession) Fetch(
 		return nil
 	}
 	uidSet, ok := numSet.(imap.UIDSet)
-	if !ok || !s.config.hidden.Load() ||
-		s.selected != s.config.mailbox || !uidSet.Contains(s.config.uid) {
+	if !ok || s.selected != s.config.mailbox || !uidSet.Contains(s.config.uid) {
 		return fetch(numSet)
 	}
 	uids, static := uidSet.Nums()
 	if !static {
+		return fetch(numSet)
+	}
+	// Spend the budget only once the response is known to be one that would
+	// have carried the UID, so a one-shot omission is not used up elsewhere.
+	if !s.config.takeHide() {
 		return fetch(numSet)
 	}
 	kept := make([]imap.UID, 0, len(uids))
@@ -190,7 +213,35 @@ func StartIMAPMemServerWithMissingUID(
 	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
 	addr, user := startIMAPMemServer(
 		t, messagesPerMailbox, nil, "", 0, "", config)
-	return addr, user, func(hidden bool) { config.hidden.Store(hidden) }
+	return addr, user, func(hidden bool) {
+		if hidden {
+			config.hideRemaining.Store(-1)
+			return
+		}
+		config.hideRemaining.Store(0)
+	}
+}
+
+// StartIMAPMemServerOmittingUIDOnce runs an in-memory IMAP server that leaves
+// one UID out of the next FETCH response that would have carried it, and
+// returns it on every later fetch.
+//
+// That is a live message the server dropped from one response, not an expunge.
+// A run that believes the first omission loses it; a run that asks again finds
+// it. StartIMAPMemServerWithMissingUID is the other shape, where the message
+// really is gone and stays gone.
+func StartIMAPMemServerOmittingUIDOnce(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	mailbox string,
+	uid imap.UID,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
+	config.hideRemaining.Store(1)
+	addr, user := startIMAPMemServer(
+		t, messagesPerMailbox, nil, "", 0, "", config)
+	return addr, user
 }
 
 // AppendIMAPMessage appends one synthetic RFC822 message to a mailbox


### PR DESCRIPTION
Closes #710

A message can leave a mailbox between the moment a run enumerates it and the
moment the run fetches it. Sync now treats that as an ordinary race rather than
a fetch error, so the mailbox can still save its high water mark.

A UID missing from a FETCH response is not proof of that on its own, so the run
asks again before acting on it. The omitted UIDs of a chunk are re-fetched
once, as a set, and only the ones the server leaves out a second time are
treated as gone. A chunk with no omissions costs nothing, and anything the
recheck returns is a live message that keeps its membership.

Deletion detection still retires a message that really did leave, and every
other fetch failure keeps its current behaviour.

On a 96,000-message Microsoft 365 account, nine messages left INBOX during one
run. The mailbox saved no folder state, and the next run re-enumerated it in 80
minutes.

No configuration or usage changes.
