### PR TITLE
fix(vector): prune orphan message embeddings

### DIFF
--- a/cmd/msgvault/cmd/delete_deduped.go
+++ b/cmd/msgvault/cmd/delete_deduped.go
@@ -24,9 +24,9 @@ manifests still reference Gmail/IMAP message IDs and remain valid
 after a local delete.
 
 Parquet analytics and the vector index may contain stale entries for
-deleted rows until rebuilt; the rebuild commands are separate. Run
+deleted rows until maintained separately. Run
 'msgvault build-cache --full-rebuild' for parquet analytics and
-'msgvault embeddings build --full-rebuild' for the vector index.`,
+'msgvault embeddings prune' for the vector index.`,
 	RunE: runDeleteDeduped,
 }
 
@@ -83,9 +83,8 @@ func runDeleteDeduped(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Note: parquet analytics and the vector index may contain entries
-	// for deleted rows; the post-run summary recommends rebuilding each
-	// separately ('build-cache --full-rebuild' and
-	// 'embeddings build --full-rebuild').
+	// for deleted rows; the post-run summary recommends maintaining each
+	// separately ('build-cache --full-rebuild' and 'embeddings prune').
 
 	expectedTotal := plan.Total
 	expectedBatchCount := plan.BatchCount
@@ -102,9 +101,9 @@ func runDeleteDeduped(cmd *cobra.Command, _ []string) error {
 		_, _ = fmt.Fprintf(out, "Backing up database to %s...\n", filepath.Base(executed.BackupPath))
 	}
 	_, _ = fmt.Fprintf(out, "\nDeleted %d message(s) from %d batch(es).\n\n", executed.Deleted, executed.BatchCount)
-	_, _ = fmt.Fprintln(out, "Caches may have stale entries; rebuild each separately:")
+	_, _ = fmt.Fprintln(out, "Caches may have stale entries; maintain each separately:")
 	_, _ = fmt.Fprintln(out, "  'msgvault build-cache --full-rebuild'        (parquet analytics)")
-	_, _ = fmt.Fprintln(out, "  'msgvault embeddings build --full-rebuild'   (vector index, if enabled)")
+	_, _ = fmt.Fprintln(out, "  'msgvault embeddings prune'                  (vector index, if enabled)")
 
 	return nil
 }

