### PR TITLE
fix(cache): explain invalid encoding recovery

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -1096,12 +1096,12 @@ func buildCacheLocked(
 	junctionFile := "data.parquet"
 
 	// runExport executes a COPY query and prints timing info.
-	runExport := func(label, query string) error {
+	runExport := func(label, copyQuery string) error {
 		start := time.Now()
 		fmt.Printf("  %-25s", label+"...")
-		if _, err := exportDB.Exec(query); err != nil {
+		if _, err := exportDB.Exec(copyQuery); err != nil {
 			fmt.Println()
-			return err
+			return query.HintRepairEncoding(err)
 		}
 		fmt.Printf(" done (%s)\n", time.Since(start).Round(time.Millisecond))
 		return nil
@@ -1959,7 +1959,9 @@ func (s *cacheSourceSnapshot) prepareTables(tables []cacheSnapshotTable) error {
 			t.name, escaped, csvOpts,
 		)
 		if _, err := s.duckDB.Exec(viewSQL); err != nil {
-			return fmt.Errorf("create view sqlite_db.%s: %w", t.name, err)
+			return query.HintRepairEncoding(
+				fmt.Errorf("create view sqlite_db.%s: %w", t.name, err),
+			)
 		}
 	}
 

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -2159,6 +2159,75 @@ func TestBuildCache_UTF8Handling(t *testing.T) {
 	assert.Equal("Test émoji 🎉 and unicode", subject, "unicode should be preserved")
 }
 
+func TestBuildCacheCSVInvalidUTF8ExplainsRepairPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+	tmpDir := setupTestSQLite(t)
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(err)
+	_, err = db.Exec(`UPDATE attachments SET filename = CAST(X'80' AS TEXT) WHERE id = 1`)
+	require.NoError(err)
+	require.NoError(db.Close())
+
+	_, err = buildCache(dbPath, filepath.Join(tmpDir, "analytics"), true)
+	require.Error(err)
+	assert.Contains(err.Error(), "msgvault repair-encoding")
+	assert.Contains(err.Error(), "not a msgvault option")
+}
+
+func TestBuildCacheCSVInvalidUTF8InUnrepairedFieldScopesGuidance(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+	tmpDir := setupTestSQLite(t)
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(err)
+	_, err = db.Exec(`UPDATE messages SET source_message_id = CAST(X'80' AS TEXT) WHERE id = 1`)
+	require.NoError(err)
+	require.NoError(db.Close())
+
+	_, err = buildCache(dbPath, filepath.Join(tmpDir, "analytics"), true)
+	require.Error(err)
+	assert.Contains(err.Error(), "msgvault repair-encoding")
+	assert.Contains(err.Error(), "common archived text fields")
+	assert.Contains(err.Error(), "if the cache rebuild still fails")
+	assert.Contains(err.Error(), "messages")
+}
+
+// TestBuildCacheCSVInvalidUTF8PastSampleExplainsRepairPath covers the case
+// where DuckDB's CSV sniffer does not reach the invalid row, so the error
+// surfaces during the Parquet export instead of view creation.
+func TestBuildCacheCSVInvalidUTF8PastSampleExplainsRepairPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+	tmpDir := setupTestSQLite(t)
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(err)
+	_, err = db.Exec(`
+		INSERT INTO messages (source_id, source_message_id, sent_at)
+		WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < 30000)
+		SELECT 1, 'bulk-' || i, datetime('2024-04-01', '+' || i || ' minutes') FROM seq;
+	`)
+	require.NoError(err)
+	_, err = db.Exec(`UPDATE messages SET subject = CAST(X'80' AS TEXT) WHERE id = (SELECT MAX(id) FROM messages)`)
+	require.NoError(err)
+	require.NoError(db.Close())
+
+	_, err = buildCache(dbPath, filepath.Join(tmpDir, "analytics"), true)
+	require.Error(err)
+	assert.Contains(err.Error(), "export messages")
+	assert.Contains(err.Error(), "msgvault repair-encoding")
+	assert.Contains(err.Error(), "not a msgvault option")
+}
+
 func TestBuildCacheExportsAttachmentMetadataForRawQuery(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/internal/query/encoding_hint.go
+++ b/internal/query/encoding_hint.go
@@ -5,14 +5,20 @@ import (
 	"strings"
 )
 
-// encodingErrorSubstring is the error text emitted by DuckDB when it encounters
-// invalid UTF-8 in a Parquet file.
-const encodingErrorSubstring = "Invalid string encoding found in Parquet file"
+const (
+	// parquetEncodingErrorSubstring is emitted when DuckDB encounters invalid
+	// UTF-8 in an existing Parquet cache.
+	parquetEncodingErrorSubstring = "Invalid string encoding found in Parquet file"
+	// csvEncodingErrorSubstring is emitted while the cache builder reads its
+	// SQLite CSV snapshot on platforms where sqlite_scanner is unavailable.
+	csvEncodingErrorSubstring = "Invalid unicode (byte sequence mismatch) detected"
+)
 
-// IsEncodingError reports whether err contains the DuckDB invalid-string-encoding
-// error that can be resolved by running `msgvault repair-encoding`.
+// IsEncodingError reports whether err contains a DuckDB encoding error that
+// can be resolved by running `msgvault repair-encoding`.
 func IsEncodingError(err error) bool {
-	return err != nil && strings.Contains(err.Error(), encodingErrorSubstring)
+	return err != nil && (strings.Contains(err.Error(), parquetEncodingErrorSubstring) ||
+		strings.Contains(err.Error(), csvEncodingErrorSubstring))
 }
 
 // HintRepairEncoding wraps err with a user-facing hint suggesting
@@ -21,6 +27,9 @@ func IsEncodingError(err error) bool {
 func HintRepairEncoding(err error) error {
 	if !IsEncodingError(err) {
 		return err
+	}
+	if strings.Contains(err.Error(), csvEncodingErrorSubstring) {
+		return fmt.Errorf("%w\nHint: run 'msgvault repair-encoding' to repair common archived text fields and retry the cache rebuild; if the cache rebuild still fails, report the affected table. DuckDB's ignore_errors setting is not a msgvault option", err)
 	}
 	return fmt.Errorf("%w\nHint: try running 'msgvault repair-encoding' to fix encoding issues", err)
 }

--- a/internal/query/encoding_hint_test.go
+++ b/internal/query/encoding_hint_test.go
@@ -20,6 +20,7 @@ func TestIsEncodingError(t *testing.T) {
 		{"encoding error", errors.New("Invalid string encoding found in Parquet file"), true},
 		{"wrapped encoding error", fmt.Errorf("aggregate query: %w", errors.New("Invalid string encoding found in Parquet file")), true},
 		{"encoding error substring", errors.New("scan: Invalid string encoding found in Parquet file foo.parquet"), true},
+		{"CSV invalid unicode", errors.New("CSV Error on Line: 4\nInvalid unicode (byte sequence mismatch) detected"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -53,5 +54,16 @@ func TestHintRepairEncoding(t *testing.T) {
 		wrapped := fmt.Errorf("aggregate query: %w", inner)
 		got := HintRepairEncoding(wrapped)
 		assert.Contains(t, got.Error(), "repair-encoding")
+	})
+
+	t.Run("CSV encoding error explains DuckDB option", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		orig := errors.New("CSV Error on Line: 4\nInvalid unicode (byte sequence mismatch) detected\nignore_errors = false")
+		got := HintRepairEncoding(orig)
+		require.Error(got)
+		assert.Contains(got.Error(), "msgvault repair-encoding")
+		assert.Contains(got.Error(), "not a msgvault option")
+		assert.ErrorIs(got, orig)
 	})
 }


### PR DESCRIPTION
## What changed

- Recognize DuckDB CSV invalid-UTF-8 failures during both snapshot setup and Parquet export.
- Point affected cache builds to `msgvault repair-encoding` and explain that DuckDB's `ignore_errors` setting is not a msgvault option.
- Scope the recovery guidance to common archived text fields and tell users to report the affected table if another exported field remains invalid.
- Keep strict cache validation unchanged, with coverage for invalid rows inside and beyond DuckDB's CSV sample and in a field outside the current repair set.

## Why

Large imports can leave invalid UTF-8 in archived fields. DuckDB recommends `ignore_errors=true`, but msgvault does not expose that setting and skipping the row would hide data. `repair-encoding` handles common archived text fields, but not every identifier in the CSV snapshot, so the error now gives the repair path without promising complete recovery.

## Usage

```sh
msgvault repair-encoding
```

If the cache rebuild still fails, report the affected table from the error.

Closes #402
