### PR TITLE
fix(ci): stop lease renewal deadlock and relax two timing-bound tests

### DIFF
--- a/internal/meetingimport/importer_test.go
+++ b/internal/meetingimport/importer_test.go
@@ -839,16 +839,19 @@ func TestImporterCancellationDuringParticipantResolutionRollsBackParticipants(t 
 		done <- importErr
 	}()
 
+	// These are liveness bounds, not latency budgets: the import stops
+	// within milliseconds when it works, and a hang is the only failure they
+	// exist to catch. Keep them generous so a slow runner cannot fail them.
 	select {
 	case <-participantStarted:
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		require.FailNow("meeting import did not reach attendee insertion")
 	}
 	cancel()
 
 	select {
 	case err = <-done:
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		require.FailNow("meeting import did not stop after cancellation")
 	}
 	require.ErrorIs(err, context.Canceled)

--- a/internal/store/changed_messages_commit_bound_test.go
+++ b/internal/store/changed_messages_commit_bound_test.go
@@ -1122,7 +1122,7 @@ func TestListChangedMessages_ConcurrentWithActiveImportMakesProgress(t *testing.
 
 	require.NoError(<-importErrs, "the import path must not fail while the feed polls")
 	require.NoError(pollErr, "the feed must not error while an import holds the write lock")
-	require.Greaterf(polls, 10,
+	require.Greaterf(polls, 2,
 		"the feed completed only %d polls in 5s against an active import; "+
 			"that is a stall, not contention", polls)
 	require.Positive(imported.Load(),

--- a/internal/store/person_enrichment_results.go
+++ b/internal/store/person_enrichment_results.go
@@ -376,9 +376,26 @@ func (s *Store) recheckPersonEnrichmentCommitTx(
 	if s.personEnrichmentTxBarrier != nil {
 		s.personEnrichmentTxBarrier("result_person_locked")
 	}
+	// Lock the work row BEFORE the attempt row. Every other lease path
+	// (RenewLease, BeginAttempt, AuthorizeAttemptDispatch, the schedule and
+	// release paths) locks person_enrichment_work first and then
+	// person_enrichment_attempts, and the worker's lease-renewal goroutine runs
+	// RenewLease concurrently with this commit. Locking the attempt first here
+	// inverted that order and PostgreSQL reported "deadlock detected" on the
+	// renewal whenever a renewal tick landed during a result commit. The lock
+	// is taken by key alone, without verifying the lease: a replayed commit
+	// whose work row has already been settled must still reach the replay
+	// disposition below, and the lease itself is verified afterwards.
+	if err := lockEnrichmentWorkRowForOrderingTx(
+		ctx, tx, s.dialect, commit.PersonID, commit.ProfileFingerprint); err != nil {
+		return enrichmentCommitDisposition{}, err
+	}
 	attempt, err := s.loadPersonEnrichmentCommitAttempt(ctx, tx, commit.AttemptID, true)
 	if err != nil {
 		return enrichmentCommitDisposition{}, err
+	}
+	if s.personEnrichmentTxBarrier != nil {
+		s.personEnrichmentTxBarrier("result_attempt_locked")
 	}
 	if attempt.State == "starting" {
 		programFingerprint, fingerprintErr := personenrichment.ProgramFingerprint(

--- a/internal/store/person_enrichment_results_test.go
+++ b/internal/store/person_enrichment_results_test.go
@@ -1133,3 +1133,61 @@ func TestPersonEnrichmentResultMetadataStructsDoNotExposeSecretsOrRawIdentifiers
 		assert.NotContains(t, string(encoded), forbidden)
 	}
 }
+
+// TestPersonEnrichmentResultCommitAndLeaseRenewalDoNotDeadlock pins the lock
+// order between a result commit and the worker's concurrent lease renewal.
+// The commit is held after it has locked the attempt row, and a renewal for the
+// same attempt is started against it. Before the work row was locked ahead of
+// the attempt row here, the renewal took the work row and then waited on the
+// attempt row while the released commit waited on the work row, and PostgreSQL
+// aborted one side with "deadlock detected". With the shared order the renewal
+// simply waits for the commit; it then either renews or, because the commit
+// settled the work row, reports a stale lease. Either is fine; a deadlock is
+// not.
+func TestPersonEnrichmentResultCommitAndLeaseRenewalDoNotDeadlock(t *testing.T) {
+	checks := assert.New(t)
+	requirements := require.New(t)
+	f := newEnrichmentResultFixture(t)
+
+	attemptLocked := make(chan struct{})
+	releaseResult := make(chan struct{})
+	var resultOnce sync.Once
+	SetPersonEnrichmentTxBarrierForTest(f.store, func(phase string) {
+		if phase == "result_attempt_locked" {
+			resultOnce.Do(func() {
+				close(attemptLocked)
+				<-releaseResult
+			})
+		}
+	})
+	claimDone := make(chan enrichmentClaimResult, 1)
+	go func() {
+		outcome, commitErr := f.store.CommitEnrichmentClaims(t.Context(), f.commit)
+		claimDone <- enrichmentClaimResult{outcome: outcome, err: commitErr}
+	}()
+	requireEnrichmentResultSignal(t, attemptLocked, "result did not lock its attempt")
+
+	renewDone := make(chan error, 1)
+	go func() {
+		renewDone <- f.store.RenewLease(t.Context(), f.attempt.Token, f.now.Add(time.Minute))
+	}()
+	// Give the renewal time to reach the row locks while the commit is held.
+	// The test cannot observe a blocked statement directly; without this the
+	// renewal may not have started before the commit is released, and the
+	// interleaving under test never happens.
+	select {
+	case err := <-renewDone:
+		requirements.FailNowf("lease renewal did not wait for the held commit", "%v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+	close(releaseResult)
+
+	claim := requireEnrichmentClaimResult(t, claimDone)
+	requirements.NoError(claim.err)
+	requirements.NotNil(claim.outcome)
+	checks.Equal(personenrichment.ClaimApplied, claim.outcome.Status)
+	renewErr := requireEnrichmentErrorResult(t, renewDone, "lease renewal deadlocked")
+	if renewErr != nil {
+		checks.ErrorIs(renewErr, ErrStaleLease)
+	}
+}

--- a/internal/store/person_enrichment_work.go
+++ b/internal/store/person_enrichment_work.go
@@ -1707,6 +1707,25 @@ func lockEnrichmentWorkStateTx(
 	return work, nil
 }
 
+// lockEnrichmentWorkRowForOrderingTx takes the row lock on a work row by key
+// without verifying any lease on it. It exists so a transaction that must lock
+// the attempt row can first take the work row in the order every lease
+// mutation uses (work, then attempt). A missing row is not an error: the caller
+// is about to read the attempt and decide from that what the missing work row
+// means.
+func lockEnrichmentWorkRowForOrderingTx(
+	ctx context.Context, tx *loggedTx, dialect Dialect, personID int64, fingerprint string,
+) error {
+	var one int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM person_enrichment_work
+		WHERE person_id = ? AND profile_fingerprint = ?`+dialect.SelectForUpdate(),
+		personID, fingerprint).Scan(&one)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("lock person enrichment work for ordering: %w", err)
+	}
+	return nil
+}
+
 func lockPersonEnrichmentPersonTx(
 	ctx context.Context, tx *loggedTx, dialect Dialect, personID int64,
 ) (int64, error) {


### PR DESCRIPTION
## What changed

- Person enrichment result commits now lock the `person_enrichment_work` row before the `person_enrichment_attempts` row, the same order as `RenewLease` and every other lease path. A new store test holds a commit after its attempt lock, starts a lease renewal against it, and checks that neither side deadlocks.
- `TestImporterCancellationDuringParticipantResolutionRollsBackParticipants` waits up to 10 s (was 1 s) for the cancelled import to unwind.
- `TestListChangedMessages_ConcurrentWithActiveImportMakesProgress` requires more than 2 polls in 5 s (was more than 10).

## Why

`main` failed CI three runs in a row (#1891 Postgres, #1892 Windows, #1893 macOS), each on a different test.

The Postgres one is a real bug. The worker renews its lease on a timer in a separate goroutine, so a renewal could run concurrently with a result commit. The two took the work and attempt row locks in opposite orders, and PostgreSQL aborted one with `deadlock detected` — the worker then reported a failed renewal for an attempt that had in fact succeeded. On a Postgres 16 instance the new test fails with the old order (after the 1 s deadlock timeout) and passes with the new one. SQLite has a single writer and was never affected.

The other two are liveness checks with bounds a correct build can miss on a slow runner. Each change-feed poll can wait the full 250 ms probe timeout while an importer holds SQLite's write lock, so ten polls in five seconds is close to the arithmetic ceiling. A genuine stall still fails both tests, and the feed test's real assertions (bound published, bound advances, pages carry importer-written rows) are unchanged.

Not addressed: #1891 also hit the Postgres lane's one-hour timeout (60 min against a 42 min pass on the previous commit). That is runner load, not a test defect.

## Usage

No usage change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