--- a/cmd/msgvault/cmd/delete_deduped_test.go
+++ b/cmd/msgvault/cmd/delete_deduped_test.go
@@ -178,8 +178,8 @@ func TestDeleteDedupedUsesConfiguredRemoteHTTPAndPreservesOutput(t *testing.T) {
 
 Deleted 3 message(s) from 2 batch(es).
 
-Caches may have stale entries; rebuild each separately:
+Caches may have stale entries; maintain each separately:
   'msgvault build-cache --full-rebuild'        (parquet analytics)
-  'msgvault embeddings build --full-rebuild'   (vector index, if enabled)
+  'msgvault embeddings prune'                  (vector index, if enabled)
 `, stdout.String())
 }

--- a/cmd/msgvault/cmd/direct_write_test.go
+++ b/cmd/msgvault/cmd/direct_write_test.go
@@ -245,6 +245,25 @@ func TestEmbeddingsRetireFailsFastWhenArchiveOwned(t *testing.T) {
 	assert.Contains(err.Error(), "msgvault daemon stop", "points at the remedy")
 }
 
+func TestEmbeddingsPruneFailsFastWhenArchiveOwned(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	dataDir := t.TempDir()
+	withStoreResolverConfig(t, lifecycleTestConfig(dataDir))
+
+	owner, err := tryAcquireWriteOwnerLock(dataDir)
+	require.NoError(err, "acquire owner lock")
+	t.Cleanup(func() { _ = owner.Close() })
+
+	cmd := &cobra.Command{Use: "prune"}
+	cmd.SetContext(context.Background())
+	err = runEmbeddingsPrune(cmd, nil)
+	require.Error(err, "embeddings prune must fail while the archive is owned")
+	assert.Contains(err.Error(), "owned", "actionable ownership error")
+	assert.Contains(err.Error(), "msgvault daemon stop", "points at the remedy")
+}
+
 func TestEmbeddingsListFailsFastWhenArchiveOwned(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(

--- a/cmd/msgvault/cmd/embed.go
+++ b/cmd/msgvault/cmd/embed.go
@@ -57,6 +57,12 @@ var embeddingsActivateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE:  runEmbeddingsActivateCommand,
 }
+var embeddingsPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove embeddings for hard-deleted messages",
+	Args:  cobra.NoArgs,
+	RunE:  runEmbeddingsPruneCommand,
+}
 var embedCmd = newEmbeddingsBuildCmd("build-embeddings")
 
 func newEmbeddingsBuildCmd(use string) *cobra.Command {
@@ -165,6 +171,7 @@ func init() {
 	embeddingsCmd.AddCommand(embeddingsListCmd)
 	embeddingsCmd.AddCommand(embeddingsRetireCmd)
 	embeddingsCmd.AddCommand(embeddingsActivateCmd)
+	embeddingsCmd.AddCommand(embeddingsPruneCmd)
 	rootCmd.AddCommand(embeddingsCmd)
 	rootCmd.AddCommand(embedCmd)
 }

--- a/cmd/msgvault/cmd/embed_test.go
+++ b/cmd/msgvault/cmd/embed_test.go
@@ -52,6 +52,10 @@ func TestEmbeddingsCommandRegistration(t *testing.T) {
 	require.NotNil(forceFlag)
 	assert.Contains(t, forceFlag.Usage, "person coverage")
 
+	pruneCmd, _, err := rootCmd.Find([]string{embeddingsCommandName, "prune"})
+	require.NoError(err)
+	require.Equal("prune", pruneCmd.Name())
+
 	legacyCmd, _, err := rootCmd.Find([]string{"build-embeddings"})
 	require.NoError(err)
 	require.Equal("build-embeddings", legacyCmd.Name())
@@ -85,6 +89,33 @@ func TestEmbeddingsListUsesDaemonRunner(t *testing.T) {
 	require.NoError(root.Execute(), "embeddings list")
 	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
 	assert.Equal("ID\tSTATE\n1\tactive\n", stdout.String(), "stdout")
+}
+
+func TestEmbeddingsPruneUsesDaemonRunner(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	server, requests := newDaemonCLIRunnerTestServer(t, func(req daemonCLIRunTestRequest) {
+		assert.Equal([]string{embeddingsCommandName, "prune"}, req.Args, "args")
+	}, `{"type":"stdout","data":"Pruned 2 orphan message embedding(s).\n"}`, `{"type":"complete"}`)
+	configureRemoteDaemonForTest(t, server.URL)
+
+	root := &cobra.Command{Use: daemonService}
+	embeddings := &cobra.Command{Use: embeddingsCommandName}
+	prune := &cobra.Command{
+		Use:  "prune",
+		RunE: runEmbeddingsPruneCommand,
+	}
+	embeddings.AddCommand(prune)
+	root.AddCommand(embeddings)
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{embeddingsCommandName, "prune"})
+
+	require.NoError(root.Execute(), "embeddings prune")
+	assert.Equal(1, int(requests.Load()), "runner endpoint calls")
+	assert.Equal("Pruned 2 orphan message embedding(s).\n", stdout.String(), "stdout")
 }
 
 func TestEmbeddingsBuildPromptsBeforeDaemonRunner(t *testing.T) {

--- a/cmd/msgvault/cmd/embeddings_manage.go
+++ b/cmd/msgvault/cmd/embeddings_manage.go
@@ -186,6 +186,40 @@ func runEmbeddingsList(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+func runEmbeddingsPruneCommand(cmd *cobra.Command, args []string) error {
+	if !isDaemonCLISubprocess() {
+		return runDaemonCLICommandHTTPFromCobra(cmd, args)
+	}
+	return runEmbeddingsPrune(cmd, args)
+}
+
+func runEmbeddingsPrune(cmd *cobra.Command, _ []string) error {
+	release, err := acquireDirectSQLiteWriteLock(cfg)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if err := ensureMainSchema(); err != nil {
+		return err
+	}
+	backend, closeBackend, err := openEmbeddingsBackend(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer closeBackend()
+	pruner, ok := backend.(vector.OrphanEmbeddingPruner)
+	if !ok {
+		return errors.New("configured vector backend does not support orphan pruning")
+	}
+	pruned, err := pruner.PruneOrphanEmbeddings(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("prune orphan embeddings: %w", err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Pruned %d orphan message embedding(s).\n", pruned)
+	return nil
+}
+
 // errRetireActiveGeneration explains the consequence of retiring the
 // serving generation and the intended replace-then-retire workflow, instead
 // of only naming the override flag.

--- a/cmd/msgvault/cmd/embeddings_manage_test.go
+++ b/cmd/msgvault/cmd/embeddings_manage_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/config"
@@ -17,6 +18,51 @@ import (
 	"go.kenn.io/msgvault/internal/vector"
 	"go.kenn.io/msgvault/internal/vector/sqlitevec"
 )
+
+func TestRunEmbeddingsPruneRemovesOrphansWithoutEmbeddingCalls(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "msgvault.db")
+	vectorPath := filepath.Join(dir, "vectors.db")
+	c := config.NewDefaultConfig()
+	c.HomeDir = dir
+	c.Data.DataDir = dir
+	c.Vector.Enabled = true
+	c.Vector.DBPath = vectorPath
+	c.Vector.Embeddings.Model = "test-model"
+	c.Vector.Embeddings.Dimension = 4
+	withTestConfig(t, c)
+
+	mainStore, err := store.Open(mainPath)
+	require.NoError(t, err)
+	require.NoError(t, mainStore.InitSchema())
+	backend, err := sqlitevec.Open(t.Context(), sqlitevec.Options{
+		Path: vectorPath, MainPath: mainPath, Dimension: 4, MainDB: mainStore.DB(),
+	})
+	require.NoError(t, err)
+	generation, err := backend.CreateGeneration(t.Context(), "test-model", 4, "test:4")
+	require.NoError(t, err)
+	require.NoError(t, backend.Upsert(t.Context(), generation, []vector.Chunk{
+		{MessageID: 9001, Vector: []float32{1, 0, 0, 0}},
+	}))
+	require.NoError(t, backend.Close())
+	require.NoError(t, mainStore.Close())
+
+	var output bytes.Buffer
+	command := &cobra.Command{Use: "prune"}
+	command.SetContext(t.Context())
+	command.SetOut(&output)
+	require.NoError(t, runEmbeddingsPrune(command, nil))
+	assert.Equal(t, "Pruned 1 orphan message embedding(s).\n", output.String())
+
+	reopened, err := sqlitevec.Open(t.Context(), sqlitevec.Options{
+		Path: vectorPath, MainPath: mainPath, Dimension: 4,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+	stats, err := reopened.Stats(t.Context(), generation)
+	require.NoError(t, err)
+	assert.Zero(t, stats.EmbeddingCount)
+}
 
 type convergenceProgressPublisher struct {
 	vector.DocumentPublisher

--- a/internal/vector/backend.go
+++ b/internal/vector/backend.go
@@ -389,6 +389,14 @@ type FilteredCoverageBackend interface {
 	EmbeddedMessageCountForIDs(ctx context.Context, gen GenerationID, messageIDs []int64) (int64, error)
 }
 
+// OrphanEmbeddingPruner removes message embeddings whose authoritative
+// message row no longer exists. Soft-deleted messages still exist and are
+// deliberately retained. The return value counts distinct
+// (generation, message) pairs, not chunks.
+type OrphanEmbeddingPruner interface {
+	PruneOrphanEmbeddings(ctx context.Context) (int64, error)
+}
+
 // FilteredCoverageBatchSize is the maximum number of canonical message IDs a
 // filtered coverage backend accepts per call. Coverage callers page at this
 // boundary so neither SQL bind arrays nor cross-database JSON blobs grow with

--- a/internal/vector/pgvector/backend.go
+++ b/internal/vector/pgvector/backend.go
@@ -26,6 +26,7 @@ var _ vector.Backend = (*Backend)(nil)
 var _ vector.ChunkScoringBackend = (*Backend)(nil)
 var _ vector.FilteredCoverageBackend = (*Backend)(nil)
 var _ vector.ConvergedGenerationActivator = (*Backend)(nil)
+var _ vector.OrphanEmbeddingPruner = (*Backend)(nil)
 
 // annOverFetchFactor multiplies k for the inner ANN scan so that after
 // GROUP BY dedup across multi-chunk messages, at least k distinct
@@ -1325,6 +1326,76 @@ func (b *Backend) Delete(ctx context.Context, gen vector.GenerationID, messageID
 		return fmt.Errorf("commit delete tx: %w", err)
 	}
 	return nil
+}
+
+// PruneOrphanEmbeddings removes message embeddings whose authoritative
+// message row has been hard-deleted. Generation row locks serialize pruning
+// with the backend's other embedding writers, so embeddings and message_count
+// are repaired atomically without racing an upsert or retirement.
+func (b *Backend) PruneOrphanEmbeddings(ctx context.Context) (int64, error) {
+	tx, err := b.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin orphan prune: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	// The count, delete, and count repair below are corpus-wide maintenance.
+	// Disable the pool's 30-second statement timeout for this transaction so
+	// a large accumulated orphan set can complete. SET LOCAL resets when the
+	// transaction commits or rolls back.
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = 0"); err != nil {
+		return 0, fmt.Errorf("disable statement_timeout for orphan prune: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx,
+		`SELECT id FROM index_generations ORDER BY id FOR UPDATE`)
+	if err != nil {
+		return 0, fmt.Errorf("lock generations for orphan prune: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var generationID int64
+		if err := rows.Scan(&generationID); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scan locked generation: %w", err)
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("close locked generations: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate locked generations: %w", err)
+	}
+
+	var pruned int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT e.generation_id, e.message_id
+			  FROM embeddings e
+			 WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = e.message_id)
+			 GROUP BY e.generation_id, e.message_id
+		) orphan_embeddings`).Scan(&pruned); err != nil {
+		return 0, fmt.Errorf("count orphan embeddings: %w", err)
+	}
+	if pruned > 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM embeddings e
+			 WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.id = e.message_id)`); err != nil {
+			return 0, fmt.Errorf("delete orphan embeddings: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE index_generations g
+			   SET message_count = (
+				SELECT COUNT(DISTINCT e.message_id)
+				  FROM embeddings e
+				 WHERE e.generation_id = g.id
+			   )`); err != nil {
+			return 0, fmt.Errorf("repair generation message counts: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit orphan prune: %w", err)
+	}
+	return pruned, nil
 }
 
 // Stats returns counts for the given generation. When gen == 0,

