### PR TITLE
ci: restore PostgreSQL lanes to managed runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,13 +438,7 @@ jobs:
   # tag is required; without it these files compile out and ship no tests,
   # so this code would otherwise have zero CI coverage.
   test-pgvector:
-    # Pinned to GitHub-hosted runners. These two lanes are the only ones that
-    # drive the full Go suite against a live PostgreSQL service container, and
-    # that container's disk I/O is roughly 5x slower on the managed public
-    # fleet — enough to push cmd/msgvault/cmd past Go's default 10m per-package
-    # test timeout (1m48s here vs. a timeout panic there). Move back once the
-    # runner-group I/O is addressed.
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -467,7 +461,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-          cache: 'true'
+          cache: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       - name: Enable pgvector extension
         run: |
@@ -495,10 +489,7 @@ jobs:
   # unique constraints) surface here rather than slipping past a single
   # pass.
   test-postgres:
-    # Pinned to GitHub-hosted runners for the same reason as test-pgvector
-    # above: the PostgreSQL service container is I/O-bound on the managed
-    # public fleet (5m11s here vs. a 10m timeout panic there).
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     services:
       postgres:
         image: postgres:16
@@ -522,7 +513,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
-          cache: 'true'
+          cache: ${{ github.repository == 'kenn-io/msgvault' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'false' || 'true' }}
 
       # This lane uses a stock postgres:16 image (no pgvector extension), so it
       # must NOT build the pgvector tag — those tests CREATE EXTENSION "vector"


### PR DESCRIPTION
## What changed

- Route the PostgreSQL and pgvector test lanes back to the managed Linux runner for main pushes and internal pull requests.
- Keep fork pull requests and other events on GitHub-hosted runners.
- Disable `setup-go` caching only on the managed runner, matching the existing Linux jobs.

## Why

The two database lanes were temporarily pinned to GitHub-hosted runners while the managed runner I/O issue was addressed. Leaving that workaround in place keeps the database-heavy jobs off the managed fleet after the runner-side fix.

## Usage

No usage changes.

Closes #516