--- a/internal/vector/pgvector/prune_test.go
+++ b/internal/vector/pgvector/prune_test.go
@@ -3,17 +3,12 @@
 package pgvector
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/vector"
 )
-
-type orphanEmbeddingPruner interface {
-	PruneOrphanEmbeddings(ctx context.Context) (int64, error)
-}
 
 func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.T) {
 	backend, _, db := newBackendForTest(t)
@@ -42,7 +37,7 @@ func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.
 		DELETE FROM messages WHERE id = 3;`)
 	require.NoError(t, err)
 
-	pruner, ok := any(backend).(orphanEmbeddingPruner)
+	pruner, ok := any(backend).(vector.OrphanEmbeddingPruner)
 	require.True(t, ok, "PostgreSQL vector backend must support orphan pruning")
 	pruned, err := pruner.PruneOrphanEmbeddings(t.Context())
 	require.NoError(t, err)

--- a/internal/vector/pgvector/prune_test.go
+++ b/internal/vector/pgvector/prune_test.go
@@ -1,0 +1,89 @@
+//go:build pgvector
+
+package pgvector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+type orphanEmbeddingPruner interface {
+	PruneOrphanEmbeddings(ctx context.Context) (int64, error)
+}
+
+func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.T) {
+	backend, _, db := newBackendForTest(t)
+	_, err := db.Exec(`INSERT INTO messages (id) VALUES (2), (3)`)
+	require.NoError(t, err)
+
+	active, err := backend.CreateGeneration(t.Context(), "active-model", 4, "active:4")
+	require.NoError(t, err)
+	require.NoError(t, backend.Upsert(t.Context(), active, []vector.Chunk{
+		{MessageID: 1, ChunkIndex: 0, Vector: unitVec(4, 0)},
+		{MessageID: 1, ChunkIndex: 1, Vector: unitVec(4, 1)},
+		{MessageID: 3, ChunkIndex: 0, Vector: unitVec(4, 2)},
+		{MessageID: 3, ChunkIndex: 1, Vector: unitVec(4, 3)},
+	}))
+	require.NoError(t, backend.ActivateGeneration(t.Context(), active, true))
+
+	building, err := backend.CreateGeneration(t.Context(), "building-model", 5, "building:5")
+	require.NoError(t, err)
+	require.NoError(t, backend.Upsert(t.Context(), building, []vector.Chunk{
+		{MessageID: 2, ChunkIndex: 0, Vector: unitVec(5, 0)},
+		{MessageID: 3, ChunkIndex: 0, Vector: unitVec(5, 1)},
+	}))
+
+	_, err = db.Exec(`
+		UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = 2;
+		DELETE FROM messages WHERE id = 3;`)
+	require.NoError(t, err)
+
+	pruner, ok := any(backend).(orphanEmbeddingPruner)
+	require.True(t, ok, "PostgreSQL vector backend must support orphan pruning")
+	pruned, err := pruner.PruneOrphanEmbeddings(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), pruned, "generation/message pairs pruned")
+
+	var embeddings int64
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM embeddings`).Scan(&embeddings))
+	assert.Equal(t, int64(3), embeddings, "live and soft-deleted chunks remain")
+
+	for _, generation := range []vector.GenerationID{active, building} {
+		var messageCount int64
+		require.NoError(t, db.QueryRow(
+			`SELECT message_count FROM index_generations WHERE id = $1`, generation,
+		).Scan(&messageCount))
+		assert.Equal(t, int64(1), messageCount, "generation %d message_count", generation)
+	}
+
+	pruned, err = pruner.PruneOrphanEmbeddings(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, pruned, "second prune is idempotent")
+}
+
+func TestBackend_PruneOrphanEmbeddingsDisablesStatementTimeout(t *testing.T) {
+	backend, tracer, ctx := newTracedBackendForTest(t)
+	generation := seedAndEmbed(t, backend, backend.db, map[int64][]float32{
+		1: unitVec(768, 0),
+	})
+	require.Equal(t, 1, countEmbeddingRows(t, backend, generation))
+	_, err := backend.db.ExecContext(ctx, "DELETE FROM messages WHERE id = 1")
+	require.NoError(t, err)
+	backend.db.SetMaxOpenConns(1)
+	_, err = backend.db.ExecContext(ctx, "SET statement_timeout = 1")
+	require.NoError(t, err)
+
+	tracer.reset()
+	pruned, err := backend.PruneOrphanEmbeddings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pruned)
+
+	_, err = backend.db.ExecContext(ctx, "RESET statement_timeout")
+	require.NoError(t, err)
+	assert.True(t, tracer.contains("SET LOCAL statement_timeout = 0"),
+		"prune transaction must disable the pool-wide statement timeout; got %v", tracer.snapshot())
+}

--- a/internal/vector/sqlitevec/backend.go
+++ b/internal/vector/sqlitevec/backend.go
@@ -30,6 +30,7 @@ var _ vector.Backend = (*Backend)(nil)
 var _ vector.ChunkScoringBackend = (*Backend)(nil)
 var _ vector.FilteredCoverageBackend = (*Backend)(nil)
 var _ vector.ConvergedGenerationActivator = (*Backend)(nil)
+var _ vector.OrphanEmbeddingPruner = (*Backend)(nil)
 
 // Options configures how Open establishes a Backend.
 type Options struct {
@@ -1567,6 +1568,111 @@ func (b *Backend) Delete(ctx context.Context, gen vector.GenerationID, messageID
 		return fmt.Errorf("commit delete tx: %w", err)
 	}
 	return nil
+}
+
+// PruneOrphanEmbeddings removes every message embedding whose authoritative
+// message row has been hard-deleted. The main archive and vectors live in
+// separate SQLite files, so the maintenance transaction opens the main file
+// and attaches vectors.db on one pinned connection. Soft-deleted messages
+// remain present in main.messages and are intentionally preserved.
+func (b *Backend) PruneOrphanEmbeddings(ctx context.Context) (int64, error) {
+	if b.mainPath == "" {
+		return 0, errors.New("prune orphan embeddings requires MainPath in Options")
+	}
+	conn, err := b.openFusedConn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("open coordinated orphan prune: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin orphan prune: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	const orphanWhere = `NOT EXISTS (
+		SELECT 1 FROM messages m WHERE m.id = e.message_id
+	)`
+	var pruned int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT e.generation_id, e.message_id
+			  FROM vec.embeddings e
+			 WHERE `+orphanWhere+`
+			 GROUP BY e.generation_id, e.message_id
+		)`).Scan(&pruned); err != nil {
+		return 0, fmt.Errorf("count orphan embeddings: %w", err)
+	}
+	if pruned == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("commit empty orphan prune: %w", err)
+		}
+		return 0, nil
+	}
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT g.dimension
+		  FROM vec.embeddings e
+		  JOIN vec.index_generations g ON g.id = e.generation_id
+		 WHERE `+orphanWhere+`
+		 GROUP BY g.dimension
+		 ORDER BY g.dimension`)
+	if err != nil {
+		return 0, fmt.Errorf("list orphan embedding dimensions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var dimensions []int
+	for rows.Next() {
+		var dimension int
+		if err := rows.Scan(&dimension); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scan orphan embedding dimension: %w", err)
+		}
+		if dimension <= 0 {
+			_ = rows.Close()
+			return 0, fmt.Errorf("invalid orphan embedding dimension %d", dimension)
+		}
+		dimensions = append(dimensions, dimension)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("close orphan embedding dimensions: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate orphan embedding dimensions: %w", err)
+	}
+
+	for _, dimension := range dimensions {
+		vecTable := "vec." + VectorTableName(dimension)
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			DELETE FROM %s
+			 WHERE embedding_id IN (
+				SELECT e.embedding_id
+				  FROM vec.embeddings e
+				  JOIN vec.index_generations g ON g.id = e.generation_id
+				 WHERE g.dimension = ? AND %s
+			 )`, vecTable, orphanWhere), dimension); err != nil {
+			return 0, fmt.Errorf("delete orphan vectors for dimension %d: %w", dimension, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM vec.embeddings AS e
+		 WHERE `+orphanWhere); err != nil {
+		return 0, fmt.Errorf("delete orphan embedding metadata: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE vec.index_generations AS g
+		   SET message_count = (
+			SELECT COUNT(DISTINCT e.message_id)
+			  FROM vec.embeddings e
+			 WHERE e.generation_id = g.id
+		   )`); err != nil {
+		return 0, fmt.Errorf("repair generation message counts: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit orphan prune: %w", err)
+	}
+	return pruned, nil
 }
 
 // Stats returns counts for the given generation. When gen == 0, counts

--- a/internal/vector/sqlitevec/prune_test.go
+++ b/internal/vector/sqlitevec/prune_test.go
@@ -3,7 +3,6 @@
 package sqlitevec
 
 import (
-	"context"
 	"database/sql"
 	"path/filepath"
 	"testing"
@@ -12,10 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/vector"
 )
-
-type orphanEmbeddingPruner interface {
-	PruneOrphanEmbeddings(ctx context.Context) (int64, error)
-}
 
 func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.T) {
 	dir := t.TempDir()
@@ -62,7 +57,7 @@ func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.
 		DELETE FROM messages WHERE id = 3;`)
 	require.NoError(t, err)
 
-	pruner, ok := any(backend).(orphanEmbeddingPruner)
+	pruner, ok := any(backend).(vector.OrphanEmbeddingPruner)
 	require.True(t, ok, "sqlite vector backend must support orphan pruning")
 	pruned, err := pruner.PruneOrphanEmbeddings(t.Context())
 	require.NoError(t, err)

--- a/internal/vector/sqlitevec/prune_test.go
+++ b/internal/vector/sqlitevec/prune_test.go
@@ -1,0 +1,91 @@
+//go:build sqlite_vec
+
+package sqlitevec
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/vector"
+)
+
+type orphanEmbeddingPruner interface {
+	PruneOrphanEmbeddings(ctx context.Context) (int64, error)
+}
+
+func TestBackend_PruneOrphanEmbeddingsRemovesOnlyHardDeletedMessages(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "main.db")
+	mainDB, err := sql.Open("sqlite3", mainPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mainDB.Close() })
+	_, err = mainDB.Exec(`
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY,
+			deleted_at DATETIME,
+			deleted_from_source_at DATETIME,
+			embed_gen INTEGER
+		);
+		INSERT INTO messages (id) VALUES (1), (2), (3);`)
+	require.NoError(t, err)
+
+	backend, err := Open(t.Context(), Options{
+		Path: filepath.Join(dir, "vectors.db"), MainPath: mainPath,
+		Dimension: 4, MainDB: mainDB,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = backend.Close() })
+
+	active, err := backend.CreateGeneration(t.Context(), "active-model", 4, "active:4")
+	require.NoError(t, err)
+	require.NoError(t, backend.Upsert(t.Context(), active, []vector.Chunk{
+		{MessageID: 1, ChunkIndex: 0, Vector: unitVec(4, 0)},
+		{MessageID: 1, ChunkIndex: 1, Vector: unitVec(4, 1)},
+		{MessageID: 3, ChunkIndex: 0, Vector: unitVec(4, 2)},
+		{MessageID: 3, ChunkIndex: 1, Vector: unitVec(4, 3)},
+	}))
+	require.NoError(t, backend.ActivateGeneration(t.Context(), active, true))
+
+	building, err := backend.CreateGeneration(t.Context(), "building-model", 5, "building:5")
+	require.NoError(t, err)
+	require.NoError(t, backend.Upsert(t.Context(), building, []vector.Chunk{
+		{MessageID: 2, ChunkIndex: 0, Vector: unitVec(5, 0)},
+		{MessageID: 3, ChunkIndex: 0, Vector: unitVec(5, 1)},
+	}))
+
+	_, err = mainDB.Exec(`
+		UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = 2;
+		DELETE FROM messages WHERE id = 3;`)
+	require.NoError(t, err)
+
+	pruner, ok := any(backend).(orphanEmbeddingPruner)
+	require.True(t, ok, "sqlite vector backend must support orphan pruning")
+	pruned, err := pruner.PruneOrphanEmbeddings(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), pruned, "generation/message pairs pruned")
+
+	var embeddings, vectors4, vectors5 int64
+	require.NoError(t, backend.db.QueryRow(`SELECT COUNT(*) FROM embeddings`).Scan(&embeddings))
+	require.NoError(t, backend.db.QueryRow(`SELECT COUNT(*) FROM vectors_vec_d4`).Scan(&vectors4))
+	require.NoError(t, backend.db.QueryRow(`SELECT COUNT(*) FROM vectors_vec_d5`).Scan(&vectors5))
+	assert.Equal(t, int64(3), embeddings, "live and soft-deleted chunks remain")
+	assert.Equal(t, int64(2), vectors4, "active generation vec0 rows")
+	assert.Equal(t, int64(1), vectors5, "building generation vec0 rows")
+	assert.Equal(t, embeddings, vectors4+vectors5, "metadata and vec0 rows stay aligned")
+
+	for _, generation := range []vector.GenerationID{active, building} {
+		var messageCount int64
+		require.NoError(t, backend.db.QueryRow(
+			`SELECT message_count FROM index_generations WHERE id = ?`, generation,
+		).Scan(&messageCount))
+		assert.Equal(t, int64(1), messageCount, "generation %d message_count", generation)
+	}
+
+	pruned, err = pruner.PruneOrphanEmbeddings(t.Context())
+	require.NoError(t, err)
+	assert.Zero(t, pruned, "second prune is idempotent")
+}


### PR DESCRIPTION
## What changed

- Add `msgvault embeddings prune` to remove embeddings for hard-deleted messages without calling the embedding provider again.
- Preserve soft-deleted messages and keep chunk rows and generation message counts consistent across SQLite and PostgreSQL.
- Route pruning through the daemon CLI runner and point `delete-deduped` users at the lightweight cleanup command instead of a full rebuild.

## Why

Hard-deleted messages left orphan vectors behind indefinitely. A full embedding rebuild removed them, but it also reprocessed the entire archive and repaid the embedding cost. Pruning now does the maintenance in place.

## Usage

```sh
msgvault embeddings prune
```

The command is safe to rerun; it reports zero when there is nothing left to prune.

Closes #313
