### PR TITLE
feat: sync Notion AI Meeting Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+last_edited: "2026-08-30"
+---
+
 <p align="center">
   <img src=".github/assets/msgvault-mark.svg" width="160" height="160" alt="msgvault logo">
 </p>
@@ -26,9 +30,9 @@ Archive a lifetime of email, messages, meetings. Analytics and search in millise
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
 Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, CardDAV,
-Granola, Circleback, Beeper Desktop, and IMAP sync, plus offline imports from
-Slackdump, MBOX exports, Apple Mail (`.emlx`) directories, PST archives, and
-common chat/text export formats.
+Granola, Circleback, Notion AI Meeting Notes, Beeper Desktop, and IMAP sync,
+plus offline imports from Slackdump, MBOX exports, Apple Mail (`.emlx`)
+directories, PST archives, and common chat/text export formats.
 
 ## Features
 
@@ -38,7 +42,7 @@ common chat/text export formats.
 - **Discord sync**: archive guild channels, threads, forum posts, and attachments through a read-only bot with `message_type = discord`
 - **Slack sync**: archive joined channels, group DMs, direct messages, threads, reactions, and files with `message_type = slack`
 - **Slackdump import**: archive a Slackdump directory or ZIP without a Slack token or network access
-- **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
+- **Meeting notes**: sync Granola, Circleback, and Notion AI Meeting Notes, then browse them in the TUI
 - **Beeper Desktop sync**: archive chats and media from every network connected to Beeper, including iMessage, through its local API
 - **IMAP sync**: archive mail from any standard IMAP server
 - **CardDAV contacts**: pull address books, explicitly publish curated people, and resolve conflicts without losing remote card data
@@ -134,6 +138,7 @@ available with `msgvault tui`.
 | `backfill-discord-media` | Retry incomplete Discord attachment downloads |
 | `add-granola` / `sync-granola` | Register and sync Granola meeting notes and transcripts |
 | `add-circleback` / `sync-circleback` | Authorize and sync Circleback meetings, notes, and transcripts |
+| `add-notion-meetings` / `sync-notion-meetings` | Register and sync Notion AI Meeting Notes |
 | `add-beeper` / `sync-beeper` | Register and sync Beeper Desktop chats and media |
 | `backup` | Initialize, create, list, verify, and restore backup snapshots |
 | `pack-attachments` | Migrate all eligible loose attachment files into immutable packs |

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -3,16 +3,17 @@ package cmd
 // Source-type identifiers stored in sources.source_type and matched against
 // when dispatching sync/import logic per account kind.
 const (
-	sourceTypeGmail      = "gmail"
-	sourceTypeIMAP       = "imap"
-	sourceTypeMbox       = "mbox"
-	sourceTypeTeams      = "teams"
-	sourceTypeCalendar   = "gcal"
-	sourceTypeBeeper     = "beeper"
-	sourceTypeSlack      = "slack"
-	sourceTypeSlackdump  = "slackdump"
-	sourceTypeGranola    = "granola"
-	sourceTypeCircleback = "circleback"
+	sourceTypeGmail          = "gmail"
+	sourceTypeIMAP           = "imap"
+	sourceTypeMbox           = "mbox"
+	sourceTypeTeams          = "teams"
+	sourceTypeCalendar       = "gcal"
+	sourceTypeBeeper         = "beeper"
+	sourceTypeSlack          = "slack"
+	sourceTypeSlackdump      = "slackdump"
+	sourceTypeGranola        = "granola"
+	sourceTypeCircleback     = "circleback"
+	sourceTypeNotionMeetings = "notion_meetings"
 )
 
 // Analytics dataset / SQLite table names: the Parquet subdirectory under

--- a/cmd/msgvault/cmd/meeting_source.go
+++ b/cmd/msgvault/cmd/meeting_source.go
@@ -35,7 +35,8 @@ func registerMeetingSource(
 		return nil, fmt.Errorf("confirm meeting account identity: %w", err)
 	}
 	_, _ = fmt.Fprintf(out, "Confirmed identity %s on %s (signal: account-email).\n", primary, identifier)
+	commandSource := strings.ReplaceAll(sourceType, "_", "-")
 	_, _ = fmt.Fprintf(out, "After identity changes, run msgvault sync-%s %s --full to refresh existing meeting attribution.\n",
-		sourceType, identifier)
+		commandSource, identifier)
 	return source, nil
 }

--- a/cmd/msgvault/cmd/meeting_source_test.go
+++ b/cmd/msgvault/cmd/meeting_source_test.go
@@ -36,6 +36,7 @@ func TestMeetingConfigurationHintsLoad(t *testing.T) {
 	}{
 		{name: "Granola", hint: granolaConfigHint},
 		{name: "Circleback", hint: circlebackConfigHint},
+		{name: "Notion", hint: notionMeetingsConfigHint},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
@@ -53,6 +54,9 @@ func TestMeetingConfigurationHintsLoad(t *testing.T) {
 			case "Circleback":
 				require.Len(cfg.Circleback, 1)
 				assert.Equal("you@example.com", cfg.Circleback[0].AccountEmail)
+			case "Notion":
+				require.Len(cfg.NotionMeetings, 1)
+				assert.Equal("you@example.com", cfg.NotionMeetings[0].AccountEmail)
 			}
 		})
 	}

--- a/cmd/msgvault/cmd/notion_meetings.go
+++ b/cmd/msgvault/cmd/notion_meetings.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/notionmeetings"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	syncNotionMeetingsLimit int
+	syncNotionMeetingsAfter string
+	syncNotionMeetingsFull  bool
+	syncNotionMeetingsProbe bool
+)
+
+var (
+	newNotionMeetingsClient = func(baseURL, token string) notionmeetings.Source {
+		return notionmeetings.NewClient(baseURL, token)
+	}
+	rebuildNotionMeetingsCacheAfterWrite         = rebuildCacheAfterWrite
+	rebuildNotionMeetingsCacheAfterScheduledSync = rebuildCacheAfterScheduledSync
+)
+
+const notionMeetingsConfigHint = `Add to your config.toml:
+
+  [[notion_meetings]]
+  identifier = "notion-personal"      # stable label for this identity
+  account_email = "you@example.com"   # primary identity for relationships
+  token = "ntn_..."                   # read-only Notion integration token
+  enabled = true
+  # schedule = "15 */6 * * *"         # optional daemon schedule`
+
+func resolveNotionMeetingsSource(args []string) (*config.NotionMeetingsSource, error) {
+	if len(cfg.NotionMeetings) == 0 {
+		return nil, errors.New("no [[notion_meetings]] sources configured\n\n" + notionMeetingsConfigHint)
+	}
+	if len(args) > 0 {
+		source := cfg.GetNotionMeetingsSource(args[0])
+		if source == nil {
+			identifiers := make([]string, 0, len(cfg.NotionMeetings))
+			for _, candidate := range cfg.NotionMeetings {
+				identifiers = append(identifiers, candidate.Identifier)
+			}
+			return nil, fmt.Errorf("no [[notion_meetings]] entry with identifier %q (configured: %s)",
+				args[0], strings.Join(identifiers, ", "))
+		}
+		return source, nil
+	}
+	if len(cfg.NotionMeetings) > 1 {
+		return nil, errors.New("multiple [[notion_meetings]] sources configured; pass an identifier")
+	}
+	source := cfg.NotionMeetings[0]
+	return &source, nil
+}
+
+func resolveNotionMeetingsSources(args []string, probe bool) ([]config.NotionMeetingsSource, error) {
+	if probe || len(args) > 0 || len(cfg.NotionMeetings) == 1 {
+		source, err := resolveNotionMeetingsSource(args)
+		if err != nil {
+			return nil, err
+		}
+		return []config.NotionMeetingsSource{*source}, nil
+	}
+	if len(cfg.NotionMeetings) == 0 {
+		return nil, errors.New("no [[notion_meetings]] sources configured\n\n" + notionMeetingsConfigHint)
+	}
+	return cfg.NotionMeetings, nil
+}
+
+type notionMeetingsQuerySource interface {
+	QueryMeetingNotes(ctx context.Context, limit int) (*notionmeetings.QueryResult, error)
+	RetrieveBlock(ctx context.Context, blockID string) (*notionmeetings.Block, error)
+	RetrievePageMarkdown(ctx context.Context, pageID string, includeTranscript bool) (*notionmeetings.MarkdownPage, error)
+	ListUsers(ctx context.Context, cursor string) (*notionmeetings.UserPage, error)
+}
+
+func runNotionMeetingsProbe(ctx context.Context, out io.Writer, client notionMeetingsQuerySource) error {
+	result, err := client.QueryMeetingNotes(ctx, 1)
+	if err != nil {
+		return fmt.Errorf("probe Notion AI Meeting Notes access: %w", err)
+	}
+	if result == nil {
+		return errors.New("probe Notion AI Meeting Notes access returned no response")
+	}
+	_, _ = fmt.Fprintln(out, "Notion AI Meeting Notes probe succeeded.")
+	_, _ = fmt.Fprintf(out, "  Returned meetings: %d\n", len(result.Results))
+	_, _ = fmt.Fprintf(out, "  Partial coverage: %t\n", result.HasMore)
+	if len(result.Results) == 0 {
+		_, _ = fmt.Fprintln(out, "  Read Content: not tested (no visible meeting)")
+	} else {
+		meeting := result.Results[0]
+		block, retrieveErr := client.RetrieveBlock(ctx, meeting.ID)
+		if retrieveErr != nil {
+			return fmt.Errorf("probe Notion meeting block access: %w", retrieveErr)
+		}
+		if block == nil {
+			return errors.New("probe Notion meeting block access returned no response")
+		}
+		pageID := strings.TrimSpace(meeting.Parent.PageID)
+		if pageID == "" {
+			pageID = strings.TrimSpace(block.Parent.PageID)
+		}
+		if pageID == "" {
+			return errors.New("probe result has no parent page ID")
+		}
+		if _, err := client.RetrievePageMarkdown(ctx, pageID, true); err != nil {
+			return fmt.Errorf("probe Notion Read Content access: %w", err)
+		}
+		_, _ = fmt.Fprintln(out, "  Read Content: available")
+	}
+	if _, err := client.ListUsers(ctx, ""); errors.Is(err, notionmeetings.ErrUserInformation) {
+		_, _ = fmt.Fprintln(out, "  User Information: unavailable (attendees remain display-only)")
+	} else if errors.Is(err, notionmeetings.ErrRateLimited) {
+		_, _ = fmt.Fprintf(out, "  User Information: unavailable (error: %v; attendees remain display-only)\n", err)
+	} else if err != nil {
+		return fmt.Errorf("probe Notion User Information access: %w", err)
+	} else {
+		_, _ = fmt.Fprintln(out, "  User Information: available")
+	}
+	return nil
+}
+
+var addNotionMeetingsCmd = &cobra.Command{
+	Use:   "add-notion-meetings [identifier]",
+	Short: "Register and validate a Notion AI Meeting Notes source",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isDaemonCLISubprocess() {
+			return runDaemonCLICommandHTTPFromCobra(cmd, args)
+		}
+		source, err := resolveNotionMeetingsSource(args)
+		if err != nil {
+			return err
+		}
+		accountEmail, err := source.EffectiveAccountEmail()
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(source.Token) == "" {
+			return fmt.Errorf("[[notion_meetings]] entry %q has no token\n\n%s", source.Identifier, notionMeetingsConfigHint)
+		}
+		client := newNotionMeetingsClient(notionmeetings.DefaultBaseURL, source.Token)
+		if err := runNotionMeetingsProbe(cmd.Context(), cmd.OutOrStdout(), client); err != nil {
+			return err
+		}
+		st, cleanup, err := openWritableStoreAndInitForIngest()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		if _, err := registerMeetingSource(cmd.OutOrStdout(), st, sourceTypeNotionMeetings,
+			source.Identifier, accountEmail); err != nil {
+			return err
+		}
+		if err := runPostSourceCreateMigrations(st); err != nil {
+			return fmt.Errorf("post-source-create migrations: %w", err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nNotion meeting source %s registered.\n", source.Identifier)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Run: msgvault sync-notion-meetings %s\n", source.Identifier)
+		return nil
+	},
+}
+
+var syncNotionMeetingsCmd = &cobra.Command{
+	Use:   "sync-notion-meetings [identifier]",
+	Short: "Sync Notion AI Meeting Notes",
+	Long: `Sync the latest visible Notion AI Meeting Notes into the canonical meeting archive.
+
+Notion currently returns at most 50 attendee-visible meetings and does not
+provide a discovery cursor. Every run checks that visible window. --after is
+a local visible-set filter. --limit caps discovery work but not due transcript
+maintenance. --probe validates access without printing meeting content.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !isDaemonCLISubprocess() {
+			return runDaemonCLICommandHTTPFromCobra(cmd, args)
+		}
+		sources, err := resolveNotionMeetingsSources(args, syncNotionMeetingsProbe)
+		if err != nil {
+			return err
+		}
+
+		var after time.Time
+		if syncNotionMeetingsAfter != "" {
+			parsed, err := time.Parse(time.DateOnly, syncNotionMeetingsAfter)
+			if err != nil {
+				return usageErr(cmd, fmt.Errorf("invalid --after %q (expected YYYY-MM-DD): %w", syncNotionMeetingsAfter, err))
+			}
+			after = parsed.UTC()
+		}
+		for _, source := range sources {
+			if strings.TrimSpace(source.Token) == "" {
+				return fmt.Errorf("[[notion_meetings]] entry %q has no token", source.Identifier)
+			}
+			if _, err := source.EffectiveAccountEmail(); err != nil {
+				return err
+			}
+		}
+		if syncNotionMeetingsProbe {
+			source := sources[0]
+			return runNotionMeetingsProbe(cmd.Context(), cmd.OutOrStdout(),
+				newNotionMeetingsClient(notionmeetings.DefaultBaseURL, source.Token))
+		}
+
+		st, cleanup, err := openWritableStoreAndInitForIngest()
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		dbPath := cfg.DatabaseDSN()
+		pendingWrites := &notionmeetings.ImportSummary{}
+		for _, source := range sources {
+			accountEmail, _ := source.EffectiveAccountEmail()
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Syncing Notion meetings for %s\n\n", source.Identifier)
+			importer := notionmeetings.NewImporter(st,
+				newNotionMeetingsClient(notionmeetings.DefaultBaseURL, source.Token))
+			summary, importErr := importer.Import(cmd.Context(), notionmeetings.ImportOptions{
+				Identifier: source.Identifier, AccountEmail: accountEmail,
+				Full: syncNotionMeetingsFull || !after.IsZero(), Limit: syncNotionMeetingsLimit,
+				CreatedAfter: after,
+				Progress:     func(line string) { _, _ = fmt.Fprintln(cmd.OutOrStdout(), "  "+line) },
+			})
+			accumulateNotionMeetingsWrites(pendingWrites, summary)
+			if err := finishNotionMeetingsImport(source.Identifier, pendingWrites, importErr,
+				func() error { return rebuildNotionMeetingsCacheAfterWrite(dbPath) }); err != nil {
+				return err
+			}
+			writeNotionMeetingsSummary(cmd.OutOrStdout(), summary)
+		}
+		return rebuildNotionMeetingsCacheAfterWrite(dbPath)
+	},
+}
+
+func accumulateNotionMeetingsWrites(total, current *notionmeetings.ImportSummary) {
+	if total == nil || current == nil {
+		return
+	}
+	total.MeetingsAdded += current.MeetingsAdded
+	total.MeetingsUpdated += current.MeetingsUpdated
+}
+
+func finishNotionMeetingsImport(identifier string, summary *notionmeetings.ImportSummary, importErr error, refresh func() error) error {
+	if importErr == nil {
+		return nil
+	}
+	var refreshErr error
+	if summary != nil && summary.MeetingsAdded+summary.MeetingsUpdated > 0 && refresh != nil {
+		refreshErr = refresh()
+	}
+	return errors.Join(fmt.Errorf("notion meetings sync %s failed: %w", identifier, importErr), refreshErr)
+}
+
+func writeNotionMeetingsSummary(out io.Writer, summary *notionmeetings.ImportSummary) {
+	_, _ = fmt.Fprintln(out, "\nNotion meetings sync complete!")
+	_, _ = fmt.Fprintf(out, "  Meetings processed: %d\n", summary.MeetingsProcessed)
+	_, _ = fmt.Fprintf(out, "  Meetings added:     %d\n", summary.MeetingsAdded)
+	_, _ = fmt.Fprintf(out, "  Meetings updated:   %d\n", summary.MeetingsUpdated)
+	if summary.MaintenanceRetries > 0 {
+		_, _ = fmt.Fprintf(out, "  Maintenance items: %d\n", summary.MaintenanceRetries)
+	}
+	if summary.PartialCoverage {
+		_, _ = fmt.Fprintln(out, "  Coverage: partial (Notion reports more than the visible 50-item window)")
+	}
+}
+
+func runConfiguredNotionMeetingsSync(ctx context.Context, st *store.Store, source config.NotionMeetingsSource) error {
+	if _, err := st.GetSourceByTypeAndIdentifier(notionmeetings.SourceType, source.Identifier); err != nil {
+		if errors.Is(err, store.ErrSourceNotFound) {
+			return fmt.Errorf("notion meeting source %q is not registered; run msgvault add-notion-meetings %s first",
+				source.Identifier, source.Identifier)
+		}
+		return err
+	}
+	if strings.TrimSpace(source.Token) == "" {
+		return fmt.Errorf("notion meeting source %q has no token", source.Identifier)
+	}
+	accountEmail, err := source.EffectiveAccountEmail()
+	if err != nil {
+		return err
+	}
+	importer := notionmeetings.NewImporter(st,
+		newNotionMeetingsClient(notionmeetings.DefaultBaseURL, source.Token))
+	summary, importErr := importer.Import(ctx, notionmeetings.ImportOptions{
+		Identifier: source.Identifier, AccountEmail: accountEmail,
+	})
+	refreshCtx := context.WithoutCancel(ctx)
+	refresh := func() error {
+		return rebuildNotionMeetingsCacheAfterScheduledSync(refreshCtx, "notion-meetings:"+source.Identifier)
+	}
+	if err := finishNotionMeetingsImport(source.Identifier, summary, importErr, refresh); err != nil {
+		return err
+	}
+	return refresh()
+}
+
+func init() {
+	syncNotionMeetingsCmd.Flags().IntVar(&syncNotionMeetingsLimit, "limit", 0,
+		"max visible meetings hydrated and verified per run; due transcript maintenance is additional (0 = unlimited)")
+	syncNotionMeetingsCmd.Flags().StringVar(&syncNotionMeetingsAfter, "after", "",
+		"local visible-set lower bound (YYYY-MM-DD; implies --full)")
+	syncNotionMeetingsCmd.Flags().BoolVar(&syncNotionMeetingsFull, "full", false,
+		"force selected snapshots through archive upsert instead of skipping matching checksums")
+	syncNotionMeetingsCmd.Flags().BoolVar(&syncNotionMeetingsProbe, "probe", false,
+		"validate capabilities and result shape without printing meeting content")
+	rootCmd.AddCommand(addNotionMeetingsCmd)
+	rootCmd.AddCommand(syncNotionMeetingsCmd)
+}

--- a/cmd/msgvault/cmd/notion_meetings_test.go
+++ b/cmd/msgvault/cmd/notion_meetings_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/notionmeetings"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type fakeNotionProbe struct {
+	result   *notionmeetings.QueryResult
+	block    *notionmeetings.Block
+	err      error
+	blockErr error
+	usersErr error
+}
+
+func (f fakeNotionProbe) QueryMeetingNotes(context.Context, int) (*notionmeetings.QueryResult, error) {
+	return f.result, f.err
+}
+
+func (f fakeNotionProbe) RetrieveBlock(context.Context, string) (*notionmeetings.Block, error) {
+	return f.block, f.blockErr
+}
+
+func (f fakeNotionProbe) RetrievePageMarkdown(context.Context, string, bool) (*notionmeetings.MarkdownPage, error) {
+	return &notionmeetings.MarkdownPage{Markdown: "private transcript"}, nil
+}
+
+func (f fakeNotionProbe) ListUsers(context.Context, string) (*notionmeetings.UserPage, error) {
+	return &notionmeetings.UserPage{}, f.usersErr
+}
+
+func TestResolveNotionMeetingsSource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	previous := cfg
+	t.Cleanup(func() { cfg = previous })
+	cfg = &config.Config{NotionMeetings: []config.NotionMeetingsSource{
+		{Identifier: "personal", Token: "secret-1"},
+		{Identifier: "work", Token: "secret-2"},
+	}}
+
+	_, err := resolveNotionMeetingsSource(nil)
+	require.Error(err)
+	assert.Contains(err.Error(), "multiple [[notion_meetings]]")
+
+	source, err := resolveNotionMeetingsSource([]string{"work"})
+	require.NoError(err)
+	assert.Equal("work", source.Identifier)
+}
+
+func TestResolveNotionMeetingsSourcesRequiresProbeIdentifierForMultipleSources(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	previous := cfg
+	t.Cleanup(func() { cfg = previous })
+	cfg = &config.Config{NotionMeetings: []config.NotionMeetingsSource{
+		{Identifier: "personal", Token: "secret-1"},
+		{Identifier: "work", Token: "secret-2"},
+	}}
+
+	_, err := resolveNotionMeetingsSources(nil, true)
+	require.Error(err)
+	assert.Contains(err.Error(), "multiple [[notion_meetings]]")
+
+	sources, err := resolveNotionMeetingsSources([]string{"work"}, true)
+	require.NoError(err)
+	require.Len(sources, 1)
+	assert.Equal("work", sources[0].Identifier)
+}
+
+func TestRunNotionMeetingsProbeIsContentAndTokenSafe(t *testing.T) {
+	assert := assert.New(t)
+	meeting := notionmeetings.MeetingNote{
+		ID: "private-block-id", MeetingNotes: notionmeetings.MeetingNotesData{
+			Title: []notionmeetings.RichText{{PlainText: "Private meeting title"}},
+		},
+		Parent: notionmeetings.Parent{PageID: "private-page-id"},
+	}
+	var out bytes.Buffer
+	err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+		result: &notionmeetings.QueryResult{Results: []notionmeetings.MeetingNote{meeting}, HasMore: true},
+		block:  &notionmeetings.Block{Parent: notionmeetings.Parent{PageID: "private-page-id"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(out.String(), "Returned meetings: 1")
+	assert.Contains(out.String(), "Partial coverage: true")
+	assert.NotContains(out.String(), "private-block-id")
+	assert.NotContains(out.String(), "Private meeting title")
+	assert.NotContains(out.String(), "secret-token")
+	assert.NotContains(out.String(), "private transcript")
+	assert.Contains(out.String(), "Read Content: available")
+	assert.Contains(out.String(), "User Information: available")
+}
+
+func TestRunNotionMeetingsProbeResolvesParentFromMeetingBlock(t *testing.T) {
+	var out bytes.Buffer
+	err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+		result: &notionmeetings.QueryResult{Results: []notionmeetings.MeetingNote{{ID: "meeting-1"}}},
+		block:  &notionmeetings.Block{Parent: notionmeetings.Parent{PageID: "page-1"}},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Read Content: available")
+}
+
+func TestRunNotionMeetingsProbeChecksBlockWhenQueryHasParent(t *testing.T) {
+	var out bytes.Buffer
+	err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+		result: &notionmeetings.QueryResult{Results: []notionmeetings.MeetingNote{{
+			ID: "meeting-1", Parent: notionmeetings.Parent{PageID: "page-1"},
+		}}},
+		blockErr: errors.New("block endpoint unavailable"),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "block endpoint unavailable")
+}
+
+func TestRunNotionMeetingsProbeDegradesWithoutUserInformation(t *testing.T) {
+	var out bytes.Buffer
+	err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+		result: &notionmeetings.QueryResult{}, usersErr: notionmeetings.ErrUserInformation,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "Read Content: not tested")
+	assert.Contains(t, out.String(), "User Information: unavailable")
+}
+
+func TestRunNotionMeetingsProbeDegradesOnTransientUserListingFailure(t *testing.T) {
+	var out bytes.Buffer
+	err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+		result: &notionmeetings.QueryResult{}, usersErr: &notionmeetings.APIError{
+			Kind: notionmeetings.ErrRateLimited, Status: 503, Code: "service_unavailable",
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "User Information: unavailable")
+	assert.Contains(t, out.String(), "retry budget exhausted")
+}
+
+func TestRunNotionMeetingsProbeSurfacesSystemicUserListingFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: &notionmeetings.APIError{
+			Kind: notionmeetings.ErrUnauthorized, Status: 401, Code: "unauthorized",
+		}},
+		{name: "context canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+		{name: "malformed response", err: notionmeetings.ErrMalformedResponse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			err := runNotionMeetingsProbe(context.Background(), &out, fakeNotionProbe{
+				result: &notionmeetings.QueryResult{}, usersErr: tt.err,
+			})
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestFinishNotionMeetingsImportRefreshesCommittedWritesOnFailure(t *testing.T) {
+	refreshed := 0
+	err := finishNotionMeetingsImport("work", &notionmeetings.ImportSummary{MeetingsAdded: 1},
+		errors.New("hydrate failed"), func() error { refreshed++; return nil })
+	require.Error(t, err)
+	assert.Equal(t, 1, refreshed)
+	assert.Contains(t, err.Error(), "notion meetings sync work failed")
+}
+
+func TestRunConfiguredNotionMeetingsSyncRefusesRemovedSource(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	err := runConfiguredNotionMeetingsSync(context.Background(), st, config.NotionMeetingsSource{
+		Identifier: "removed", Token: "secret-token",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "add-notion-meetings removed")
+}

--- a/cmd/msgvault/cmd/remove_account_test.go
+++ b/cmd/msgvault/cmd/remove_account_test.go
@@ -1399,6 +1399,34 @@ func TestRemoveAccountCmd_CirclebackRemovesToken(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "token file should be removed for Circleback source")
 }
 
+func TestRemoveAccountCmd_RemovesNotionMeetingSource(t *testing.T) {
+	require := require.New(t)
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "msgvault.db")
+	st, err := store.Open(dbPath)
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	_, err = st.GetOrCreateSource(sourceTypeNotionMeetings, "notion-personal")
+	require.NoError(err)
+	require.NoError(st.Close())
+
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+	root := newTestRootCmd()
+	root.AddCommand(newRemoveAccountLocalTestCmd())
+	root.SetArgs([]string{
+		"remove-account", "notion-personal", "--yes", "--type", sourceTypeNotionMeetings,
+	})
+	require.NoError(root.Execute())
+
+	check, err := store.Open(dbPath)
+	require.NoError(err)
+	defer func() { require.NoError(check.Close()) }()
+	_, err = check.GetSourceByTypeAndIdentifier(sourceTypeNotionMeetings, "notion-personal")
+	require.ErrorIs(err, store.ErrSourceNotFound)
+}
+
 func TestRemoveAccountCmd_SlackRemovesToken(t *testing.T) {
 	require := require.New(t)
 	tmpDir := t.TempDir()

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -28,6 +28,7 @@ import (
 	"go.kenn.io/msgvault/internal/granola"
 	"go.kenn.io/msgvault/internal/meetingimport"
 	"go.kenn.io/msgvault/internal/microsoft"
+	"go.kenn.io/msgvault/internal/notionmeetings"
 	"go.kenn.io/msgvault/internal/oauth"
 	"go.kenn.io/msgvault/internal/personenrichment"
 	"go.kenn.io/msgvault/internal/personfacts"
@@ -532,6 +533,32 @@ func runServe(cmd *cobra.Command, args []string) error {
 			logger.Error("failed to schedule circleback source", "source", source.Identifier, "error", err)
 		} else {
 			logger.Info("scheduled circleback source", "source", source.Identifier, "schedule", source.Schedule)
+		}
+	}
+	for _, src := range cfg.NotionMeetings {
+		if src.Enabled && src.Schedule == "" {
+			logger.Warn("notion meeting source is enabled but has no schedule — the daemon will not sync it; its freshness will eventually go stale",
+				"source", src.Identifier,
+				"hint", `set a cron schedule (e.g. "15 */6 * * *") on the [[notion_meetings]] entry`)
+		}
+	}
+	for _, src := range cfg.ScheduledNotionMeetingsSources() {
+		source := src
+		jobName, ok := api.SchedulerJobNameForSource(notionmeetings.SourceType, source.Identifier)
+		if !ok {
+			logger.Error("no scheduler job mapping for notion meeting source", "source", source.Identifier)
+			continue
+		}
+		if err := sched.AddJob(scheduler.Job{
+			Name:     jobName,
+			Schedule: source.Schedule,
+			Run: func(ctx context.Context) error {
+				return runConfiguredNotionMeetingsSync(ctx, s, source)
+			},
+		}); err != nil {
+			logger.Error("failed to schedule notion meeting source", "source", source.Identifier, "error", err)
+		} else {
+			logger.Info("scheduled notion meeting source", "source", source.Identifier, "schedule", source.Schedule)
 		}
 	}
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,10 +1,11 @@
 ---
+last_edited: "2026-08-30"
 title: Architecture Overview
 description: Package structure and data flow.
 ---
 
 msgvault syncs Gmail, Google Calendar, IMAP, Microsoft 365 mail, Microsoft
-Teams, Discord, Slack, Beeper Desktop, Granola, and Circleback into a local SQLite database by
+Teams, Discord, Slack, Beeper Desktop, Granola, Circleback, and Notion into a local SQLite database by
 default and can import local PST/MBOX archives, Apple Mail exports, and common
 chat/text formats. PostgreSQL is available as an opt-in backend for new
 archives. Keyword search, analytics, the Web UI, the TUI, and the MCP server run against
@@ -54,6 +55,8 @@ msgvault/
 │   ├── beeper/              # Beeper Desktop client and importer
 │   ├── granola/             # Granola meeting-note client and importer
 │   ├── circleback/          # Circleback MCP/OAuth client and importer
+│   ├── notionmeetings/      # Notion Meeting Notes client, hydration, and sync state
+│   ├── meetingarchive/      # Provider-neutral canonical meeting persistence
 │   ├── oauth/               # OAuth2 flows (browser + device)
 │   └── mime/                # MIME parsing
 ├── go.mod
@@ -94,7 +97,8 @@ msgvault/
 | `internal/teams` | Microsoft Teams Graph client mapping, sync cursors, and importer |
 | `internal/discord` | Read-only Discord REST client, credential bindings, channel/thread checkpoints, mapping, and media archival |
 | `internal/beeper` | Beeper Desktop local-API client, resumable sync state, media download, and message mapping |
-| `internal/granola` / `internal/circleback` | Meeting-note provider clients, authentication, formatting, and archive ingestion |
+| `internal/granola` / `internal/circleback` / `internal/notionmeetings` | Meeting-note provider clients, authentication, formatting, and sync state |
+| `internal/meetingarchive` | Provider-neutral canonical meeting persistence |
 | `internal/mime` | MIME message parsing, charset detection |
 
 ## Design Decisions

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-08-09"
+last_edited: "2026-08-30"
 title: Data Storage
 description: Database schema, Parquet analytics cache, content-addressed attachments, and token storage.
 ---
@@ -25,7 +25,7 @@ All message data (metadata, labels, participants, and raw MIME) lives in the con
 | Column | Type | Description |
 |---|---|---|
 | `id` | INTEGER PK | Auto-increment |
-| `source_type` | TEXT | Provider/import type, for example `gmail`, `imap`, `gcal`, `teams`, `discord`, `beeper`, `mbox`, `whatsapp`, `granola`, or `circleback` |
+| `source_type` | TEXT | Provider/import type, for example `gmail`, `imap`, `gcal`, `teams`, `discord`, `beeper`, `mbox`, `whatsapp`, `granola`, `circleback`, or `notion_meetings` |
 | `identifier` | TEXT | Provider-stable identifier such as an email address, phone number, or Discord guild ID |
 | `display_name` | TEXT | Account display name |
 | `sync_cursor` | TEXT | Sync cursor (Gmail history ID for Gmail accounts) |
@@ -67,6 +67,12 @@ All message data (metadata, labels, participants, and raw MIME) lives in the con
 | `message_id` | INTEGER PK/FK | References `messages` |
 | `raw_data` | BLOB | Compressed MIME or provider JSON data |
 | `compression` | TEXT | `zlib` |
+
+Native Notion meetings use raw format `notion_meeting_json`. The compressed
+envelope keeps provider discovery, structured blocks, page Markdown, minimized
+resolved users, canonical text used for safe transcript preservation, and
+hydration warnings. Integration tokens and authorization headers are never
+part of the envelope.
 
 **participants** -- Unified contacts.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -49,6 +49,10 @@ All notable changes to msgvault, grouped by release.
   local search backends, while the TUI and web analytical workspace expose a
   Lists grouping with exact case-insensitive drill-down.
 
+- Native read-only Notion AI Meeting Notes sync, including sanitized access
+  probing, changed-meeting refresh, verified attendee resolution, bounded late
+  transcript retries, raw evidence, daemon scheduling, and Meetings TUI support.
+
 - Exact source selection is available through `--source-id` on `sync`,
   `sync-full`, `update-account`, `remove-account`, and `delete-staged`.
   Account arguments continue to accept identifiers and display names, while

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-08-30
+last_edited: "2026-08-31"
 title: CLI Reference
 description: Complete command reference for all msgvault commands.
 ---
@@ -350,6 +350,50 @@ removed from the archive and directs you to run `add-granola` again.
 | `--full` | `false` | Ignore stored cursor and re-fetch every note |
 
 See [Meeting Transcripts](/usage/meetings/) for setup and what gets stored.
+
+---
+
+## add-notion-meetings
+
+Validate a configured read-only Notion integration and register its meeting
+source without printing meeting content.
+
+```bash
+msgvault add-notion-meetings [identifier]
+```
+
+The matching `[[notion_meetings]]` entry requires `account_email` and `token`.
+With one entry, the identifier may be omitted.
+
+---
+
+## sync-notion-meetings
+
+Sync Notion AI Meeting Notes from the attendee-visible recent window.
+
+```bash
+msgvault sync-notion-meetings [identifier]
+msgvault sync-notion-meetings --limit 3
+msgvault sync-notion-meetings --full --after 2026-01-01
+msgvault sync-notion-meetings --probe
+```
+
+Notion returns at most 50 meeting notes and exposes no discovery cursor.
+Every run hydrates and checksum-verifies the selected visible meetings.
+`--full` also sends matching snapshots through archive upsert so cursor/archive
+divergence can be repaired; `--after` filters the visible set locally. Partial
+coverage is reported when Notion says more records exist. Due transcript
+maintenance runs outside `--limit`.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--limit` | `0` | Maximum visible meetings hydrated and verified; due maintenance is additional |
+| `--after` | — | Local visible-set lower bound in `YYYY-MM-DD` form; implies `--full` |
+| `--full` | `false` | Force selected snapshots through archive upsert instead of skipping matching checksums |
+| `--probe` | `false` | Validate capabilities and result shape without printing meeting content |
+
+See [Meeting Transcripts](/usage/meetings/#notion-ai-meeting-notes) for setup,
+privacy, retry behavior, and stored evidence.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -808,6 +808,36 @@ label, add `account_email`, manage aliases with `msgvault identity`, and run
 Circleback OAuth always confirms the primary identity; there is no identity
 opt-out flag.
 
+### Notion AI Meeting Notes Sources
+
+Notion meeting sync uses one top-level `[[notion_meetings]]` entry per Notion
+identity. The token must belong to a read-only integration with AI Meeting
+Notes access and Read Content access. User Information access is optional; it
+is required only to resolve attendee IDs to verified email addresses.
+
+```toml
+[[notion_meetings]]
+identifier = "notion-personal"      # stable source label; defaults to "default" for one entry
+account_email = "you@example.com"   # required primary account identity
+token = "ntn_..."                   # Notion integration token; keep this file private
+schedule = "15 */6 * * *"           # optional 5-field cron, no seconds
+enabled = true
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `identifier` | `default` (single entry) | Source name used by commands and scheduler logs |
+| `account_email` | (required) | Normalized primary identity for relationships; it is not assumed to be the meeting organizer |
+| `token` | (required) | Read-only Notion integration token |
+| `schedule` | — | Cron expression used by `msgvault serve` |
+| `enabled` | `false` | Whether the source is daemon-scheduled |
+
+Run `msgvault add-notion-meetings <identifier>` to validate access and register
+the source before enabling a schedule. Removing the source prevents the
+scheduler from recreating it. See [Meeting Transcripts](/usage/meetings/) for
+the 50-result discovery limit, attendee visibility, transcript retries, and
+stored data.
+
 ### `[vector]`
 
 Top-level toggle and backend marker for semantic/hybrid search. SQLite vector search requires a build with `sqlite_vec` support (default via `make build`). PostgreSQL vector search requires a build with the `pgvector` tag and a PostgreSQL `[data].database_url`. See [Vector Search](/usage/vector-search/) for prerequisites, initial embedding, and the full workflow.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,7 @@
 ---
+last_edited: "2026-08-30"
 title: msgvault
-description: Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, a keyboard-driven TUI, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, and Circleback.
+description: Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, a keyboard-driven TUI, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, Circleback, and Notion.
 ---
 
 # msgvault
@@ -18,7 +19,7 @@ search, and local AI workflows.
   <img src="/assets/generated/tui-senders.svg" alt="msgvault TUI showing the Senders view" loading="eager">
 </figure>
 
-Supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, Granola, Circleback, Beeper
+Supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, Granola, Circleback, Notion AI Meeting Notes, Beeper
 Desktop, IMAP, and Microsoft 365 mail sync; verifiable backup snapshots; PST,
 MBOX, and Apple Mail import; and chat/text import from WhatsApp, iMessage,
 Google Voice, Facebook Messenger, and SMS Backup & Restore.
@@ -53,7 +54,7 @@ Your email and message data is yours. msgvault downloads a complete local copy
 of your email (from Gmail, IMAP, or local archives) and imports chats and texts
 from WhatsApp, iMessage, Google Voice, Facebook Messenger, and SMS Backup &
 Restore, and can sync Teams conversations, Discord guilds, Slack workspaces,
-Beeper chats, plus Granola and Circleback meeting notes.
+Beeper chats, plus Granola, Circleback, and Notion meeting notes.
 Keyword search, analytics, the Web UI, the TUI, and the MCP server query your archive.
 **Source services are contacted only by authorization/registration, sync,
 media-backfill, provider-backed identity discovery, and deletion workflows that
@@ -88,7 +89,7 @@ it lives in an archive on disk that you own and control.
   </section>
   <section>
     <h3>Slack, Meetings &amp; Beeper</h3>
-    <p>Archive Slack workspaces, sync Granola and Circleback notes and transcripts, and archive chats and media from networks connected to Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
+    <p>Archive Slack workspaces, sync Granola, Circleback, and Notion notes and transcripts, and archive chats and media from networks connected to Beeper Desktop. Explore each source in the Web UI or its dedicated TUI mode.</p>
   </section>
   <section>
     <h3>Backup Snapshots</h3>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-30"
 title: Introduction
 description: Why msgvault was created and what problem it solves.
 ---
@@ -25,7 +26,7 @@ This means:
 
 I started with Gmail but I want all my life's messages in this system,
 including Google Calendar, Microsoft Teams, Discord guilds, Slack workspaces,
-Beeper Desktop chats, Granola and Circleback meeting notes, WhatsApp, iMessage,
+Beeper Desktop chats, Granola, Circleback, and Notion meeting notes, WhatsApp, iMessage,
 Google Voice, Facebook Messenger,
 SMS Backup & Restore archives, and old local email
 archives.

--- a/docs/usage/meetings.md
+++ b/docs/usage/meetings.md
@@ -1,6 +1,7 @@
 ---
+last_edited: "2026-08-31"
 title: Meeting Transcripts
-description: Archive AI meeting notes and transcripts from Granola and Circleback into your searchable local archive.
+description: Archive AI meeting notes and transcripts from Granola, Circleback, and Notion into your searchable local archive.
 ---
 
 msgvault can archive meeting notes and transcripts from AI meeting-notes
@@ -30,7 +31,7 @@ Each meeting source has two distinct values:
 rejects a missing or invalid value with guidance to preserve the source label
 and add the account email separately.
 
-`add-granola` and `add-circleback` always confirm the primary email for their
+`add-granola`, `add-circleback`, and `add-notion-meetings` always confirm the primary email for their
 source. Add other confirmed aliases with the identity command:
 
 ```bash
@@ -153,7 +154,7 @@ modalities, or filter to meeting notes only. Open a result to read the note in
 its containing context.
 
 Launch `msgvault tui` and press `m` until the title bar shows **Meetings**.
-The list combines Granola and Circleback meetings and shows their date, title,
+The list combines Granola, Circleback, and Notion meetings and shows their date, title,
 organizer, and source. Press `A` to select one meeting source, `/` to search
 meeting titles, people, transcripts, and notes, and `Enter` to open the full
 transcript. The detail view renders summary Markdown with terminal-friendly
@@ -187,6 +188,95 @@ remain searchable. Fix the reported problem and rerun the same sync.
 | Body | AI summary (markdown) + `[mm:ss] Speaker: text` transcript |
 | Metadata | Duration, web link, calendar event ID, folders, segment count |
 | Raw archive | The verbatim API response (`granola_json`) |
+
+## Notion AI Meeting Notes
+
+Notion sync uses the official read-only Meeting Notes and block APIs. It does
+not modify pages, upload content, or download recording media. Visibility is
+attendee-scoped to the Notion user associated with the integration; it is not
+a workspace-wide export.
+
+### Configure and register
+
+Create a Notion integration with AI Meeting Notes and Read Content access.
+Grant User Information access if you want attendee IDs resolved to verified
+emails and relationship participants. Without it, meetings still sync, but
+attendees remain display-only names or IDs.
+
+```toml
+[[notion_meetings]]
+identifier = "notion-personal"
+account_email = "you@example.com"
+token = "ntn_..."
+schedule = "15 */6 * * *"         # optional daemon schedule
+enabled = true
+```
+
+Keep `config.toml` owner-readable: the token is read from config and is never
+written to logs, sync cursors, archived raw evidence, or command output.
+
+```bash
+msgvault add-notion-meetings notion-personal
+msgvault sync-notion-meetings notion-personal --probe
+```
+
+Both commands print capability and result-count diagnostics without printing
+meeting titles, notes, transcripts, attendee details, block IDs, page URLs, or
+the token.
+
+### Sync and discovery limit
+
+```bash
+msgvault sync-notion-meetings                         # all configured identities
+msgvault sync-notion-meetings notion-personal        # one identity
+msgvault sync-notion-meetings notion-personal --limit 3
+msgvault sync-notion-meetings --full
+msgvault sync-notion-meetings --after 2026-01-01
+```
+
+Notion's Meeting Notes query currently returns at most 50 records and can say
+that more exist without providing a cursor. msgvault makes one maximum-size
+query per run, never loops the same page, and reports partial coverage when
+Notion sets `has_more`. This means native sync is reliable for the visible
+recent window but is not a complete historical workspace export.
+
+Every run hydrates the visible meetings that pass local filters, then compares
+their complete snapshots; matching checksums skip the archive write. `--full`
+instead sends every selected snapshot through archive upsert, which can repair
+cursor/archive divergence while identical archived content remains a no-op. It
+does not expose history beyond the visible window. `--after` is a local filter
+over returned meetings. `--limit` caps visible meetings hydrated and verified
+but does not suppress due transcript maintenance.
+
+Notion may publish notes before a transcript. Missing transcripts retry every
+six hours until seven days after the best known meeting end, or for 48 hours
+from discovery when timing is unknown. A temporary omission never erases a
+transcript already archived. Hard per-meeting failures retain the previous
+successful state; meetings written earlier in that failed run remain safe and
+idempotent.
+
+### What gets stored (Notion)
+
+Each meeting-note block becomes one `meeting_transcript` message in one
+`meeting` conversation, keyed by the block ID. The body contains deterministic
+title, time, attendee, summary, notes, and transcript sections. Raw format
+`notion_meeting_json` preserves the query object, block trees, Markdown page,
+privacy-safe attendee display labels, minimal resolved users, and warnings.
+
+Notion's `created_by` user is stored as creator metadata and is never assumed
+to be the organizer. Only attendees with provider-verified email addresses
+become participant rows. Unknown IDs and names remain display-only evidence.
+
+If registration reports invalid token, Meeting Notes access, or Read Content
+errors, correct that integration capability and rerun `add-notion-meetings`.
+User Information errors are non-fatal. Remove the archive source with:
+
+```bash
+msgvault remove-account notion-personal --type notion_meetings --yes
+```
+
+A configured schedule will then refuse to recreate it until
+`add-notion-meetings` is run again.
 
 ## Circleback
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "msgvault"
 site_url = "https://msgvault.io"
-site_description = "Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, and Circleback."
+site_description = "Offline email, chat, calendar, and meeting archive with a daemon-served analytical Web UI, full-text and semantic search, and sync for Gmail, IMAP, Teams, Discord, Slack, Beeper, Granola, Circleback, and Notion."
 site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>. MIT License.'
 docs_dir = "docs"

--- a/internal/api/cli_allowlist_slack_test.go
+++ b/internal/api/cli_allowlist_slack_test.go
@@ -23,3 +23,16 @@ func TestCLIRunCommandAllowedSlackCommands(t *testing.T) {
 	}
 	assert.False(t, cliRunCommandAllowed([]string{"slack-not-a-command"}))
 }
+
+func TestCLIRunCommandAllowedNotionMeetingsCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"add-notion-meetings"},
+		{"add-notion-meetings", "notion-personal"},
+		{"sync-notion-meetings"},
+		{"sync-notion-meetings", "notion-personal", "--full"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			assert.True(t, cliRunCommandAllowed(args), "%v must be runnable via the daemon CLI", args)
+		})
+	}
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1537,6 +1537,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"add-discord",
 		"add-granola",
 		"add-imap",
+		"add-notion-meetings",
 		"add-o365",
 		"add-slack",
 		"add-synctech-sms-drive",
@@ -1583,6 +1584,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"sync-circleback",
 		"sync-discord",
 		"sync-granola",
+		"sync-notion-meetings",
 		"sync-slack",
 		"sync-synctech-sms",
 		"sync-teams":

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -39,6 +39,7 @@ import (
 	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/granola"
 	"go.kenn.io/msgvault/internal/meetingimport"
+	"go.kenn.io/msgvault/internal/notionmeetings"
 	"go.kenn.io/msgvault/internal/opserr"
 	"go.kenn.io/msgvault/internal/personenrichment"
 	"go.kenn.io/msgvault/internal/query"
@@ -4059,6 +4060,7 @@ func TestSchedulerJobNameForSource(t *testing.T) {
 		{"gcal no calendar id", gcal.SourceType, "alice@example.com", "", false},
 		{"granola", granola.SourceType, "acct-1", "granola:acct-1", true},
 		{"circleback", circleback.SourceType, "acct-2", "circleback:acct-2", true},
+		{"notion meetings", notionmeetings.SourceType, "acct-3", "notion-meetings:acct-3", true},
 		{"beeper", "beeper", "beeper-account-1", "beeper", true},
 		{"slack", "slack", "T01:U01", "slack", true},
 		{"account scheduler type", "gmail", "alice@example.com", "", false},

--- a/internal/api/scheduler_jobs.go
+++ b/internal/api/scheduler_jobs.go
@@ -7,6 +7,7 @@ import (
 	"go.kenn.io/msgvault/internal/gcal"
 	"go.kenn.io/msgvault/internal/granola"
 	"go.kenn.io/msgvault/internal/meetingimport"
+	"go.kenn.io/msgvault/internal/notionmeetings"
 	"go.kenn.io/msgvault/internal/synctechsms"
 )
 
@@ -99,6 +100,8 @@ func SchedulerJobNameForSource(sourceType, identifier string) (string, bool) {
 		// Store identifier == config Identifier (see
 		// internal/circleback/importer.go GetOrCreateSource call).
 		return "circleback:" + identifier, true
+	case notionmeetings.SourceType:
+		return "notion-meetings:" + identifier, true
 	case sourceTypeBeeper:
 		// One scheduler job syncs every beeper source (see
 		// internal/beeper/importer.go GetOrCreateSource, one store source

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -396,35 +396,36 @@ func (b *BackupConfig) Validate() error {
 }
 
 type Config struct {
-	Data         DataConfig                      `toml:"data"`
-	Log          LogConfig                       `toml:"log"`
-	OAuth        OAuthConfig                     `toml:"oauth"`
-	Microsoft    MicrosoftConfig                 `toml:"microsoft"`
-	Sync         SyncConfig                      `toml:"sync"`
-	Chat         ChatConfig                      `toml:"chat"`
-	Server       ServerConfig                    `toml:"server"`
-	Analytics    AnalyticsConfig                 `toml:"analytics"`
-	Web          WebConfig                       `toml:"web"`
-	Integrations IntegrationsConfig              `toml:"integrations"`
-	Remote       RemoteConfig                    `toml:"remote"`
-	Vector       vector.Config                   `toml:"vector"`
-	Identity     IdentityConfig                  `toml:"identity"`
-	Fastmail     []FastmailSource                `toml:"fastmail"`
-	CardDAV      CardDAVConfig                   `toml:"carddav"`
-	Accounts     []AccountSchedule               `toml:"accounts"`
-	SynctechSMS  SynctechSMSConfig               `toml:"synctech_sms"`
-	GCal         []GCalSource                    `toml:"gcal"`
-	Beeper       BeeperConfig                    `toml:"beeper"`
-	Slack        SlackConfig                     `toml:"slack"`
-	Granola      []GranolaSource                 `toml:"granola"`
-	Circleback   []CirclebackSource              `toml:"circleback"`
-	Backup       BackupConfig                    `toml:"backup"`
-	Discord      DiscordConfig                   `toml:"discord"`
-	Attachments  documentindex.AttachmentsConfig `toml:"attachments"`
-	Activity     ActivityConfig                  `toml:"activity"`
-	People       PeopleConfig                    `toml:"people"`
-	Teams        TeamsConfig                     `toml:"teams"`
-	Deletion     DeletionConfig                  `toml:"deletion"`
+	Data           DataConfig                      `toml:"data"`
+	Log            LogConfig                       `toml:"log"`
+	OAuth          OAuthConfig                     `toml:"oauth"`
+	Microsoft      MicrosoftConfig                 `toml:"microsoft"`
+	Sync           SyncConfig                      `toml:"sync"`
+	Chat           ChatConfig                      `toml:"chat"`
+	Server         ServerConfig                    `toml:"server"`
+	Analytics      AnalyticsConfig                 `toml:"analytics"`
+	Web            WebConfig                       `toml:"web"`
+	Integrations   IntegrationsConfig              `toml:"integrations"`
+	Remote         RemoteConfig                    `toml:"remote"`
+	Vector         vector.Config                   `toml:"vector"`
+	Identity       IdentityConfig                  `toml:"identity"`
+	Fastmail       []FastmailSource                `toml:"fastmail"`
+	CardDAV        CardDAVConfig                   `toml:"carddav"`
+	Accounts       []AccountSchedule               `toml:"accounts"`
+	SynctechSMS    SynctechSMSConfig               `toml:"synctech_sms"`
+	GCal           []GCalSource                    `toml:"gcal"`
+	Beeper         BeeperConfig                    `toml:"beeper"`
+	Slack          SlackConfig                     `toml:"slack"`
+	Granola        []GranolaSource                 `toml:"granola"`
+	Circleback     []CirclebackSource              `toml:"circleback"`
+	NotionMeetings []NotionMeetingsSource          `toml:"notion_meetings"`
+	Backup         BackupConfig                    `toml:"backup"`
+	Discord        DiscordConfig                   `toml:"discord"`
+	Attachments    documentindex.AttachmentsConfig `toml:"attachments"`
+	Activity       ActivityConfig                  `toml:"activity"`
+	People         PeopleConfig                    `toml:"people"`
+	Teams          TeamsConfig                     `toml:"teams"`
+	Deletion       DeletionConfig                  `toml:"deletion"`
 
 	// Computed paths (not from config file)
 	HomeDir    string `toml:"-"`
@@ -1497,6 +1498,22 @@ type CirclebackSource struct {
 	Enabled      bool   `toml:"enabled"`
 }
 
+// NotionMeetingsSource is one configured Notion AI Meeting Notes identity.
+// Authentication uses a read-only integration token stored in config.toml.
+type NotionMeetingsSource struct {
+	Identifier   string `toml:"identifier"`
+	AccountEmail string `toml:"account_email"`
+	Token        string `toml:"token"`
+	Schedule     string `toml:"schedule"`
+	Enabled      bool   `toml:"enabled"`
+}
+
+// EffectiveAccountEmail returns the normalized primary identity configured
+// for this source.
+func (s NotionMeetingsSource) EffectiveAccountEmail() (string, error) {
+	return effectiveMeetingAccountEmail("notion_meetings", s.Identifier, s.AccountEmail)
+}
+
 // EffectiveAccountEmail returns the normalized primary identity configured
 // for this source.
 func (s CirclebackSource) EffectiveAccountEmail() (string, error) {
@@ -1528,7 +1545,7 @@ func normalizedMeetingAccountEmail(value string) (string, bool) {
 	return email, true
 }
 
-// applyMeetingSourceDefaults normalizes [[granola]]/[[circleback]] entries: a
+// applyMeetingSourceDefaults normalizes native meeting-source entries: a
 // single entry with no identifier becomes "default" so the CLI argument can
 // be omitted in the common one-account case.
 func (c *Config) applyMeetingSourceDefaults() {
@@ -1538,9 +1555,12 @@ func (c *Config) applyMeetingSourceDefaults() {
 	if len(c.Circleback) == 1 && c.Circleback[0].Identifier == "" {
 		c.Circleback[0].Identifier = "default"
 	}
+	if len(c.NotionMeetings) == 1 && c.NotionMeetings[0].Identifier == "" {
+		c.NotionMeetings[0].Identifier = "default"
+	}
 }
 
-// validateMeetingSources rejects [[granola]]/[[circleback]] lists with empty
+// validateMeetingSources rejects native meeting-source lists with empty
 // or duplicate identifiers — the identifier keys the source row and token
 // file, so a collision would silently merge two accounts.
 func (c *Config) validateMeetingSources() error {
@@ -1590,6 +1610,22 @@ func (c *Config) validateMeetingSources() error {
 			c.Circleback[i].AccountEmail = email
 		}
 	}
+	notionIDs := make([]string, len(c.NotionMeetings))
+	for i, s := range c.NotionMeetings {
+		notionIDs[i] = s.Identifier
+	}
+	if err := check("notion_meetings", notionIDs); err != nil {
+		return err
+	}
+	for i := range c.NotionMeetings {
+		email, err := c.NotionMeetings[i].EffectiveAccountEmail()
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(c.NotionMeetings[i].AccountEmail) != "" {
+			c.NotionMeetings[i].AccountEmail = email
+		}
+	}
 	return nil
 }
 
@@ -1632,6 +1668,30 @@ func (c *Config) GetCirclebackSource(identifier string) *CirclebackSource {
 func (c *Config) ScheduledCirclebackSources() []CirclebackSource {
 	var out []CirclebackSource
 	for _, src := range c.Circleback {
+		if src.Enabled && src.Schedule != "" {
+			out = append(out, src)
+		}
+	}
+	return out
+}
+
+// GetNotionMeetingsSource returns the configured Notion meeting source
+// matching identifier (case-insensitive), or nil.
+func (c *Config) GetNotionMeetingsSource(identifier string) *NotionMeetingsSource {
+	for _, src := range c.NotionMeetings {
+		if strings.EqualFold(src.Identifier, identifier) {
+			cp := src
+			return &cp
+		}
+	}
+	return nil
+}
+
+// ScheduledNotionMeetingsSources returns enabled Notion meeting sources with
+// a cron schedule.
+func (c *Config) ScheduledNotionMeetingsSources() []NotionMeetingsSource {
+	var out []NotionMeetingsSource
+	for _, src := range c.NotionMeetings {
 		if src.Enabled && src.Schedule != "" {
 			out = append(out, src)
 		}

--- a/internal/config/config_meeting_test.go
+++ b/internal/config/config_meeting_test.go
@@ -40,6 +40,13 @@ identifier = "alice@example.com"
 account_email = "alice@example.com"
 schedule = "30 */6 * * *"
 enabled = true
+
+[[notion_meetings]]
+identifier = "notion-work"
+account_email = " Notion.User@Example.COM "
+token = "ntn_test"
+schedule = "15 */6 * * *"
+enabled = true
 `)
 
 	cfg, err := Load(configPath, "")
@@ -60,6 +67,12 @@ enabled = true
 	cb := cfg.GetCirclebackSource("alice@example.com")
 	require.NotNil(cb)
 	require.Len(cfg.ScheduledCirclebackSources(), 1)
+
+	notion := cfg.GetNotionMeetingsSource("NOTION-WORK")
+	require.NotNil(notion)
+	assert.Equal("notion.user@example.com", notion.AccountEmail)
+	assert.Equal("ntn_test", notion.Token)
+	require.Len(cfg.ScheduledNotionMeetingsSources(), 1)
 }
 
 func TestLoadMeetingSourceSingleEntryDefaultsIdentifier(t *testing.T) {
@@ -73,12 +86,18 @@ enabled = true
 [[circleback]]
 account_email = "circleback@example.com"
 enabled = true
+
+[[notion_meetings]]
+account_email = "notion@example.com"
+token = "ntn_test"
+enabled = true
 `)
 
 	cfg, err := Load(configPath, "")
 	require.NoError(err, "Load()")
 	require.Equal("default", cfg.Granola[0].Identifier)
 	require.Equal("default", cfg.Circleback[0].Identifier)
+	require.Equal("default", cfg.NotionMeetings[0].Identifier)
 }
 
 func TestMeetingSourceEffectiveAccountEmail(t *testing.T) {
@@ -99,6 +118,12 @@ func TestMeetingSourceEffectiveAccountEmail(t *testing.T) {
 			name:      "circleback explicit account email is normalized and preferred",
 			provider:  "circleback",
 			config:    "identifier = \"label@example.net\"\naccount_email = \"  User-A@Example.COM  \"",
+			wantEmail: "user-a@example.com",
+		},
+		{
+			name:      "notion explicit account email is normalized and preferred",
+			provider:  "notion_meetings",
+			config:    "identifier = \"label@example.net\"\naccount_email = \"  User-A@Example.COM  \"\ntoken = \"ntn_test\"",
 			wantEmail: "user-a@example.com",
 		},
 		{
@@ -148,12 +173,36 @@ func TestMeetingSourceEffectiveAccountEmail(t *testing.T) {
 				assert.Equal(tt.wantEmail, got)
 				return
 			}
-			require.Len(cfg.Circleback, 1)
-			got, effectiveErr := cfg.Circleback[0].EffectiveAccountEmail()
+			if tt.provider == "circleback" {
+				require.Len(cfg.Circleback, 1)
+				got, effectiveErr := cfg.Circleback[0].EffectiveAccountEmail()
+				require.NoError(effectiveErr)
+				assert.Equal(tt.wantEmail, got)
+				return
+			}
+			require.Len(cfg.NotionMeetings, 1)
+			got, effectiveErr := cfg.NotionMeetings[0].EffectiveAccountEmail()
 			require.NoError(effectiveErr)
 			assert.Equal(tt.wantEmail, got)
 		})
 	}
+}
+
+func TestLoadNotionMeetingSourceDuplicateIdentifiersRejected(t *testing.T) {
+	configPath := writeMeetingConfig(t, `
+[[notion_meetings]]
+identifier = "work"
+account_email = "first@example.com"
+token = "ntn_a"
+
+[[notion_meetings]]
+identifier = "WORK"
+account_email = "second@example.com"
+token = "ntn_b"
+`)
+
+	_, err := Load(configPath, "")
+	require.ErrorContains(t, err, "[[notion_meetings]]: duplicate identifier")
 }
 
 func TestLoadMeetingSourceDuplicateIdentifiersRejected(t *testing.T) {

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -892,6 +892,9 @@ func validateEditableCandidate(cfg *Config) error {
 	for index, source := range cfg.Circleback {
 		schedules[fmt.Sprintf("circleback[%d].schedule", index)] = source.Schedule
 	}
+	for index, source := range cfg.NotionMeetings {
+		schedules[fmt.Sprintf("notion_meetings[%d].schedule", index)] = source.Schedule
+	}
 	for key, expression := range schedules {
 		if expression == "" {
 			continue

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1999,6 +1999,28 @@ func TestEditConfigRejectsInvalidSlackSchedule(t *testing.T) {
 	assert.Equal(before, string(got))
 }
 
+func TestEditConfigRejectsInvalidNotionMeetingsSchedule(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	before := "[[notion_meetings]]\n" +
+		"identifier = \"notion-work\"\n" +
+		"account_email = \"notion@example.com\"\n" +
+		"token = \"ntn_test\"\n" +
+		"schedule = \"15 */6 * * *\"\n" +
+		"enabled = true\n"
+	require.NoError(os.WriteFile(path, []byte(before), 0o600))
+	snapshot, err := ReadConfigFile(path)
+	require.NoError(err)
+
+	_, err = EditConfigFile(path, snapshot.ETag, []Edit{{Key: "notion_meetings.schedule", Value: "not a cron"}})
+	require.ErrorIs(err, ErrInvalidConfigCandidate)
+	assert.Contains(err.Error(), "invalid notion_meetings[0].schedule")
+	got, readErr := os.ReadFile(path)
+	require.NoError(readErr)
+	assert.Equal(before, string(got))
+}
+
 func TestEditConfigPreservesModeAndExistingSymlink(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		t.Skip("symlink permission semantics differ on Windows")

--- a/internal/meetingarchive/archive.go
+++ b/internal/meetingarchive/archive.go
@@ -1,0 +1,237 @@
+// Package meetingarchive persists provider-normalized meetings through one
+// canonical store path. Providers retain ownership of discovery, sync state,
+// lifecycle handling, and raw-evidence construction.
+package meetingarchive
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/meetingidentity"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	ConversationType = "meeting"
+	MessageType      = "meeting_transcript"
+)
+
+var ErrUnavailable = errors.New("meeting archiver is unavailable")
+
+type Person struct {
+	Name  string
+	Email string
+}
+
+type Snapshot struct {
+	SourceID             int64
+	AccountEmail         string
+	SourceMessageID      string
+	SourceConversationID string
+	Title                string
+	StartedAt            time.Time
+	Body                 string
+	Snippet              string
+	Metadata             []byte
+	Raw                  []byte
+	RawFormat            string
+	Organizer            *Person
+	Attendees            []Person
+}
+
+type Result struct {
+	MessageID int64
+	Created   bool
+	// Changed means the archive write committed, including when Upsert returns
+	// a later conversation-stat maintenance error.
+	Changed bool
+}
+
+// UpsertOptions controls archive repair behavior.
+type UpsertOptions struct {
+	// Force rewrites every derived projection even when the stored raw snapshot
+	// and sender attribution already match.
+	Force bool
+}
+
+type Archiver struct {
+	store *store.Store
+}
+
+func New(s *store.Store) *Archiver {
+	return &Archiver{store: s}
+}
+
+func (a *Archiver) Upsert(
+	ctx context.Context,
+	snapshot Snapshot,
+	opts UpsertOptions,
+) (Result, error) {
+	if a == nil || a.store == nil {
+		return Result{}, ErrUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	existing, err := a.store.MessageExistsBatch(snapshot.SourceID, []string{snapshot.SourceMessageID})
+	if err != nil {
+		return Result{}, fmt.Errorf("lookup existing meeting: %w", err)
+	}
+	existingMessageID, existed := existing[snapshot.SourceMessageID]
+
+	identities, err := meetingidentity.ForSource(a.store, snapshot.SourceID, snapshot.AccountEmail)
+	if err != nil {
+		return Result{}, err
+	}
+	organizerEmail, organizerName := "", ""
+	if snapshot.Organizer != nil {
+		organizerEmail = normalizeEmail(snapshot.Organizer.Email)
+		organizerName = strings.TrimSpace(snapshot.Organizer.Name)
+	}
+	expectedIsFromMe := organizerEmail != "" && identities.Contains(organizerEmail)
+
+	if existed && !opts.Force {
+		storedRaw, rawErr := a.store.GetMessageRaw(existingMessageID)
+		storedIsFromMe, attributionErr := a.store.GetMessageIsFromMe(existingMessageID)
+		if rawErr == nil && attributionErr == nil && bytes.Equal(storedRaw, snapshot.Raw) && storedIsFromMe == expectedIsFromMe {
+			if err := a.store.RecomputeConversationStatsForMessageContext(ctx, existingMessageID); err != nil {
+				return Result{}, fmt.Errorf("recompute meeting conversation stats: %w", err)
+			}
+			return Result{MessageID: existingMessageID}, nil
+		}
+	}
+
+	participants := make([]store.ParticipantPersistData, 0, len(snapshot.Attendees)+1)
+	hasOrganizer := organizerEmail != ""
+	if hasOrganizer {
+		participants = append(participants, store.ParticipantPersistData{
+			EmailAddress: organizerEmail,
+			DisplayName:  organizerName,
+			Domain:       emailDomain(organizerEmail),
+		})
+	}
+
+	attendeeNames := make([]string, 0, len(snapshot.Attendees))
+	attendeeEmails := make([]string, 0, len(snapshot.Attendees))
+	for _, attendee := range snapshot.Attendees {
+		if err := ctx.Err(); err != nil {
+			return Result{}, err
+		}
+		email := normalizeEmail(attendee.Email)
+		if email == "" {
+			continue
+		}
+		name := strings.TrimSpace(attendee.Name)
+		participants = append(participants, store.ParticipantPersistData{
+			EmailAddress: email,
+			DisplayName:  name,
+			Domain:       emailDomain(email),
+		})
+		attendeeNames = append(attendeeNames, name)
+		attendeeEmails = append(attendeeEmails, email)
+	}
+
+	conversationID := strings.TrimSpace(snapshot.SourceConversationID)
+	if conversationID == "" {
+		conversationID = snapshot.SourceMessageID
+	}
+	metadata := sql.NullString{String: string(snapshot.Metadata), Valid: len(snapshot.Metadata) > 0}
+	messageID, err := a.store.PersistMessageWithParticipantsContext(
+		ctx,
+		participants,
+		func(participantIDs []int64) *store.MessagePersistData {
+			attendeeOffset := 0
+			var senderID int64
+			var fromIDs []int64
+			var fromNames []string
+			var fromEmails []string
+			if hasOrganizer {
+				senderID = participantIDs[0]
+				attendeeOffset = 1
+				fromIDs = []int64{senderID}
+				fromNames = []string{organizerName}
+				fromEmails = []string{organizerEmail}
+			}
+			attendeeIDs := participantIDs[attendeeOffset:]
+			conversationParticipants := make([]store.ConversationParticipantRef, 0, len(attendeeIDs))
+			for _, participantID := range attendeeIDs {
+				conversationParticipants = append(conversationParticipants, store.ConversationParticipantRef{
+					ParticipantID: participantID,
+					Role:          "member",
+				})
+			}
+
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:                snapshot.SourceID,
+					SourceMessageID:         snapshot.SourceMessageID,
+					MessageType:             MessageType,
+					SentAt:                  sql.NullTime{Time: snapshot.StartedAt, Valid: !snapshot.StartedAt.IsZero()},
+					SenderID:                sql.NullInt64{Int64: senderID, Valid: senderID != 0},
+					IsFromMe:                expectedIsFromMe,
+					IdentityDerivedIsFromMe: expectedIsFromMe,
+					Subject:                 sql.NullString{String: snapshot.Title, Valid: snapshot.Title != ""},
+					Snippet:                 sql.NullString{String: snapshot.Snippet, Valid: snapshot.Snippet != ""},
+					SizeEstimate:            int64(len(snapshot.Body)),
+				},
+				Conversation: &store.ConversationPersistData{
+					SourceConversationID: conversationID,
+					ConversationType:     ConversationType,
+					Title:                snapshot.Title,
+					Participants:         conversationParticipants,
+				},
+				Metadata:  &metadata,
+				BodyText:  sql.NullString{String: snapshot.Body, Valid: snapshot.Body != ""},
+				RawMIME:   snapshot.Raw,
+				RawFormat: snapshot.RawFormat,
+				Recipients: []store.RecipientSet{
+					{
+						Type:           "from",
+						ParticipantIDs: fromIDs,
+						DisplayNames:   fromNames,
+						EmailAddresses: fromEmails,
+					},
+					{
+						Type:           "to",
+						ParticipantIDs: attendeeIDs,
+						DisplayNames:   attendeeNames,
+						EmailAddresses: attendeeEmails,
+					},
+				},
+				PreserveLabels: true,
+				FTS: &store.FTSDoc{
+					Subject:  snapshot.Title,
+					Body:     snapshot.Body,
+					FromAddr: organizerEmail,
+					ToAddrs:  strings.Join(attendeeEmails, " "),
+				},
+			}
+		},
+	)
+	if err != nil {
+		return Result{}, fmt.Errorf("persist meeting: %w", err)
+	}
+	result := Result{MessageID: messageID, Created: !existed, Changed: true}
+	if err := a.store.RecomputeConversationStatsForMessageContext(ctx, messageID); err != nil {
+		return result, fmt.Errorf("recompute meeting conversation stats: %w", err)
+	}
+	return result, nil
+}
+
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func emailDomain(email string) string {
+	at := strings.LastIndexByte(email, '@')
+	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return strings.ToLower(email[at+1:])
+}

--- a/internal/meetingarchive/archive_test.go
+++ b/internal/meetingarchive/archive_test.go
@@ -1,0 +1,163 @@
+package meetingarchive
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func testSnapshot(sourceID int64) Snapshot {
+	return Snapshot{
+		SourceID:             sourceID,
+		AccountEmail:         "user@example.com",
+		SourceMessageID:      "meeting-note-42",
+		SourceConversationID: "meeting-note-42",
+		Title:                "Weekly planning",
+		StartedAt:            time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC),
+		Body:                 "Weekly planning\n\nSummary:\nShip the importer.\n\nTranscript:\nTest Speaker: Ready.",
+		Snippet:              "Weekly planning",
+		Metadata:             []byte(`{"platform":"notion_meetings"}`),
+		Raw:                  []byte(`{"discovery":{"id":"meeting-note-42"}}`),
+		RawFormat:            "notion_meeting_json",
+		Organizer: &Person{
+			Name:  "Test Organizer",
+			Email: "organizer@example.com",
+		},
+		Attendees: []Person{{Name: "Test Attendee", Email: "attendee@example.com"}},
+	}
+}
+
+func TestArchiverCreatesProviderCanonicalMeeting(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("notion_meetings", "work")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(source.ID, "user@example.com", "account-email"))
+
+	result, err := New(st).Upsert(context.Background(), testSnapshot(source.ID), UpsertOptions{})
+	require.NoError(err)
+	assert.True(result.Created)
+	assert.True(result.Changed)
+	assert.NotZero(result.MessageID)
+
+	var (
+		messageType, sourceMessageID, subject string
+		conversationType, conversationID      string
+		body, rawFormat, metadata             string
+		sender                                sql.NullString
+		messageCount, participantCount        int
+	)
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT m.message_type, m.source_message_id, m.subject,
+		       c.conversation_type, c.source_conversation_id,
+		       mb.body_text, mr.raw_format, m.metadata, p.email_address,
+		       c.message_count, c.participant_count
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		JOIN message_bodies mb ON mb.message_id = m.id
+		JOIN message_raw mr ON mr.message_id = m.id
+		LEFT JOIN participants p ON p.id = m.sender_id
+		WHERE m.id = ?
+	`), result.MessageID).Scan(
+		&messageType, &sourceMessageID, &subject,
+		&conversationType, &conversationID,
+		&body, &rawFormat, &metadata, &sender,
+		&messageCount, &participantCount,
+	))
+	assert.Equal("meeting_transcript", messageType)
+	assert.Equal("meeting-note-42", sourceMessageID)
+	assert.Equal("Weekly planning", subject)
+	assert.Equal("meeting", conversationType)
+	assert.Equal("meeting-note-42", conversationID)
+	assert.Contains(body, "Test Speaker: Ready.")
+	assert.Equal("notion_meeting_json", rawFormat)
+	assert.JSONEq(`{"platform":"notion_meetings"}`, metadata)
+	assert.Equal("organizer@example.com", sender.String)
+	assert.Equal(1, messageCount)
+	assert.Equal(1, participantCount)
+
+	var recipient, recipientEnvelope string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT p.email_address, mr.email_address
+		FROM message_recipients mr
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE mr.message_id = ? AND mr.recipient_type = 'to'
+	`), result.MessageID).Scan(&recipient, &recipientEnvelope))
+	assert.Equal("attendee@example.com", recipient)
+	assert.Equal("attendee@example.com", recipientEnvelope)
+
+	var organizerEnvelope string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mr.email_address
+		FROM message_recipients mr
+		WHERE mr.message_id = ? AND mr.recipient_type = 'from'
+	`), result.MessageID).Scan(&organizerEnvelope))
+	assert.Equal("organizer@example.com", organizerEnvelope)
+
+	raw, err := st.GetMessageRaw(result.MessageID)
+	require.NoError(err)
+	assert.JSONEq(`{"discovery":{"id":"meeting-note-42"}}`, string(raw))
+}
+
+func TestArchiverUnchangedSnapshotIsNoOp(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("notion_meetings", "work")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(source.ID, "user@example.com", "account-email"))
+	archiver := New(st)
+
+	first, err := archiver.Upsert(context.Background(), testSnapshot(source.ID), UpsertOptions{})
+	require.NoError(err)
+	var before string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT CAST(last_modified AS TEXT) FROM messages WHERE id = ?`,
+	), first.MessageID).Scan(&before))
+
+	second, err := archiver.Upsert(context.Background(), testSnapshot(source.ID), UpsertOptions{})
+	require.NoError(err)
+	assert.False(second.Created)
+	assert.False(second.Changed)
+	assert.Equal(first.MessageID, second.MessageID)
+
+	var after string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT CAST(last_modified AS TEXT) FROM messages WHERE id = ?`,
+	), first.MessageID).Scan(&after))
+	assert.Equal(before, after)
+}
+
+func TestArchiverWithoutOrganizerDoesNotInventSender(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("notion_meetings", "work")
+	require.NoError(err)
+	require.NoError(st.AddAccountIdentity(source.ID, "user@example.com", "account-email"))
+	snapshot := testSnapshot(source.ID)
+	snapshot.Organizer = nil
+	snapshot.Attendees = nil
+	snapshot.Body = "Attendees: Unresolved User"
+
+	result, err := New(st).Upsert(context.Background(), snapshot, UpsertOptions{})
+	require.NoError(err)
+
+	var sender sql.NullInt64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT sender_id FROM messages WHERE id = ?`,
+	), result.MessageID).Scan(&sender))
+	assert.False(sender.Valid)
+
+	var participantCount int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM participants`,
+	).Scan(&participantCount))
+	assert.Zero(participantCount)
+}

--- a/internal/meetingimport/importer.go
+++ b/internal/meetingimport/importer.go
@@ -1,15 +1,13 @@
 package meetingimport
 
 import (
-	"bytes"
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 
-	"go.kenn.io/msgvault/internal/meetingidentity"
+	"go.kenn.io/msgvault/internal/meetingarchive"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -119,167 +117,52 @@ func (i *Importer) Import(ctx context.Context, req Request) (result Result, retE
 		}
 	}()
 
-	existing, err := i.store.MessageExistsBatch(source.ID, []string{snapshot.SourceMessageID})
-	if err != nil {
-		return result, fmt.Errorf("lookup existing meeting: %w", err)
-	}
-	identities, err := meetingidentity.ForSource(i.store, source.ID, snapshot.AccountEmail)
-	if err != nil {
-		return result, err
-	}
-
-	organizerEmail := ""
-	organizerName := ""
+	var organizer *meetingarchive.Person
 	if snapshot.Organizer != nil {
-		organizerEmail = snapshot.Organizer.Email
-		organizerName = snapshot.Organizer.Name
-	}
-	expectedIsFromMe := organizerEmail != "" && identities.Contains(organizerEmail)
-
-	existingMessageID, existed := existing[snapshot.SourceMessageID]
-	if existed {
-		result.Status = StatusUpdated
-		result.MessageID = existingMessageID
-
-		storedRaw, rawErr := i.store.GetMessageRaw(existingMessageID)
-		if rawErr == nil && bytes.Equal(storedRaw, snapshot.Raw) {
-			storedIsFromMe, attributionErr := i.store.GetMessageIsFromMe(existingMessageID)
-			if attributionErr == nil && storedIsFromMe == expectedIsFromMe {
-				if err := ctx.Err(); err != nil {
-					return result, err
-				}
-				checkpoint.MessagesProcessed = 1
-				if i.beforeCheckpointForTest != nil {
-					i.beforeCheckpointForTest()
-				}
-				if err := i.store.UpdateSyncCheckpointContext(ctx, syncID, checkpoint); err != nil {
-					return result, fmt.Errorf("checkpoint meeting import sync: %w", err)
-				}
-				if err := i.store.RecomputeConversationStatsForMessageContext(ctx, existingMessageID); err != nil {
-					return result, fmt.Errorf("recompute meeting conversation stats: %w", err)
-				}
-				if err := i.store.CompleteSyncContext(ctx, syncID, ""); err != nil {
-					return result, fmt.Errorf("complete meeting import sync: %w", err)
-				}
-				i.refreshCache(ctx, SourceType+":"+snapshot.SourceIdentifier,
-					source.ID, snapshot.SourceMessageID)
-				return result, nil
-			}
+		organizer = &meetingarchive.Person{
+			Name:  snapshot.Organizer.Name,
+			Email: snapshot.Organizer.Email,
 		}
-		// Missing or unreadable canonical data, or mismatched derived
-		// attribution, is not a match. Continue through the transactional
-		// persistence path so a valid retry repairs the message; genuine
-		// storage failures surface from that rewrite.
 	}
-
-	participants := make(
-		[]store.ParticipantPersistData,
-		0,
-		len(snapshot.Attendees)+1,
-	)
-	hasOrganizer := snapshot.Organizer != nil
-	if hasOrganizer {
-		participants = append(participants, store.ParticipantPersistData{
-			EmailAddress: organizerEmail,
-			DisplayName:  organizerName,
-			Domain:       emailDomain(organizerEmail),
-		})
-	}
-
-	attendeeNames := make([]string, 0, len(snapshot.Attendees))
-	attendeeEmails := make([]string, 0, len(snapshot.Attendees))
+	attendees := make([]meetingarchive.Person, 0, len(snapshot.Attendees))
 	for _, attendee := range snapshot.Attendees {
-		if err := ctx.Err(); err != nil {
-			return result, err
-		}
-		participants = append(participants, store.ParticipantPersistData{
-			EmailAddress: attendee.Email,
-			DisplayName:  attendee.Name,
-			Domain:       emailDomain(attendee.Email),
+		attendees = append(attendees, meetingarchive.Person{
+			Name:  attendee.Name,
+			Email: attendee.Email,
 		})
-		attendeeNames = append(attendeeNames, attendee.Name)
-		attendeeEmails = append(attendeeEmails, attendee.Email)
 	}
-
-	metadata := sql.NullString{String: string(snapshot.Metadata), Valid: true}
-	messageID, err := i.store.PersistMessageWithParticipantsContext(
-		ctx,
-		participants,
-		func(participantIDs []int64) *store.MessagePersistData {
-			attendeeOffset := 0
-			var senderID int64
-			var fromIDs []int64
-			var fromNames []string
-			if hasOrganizer {
-				senderID = participantIDs[0]
-				attendeeOffset = 1
-				fromIDs = []int64{senderID}
-				fromNames = []string{organizerName}
-			}
-			attendeeIDs := participantIDs[attendeeOffset:]
-			conversationParticipants := make(
-				[]store.ConversationParticipantRef,
-				0,
-				len(attendeeIDs),
-			)
-			for _, participantID := range attendeeIDs {
-				conversationParticipants = append(
-					conversationParticipants,
-					store.ConversationParticipantRef{
-						ParticipantID: participantID,
-						Role:          "member",
-					},
-				)
-			}
-
-			return &store.MessagePersistData{
-				Message: &store.Message{
-					SourceID:                source.ID,
-					SourceMessageID:         snapshot.SourceMessageID,
-					MessageType:             MessageType,
-					SentAt:                  sql.NullTime{Time: snapshot.StartedAt, Valid: true},
-					SenderID:                sql.NullInt64{Int64: senderID, Valid: senderID != 0},
-					IsFromMe:                expectedIsFromMe,
-					IdentityDerivedIsFromMe: expectedIsFromMe,
-					Subject:                 sql.NullString{String: snapshot.Title, Valid: snapshot.Title != ""},
-					Snippet:                 sql.NullString{String: snapshot.Snippet, Valid: snapshot.Snippet != ""},
-					SizeEstimate:            int64(len(snapshot.Body)),
-				},
-				Conversation: &store.ConversationPersistData{
-					SourceConversationID: snapshot.SourceMessageID,
-					ConversationType:     ConversationType,
-					Title:                snapshot.Title,
-					Participants:         conversationParticipants,
-				},
-				Metadata:  &metadata,
-				BodyText:  sql.NullString{String: snapshot.Body, Valid: snapshot.Body != ""},
-				RawMIME:   snapshot.Raw,
-				RawFormat: RawFormat,
-				Recipients: []store.RecipientSet{
-					{Type: "from", ParticipantIDs: fromIDs, DisplayNames: fromNames},
-					{Type: "to", ParticipantIDs: attendeeIDs, DisplayNames: attendeeNames},
-				},
-				PreserveLabels: true,
-				FTS: &store.FTSDoc{
-					Subject:  snapshot.Title,
-					Body:     snapshot.Body,
-					FromAddr: organizerEmail,
-					ToAddrs:  strings.Join(attendeeEmails, " "),
-				},
-			}
-		},
-	)
-	if err != nil {
-		return result, fmt.Errorf("persist meeting: %w", err)
-	}
-	result.MessageID = messageID
-	result.Status = StatusCreated
-	checkpoint.MessagesProcessed = 1
-	checkpoint.MessagesAdded = 1
-	if existed {
+	archiveResult, archiveErr := meetingarchive.New(i.store).Upsert(ctx, meetingarchive.Snapshot{
+		SourceID:             source.ID,
+		AccountEmail:         snapshot.AccountEmail,
+		SourceMessageID:      snapshot.SourceMessageID,
+		SourceConversationID: snapshot.SourceMessageID,
+		Title:                snapshot.Title,
+		StartedAt:            snapshot.StartedAt,
+		Body:                 snapshot.Body,
+		Snippet:              snapshot.Snippet,
+		Metadata:             snapshot.Metadata,
+		Raw:                  snapshot.Raw,
+		RawFormat:            RawFormat,
+		Organizer:            organizer,
+		Attendees:            attendees,
+	}, meetingarchive.UpsertOptions{})
+	if archiveResult.MessageID != 0 {
+		result.MessageID = archiveResult.MessageID
 		result.Status = StatusUpdated
-		checkpoint.MessagesAdded = 0
-		checkpoint.MessagesUpdated = 1
+		checkpoint.MessagesProcessed = 1
+		if archiveResult.Created {
+			result.Status = StatusCreated
+			checkpoint.MessagesAdded = 1
+		} else if archiveResult.Changed {
+			checkpoint.MessagesUpdated = 1
+		}
+	}
+	if archiveErr != nil {
+		if archiveResult.Changed {
+			i.refreshCache(context.WithoutCancel(ctx), SourceType+":"+snapshot.SourceIdentifier,
+				source.ID, snapshot.SourceMessageID)
+		}
+		return result, archiveErr
 	}
 
 	if i.beforeCheckpointForTest != nil {
@@ -287,9 +170,6 @@ func (i *Importer) Import(ctx context.Context, req Request) (result Result, retE
 	}
 	if err := i.store.UpdateSyncCheckpointContext(ctx, syncID, checkpoint); err != nil {
 		return result, fmt.Errorf("checkpoint meeting import sync: %w", err)
-	}
-	if err := i.store.RecomputeConversationStatsForMessageContext(ctx, messageID); err != nil {
-		return result, fmt.Errorf("recompute meeting conversation stats: %w", err)
 	}
 	if err := i.store.CompleteSyncContext(ctx, syncID, ""); err != nil {
 		return result, fmt.Errorf("complete meeting import sync: %w", err)
@@ -319,12 +199,4 @@ func (i *Importer) refreshCache(ctx context.Context, label string, sourceID int6
 			"error", err,
 		)
 	}
-}
-
-func emailDomain(email string) string {
-	at := strings.LastIndexByte(email, '@')
-	if at < 0 || at == len(email)-1 {
-		return ""
-	}
-	return strings.ToLower(email[at+1:])
 }

--- a/internal/notionmeetings/client.go
+++ b/internal/notionmeetings/client.go
@@ -1,0 +1,355 @@
+package notionmeetings
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/httpretry"
+)
+
+const (
+	maxRetries      = 8
+	maxResponseSize = int64(16 << 20)
+	maxRetryAfter   = httpretry.ProviderMaxRetryAfter
+	maxQueryResults = 50
+	pageSize        = 100
+)
+
+var (
+	ErrUnauthorized      = errors.New("notion integration token is invalid or expired")
+	ErrMeetingAccess     = errors.New("notion AI Meeting Notes access is unavailable")
+	ErrReadContent       = errors.New("notion integration lacks Read Content access")
+	ErrUserInformation   = errors.New("notion integration lacks User Information access")
+	ErrRateLimited       = errors.New("notion rate limit retry budget exhausted")
+	ErrMalformedResponse = errors.New("notion returned a malformed response")
+	ErrProvider          = errors.New("notion API request failed")
+)
+
+type APIError struct {
+	Kind   error  `json:"-"`
+	Status int    `json:"status"`
+	Code   string `json:"code,omitempty"`
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ErrProvider.Error()
+	}
+	return fmt.Sprintf("%s (status %d, code %s)", e.Kind, e.Status, e.Code)
+}
+
+func (e *APIError) Unwrap() error {
+	if e == nil || e.Kind == nil {
+		return ErrProvider
+	}
+	return e.Kind
+}
+
+type Client struct {
+	baseURL string
+	token   string
+	http    *http.Client
+	wait    func(context.Context, time.Duration) error
+}
+
+func NewClient(baseURL, token string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		wait:    waitContext,
+	}
+}
+
+func (c *Client) QueryMeetingNotes(ctx context.Context, limit int) (*QueryResult, error) {
+	if limit <= 0 || limit > maxQueryResults {
+		limit = maxQueryResults
+	}
+	payload := struct {
+		Sort []struct {
+			Property  string `json:"property"`
+			Direction string `json:"direction"`
+		} `json:"sort"`
+		Limit int `json:"limit"`
+	}{Limit: limit}
+	payload.Sort = append(payload.Sort, struct {
+		Property  string `json:"property"`
+		Direction string `json:"direction"`
+	}{Property: "created_time", Direction: "descending"})
+	var result QueryResult
+	raw, err := c.doJSON(ctx, http.MethodPost, "/v1/blocks/meeting_notes/query", payload, &result, operationQuery)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateListEnvelope(raw); err != nil {
+		return nil, err
+	}
+	for index := range result.Results {
+		if err := validateBlockResponse(result.Results[index].Raw, "", "meeting_notes"); err != nil {
+			return nil, fmt.Errorf("validate meeting-note query result %d: %w", index, err)
+		}
+	}
+	result.Raw = raw
+	return &result, nil
+}
+
+func (c *Client) RetrieveBlock(ctx context.Context, blockID string) (*Block, error) {
+	var result Block
+	raw, err := c.doJSON(ctx, http.MethodGet, "/v1/blocks/"+url.PathEscape(blockID), nil, &result, operationContent)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateBlockResponse(raw, blockID, ""); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) RetrieveBlockChildren(ctx context.Context, blockID, cursor string) (*BlockPage, error) {
+	query := url.Values{"page_size": {strconv.Itoa(pageSize)}}
+	if cursor != "" {
+		query.Set("start_cursor", cursor)
+	}
+	path := "/v1/blocks/" + url.PathEscape(blockID) + "/children?" + query.Encode()
+	var result BlockPage
+	raw, err := c.doJSON(ctx, http.MethodGet, path, nil, &result, operationContent)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateListEnvelope(raw); err != nil {
+		return nil, err
+	}
+	for index := range result.Results {
+		if err := validateBlockResponse(result.Results[index].Raw, "", ""); err != nil {
+			return nil, fmt.Errorf("validate block child %d: %w", index, err)
+		}
+	}
+	result.Raw = raw
+	return &result, nil
+}
+
+func (c *Client) RetrievePageMarkdown(ctx context.Context, pageID string, includeTranscript bool) (*MarkdownPage, error) {
+	query := url.Values{}
+	if includeTranscript {
+		query.Set("include_transcript", "true")
+	}
+	path := "/v1/pages/" + url.PathEscape(pageID) + "/markdown"
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+	var result MarkdownPage
+	raw, err := c.doJSON(ctx, http.MethodGet, path, nil, &result, operationContent)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateMarkdownResponse(raw, pageID); err != nil {
+		return nil, err
+	}
+	result.Raw = raw
+	return &result, nil
+}
+
+func (c *Client) ListUsers(ctx context.Context, cursor string) (*UserPage, error) {
+	query := url.Values{"page_size": {strconv.Itoa(pageSize)}}
+	if cursor != "" {
+		query.Set("start_cursor", cursor)
+	}
+	var result UserPage
+	raw, err := c.doJSON(ctx, http.MethodGet, "/v1/users?"+query.Encode(), nil, &result, operationUsers)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateListEnvelope(raw); err != nil {
+		return nil, err
+	}
+	result.Raw = raw
+	return &result, nil
+}
+
+func validateListEnvelope(raw json.RawMessage) error {
+	var envelope struct {
+		Results *json.RawMessage `json:"results"`
+		HasMore *bool            `json:"has_more"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: decode list response: %w", ErrMalformedResponse, err)
+	}
+	if envelope.Results == nil || envelope.HasMore == nil {
+		return fmt.Errorf("%w: list response is missing required fields", ErrMalformedResponse)
+	}
+	return nil
+}
+
+func validateBlockResponse(raw json.RawMessage, expectedID, expectedType string) error {
+	var envelope struct {
+		Object      *string `json:"object"`
+		ID          *string `json:"id"`
+		Type        *string `json:"type"`
+		HasChildren *bool   `json:"has_children"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: decode block response: %w", ErrMalformedResponse, err)
+	}
+	if envelope.Object == nil || *envelope.Object != "block" || envelope.ID == nil ||
+		strings.TrimSpace(*envelope.ID) == "" || envelope.Type == nil || strings.TrimSpace(*envelope.Type) == "" ||
+		envelope.HasChildren == nil {
+		return fmt.Errorf("%w: block response is missing required fields", ErrMalformedResponse)
+	}
+	if expectedID != "" && *envelope.ID != expectedID {
+		return fmt.Errorf("%w: block response ID does not match the request", ErrMalformedResponse)
+	}
+	if expectedType != "" && *envelope.Type != expectedType {
+		return fmt.Errorf("%w: block response has unexpected type", ErrMalformedResponse)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return fmt.Errorf("%w: decode block fields: %w", ErrMalformedResponse, err)
+	}
+	payload, ok := fields[*envelope.Type]
+	if !ok {
+		return fmt.Errorf("%w: block response is missing its type payload", ErrMalformedResponse)
+	}
+	var typePayload map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &typePayload); err != nil || typePayload == nil {
+		return fmt.Errorf("%w: block response has an invalid type payload", ErrMalformedResponse)
+	}
+	return nil
+}
+
+func validateMarkdownResponse(raw json.RawMessage, expectedID string) error {
+	var envelope struct {
+		Object          *string   `json:"object"`
+		ID              *string   `json:"id"`
+		Markdown        *string   `json:"markdown"`
+		Truncated       *bool     `json:"truncated"`
+		UnknownBlockIDs *[]string `json:"unknown_block_ids"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: decode page Markdown response: %w", ErrMalformedResponse, err)
+	}
+	if envelope.Object == nil || *envelope.Object != "page_markdown" || envelope.ID == nil ||
+		strings.TrimSpace(*envelope.ID) == "" || envelope.Markdown == nil || envelope.Truncated == nil ||
+		envelope.UnknownBlockIDs == nil {
+		return fmt.Errorf("%w: page Markdown response is missing required fields", ErrMalformedResponse)
+	}
+	if *envelope.ID != expectedID {
+		return fmt.Errorf("%w: page Markdown response ID does not match the request", ErrMalformedResponse)
+	}
+	return nil
+}
+
+type operation int
+
+const (
+	operationQuery operation = iota
+	operationContent
+	operationUsers
+)
+
+func (c *Client) doJSON(ctx context.Context, method, path string, payload any, target any, op operation) (json.RawMessage, error) {
+	var encoded []byte
+	var err error
+	if payload != nil {
+		encoded, err = json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("encode Notion request: %w", err)
+		}
+	}
+	for attempt := range maxRetries {
+		var bodyReader io.Reader
+		if encoded != nil {
+			bodyReader = bytes.NewReader(encoded)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bodyReader)
+		if err != nil {
+			return nil, fmt.Errorf("build Notion request: %w", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Notion-Version", APIVersion)
+		req.Header.Set("Accept", "application/json")
+		if encoded != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := c.http.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("perform Notion request: %w", err)
+		}
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return nil, fmt.Errorf("read Notion response: %w", readErr)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close Notion response: %w", closeErr)
+		}
+		if int64(len(body)) > maxResponseSize {
+			return nil, fmt.Errorf("%w: response exceeds %d bytes", ErrMalformedResponse, maxResponseSize)
+		}
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			if err := json.Unmarshal(body, target); err != nil {
+				return nil, fmt.Errorf("%w: decode response: %w", ErrMalformedResponse, err)
+			}
+			return append(json.RawMessage(nil), body...), nil
+		}
+
+		var providerErr struct {
+			Code string `json:"code"`
+		}
+		_ = json.Unmarshal(body, &providerErr)
+		if transientStatus(resp.StatusCode) {
+			if attempt == maxRetries-1 {
+				return nil, &APIError{Kind: ErrRateLimited, Status: resp.StatusCode, Code: providerErr.Code}
+			}
+			delay := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
+			if err := c.wait(ctx, delay); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		return nil, &APIError{Kind: classifyError(resp.StatusCode, op), Status: resp.StatusCode, Code: providerErr.Code}
+	}
+	return nil, ErrProvider
+}
+
+func transientStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status == http.StatusInternalServerError ||
+		status == http.StatusBadGateway || status == http.StatusServiceUnavailable ||
+		status == http.StatusGatewayTimeout || status == 529
+}
+
+func classifyError(status int, op operation) error {
+	if status == http.StatusUnauthorized {
+		return ErrUnauthorized
+	}
+	if status == http.StatusForbidden {
+		switch op {
+		case operationQuery:
+			return ErrMeetingAccess
+		case operationUsers:
+			return ErrUserInformation
+		default:
+			return ErrReadContent
+		}
+	}
+	return ErrProvider
+}
+
+func waitContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/notionmeetings/client_test.go
+++ b/internal/notionmeetings/client_test.go
@@ -1,0 +1,409 @@
+package notionmeetings
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientQueryMeetingNotesUsesDocumentedReadContract(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/v1/blocks/meeting_notes/query", r.URL.Path)
+		assert.Equal("Bearer ntn_test_secret", r.Header.Get("Authorization"))
+		assert.Equal(APIVersion, r.Header.Get("Notion-Version"))
+		assert.Equal("application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(err)
+		assert.JSONEq(`{
+			"sort":[{"property":"created_time","direction":"descending"}],
+			"limit":50
+		}`, string(body))
+		_, err = io.WriteString(w, `{
+			"results":[{
+				"object":"block",
+				"id":"meeting-1",
+				"type":"meeting_notes",
+				"meeting_notes":{
+					"title":[{"plain_text":"Weekly planning"}],
+					"status":"notes_ready",
+					"children":{"summary_block_id":"summary-1","transcript_block_id":"transcript-1"},
+					"calendar_event":{"start_time":"2026-08-29T10:00:00Z","end_time":"2026-08-29T10:30:00Z","attendees":["user-1"]}
+				},
+				"created_time":"2026-08-29T09:59:00Z",
+				"last_edited_time":"2026-08-29T10:35:00Z",
+				"created_by":{"id":"creator-1","object":"user"},
+				"parent":{"type":"page_id","page_id":"page-1"},
+				"has_children":true,
+				"future_field":{"kept":true}
+			}],
+			"has_more":true
+		}`)
+		assert.NoError(err)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ntn_test_secret")
+	result, err := client.QueryMeetingNotes(context.Background(), 50)
+	require.NoError(err)
+	require.Len(result.Results, 1)
+	assert.True(result.HasMore)
+	assert.Equal("meeting-1", result.Results[0].ID)
+	assert.Equal("Weekly planning", result.Results[0].Title())
+	assert.Equal("page-1", result.Results[0].Parent.PageID)
+	assert.Equal("summary-1", result.Results[0].MeetingNotes.Children.SummaryBlockID)
+	assert.JSONEq(`{"kept":true}`, string(result.Results[0].Extra["future_field"]))
+	assert.Contains(string(result.Results[0].Raw), `"future_field"`)
+}
+
+func TestClientReadEndpointsPreserveRawResponses(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(APIVersion, r.Header.Get("Notion-Version"))
+		assert.Equal("Bearer ntn_test", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/v1/blocks/block-1":
+			assert.Equal(http.MethodGet, r.Method)
+			_, _ = io.WriteString(w, `{"object":"block","id":"block-1","type":"paragraph","has_children":false,"paragraph":{"rich_text":[{"plain_text":"Hello"}]}}`)
+		case "/v1/blocks/block-1/children":
+			assert.Equal("cursor-1", r.URL.Query().Get("start_cursor"))
+			assert.Equal("100", r.URL.Query().Get("page_size"))
+			_, _ = io.WriteString(w, `{"object":"list","results":[{"object":"block","id":"child-1","type":"paragraph","has_children":false,"paragraph":{}}],"next_cursor":"cursor-2","has_more":true}`)
+		case "/v1/pages/page-1/markdown":
+			assert.Equal("true", r.URL.Query().Get("include_transcript"))
+			_, _ = io.WriteString(w, `{"object":"page_markdown","id":"page-1","markdown":"# Weekly planning\nTranscript: Ready","truncated":false,"unknown_block_ids":[]}`)
+		case "/v1/users":
+			assert.Equal("users-1", r.URL.Query().Get("start_cursor"))
+			assert.Equal("100", r.URL.Query().Get("page_size"))
+			_, _ = io.WriteString(w, `{"object":"list","results":[{"object":"user","id":"user-1","name":"Test User","type":"person","person":{"email":"user@example.com","email_verified":true}}],"next_cursor":null,"has_more":false}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ntn_test")
+	block, err := client.RetrieveBlock(context.Background(), "block-1")
+	require.NoError(err)
+	assert.Equal("Hello", block.PlainText())
+	assert.Contains(string(block.Raw), `"paragraph"`)
+
+	children, err := client.RetrieveBlockChildren(context.Background(), "block-1", "cursor-1")
+	require.NoError(err)
+	require.Len(children.Results, 1)
+	assert.Equal("cursor-2", children.NextCursor)
+	assert.Contains(string(children.Raw), `"child-1"`)
+
+	markdown, err := client.RetrievePageMarkdown(context.Background(), "page-1", true)
+	require.NoError(err)
+	assert.Contains(markdown.Markdown, "Transcript: Ready")
+	assert.Contains(string(markdown.Raw), `"page_markdown"`)
+
+	users, err := client.ListUsers(context.Background(), "users-1")
+	require.NoError(err)
+	require.Len(users.Results, 1)
+	assert.Equal("user@example.com", users.Results[0].Person.Email)
+	assert.True(users.Results[0].Person.EmailVerified)
+}
+
+func TestClientClassifiesAndSanitizesProviderErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		status    int
+		code      string
+		wantError error
+	}{
+		{name: "unauthorized", path: "/query", status: http.StatusUnauthorized, code: "unauthorized", wantError: ErrUnauthorized},
+		{name: "meeting access", path: "/query", status: http.StatusForbidden, code: "restricted_resource", wantError: ErrMeetingAccess},
+		{name: "read content", path: "/block", status: http.StatusForbidden, code: "restricted_resource", wantError: ErrReadContent},
+		{name: "user information", path: "/users", status: http.StatusForbidden, code: "restricted_resource", wantError: ErrUserInformation},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, `{"object":"error","code":"`+tc.code+`","message":"private meeting title ntn_test_secret"}`)
+			}))
+			defer server.Close()
+			client := NewClient(server.URL, "ntn_test_secret")
+
+			var err error
+			switch tc.path {
+			case "/query":
+				_, err = client.QueryMeetingNotes(context.Background(), 1)
+			case "/block":
+				_, err = client.RetrieveBlock(context.Background(), "block-1")
+			case "/users":
+				_, err = client.ListUsers(context.Background(), "")
+			}
+			require.Error(err)
+			require.ErrorIs(err, tc.wantError)
+			assert.NotContains(err.Error(), "private meeting title")
+			assert.NotContains(err.Error(), "ntn_test_secret")
+		})
+	}
+}
+
+func TestClientRetriesRateLimitThenReturnsQuery(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.Header().Set("Retry-After", "120")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, `{"object":"error","code":"rate_limited","message":"slow down"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"results":[],"has_more":false}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "ntn_test")
+	var waits []time.Duration
+	client.wait = func(_ context.Context, duration time.Duration) error {
+		waits = append(waits, duration)
+		return nil
+	}
+	result, err := client.QueryMeetingNotes(context.Background(), 50)
+	require.NoError(err)
+	assert.Empty(result.Results)
+	assert.Equal(3, attempts)
+	require.Len(waits, 2)
+	for _, wait := range waits {
+		assert.LessOrEqual(wait, maxRetryAfter)
+	}
+}
+
+func TestClientRejectsMalformedSuccessWithoutLeakingBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"results":[private meeting content]}`)
+	}))
+	defer server.Close()
+
+	_, err := NewClient(server.URL, "ntn_test").QueryMeetingNotes(context.Background(), 50)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrMalformedResponse)
+	assert.NotContains(t, err.Error(), "private meeting content")
+}
+
+func TestClientQueryMeetingNotesRejectsMalformedListEnvelopes(t *testing.T) {
+	const responseSentinel = "private meeting response sentinel"
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty object", body: `{}`},
+		{name: "null", body: `null`},
+		{name: "missing has more", body: `{"results":[],"private":"` + responseSentinel + `"}`},
+		{name: "missing results", body: `{"has_more":false}`},
+		{name: "null results", body: `{"results":null,"has_more":false}`},
+		{name: "null has more", body: `{"results":[],"has_more":null}`},
+		{name: "wrong results type", body: `{"results":{},"has_more":false}`},
+		{name: "wrong has more type", body: `{"results":[],"has_more":"false"}`},
+		{name: "empty body", body: ``},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newStaticNotionClient(t, tc.body)
+
+			result, err := client.QueryMeetingNotes(context.Background(), 50)
+
+			require.ErrorIs(t, err, ErrMalformedResponse)
+			assert.Nil(t, result)
+			assert.NotContains(t, err.Error(), responseSentinel)
+		})
+	}
+}
+
+func TestClientQueryMeetingNotesAcceptsCompleteListEnvelopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantResult int
+	}{
+		{
+			name: "empty page without next cursor",
+			body: `{"results":[],"has_more":false}`,
+		},
+		{
+			name: "canonical page with null next cursor",
+			body: `{
+				"object":"list",
+				"results":[{"object":"block","id":"meeting-1","type":"meeting_notes","has_children":false,"meeting_notes":{"title":[]}}],
+				"next_cursor":null,
+				"has_more":false
+			}`,
+			wantResult: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newStaticNotionClient(t, tc.body)
+
+			result, err := client.QueryMeetingNotes(context.Background(), 50)
+
+			require.NoError(t, err)
+			assert.Len(t, result.Results, tc.wantResult)
+		})
+	}
+}
+
+func TestClientQueryMeetingNotesRejectsNonMeetingBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		block string
+	}{
+		{
+			name:  "wrong object",
+			block: `{"object":"page","id":"meeting-1","type":"meeting_notes","has_children":false,"meeting_notes":{}}`,
+		},
+		{
+			name:  "wrong block type",
+			block: `{"object":"block","id":"meeting-1","type":"paragraph","has_children":false,"paragraph":{}}`,
+		},
+		{
+			name:  "missing required block field",
+			block: `{"object":"block","id":"meeting-1","type":"meeting_notes","meeting_notes":{}}`,
+		},
+		{
+			name:  "missing meeting payload",
+			block: `{"object":"block","id":"meeting-1","type":"meeting_notes","has_children":false}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newStaticNotionClient(t, `{"results":[`+tt.block+`],"has_more":false}`)
+
+			result, err := client.QueryMeetingNotes(context.Background(), 50)
+
+			require.ErrorIs(t, err, ErrMalformedResponse)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestClientOtherListEndpointsRejectMalformedEnvelopes(t *testing.T) {
+	t.Run("block children", func(t *testing.T) {
+		client := newStaticNotionClient(t, `{}`)
+
+		result, err := client.RetrieveBlockChildren(context.Background(), "block-1", "")
+
+		require.ErrorIs(t, err, ErrMalformedResponse)
+		assert.Nil(t, result)
+	})
+
+	t.Run("users", func(t *testing.T) {
+		client := newStaticNotionClient(t, `null`)
+
+		result, err := client.ListUsers(context.Background(), "")
+
+		require.ErrorIs(t, err, ErrMalformedResponse)
+		assert.Nil(t, result)
+	})
+}
+
+func TestClientOtherListEndpointsAllowOptionalNextCursor(t *testing.T) {
+	t.Run("block children without next cursor", func(t *testing.T) {
+		client := newStaticNotionClient(t, `{"results":[],"has_more":false}`)
+
+		result, err := client.RetrieveBlockChildren(context.Background(), "block-1", "")
+
+		require.NoError(t, err)
+		assert.Empty(t, result.NextCursor)
+	})
+
+	t.Run("users with null next cursor", func(t *testing.T) {
+		client := newStaticNotionClient(t, `{"results":[],"next_cursor":null,"has_more":false}`)
+
+		result, err := client.ListUsers(context.Background(), "")
+
+		require.NoError(t, err)
+		assert.Empty(t, result.NextCursor)
+	})
+}
+
+func TestClientRejectsMalformedBlockResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing fields", body: `{}`},
+		{name: "wrong ID", body: `{"object":"block","id":"other","type":"paragraph","has_children":false,"paragraph":{}}`},
+		{name: "missing child flag", body: `{"object":"block","id":"block-1","type":"paragraph","paragraph":{}}`},
+		{name: "missing type payload", body: `{"object":"block","id":"block-1","type":"paragraph","has_children":false}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := newStaticNotionClient(t, tc.body).RetrieveBlock(context.Background(), "block-1")
+
+			require.ErrorIs(t, err, ErrMalformedResponse)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func TestClientRejectsMalformedBlockChildren(t *testing.T) {
+	client := newStaticNotionClient(t, `{
+		"results":[{"object":"block","id":"child-1","type":"paragraph","has_children":false}],
+		"has_more":false
+	}`)
+
+	result, err := client.RetrieveBlockChildren(context.Background(), "block-1", "")
+
+	require.ErrorIs(t, err, ErrMalformedResponse)
+	assert.Nil(t, result)
+}
+
+func TestClientRejectsMalformedPageMarkdownResponses(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing fields", body: `{}`},
+		{name: "wrong ID", body: `{"object":"page_markdown","id":"other","markdown":"","truncated":false,"unknown_block_ids":[]}`},
+		{name: "missing Markdown", body: `{"object":"page_markdown","id":"page-1","truncated":false,"unknown_block_ids":[]}`},
+		{name: "missing completeness fields", body: `{"object":"page_markdown","id":"page-1","markdown":""}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := newStaticNotionClient(t, tc.body).RetrievePageMarkdown(context.Background(), "page-1", true)
+
+			require.ErrorIs(t, err, ErrMalformedResponse)
+			assert.Nil(t, result)
+		})
+	}
+}
+
+func newStaticNotionClient(t *testing.T, body string) *Client {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := io.WriteString(w, body)
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	return NewClient(server.URL, "ntn_test")
+}
+
+func TestAPIErrorSupportsErrorsIs(t *testing.T) {
+	err := &APIError{Kind: ErrMeetingAccess, Status: http.StatusForbidden, Code: "restricted_resource"}
+	require.ErrorIs(t, err, ErrMeetingAccess)
+	encoded, marshalErr := json.Marshal(err)
+	require.NoError(t, marshalErr)
+	assert.NotContains(t, string(encoded), "token")
+}

--- a/internal/notionmeetings/client_test.go
+++ b/internal/notionmeetings/client_test.go
@@ -116,6 +116,29 @@ func TestClientReadEndpointsPreserveRawResponses(t *testing.T) {
 	assert.True(users.Results[0].Person.EmailVerified)
 }
 
+func TestBlockPlainTextExtractsContentBearingPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "heading 4", raw: `{"type":"heading_4","heading_4":{"rich_text":[{"plain_text":"Decisions"}]}}`, want: "Decisions"},
+		{name: "code and caption", raw: `{"type":"code","code":{"rich_text":[{"plain_text":"ship()"}],"caption":[{"plain_text":"Example"}]}}`, want: "ship()\nExample"},
+		{name: "media caption", raw: `{"type":"image","image":{"caption":[{"plain_text":"Architecture diagram"}]}}`, want: "Architecture diagram"},
+		{name: "child title", raw: `{"type":"child_page","child_page":{"title":"Project notes"}}`, want: "Project notes"},
+		{name: "equation", raw: `{"type":"equation","equation":{"expression":"e=mc^2"}}`, want: "e=mc^2"},
+		{name: "table row", raw: `{"type":"table_row","table_row":{"cells":[[{"plain_text":"Owner"}],[{"plain_text":"Status"}]]}}`, want: "Owner\nStatus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var block Block
+			require.NoError(t, json.Unmarshal([]byte(tt.raw), &block))
+			assert.Equal(t, tt.want, block.PlainText())
+		})
+	}
+}
+
 func TestClientClassifiesAndSanitizesProviderErrors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/notionmeetings/format.go
+++ b/internal/notionmeetings/format.go
@@ -1,0 +1,196 @@
+package notionmeetings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/meetingarchive"
+)
+
+type meetingMetadata struct {
+	Platform                   string         `json:"platform"`
+	SourceIdentifier           string         `json:"source_identifier,omitempty"`
+	MeetingNoteBlockID         string         `json:"meeting_note_block_id"`
+	PageID                     string         `json:"page_id"`
+	Status                     string         `json:"status,omitempty"`
+	Lifecycle                  string         `json:"lifecycle"`
+	CreatorUserID              string         `json:"creator_user_id,omitempty"`
+	StartedAt                  string         `json:"started_at"`
+	EndedAt                    string         `json:"ended_at,omitempty"`
+	SummaryBlockID             string         `json:"summary_block_id,omitempty"`
+	NotesBlockID               string         `json:"notes_block_id,omitempty"`
+	TranscriptBlockID          string         `json:"transcript_block_id,omitempty"`
+	HasSummary                 bool           `json:"has_summary"`
+	HasNotes                   bool           `json:"has_notes"`
+	HasTranscript              bool           `json:"has_transcript"`
+	MarkdownTranscriptFallback bool           `json:"markdown_transcript_fallback,omitempty"`
+	UnresolvedAttendeeIDs      []string       `json:"unresolved_attendee_ids,omitempty"`
+	ResolvedUsers              []resolvedUser `json:"resolved_users,omitempty"`
+	Warnings                   []string       `json:"warnings,omitempty"`
+}
+
+type rawBlockTree struct {
+	Root  json.RawMessage   `json:"root,omitempty"`
+	Pages []json.RawMessage `json:"pages,omitempty"`
+}
+
+type rawEvidence struct {
+	SchemaVersion  int               `json:"schema_version"`
+	Discovery      json.RawMessage   `json:"discovery"`
+	MeetingBlock   json.RawMessage   `json:"meeting_block"`
+	Summary        rawBlockTree      `json:"summary,omitzero"`
+	Notes          rawBlockTree      `json:"notes,omitzero"`
+	Transcript     rawBlockTree      `json:"transcript,omitzero"`
+	PageMarkdown   json.RawMessage   `json:"page_markdown"`
+	Canonical      canonicalEvidence `json:"canonical"`
+	AttendeeLabels []string          `json:"attendee_labels,omitempty"`
+	ResolvedUsers  []resolvedUser    `json:"resolved_users,omitempty"`
+	Warnings       []string          `json:"warnings,omitempty"`
+}
+
+type canonicalEvidence struct {
+	Summary    string `json:"summary,omitempty"`
+	Notes      string `json:"notes,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
+}
+
+func (h *HydratedMeeting) ArchiveSnapshot(sourceID int64, identifier, accountEmail string) (meetingarchive.Snapshot, error) {
+	startedAt, endedAt := h.times()
+	if startedAt.IsZero() {
+		return meetingarchive.Snapshot{}, fmt.Errorf("notion meeting %s has no usable start or creation time", h.Discovery.ID)
+	}
+	title := strings.TrimSpace(h.Discovery.Title())
+	if title == "" {
+		title = "Meeting on " + startedAt.UTC().Format(time.DateOnly)
+	}
+	body := h.body(title, startedAt, endedAt)
+	children := h.Discovery.MeetingNotes.Children
+	metadata, err := json.Marshal(meetingMetadata{
+		Platform: SourceType, SourceIdentifier: identifier, MeetingNoteBlockID: h.Discovery.ID,
+		PageID: h.Discovery.Parent.PageID, Status: h.Discovery.MeetingNotes.Status,
+		Lifecycle:      lifecycleForStatus(h.Discovery.MeetingNotes.Status, h.Transcript),
+		CreatorUserID:  h.Discovery.CreatedBy.ID,
+		StartedAt:      startedAt.UTC().Format(time.RFC3339Nano),
+		EndedAt:        formatOptionalTime(endedAt),
+		SummaryBlockID: children.SummaryBlockID, NotesBlockID: children.NotesBlockID,
+		TranscriptBlockID: children.TranscriptBlockID,
+		HasSummary:        h.Summary != "", HasNotes: h.Notes != "", HasTranscript: h.Transcript != "",
+		MarkdownTranscriptFallback: h.MarkdownTranscriptFallback,
+		UnresolvedAttendeeIDs:      h.UnresolvedAttendeeIDs,
+		ResolvedUsers:              h.ResolvedUsers,
+		Warnings:                   h.Warnings,
+	})
+	if err != nil {
+		return meetingarchive.Snapshot{}, fmt.Errorf("marshal Notion meeting metadata: %w", err)
+	}
+	raw, err := json.Marshal(rawEvidence{
+		SchemaVersion: 1, Discovery: h.Discovery.Raw,
+		MeetingBlock: rawForBlock(h.MeetingBlock),
+		Summary:      rawForTree(h.SummaryTree), Notes: rawForTree(h.NotesTree),
+		Transcript: rawForTree(h.TranscriptTree), PageMarkdown: rawForMarkdown(h.PageMarkdown),
+		Canonical:      canonicalEvidence{Summary: h.Summary, Notes: h.Notes, Transcript: h.Transcript},
+		AttendeeLabels: h.AttendeeLabels, ResolvedUsers: h.ResolvedUsers, Warnings: h.Warnings,
+	})
+	if err != nil {
+		return meetingarchive.Snapshot{}, fmt.Errorf("marshal Notion raw evidence: %w", err)
+	}
+	return meetingarchive.Snapshot{
+		SourceID: sourceID, AccountEmail: accountEmail,
+		SourceMessageID: h.Discovery.ID, SourceConversationID: h.Discovery.ID,
+		Title: title, StartedAt: startedAt.UTC(), Body: body, Snippet: meetingSnippet(body),
+		Metadata: metadata, Raw: raw, RawFormat: RawFormat,
+		Attendees: append([]meetingarchive.Person(nil), h.Attendees...),
+	}, nil
+}
+
+func (h *HydratedMeeting) times() (time.Time, time.Time) {
+	calendar := h.Discovery.MeetingNotes.CalendarEvent
+	recording := h.Discovery.MeetingNotes.Recording
+	start := parseNotionTime(calendar.StartTime)
+	if start.IsZero() {
+		start = parseNotionTime(recording.StartTime)
+	}
+	if start.IsZero() {
+		start = parseNotionTime(h.Discovery.CreatedTime)
+	}
+	end := parseNotionTime(calendar.EndTime)
+	if end.IsZero() {
+		end = parseNotionTime(recording.EndTime)
+	}
+	if !end.After(start) {
+		end = time.Time{}
+	}
+	return start, end
+}
+
+func (h *HydratedMeeting) body(title string, start, end time.Time) string {
+	lines := []string{title}
+	when := "When: " + start.UTC().Format("2006-01-02 15:04")
+	if !end.IsZero() {
+		when += " - " + end.UTC().Format("15:04")
+	}
+	lines = append(lines, when)
+	if len(h.AttendeeLabels) > 0 {
+		lines = append(lines, "Attendees: "+strings.Join(h.AttendeeLabels, ", "))
+	}
+	sections := []struct{ label, content string }{
+		{"Summary", h.Summary}, {"Notes", h.Notes}, {"Transcript", h.Transcript},
+	}
+	for _, section := range sections {
+		if strings.TrimSpace(section.content) != "" {
+			lines = append(lines, "", section.label+":", strings.TrimSpace(section.content))
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func rawForBlock(block *Block) json.RawMessage {
+	if block == nil {
+		return nil
+	}
+	return block.Raw
+}
+
+func rawForMarkdown(page *MarkdownPage) json.RawMessage {
+	if page == nil {
+		return nil
+	}
+	return page.Raw
+}
+
+func rawForTree(tree blockTree) rawBlockTree {
+	return rawBlockTree{Root: rawForBlock(tree.Root), Pages: tree.Pages}
+}
+
+func formatOptionalTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func lifecycleForStatus(status, transcript string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch {
+	case strings.Contains(normalized, "fail"):
+		return "failed"
+	case strings.Contains(normalized, "delete"):
+		return "deleted"
+	case transcript != "" || strings.Contains(normalized, "ready") || strings.Contains(normalized, "complete"):
+		return "ready"
+	case normalized == "" || strings.Contains(normalized, "not_started") || strings.Contains(normalized, "progress") || strings.Contains(normalized, "processing"):
+		return "pending"
+	default:
+		return "unknown"
+	}
+}
+
+func meetingSnippet(body string) string {
+	runes := []rune(strings.TrimSpace(body))
+	if len(runes) > 200 {
+		runes = runes[:200]
+	}
+	return string(runes)
+}

--- a/internal/notionmeetings/hydrate.go
+++ b/internal/notionmeetings/hydrate.go
@@ -1,0 +1,414 @@
+package notionmeetings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/meetingarchive"
+)
+
+const (
+	maxHydrationDepth    = 32
+	maxHydrationRequests = 256
+	maxHydrationBytes    = 32 << 20
+	maxHydrationBlocks   = 10000
+)
+
+type hydrationSource interface {
+	RetrievePageMarkdown(ctx context.Context, pageID string, includeTranscript bool) (*MarkdownPage, error)
+	RetrieveBlock(ctx context.Context, blockID string) (*Block, error)
+	RetrieveBlockChildren(ctx context.Context, blockID, cursor string) (*BlockPage, error)
+	ListUsers(ctx context.Context, cursor string) (*UserPage, error)
+}
+
+type blockTree struct {
+	Root   *Block
+	Blocks []Block
+	Pages  []json.RawMessage
+}
+
+type HydratedMeeting struct {
+	Discovery                  MeetingNote
+	MeetingBlock               *Block
+	SummaryTree                blockTree
+	NotesTree                  blockTree
+	TranscriptTree             blockTree
+	PageMarkdown               *MarkdownPage
+	Summary                    string
+	Notes                      string
+	Transcript                 string
+	Attendees                  []meetingarchive.Person
+	AttendeeLabels             []string
+	UnresolvedAttendeeIDs      []string
+	AttendeeResolutionDegraded bool
+	Warnings                   []string
+	MarkdownTranscriptFallback bool
+	ResolvedUsers              []resolvedUser
+}
+
+type resolvedUser struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name,omitempty"`
+	Email         string   `json:"email,omitempty"`
+	EmailAliases  []string `json:"email_aliases,omitempty"`
+	EmailVerified bool     `json:"email_verified,omitempty"`
+}
+
+type Hydrator struct {
+	source           hydrationSource
+	users            map[string]User
+	usersRead        bool
+	usersUnavailable bool
+	usersFailure     error
+	requests         int
+	bytes            int
+	blocks           int
+}
+
+func NewHydrator(source hydrationSource) *Hydrator {
+	return &Hydrator{source: source}
+}
+
+func (h *Hydrator) Hydrate(ctx context.Context, meeting MeetingNote) (*HydratedMeeting, error) {
+	if h == nil || h.source == nil {
+		return nil, errors.New("notion meeting hydrator is unavailable")
+	}
+	if strings.TrimSpace(meeting.ID) == "" {
+		return nil, errors.New("notion meeting query returned a blank block ID")
+	}
+	h.requests, h.bytes, h.blocks = 0, 0, 0
+
+	meetingBlock, err := h.retrieveBlock(ctx, meeting.ID)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve meeting-note block %s: %w", meeting.ID, err)
+	}
+	if meetingBlock.Object != "block" || meetingBlock.ID != meeting.ID || meetingBlock.Type != "meeting_notes" {
+		return nil, fmt.Errorf("%w: retrieved meeting-note block has unexpected identity or type", ErrMalformedResponse)
+	}
+	if strings.TrimSpace(meeting.Parent.PageID) == "" {
+		meeting.Parent = meetingBlock.Parent
+	}
+	if strings.TrimSpace(meeting.Parent.PageID) == "" {
+		return nil, fmt.Errorf("notion meeting %s has no parent page ID", meeting.ID)
+	}
+	result := &HydratedMeeting{Discovery: meeting, MeetingBlock: meetingBlock}
+	children := meeting.MeetingNotes.Children
+	if children.SummaryBlockID != "" {
+		result.SummaryTree, err = h.readTree(ctx, children.SummaryBlockID)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate summary block %s: %w", children.SummaryBlockID, err)
+		}
+		result.Summary = renderTree(result.SummaryTree)
+	}
+	if children.NotesBlockID != "" {
+		result.NotesTree, err = h.readTree(ctx, children.NotesBlockID)
+		if err != nil {
+			return nil, fmt.Errorf("hydrate notes block %s: %w", children.NotesBlockID, err)
+		}
+		result.Notes = renderTree(result.NotesTree)
+	}
+	if children.TranscriptBlockID != "" {
+		result.TranscriptTree, err = h.readTree(ctx, children.TranscriptBlockID)
+		if err != nil {
+			if !transcriptTemporarilyUnavailable(err) {
+				return nil, fmt.Errorf("hydrate transcript block %s: %w", children.TranscriptBlockID, err)
+			}
+			result.Warnings = append(result.Warnings, "structured transcript was temporarily unavailable; continued with page Markdown")
+		} else {
+			result.Transcript = renderTree(result.TranscriptTree)
+		}
+	}
+
+	if err := h.reserveRequest(); err != nil {
+		return nil, err
+	}
+	result.PageMarkdown, err = h.source.RetrievePageMarkdown(ctx, meeting.Parent.PageID, true)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve Notion page Markdown: %w", err)
+	}
+	if err := h.reserveBytes(result.PageMarkdown.Raw); err != nil {
+		return nil, err
+	}
+	markdownTranscript := extractMarkdownTranscript(result.PageMarkdown.Markdown)
+	markdownComplete := !result.PageMarkdown.Truncated && len(result.PageMarkdown.UnknownBlockIDs) == 0
+	if result.Transcript == "" && markdownTranscript != "" && !markdownComplete {
+		result.Warnings = append(result.Warnings, "page Markdown transcript was incomplete; transcript remains pending")
+	} else if result.Transcript == "" && markdownTranscript != "" {
+		result.Transcript = markdownTranscript
+		result.MarkdownTranscriptFallback = true
+		result.Warnings = append(result.Warnings, "structured transcript was empty; used page Markdown transcript")
+	} else if result.Transcript != "" && markdownTranscript != "" && markdownComplete &&
+		normalizedContent(result.Transcript) != normalizedContent(markdownTranscript) {
+		result.Warnings = append(result.Warnings, "structured transcript and page Markdown transcript differed")
+	}
+
+	if err := h.resolveAttendees(ctx, result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (h *Hydrator) retrieveBlock(ctx context.Context, id string) (*Block, error) {
+	if err := h.reserveRequest(); err != nil {
+		return nil, err
+	}
+	block, err := h.source.RetrieveBlock(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.reserveBytes(block.Raw); err != nil {
+		return nil, err
+	}
+	return block, nil
+}
+
+func (h *Hydrator) readTree(ctx context.Context, id string) (blockTree, error) {
+	root, err := h.retrieveBlock(ctx, id)
+	if err != nil {
+		return blockTree{}, err
+	}
+	tree := blockTree{Root: root, Blocks: []Block{*root}}
+	h.blocks++
+	if h.blocks > maxHydrationBlocks {
+		return blockTree{}, errors.New("notion block traversal exceeded block limit")
+	}
+	if root.HasChildren {
+		if err := h.readChildren(ctx, root.ID, 1, &tree); err != nil {
+			return blockTree{}, err
+		}
+	}
+	return tree, nil
+}
+
+func (h *Hydrator) readChildren(ctx context.Context, blockID string, depth int, tree *blockTree) error {
+	if depth > maxHydrationDepth {
+		return fmt.Errorf("notion block traversal exceeded depth limit at %s", blockID)
+	}
+	cursor := ""
+	seen := map[string]struct{}{}
+	for {
+		if err := h.reserveRequest(); err != nil {
+			return err
+		}
+		page, err := h.source.RetrieveBlockChildren(ctx, blockID, cursor)
+		if err != nil {
+			return err
+		}
+		if err := h.reserveBytes(page.Raw); err != nil {
+			return err
+		}
+		tree.Pages = append(tree.Pages, append(json.RawMessage(nil), page.Raw...))
+		for _, child := range page.Results {
+			h.blocks++
+			if h.blocks > maxHydrationBlocks {
+				return errors.New("notion block traversal exceeded block limit")
+			}
+			tree.Blocks = append(tree.Blocks, child)
+			if child.HasChildren {
+				if err := h.readChildren(ctx, child.ID, depth+1, tree); err != nil {
+					return err
+				}
+			}
+		}
+		if !page.HasMore {
+			return nil
+		}
+		next := strings.TrimSpace(page.NextCursor)
+		if next == "" {
+			return fmt.Errorf("notion child block %s has_more without next_cursor", blockID)
+		}
+		if _, duplicate := seen[next]; duplicate {
+			return fmt.Errorf("notion child block %s returned repeated child cursor %q", blockID, next)
+		}
+		seen[next] = struct{}{}
+		cursor = next
+	}
+}
+
+func (h *Hydrator) resolveAttendees(ctx context.Context, result *HydratedMeeting) error {
+	if !h.usersRead {
+		h.users = map[string]User{}
+		cursor := ""
+		seen := map[string]struct{}{}
+		for {
+			if err := h.reserveRequest(); err != nil {
+				return err
+			}
+			page, err := h.source.ListUsers(ctx, cursor)
+			if err != nil {
+				if errors.Is(err, ErrUnauthorized) || errors.Is(err, context.Canceled) ||
+					errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
+				h.usersUnavailable = true
+				h.usersFailure = err
+				h.usersRead = true
+				break
+			}
+			if err := h.reserveBytes(page.Raw); err != nil {
+				return err
+			}
+			for _, user := range page.Results {
+				h.users[user.ID] = user
+			}
+			if !page.HasMore {
+				h.usersRead = true
+				break
+			}
+			next := strings.TrimSpace(page.NextCursor)
+			if next == "" {
+				return errors.New("notion user list has_more without next_cursor")
+			}
+			if _, duplicate := seen[next]; duplicate {
+				return fmt.Errorf("notion user list returned repeated cursor %q", next)
+			}
+			seen[next] = struct{}{}
+			cursor = next
+		}
+	}
+	if h.usersUnavailable {
+		result.AttendeeResolutionDegraded = true
+		if errors.Is(h.usersFailure, ErrUserInformation) {
+			result.Warnings = append(result.Warnings, "Notion User Information access unavailable; attendee emails were not resolved")
+		} else {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Notion User Information lookup failed: %v; attendee emails were not resolved", h.usersFailure))
+		}
+	}
+
+	for _, id := range result.Discovery.MeetingNotes.CalendarEvent.Attendees {
+		user, ok := h.users[id]
+		label := id
+		if ok && strings.TrimSpace(user.Name) != "" {
+			label = strings.TrimSpace(user.Name)
+		}
+		result.AttendeeLabels = append(result.AttendeeLabels, label)
+		if !ok || !user.Person.EmailVerified || strings.TrimSpace(user.Person.Email) == "" {
+			result.UnresolvedAttendeeIDs = append(result.UnresolvedAttendeeIDs, id)
+			continue
+		}
+		result.Attendees = append(result.Attendees, meetingarchive.Person{
+			Name:  strings.TrimSpace(user.Name),
+			Email: strings.ToLower(strings.TrimSpace(user.Person.Email)),
+		})
+		result.ResolvedUsers = append(result.ResolvedUsers, resolvedUser{
+			ID: id, Name: strings.TrimSpace(user.Name),
+			Email: strings.ToLower(strings.TrimSpace(user.Person.Email)), EmailVerified: true,
+		})
+	}
+	return nil
+}
+
+func (h *Hydrator) reserveRequest() error {
+	h.requests++
+	if h.requests > maxHydrationRequests {
+		return errors.New("notion meeting hydration exceeded request limit")
+	}
+	return nil
+}
+
+func (h *Hydrator) reserveBytes(raw []byte) error {
+	h.bytes += len(raw)
+	if h.bytes > maxHydrationBytes {
+		return errors.New("notion meeting hydration exceeded response byte limit")
+	}
+	return nil
+}
+
+func renderTree(tree blockTree) string {
+	lines := make([]string, 0, len(tree.Blocks))
+	for _, block := range tree.Blocks {
+		text := strings.TrimSpace(block.PlainText())
+		if text == "" {
+			continue
+		}
+		switch block.Type {
+		case "bulleted_list_item":
+			text = "- " + text
+		case "numbered_list_item":
+			text = "1. " + text
+		case "quote":
+			text = "> " + text
+		}
+		lines = append(lines, text)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func transcriptTemporarilyUnavailable(err error) bool {
+	if errors.Is(err, ErrRateLimited) {
+		return true
+	}
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.Status == 404 && apiErr.Code == "object_not_found"
+}
+
+func extractMarkdownTranscript(markdown string) string {
+	lines := strings.Split(strings.ReplaceAll(markdown, "\r\n", "\n"), "\n")
+	for index, line := range lines {
+		headingLevel, heading, isHeading := markdownHeading(line)
+		if !isHeading {
+			heading = strings.TrimSpace(line)
+		}
+		inline, found := transcriptMarker(heading)
+		if !found {
+			continue
+		}
+		if inline != "" {
+			return inline
+		}
+		end := len(lines)
+		if !isHeading {
+			headingLevel = 6
+		}
+		for next := index + 1; next < len(lines); next++ {
+			level, _, ok := markdownHeading(lines[next])
+			if ok && level <= headingLevel {
+				end = next
+				break
+			}
+		}
+		return strings.TrimSpace(strings.Join(lines[index+1:end], "\n"))
+	}
+	return ""
+}
+
+func markdownHeading(line string) (int, string, bool) {
+	trimmed := strings.TrimSpace(line)
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 || (level < len(trimmed) && trimmed[level] != ' ' && trimmed[level] != '\t') {
+		return 0, "", false
+	}
+	heading := strings.TrimSpace(trimmed[level:])
+	heading = strings.TrimSpace(strings.TrimRight(heading, "#"))
+	return level, heading, true
+}
+
+func transcriptMarker(value string) (string, bool) {
+	label := strings.TrimSpace(value)
+	inline := ""
+	if colon := strings.Index(label, ":"); colon >= 0 {
+		inline = strings.TrimSpace(label[colon+1:])
+		label = strings.TrimSpace(label[:colon])
+	}
+	if !strings.EqualFold(label, "transcript") {
+		return "", false
+	}
+	return inline, true
+}
+
+func normalizedContent(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func parseNotionTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339Nano, strings.TrimSpace(value))
+	return parsed
+}

--- a/internal/notionmeetings/hydrate.go
+++ b/internal/notionmeetings/hydrate.go
@@ -63,6 +63,7 @@ type Hydrator struct {
 	users            map[string]User
 	usersRead        bool
 	usersUnavailable bool
+	usersIncomplete  bool
 	usersFailure     error
 	requests         int
 	bytes            int
@@ -261,10 +262,18 @@ func (h *Hydrator) resolveAttendees(ctx context.Context, result *HydratedMeeting
 			}
 			next := strings.TrimSpace(page.NextCursor)
 			if next == "" {
-				return errors.New("notion user list has_more without next_cursor")
+				h.usersUnavailable = true
+				h.usersIncomplete = true
+				h.usersFailure = errors.New("has_more without next_cursor")
+				h.usersRead = true
+				break
 			}
 			if _, duplicate := seen[next]; duplicate {
-				return fmt.Errorf("notion user list returned repeated cursor %q", next)
+				h.usersUnavailable = true
+				h.usersIncomplete = true
+				h.usersFailure = fmt.Errorf("repeated cursor %q", next)
+				h.usersRead = true
+				break
 			}
 			seen[next] = struct{}{}
 			cursor = next
@@ -272,7 +281,10 @@ func (h *Hydrator) resolveAttendees(ctx context.Context, result *HydratedMeeting
 	}
 	if h.usersUnavailable {
 		result.AttendeeResolutionDegraded = true
-		if errors.Is(h.usersFailure, ErrUserInformation) {
+		if h.usersIncomplete {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Notion User Information pagination was incomplete: %v", h.usersFailure))
+		} else if errors.Is(h.usersFailure, ErrUserInformation) {
 			result.Warnings = append(result.Warnings, "Notion User Information access unavailable; attendee emails were not resolved")
 		} else {
 			result.Warnings = append(result.Warnings,

--- a/internal/notionmeetings/hydrate_test.go
+++ b/internal/notionmeetings/hydrate_test.go
@@ -410,6 +410,54 @@ func TestHydratorDegradesWhenUserInformationIsUnavailable(t *testing.T) {
 	assert.Contains(snapshot.Body, "Attendees: user-1, user-2")
 }
 
+func TestHydratorDegradesOnInvalidUserPaginationAndKeepsFetchedUsers(t *testing.T) {
+	tests := []struct {
+		name  string
+		pages map[string]*UserPage
+		want  string
+	}{
+		{
+			name: "missing cursor",
+			pages: map[string]*UserPage{
+				"": {Results: []User{{
+					ID: "user-1", Name: "Test Attendee", Type: "person",
+					Person: UserPerson{Email: "attendee@example.com", EmailVerified: true},
+				}}, HasMore: true},
+			},
+			want: "has_more without next_cursor",
+		},
+		{
+			name: "repeated cursor",
+			pages: map[string]*UserPage{
+				"": {Results: []User{{
+					ID: "user-1", Name: "Test Attendee", Type: "person",
+					Person: UserPerson{Email: "attendee@example.com", EmailVerified: true},
+				}}, HasMore: true, NextCursor: "same"},
+				"same": {HasMore: true, NextCursor: "same"},
+			},
+			want: "repeated cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			source := completeHydrationSource()
+			source.users = tt.pages
+
+			hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+			require.NoError(err)
+			assert.True(hydrated.AttendeeResolutionDegraded)
+			require.Len(hydrated.Attendees, 1)
+			assert.Equal("attendee@example.com", hydrated.Attendees[0].Email)
+			assert.Equal([]string{"user-2"}, hydrated.UnresolvedAttendeeIDs)
+			require.Len(hydrated.Warnings, 1)
+			assert.Contains(hydrated.Warnings[0], "Notion User Information pagination was incomplete: "+tt.want)
+		})
+	}
+}
+
 func TestHydratorKeepsSystemicUserListingErrorsFatal(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/notionmeetings/hydrate_test.go
+++ b/internal/notionmeetings/hydrate_test.go
@@ -1,0 +1,456 @@
+package notionmeetings
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHydrationSource struct {
+	blocks     map[string]*Block
+	blockErrs  map[string]error
+	children   map[string]map[string]*BlockPage
+	markdown   *MarkdownPage
+	users      map[string]*UserPage
+	usersErr   error
+	userErrs   map[string]error
+	usersCalls int
+}
+
+func (f *fakeHydrationSource) RetrieveBlock(_ context.Context, id string) (*Block, error) {
+	if err := f.blockErrs[id]; err != nil {
+		return nil, err
+	}
+	block, ok := f.blocks[id]
+	if !ok {
+		return nil, errors.New("missing block")
+	}
+	return block, nil
+}
+
+func (f *fakeHydrationSource) RetrieveBlockChildren(_ context.Context, id, cursor string) (*BlockPage, error) {
+	page, ok := f.children[id][cursor]
+	if !ok {
+		return nil, errors.New("missing children page")
+	}
+	return page, nil
+}
+
+func (f *fakeHydrationSource) RetrievePageMarkdown(_ context.Context, _ string, _ bool) (*MarkdownPage, error) {
+	return f.markdown, nil
+}
+
+func (f *fakeHydrationSource) ListUsers(_ context.Context, cursor string) (*UserPage, error) {
+	f.usersCalls++
+	if err := f.userErrs[cursor]; err != nil {
+		return nil, err
+	}
+	if f.usersErr != nil {
+		return nil, f.usersErr
+	}
+	return f.users[cursor], nil
+}
+
+func paragraph(id, text string, children bool) Block {
+	raw, err := json.Marshal(struct {
+		Object string `json:"object"`
+		ID     string `json:"id"`
+		Type   string `json:"type"`
+		Text   string `json:"text"`
+	}{Object: "block", ID: id, Type: "paragraph", Text: text})
+	if err != nil {
+		panic(err)
+	}
+	return Block{
+		Object: "block", ID: id, Type: "paragraph", HasChildren: children,
+		Paragraph: RichTextBlock{RichText: []RichText{{PlainText: text}}}, Raw: raw,
+	}
+}
+
+func hydrationMeeting() MeetingNote {
+	raw := json.RawMessage(`{"object":"block","id":"meeting-1","type":"meeting_notes","future":{"kept":true}}`)
+	return MeetingNote{
+		Object: "block", ID: "meeting-1", Type: "meeting_notes", Raw: raw,
+		Parent:      Parent{Type: "page_id", PageID: "page-1"},
+		CreatedTime: "2026-08-29T09:59:00Z", LastEditedTime: "2026-08-29T10:35:00Z",
+		CreatedBy: UserRef{ID: "creator-1", Object: "user"},
+		MeetingNotes: MeetingNotesData{
+			Title:  []RichText{{PlainText: "Weekly planning"}},
+			Status: "notes_ready",
+			Children: MeetingChildren{
+				SummaryBlockID: "summary-1", NotesBlockID: "notes-1", TranscriptBlockID: "transcript-1",
+			},
+			CalendarEvent: MeetingCalendarEvent{
+				StartTime: "2026-08-29T10:00:00Z", EndTime: "2026-08-29T10:30:00Z",
+				Attendees: []string{"user-1", "user-2"},
+			},
+		},
+	}
+}
+
+func completeHydrationSource() *fakeHydrationSource {
+	meetingBlock := Block{
+		Object: "block", ID: "meeting-1", Type: "meeting_notes",
+		Parent: Parent{Type: "page_id", PageID: "page-1"},
+		Raw:    json.RawMessage(`{"object":"block","id":"meeting-1","type":"meeting_notes"}`),
+	}
+	summaryRoot := paragraph("summary-1", "Decide the release scope.", false)
+	notesRoot := paragraph("notes-1", "Owner will prepare the rollout.", true)
+	transcriptRoot := paragraph("transcript-1", "Test Speaker: Ready to ship.", false)
+	nested := paragraph("nested-1", "Nested action item.", false)
+	return &fakeHydrationSource{
+		blocks: map[string]*Block{
+			"meeting-1": &meetingBlock, "summary-1": &summaryRoot,
+			"notes-1": &notesRoot, "transcript-1": &transcriptRoot,
+		},
+		children: map[string]map[string]*BlockPage{
+			"notes-1": {
+				"": {Results: []Block{nested}, Raw: json.RawMessage(`{"results":[{"id":"nested-1"}],"has_more":false}`)},
+			},
+		},
+		markdown: &MarkdownPage{
+			Object: "page_markdown", ID: "page-1",
+			Markdown: "# Weekly planning\n\n## Transcript\nTest Speaker: Ready to ship.",
+			Raw:      json.RawMessage(`{"object":"page_markdown","id":"page-1","markdown":"redacted in test"}`),
+		},
+		users: map[string]*UserPage{
+			"": {
+				Results: []User{
+					{ID: "user-1", Name: "Test Attendee", Type: "person", Person: UserPerson{Email: "attendee@example.com", EmailVerified: true}},
+					{ID: "user-2", Name: "Unresolved Attendee", Type: "person", Person: UserPerson{Email: "unverified@example.com"}},
+				},
+			},
+		},
+	}
+}
+
+func TestHydratorResolvesParentPageFromRetrievedMeetingBlock(t *testing.T) {
+	meeting := hydrationMeeting()
+	meeting.Parent = Parent{}
+
+	hydrated, err := NewHydrator(completeHydrationSource()).Hydrate(context.Background(), meeting)
+	require.NoError(t, err)
+	assert.Equal(t, "page-1", hydrated.Discovery.Parent.PageID)
+	assert.Equal(t, "page-1", hydrated.PageMarkdown.ID)
+}
+
+func TestHydratorBuildsCanonicalSnapshotWithoutInventingOrganizer(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	hydrated, err := NewHydrator(completeHydrationSource()).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(err)
+	assert.False(hydrated.AttendeeResolutionDegraded)
+	assert.Equal("Decide the release scope.", hydrated.Summary)
+	assert.Contains(hydrated.Notes, "Nested action item.")
+	assert.Equal("Test Speaker: Ready to ship.", hydrated.Transcript)
+
+	snapshot, err := hydrated.ArchiveSnapshot(17, "work", "user@example.com")
+	require.NoError(err)
+	assert.Equal(int64(17), snapshot.SourceID)
+	assert.Equal("meeting-1", snapshot.SourceMessageID)
+	assert.Equal("meeting-1", snapshot.SourceConversationID)
+	assert.Nil(snapshot.Organizer, "created_by must not become organizer")
+	require.Len(snapshot.Attendees, 1)
+	assert.Equal("attendee@example.com", snapshot.Attendees[0].Email)
+	assert.Contains(snapshot.Body, "Attendees: Test Attendee, Unresolved Attendee")
+	assert.Contains(snapshot.Body, "Summary:\nDecide the release scope.")
+	assert.Contains(snapshot.Body, "Notes:\nOwner will prepare the rollout.\nNested action item.")
+	assert.Contains(snapshot.Body, "Transcript:\nTest Speaker: Ready to ship.")
+	assert.Equal(RawFormat, snapshot.RawFormat)
+	assert.Contains(string(snapshot.Raw), `"discovery"`)
+	assert.Contains(string(snapshot.Raw), `"page_markdown"`)
+	assert.Contains(string(snapshot.Raw), `"attendee_labels":["Test Attendee","Unresolved Attendee"]`)
+	assert.NotContains(string(snapshot.Raw), "unverified@example.com")
+	assert.NotContains(string(snapshot.Raw), "user@example.com", "configured identity must not enter provider evidence")
+	assert.Contains(string(snapshot.Metadata), `"creator_user_id":"creator-1"`)
+	assert.Contains(string(snapshot.Metadata), `"unresolved_attendee_ids":["user-2"]`)
+}
+
+func TestHydratorUsesMarkdownTranscriptFallback(t *testing.T) {
+	assert := assert.New(t)
+	source := completeHydrationSource()
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Late transcript."
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(t, err)
+	assert.Equal("Test Speaker: Late transcript.", hydrated.Transcript)
+	assert.True(hydrated.MarkdownTranscriptFallback)
+	assert.Contains(hydrated.Warnings, "structured transcript was empty; used page Markdown transcript")
+}
+
+func TestHydratorDegradesWhenTranscriptBlockIsNotReady(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "provider reports transcript block not found",
+			err:  &APIError{Kind: ErrProvider, Status: 404, Code: "object_not_found"},
+		},
+		{
+			name: "provider transient retry budget exhausted",
+			err:  &APIError{Kind: ErrRateLimited, Status: 503, Code: "service_unavailable"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			source := completeHydrationSource()
+			source.blockErrs = map[string]error{"transcript-1": tt.err}
+			source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Published in Markdown.\n\n## Action items\nFollow up."
+
+			hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+			require.NoError(t, err)
+			assert.Equal("Decide the release scope.", hydrated.Summary)
+			assert.Contains(hydrated.Notes, "Nested action item.")
+			assert.Equal("Test Speaker: Published in Markdown.", hydrated.Transcript)
+			assert.True(hydrated.MarkdownTranscriptFallback)
+			assert.Contains(hydrated.Warnings, "structured transcript was temporarily unavailable; continued with page Markdown")
+			assert.Contains(hydrated.Warnings, "structured transcript was empty; used page Markdown transcript")
+			assert.Len(hydrated.AttendeeLabels, 2)
+		})
+	}
+}
+
+func TestHydratorKeepsSystemicTranscriptErrorsFatal(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: &APIError{Kind: ErrUnauthorized, Status: 401, Code: "unauthorized"}},
+		{name: "read content forbidden", err: &APIError{Kind: ErrReadContent, Status: 403, Code: "restricted_resource"}},
+		{name: "malformed response", err: fmt.Errorf("%w: invalid block", ErrMalformedResponse)},
+		{name: "context canceled", err: context.Canceled},
+		{name: "local traversal limit", err: errors.New("notion block traversal exceeded block limit")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := completeHydrationSource()
+			source.blockErrs = map[string]error{"transcript-1": tt.err}
+
+			hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+			require.Error(t, err)
+			assert.Nil(t, hydrated)
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestHydratorRejectsNonMeetingRootBlock(t *testing.T) {
+	source := completeHydrationSource()
+	source.blocks["meeting-1"] = &Block{
+		Object: "block", ID: "meeting-1", Type: "paragraph",
+		Raw: json.RawMessage(`{"object":"block","id":"meeting-1","type":"paragraph","has_children":false,"paragraph":{}}`),
+	}
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+
+	require.ErrorIs(t, err, ErrMalformedResponse)
+	assert.Nil(t, hydrated)
+}
+
+func TestExtractMarkdownTranscriptStopsAtSameOrHigherHeading(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		want     string
+	}{
+		{
+			name: "same-level heading",
+			markdown: "# Meeting\n## Transcript\nTest Speaker: First.\n" +
+				"### Transcript detail\nTest Speaker: Second.\n## Action items\nDo not include.",
+			want: "Test Speaker: First.\n### Transcript detail\nTest Speaker: Second.",
+		},
+		{
+			name:     "higher-level heading with CRLF",
+			markdown: "# Meeting\r\n### tRaNsCrIpT\r\nTest Speaker: Keep.\r\n## Notes\r\nExclude.",
+			want:     "Test Speaker: Keep.",
+		},
+		{
+			name:     "transcript reaches EOF",
+			markdown: "# Meeting\n## Transcript\nTest Speaker: Keep to EOF.",
+			want:     "Test Speaker: Keep to EOF.",
+		},
+		{
+			name:     "bare marker stops at next heading",
+			markdown: "# Meeting\nTranscript:\nTest Speaker: Keep.\n## Action items\nExclude.",
+			want:     "Test Speaker: Keep.",
+		},
+		{
+			name:     "inline transcript",
+			markdown: "Transcript: Test Speaker: Inline text.\n## Notes\nExclude.",
+			want:     "Test Speaker: Inline text.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractMarkdownTranscript(tt.markdown))
+		})
+	}
+}
+
+func TestHydratorMarkdownFallbackExcludesLaterSections(t *testing.T) {
+	assert := assert.New(t)
+	source := completeHydrationSource()
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Late transcript.\n\n## Action items\nDo not archive as transcript."
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(t, err)
+	assert.Equal("Test Speaker: Late transcript.", hydrated.Transcript)
+	assert.NotContains(hydrated.Transcript, "Action items")
+	assert.NotContains(hydrated.Transcript, "Do not archive")
+}
+
+func TestHydratorDoesNotWarnWhenOnlyLaterMarkdownSectionDiffers(t *testing.T) {
+	source := completeHydrationSource()
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Ready to ship.\n\n## Action items\nDifferent content."
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(t, err)
+	assert.NotContains(t, hydrated.Warnings, "structured transcript and page Markdown transcript differed")
+}
+
+func TestHydratorLeavesIncompleteMarkdownTranscriptPending(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*MarkdownPage)
+	}{
+		{
+			name: "truncated",
+			mutate: func(page *MarkdownPage) {
+				page.Truncated = true
+			},
+		},
+		{
+			name: "unknown blocks",
+			mutate: func(page *MarkdownPage) {
+				page.UnknownBlockIDs = []string{"transcript-child-1"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			source := completeHydrationSource()
+			empty := paragraph("transcript-1", "", false)
+			source.blocks["transcript-1"] = &empty
+			source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Partial transcript."
+			tt.mutate(source.markdown)
+
+			hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+			require.NoError(t, err)
+			assert.Empty(hydrated.Transcript)
+			assert.False(hydrated.MarkdownTranscriptFallback)
+			assert.Contains(hydrated.Warnings, "page Markdown transcript was incomplete; transcript remains pending")
+		})
+	}
+}
+
+func TestHydratorDoesNotCompareIncompleteMarkdownTranscript(t *testing.T) {
+	source := completeHydrationSource()
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Partial conflicting transcript."
+	source.markdown.Truncated = true
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(t, err)
+	assert.NotContains(t, hydrated.Warnings, "structured transcript and page Markdown transcript differed")
+}
+
+func TestHydratorDoesNotWarnAboutIncompleteMarkdownWithoutTranscript(t *testing.T) {
+	source := completeHydrationSource()
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning\n\nMeeting context only."
+	source.markdown.UnknownBlockIDs = []string{"unrelated-block-1"}
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(t, err)
+	assert.Empty(t, hydrated.Transcript)
+	assert.NotContains(t, hydrated.Warnings, "page Markdown transcript was incomplete; transcript remains pending")
+}
+
+func TestHydratorRejectsRepeatedChildCursor(t *testing.T) {
+	source := completeHydrationSource()
+	source.children["notes-1"][""] = &BlockPage{HasMore: true, NextCursor: "same"}
+	source.children["notes-1"]["same"] = &BlockPage{HasMore: true, NextCursor: "same"}
+
+	_, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repeated child cursor")
+}
+
+func TestHydratorDegradesWhenUserInformationIsUnavailable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	source := completeHydrationSource()
+	source.usersErr = ErrUserInformation
+
+	hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(err)
+	assert.Empty(hydrated.Attendees)
+	assert.True(hydrated.AttendeeResolutionDegraded)
+	assert.Equal([]string{"user-1", "user-2"}, hydrated.UnresolvedAttendeeIDs)
+	assert.Contains(hydrated.Warnings, "Notion User Information access unavailable; attendee emails were not resolved")
+
+	snapshot, err := hydrated.ArchiveSnapshot(17, "work", "user@example.com")
+	require.NoError(err)
+	assert.Contains(snapshot.Body, "Attendees: user-1, user-2")
+}
+
+func TestHydratorKeepsSystemicUserListingErrorsFatal(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: &APIError{Kind: ErrUnauthorized, Status: 401, Code: "unauthorized"}},
+		{name: "context canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := completeHydrationSource()
+			source.usersErr = tt.err
+
+			hydrated, err := NewHydrator(source).Hydrate(context.Background(), hydrationMeeting())
+			require.Error(t, err)
+			assert.Nil(t, hydrated)
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestHydratorDegradesAndCachesTransientUserListingFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	source := completeHydrationSource()
+	source.usersErr = errors.New("rate limit exceeded")
+	hydrator := NewHydrator(source)
+
+	first, err := hydrator.Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(err)
+	assert.Empty(first.Attendees)
+	assert.True(first.AttendeeResolutionDegraded)
+	assert.Equal([]string{"user-1", "user-2"}, first.AttendeeLabels)
+	assert.Contains(first.Warnings, "Notion User Information lookup failed: rate limit exceeded; attendee emails were not resolved")
+
+	second, err := hydrator.Hydrate(context.Background(), hydrationMeeting())
+	require.NoError(err)
+	assert.Empty(second.Attendees)
+	assert.True(second.AttendeeResolutionDegraded)
+	assert.Contains(second.Warnings, "Notion User Information lookup failed: rate limit exceeded; attendee emails were not resolved")
+	assert.Equal(1, source.usersCalls)
+}

--- a/internal/notionmeetings/importer.go
+++ b/internal/notionmeetings/importer.go
@@ -1,0 +1,834 @@
+package notionmeetings
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/meetingarchive"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	syncStateVersion           = 1
+	notionSnapshotVersion      = 1
+	transcriptRetryCadence     = 6 * time.Hour
+	transcriptRetryWindow      = 7 * 24 * time.Hour
+	unknownTranscriptRetrySpan = 48 * time.Hour
+)
+
+// Source is the read-only Notion surface required by a sync run.
+type Source interface {
+	hydrationSource
+	QueryMeetingNotes(ctx context.Context, limit int) (*QueryResult, error)
+}
+
+type Importer struct {
+	store  *store.Store
+	client Source
+	now    func() time.Time
+}
+
+func NewImporter(st *store.Store, client Source) *Importer {
+	return &Importer{store: st, client: client, now: time.Now}
+}
+
+type ImportOptions struct {
+	Identifier   string
+	AccountEmail string
+	Full         bool
+	Limit        int
+	CreatedAfter time.Time
+	Progress     func(string)
+}
+
+type ImportSummary struct {
+	SourceID           int64
+	MeetingsProcessed  int64
+	MeetingsAdded      int64
+	MeetingsUpdated    int64
+	MaintenanceRetries int64
+	Errors             int64
+	PartialCoverage    bool
+	Duration           time.Duration
+}
+
+type knownMeeting struct {
+	LastEditedTime  string `json:"last_edited_time"`
+	SnapshotSHA256  string `json:"snapshot_sha256,omitempty"`
+	SnapshotVersion int    `json:"snapshot_version"`
+}
+
+type pendingTranscript struct {
+	BlockID       string `json:"block_id"`
+	NextAttemptAt string `json:"next_attempt_at"`
+	RetryUntil    string `json:"retry_until"`
+}
+
+type Coverage struct {
+	HasMore    bool   `json:"has_more"`
+	Returned   int    `json:"returned"`
+	OldestEdit string `json:"oldest_edit,omitempty"`
+	NewestEdit string `json:"newest_edit,omitempty"`
+	Limited    bool   `json:"limited,omitempty"`
+}
+
+type syncState struct {
+	Version              int                     `json:"version"`
+	LastQueryAt          string                  `json:"last_query_at"`
+	Known                map[string]knownMeeting `json:"known"`
+	Pending              []pendingTranscript     `json:"pending,omitempty"`
+	TranscriptRetryUntil map[string]string       `json:"transcript_retry_until,omitempty"`
+	Coverage             Coverage                `json:"coverage"`
+}
+
+func (s syncState) marshal() (string, error) {
+	sort.Slice(s.Pending, func(i, j int) bool { return s.Pending[i].BlockID < s.Pending[j].BlockID })
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("marshal Notion sync cursor: %w", err)
+	}
+	return string(encoded), nil
+}
+
+func (s syncState) validate() error {
+	if s.Version != syncStateVersion {
+		return fmt.Errorf("unsupported Notion sync cursor version %d", s.Version)
+	}
+	seen := make(map[string]struct{}, len(s.Pending))
+	for index, pending := range s.Pending {
+		if strings.TrimSpace(pending.BlockID) == "" {
+			return fmt.Errorf("pending[%d] has a blank block_id", index)
+		}
+		if _, duplicate := seen[pending.BlockID]; duplicate {
+			return fmt.Errorf("pending contains duplicate block_id %q", pending.BlockID)
+		}
+		seen[pending.BlockID] = struct{}{}
+		if _, err := time.Parse(time.RFC3339, pending.NextAttemptAt); err != nil {
+			return fmt.Errorf("pending %q has invalid next_attempt_at: %w", pending.BlockID, err)
+		}
+		if _, err := time.Parse(time.RFC3339, pending.RetryUntil); err != nil {
+			return fmt.Errorf("pending %q has invalid retry_until: %w", pending.BlockID, err)
+		}
+	}
+	deadlineIDs := make([]string, 0, len(s.TranscriptRetryUntil))
+	for id := range s.TranscriptRetryUntil {
+		deadlineIDs = append(deadlineIDs, id)
+	}
+	sort.Strings(deadlineIDs)
+	for _, id := range deadlineIDs {
+		if strings.TrimSpace(id) == "" {
+			return errors.New("transcript retry deadline has a blank block ID")
+		}
+		if _, err := time.Parse(time.RFC3339, s.TranscriptRetryUntil[id]); err != nil {
+			return fmt.Errorf("transcript retry deadline %q is invalid: %w", id, err)
+		}
+	}
+	return nil
+}
+
+func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (sum *ImportSummary, retErr error) {
+	if imp == nil || imp.store == nil || imp.client == nil {
+		return nil, errors.New("notion meeting importer is unavailable")
+	}
+	started := imp.now().UTC()
+	source, err := imp.store.GetSourceByTypeAndIdentifier(SourceType, strings.TrimSpace(opts.Identifier))
+	if err != nil {
+		return nil, err
+	}
+	sum = &ImportSummary{SourceID: source.ID}
+	if strings.TrimSpace(opts.AccountEmail) != "" {
+		if err := imp.store.AddAccountIdentityContext(ctx, source.ID, opts.AccountEmail, "account-email"); err != nil {
+			return sum, fmt.Errorf("confirm Notion account identity: %w", err)
+		}
+	}
+
+	state := syncState{Version: syncStateVersion, Known: map[string]knownMeeting{}}
+	previous, err := imp.store.GetLastSuccessfulSync(source.ID)
+	if err == nil && previous.CursorAfter.Valid && previous.CursorAfter.String != "" {
+		if err := json.Unmarshal([]byte(previous.CursorAfter.String), &state); err != nil {
+			return sum, fmt.Errorf("decode previous Notion sync cursor: %w", err)
+		}
+		if err := state.validate(); err != nil {
+			return sum, fmt.Errorf("validate previous Notion sync cursor: %w", err)
+		}
+	} else if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
+		return sum, fmt.Errorf("load previous Notion sync cursor: %w", err)
+	}
+	if state.Known == nil {
+		state.Known = map[string]knownMeeting{}
+	}
+	if state.TranscriptRetryUntil == nil {
+		state.TranscriptRetryUntil = map[string]string{}
+	}
+
+	syncID, err := imp.store.StartSync(source.ID, SourceType)
+	if err != nil {
+		return sum, err
+	}
+	scopedStore := imp.store.ScopedToSync(source.ID, syncID)
+	defer func() {
+		if retErr != nil {
+			_ = scopedStore.FailSyncWithCheckpoint(syncID, retErr.Error(), &store.Checkpoint{
+				MessagesProcessed: sum.MeetingsProcessed,
+				MessagesAdded:     sum.MeetingsAdded,
+				MessagesUpdated:   sum.MeetingsUpdated,
+				ErrorsCount:       sum.Errors,
+			})
+		}
+	}()
+
+	result, err := imp.client.QueryMeetingNotes(ctx, maxQueryResults)
+	if err != nil {
+		sum.Errors++
+		return sum, fmt.Errorf("query Notion meeting notes: %w", err)
+	}
+	if result == nil {
+		sum.Errors++
+		return sum, errors.New("query Notion meeting notes returned no response")
+	}
+
+	progress := opts.Progress
+	if progress == nil {
+		progress = func(string) {}
+	}
+	next := syncState{
+		Version:              syncStateVersion,
+		LastQueryAt:          imp.now().UTC().Format(time.RFC3339),
+		Known:                map[string]knownMeeting{},
+		TranscriptRetryUntil: make(map[string]string, len(state.TranscriptRetryUntil)),
+		Coverage:             coverageFor(result, opts.Limit > 0),
+	}
+	maps.Copy(next.TranscriptRetryUntil, state.TranscriptRetryUntil)
+	sum.PartialCoverage = result.HasMore
+	if result.HasMore {
+		progress(fmt.Sprintf("Notion discovery is partial: %d meetings returned and more are unavailable through pagination", len(result.Results)))
+	}
+
+	pendingByID := make(map[string]pendingTranscript, len(state.Pending))
+	for _, pending := range state.Pending {
+		if retained := next.TranscriptRetryUntil[pending.BlockID]; retained != "" {
+			retainedAt, _ := time.Parse(time.RFC3339, retained)
+			pendingUntil, _ := time.Parse(time.RFC3339, pending.RetryUntil)
+			if retainedAt.After(pendingUntil) {
+				pending.RetryUntil = retained
+			}
+		}
+		next.TranscriptRetryUntil[pending.BlockID] = pending.RetryUntil
+		pendingByID[pending.BlockID] = pending
+		if known, ok := state.Known[pending.BlockID]; ok {
+			next.Known[pending.BlockID] = known
+		}
+	}
+
+	visible := make(map[string]MeetingNote, len(result.Results))
+	work := make(map[string]MeetingNote)
+	workOrder := make([]string, 0, len(result.Results)+len(state.Pending))
+	due := make(map[string]bool)
+	seen := make(map[string]struct{}, len(result.Results))
+	for _, meeting := range result.Results {
+		id := strings.TrimSpace(meeting.ID)
+		if id == "" {
+			sum.Errors++
+			return sum, errors.New("notion discovery returned a meeting without an ID")
+		}
+		if _, duplicate := seen[id]; duplicate {
+			sum.Errors++
+			return sum, fmt.Errorf("notion discovery returned duplicate meeting ID %q", id)
+		}
+		seen[id] = struct{}{}
+		visible[id] = meeting
+		if known, ok := state.Known[id]; ok {
+			next.Known[id] = known
+		}
+	}
+
+	now := imp.now().UTC()
+	for id, pending := range pendingByID {
+		if pendingExpired(pending, now) {
+			delete(pendingByID, id)
+			continue
+		}
+		if !pendingDue(pending, now) {
+			continue
+		}
+		due[id] = true
+		if meeting, ok := visible[id]; ok {
+			work[id] = meeting
+			workOrder = append(workOrder, id)
+			continue
+		}
+		meeting, loadErr := imp.retrieveMeeting(ctx, id)
+		if loadErr != nil {
+			sum.Errors++
+			if !errors.Is(loadErr, ErrRateLimited) {
+				return sum, fmt.Errorf("load pending Notion meeting %s: %w", id, loadErr)
+			}
+			pending.NextAttemptAt = now.Add(transcriptRetryCadence).Format(time.RFC3339)
+			pendingByID[id] = pending
+			progress("pending Notion meeting " + id + ": load failed; retry deferred")
+			continue
+		}
+		work[id] = meeting
+		workOrder = append(workOrder, id)
+	}
+	sum.MaintenanceRetries = int64(len(due))
+
+	remaining := max(opts.Limit, 0)
+	for _, meeting := range result.Results {
+		id := meeting.ID
+		if due[id] {
+			continue
+		}
+		if !opts.CreatedAfter.IsZero() && candidateTime(meeting).Before(opts.CreatedAfter) {
+			continue
+		}
+		if opts.Limit > 0 && remaining == 0 {
+			continue
+		}
+		if opts.Limit > 0 {
+			remaining--
+		}
+		work[id] = meeting
+		workOrder = append(workOrder, id)
+	}
+
+	hydrator := NewHydrator(imp.client)
+	archiver := meetingarchive.New(scopedStore)
+	var hardErrors []error
+	for _, id := range workOrder {
+		if err := ctx.Err(); err != nil {
+			hardErrors = append(hardErrors, err)
+			break
+		}
+		meeting := work[id]
+		sum.MeetingsProcessed++
+		hydrated, hydrateErr := hydrator.Hydrate(ctx, meeting)
+		if hydrateErr != nil {
+			sum.Errors++
+			hardErrors = append(hardErrors, fmt.Errorf("meeting %s: %w", id, hydrateErr))
+			progress(fmt.Sprintf("meeting %s: hydration failed", id))
+			continue
+		}
+
+		providerTranscriptMissing := strings.TrimSpace(hydrated.Transcript) == ""
+		archived, recoverErr := imp.archivedState(source.ID, id)
+		if recoverErr != nil {
+			sum.Errors++
+			hardErrors = append(hardErrors, fmt.Errorf("meeting %s: recover archived evidence: %w", id, recoverErr))
+			continue
+		}
+		existingTranscript := ""
+		if archived.HasEvidence {
+			existingTranscript = archived.Evidence.Canonical.Transcript
+		}
+		if strings.TrimSpace(existingTranscript) == "" {
+			existingTranscript = transcriptFromArchivedBody(archived.Body)
+		}
+		if providerTranscriptMissing && existingTranscript != "" {
+			hydrated.Transcript = existingTranscript
+			hydrated.Warnings = append(hydrated.Warnings, "provider temporarily omitted the transcript; preserved the archived transcript")
+		}
+		if hydrated.AttendeeResolutionDegraded {
+			preserveArchivedAttendees(hydrated, archived.ResolvedUsers)
+			if archived.MessageID != 0 {
+				recipients, recipientErr := imp.store.GetMessageRecipientsContext(ctx, archived.MessageID, "to")
+				if recipientErr != nil {
+					sum.Errors++
+					hardErrors = append(hardErrors, fmt.Errorf("meeting %s: recover archived attendees: %w", id, recipientErr))
+					continue
+				}
+				preserveArchivedAttendeeRelationships(hydrated, recipients, archived.ResolvedUsers)
+			}
+		}
+
+		terminal := terminalStatus(meeting.MeetingNotes.Status)
+		if providerTranscriptMissing && !terminal {
+			previousPending, hasPrevious := pendingByID[id]
+			if retained := next.TranscriptRetryUntil[id]; retained != "" {
+				previousPending.RetryUntil = retained
+				hasPrevious = true
+			}
+			pending, keep := schedulePending(hydrated, now, previousPending, hasPrevious)
+			if keep {
+				pendingByID[id] = pending
+				next.TranscriptRetryUntil[id] = pending.RetryUntil
+			} else {
+				delete(pendingByID, id)
+				hydrated.Warnings = append(hydrated.Warnings, "transcript retry window expired")
+			}
+		} else {
+			delete(pendingByID, id)
+		}
+
+		snapshot, snapshotErr := hydrated.ArchiveSnapshot(source.ID, opts.Identifier, opts.AccountEmail)
+		if snapshotErr != nil {
+			sum.Errors++
+			hardErrors = append(hardErrors, fmt.Errorf("meeting %s: build archive snapshot: %w", id, snapshotErr))
+			continue
+		}
+		checksum := checksumBytes(snapshot.Raw)
+		known, exists := state.Known[id]
+		if archived.HasEvidence && exists && !opts.Full && known.SnapshotVersion == notionSnapshotVersion &&
+			known.SnapshotSHA256 == checksum {
+			next.Known[id] = knownMeeting{
+				LastEditedTime:  meeting.LastEditedTime,
+				SnapshotSHA256:  checksum,
+				SnapshotVersion: notionSnapshotVersion,
+			}
+			progress("verified Notion meeting " + id)
+			continue
+		}
+		archiveResult, archiveErr := archiver.Upsert(ctx, snapshot, meetingarchive.UpsertOptions{
+			Force: opts.Full,
+		})
+		if archiveResult.Created {
+			sum.MeetingsAdded++
+		} else if archiveResult.Changed {
+			sum.MeetingsUpdated++
+		}
+		if archiveErr != nil {
+			sum.Errors++
+			hardErrors = append(hardErrors, fmt.Errorf("meeting %s: archive: %w", id, archiveErr))
+			continue
+		}
+		next.Known[id] = knownMeeting{
+			LastEditedTime:  meeting.LastEditedTime,
+			SnapshotSHA256:  checksum,
+			SnapshotVersion: notionSnapshotVersion,
+		}
+		progress("imported Notion meeting " + id)
+	}
+
+	if len(hardErrors) > 0 {
+		retErr = errors.Join(hardErrors...)
+		return sum, retErr
+	}
+	for id, pending := range pendingByID {
+		next.Pending = append(next.Pending, pending)
+		if known, ok := state.Known[id]; ok {
+			if _, exists := next.Known[id]; !exists {
+				next.Known[id] = known
+			}
+		}
+	}
+	for id := range next.Known {
+		if _, inWindow := visible[id]; inWindow {
+			continue
+		}
+		if _, pending := pendingByID[id]; !pending {
+			delete(next.Known, id)
+		}
+	}
+	cursor, err := next.marshal()
+	if err != nil {
+		return sum, err
+	}
+	checkpoint := &store.Checkpoint{
+		MessagesProcessed: sum.MeetingsProcessed,
+		MessagesAdded:     sum.MeetingsAdded,
+		MessagesUpdated:   sum.MeetingsUpdated,
+		ErrorsCount:       sum.Errors,
+	}
+	if err := scopedStore.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
+		return sum, err
+	}
+	if err := scopedStore.CompleteSync(syncID, cursor); err != nil {
+		return sum, err
+	}
+	sum.Duration = imp.now().UTC().Sub(started)
+	return sum, nil
+}
+
+func (imp *Importer) retrieveMeeting(ctx context.Context, id string) (MeetingNote, error) {
+	block, err := imp.client.RetrieveBlock(ctx, id)
+	if err != nil {
+		return MeetingNote{}, err
+	}
+	var meeting MeetingNote
+	if err := json.Unmarshal(block.Raw, &meeting); err != nil {
+		return MeetingNote{}, fmt.Errorf("decode meeting-note block: %w", err)
+	}
+	if meeting.ID != id || meeting.Type != "meeting_notes" {
+		return MeetingNote{}, errors.New("retrieved block has unexpected ID or type")
+	}
+	return meeting, nil
+}
+
+type archivedMeetingState struct {
+	Evidence      rawEvidence
+	HasEvidence   bool
+	Body          string
+	MessageID     int64
+	ResolvedUsers []resolvedUser
+}
+
+func (imp *Importer) archivedState(sourceID int64, id string) (archivedMeetingState, error) {
+	existing, err := imp.store.MessageExistsBatch(sourceID, []string{id})
+	if err != nil {
+		return archivedMeetingState{}, err
+	}
+	messageID, ok := existing[id]
+	if !ok {
+		return archivedMeetingState{}, nil
+	}
+	body, err := imp.store.GetMessageBodyText(messageID)
+	if err != nil {
+		return archivedMeetingState{}, err
+	}
+	archived := archivedMeetingState{Body: body, MessageID: messageID}
+	metadata, err := imp.store.GetMessageMetadata(messageID)
+	if err != nil {
+		return archivedMeetingState{}, err
+	}
+	if metadata.Valid {
+		var decoded meetingMetadata
+		if json.Unmarshal([]byte(metadata.String), &decoded) == nil {
+			archived.ResolvedUsers = decoded.ResolvedUsers
+		}
+	}
+	raw, err := imp.store.GetMessageRaw(messageID)
+	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrInvalidMessageRaw) {
+		return archived, nil
+	}
+	if err != nil {
+		return archivedMeetingState{}, err
+	}
+	evidence, ok := decodeArchivedEvidence(raw, id)
+	archived.Evidence = evidence
+	archived.HasEvidence = ok
+	if ok {
+		archived.ResolvedUsers = evidence.ResolvedUsers
+	}
+	return archived, nil
+}
+
+func decodeArchivedEvidence(raw []byte, expectedID string) (rawEvidence, bool) {
+	var evidence rawEvidence
+	if json.Unmarshal(raw, &evidence) != nil {
+		return rawEvidence{}, false
+	}
+	if evidence.SchemaVersion != notionSnapshotVersion {
+		return rawEvidence{}, false
+	}
+	var discovery MeetingNote
+	if json.Unmarshal(evidence.Discovery, &discovery) != nil ||
+		discovery.ID != expectedID || discovery.Type != "meeting_notes" {
+		return rawEvidence{}, false
+	}
+	var meetingBlock Block
+	if json.Unmarshal(evidence.MeetingBlock, &meetingBlock) != nil ||
+		meetingBlock.ID != expectedID || meetingBlock.Type != "meeting_notes" {
+		return rawEvidence{}, false
+	}
+	var markdown MarkdownPage
+	if json.Unmarshal(evidence.PageMarkdown, &markdown) != nil ||
+		markdown.Object != "page_markdown" || strings.TrimSpace(markdown.ID) == "" {
+		return rawEvidence{}, false
+	}
+	return evidence, true
+}
+
+func transcriptFromArchivedBody(body string) string {
+	const marker = "\n\nTranscript:\n"
+	_, transcript, ok := strings.Cut(body, marker)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(transcript)
+}
+
+func preserveArchivedAttendees(meeting *HydratedMeeting, archived []resolvedUser) {
+	if meeting == nil || len(archived) == 0 {
+		return
+	}
+
+	archivedByID := make(map[string]resolvedUser, len(archived))
+	for _, user := range archived {
+		id := strings.TrimSpace(user.ID)
+		email := strings.ToLower(strings.TrimSpace(user.Email))
+		if id == "" || email == "" || !user.EmailVerified {
+			continue
+		}
+		user.ID = id
+		user.Name = strings.TrimSpace(user.Name)
+		user.Email = email
+		archivedByID[id] = user
+	}
+	if len(archivedByID) == 0 {
+		return
+	}
+
+	currentByID := make(map[string]resolvedUser, len(meeting.ResolvedUsers))
+	for _, user := range meeting.ResolvedUsers {
+		currentByID[user.ID] = user
+	}
+	unresolved := make(map[string]struct{}, len(meeting.UnresolvedAttendeeIDs))
+	for _, id := range meeting.UnresolvedAttendeeIDs {
+		unresolved[id] = struct{}{}
+	}
+
+	attendeeIDs := meeting.Discovery.MeetingNotes.CalendarEvent.Attendees
+	labels := make([]string, 0, len(attendeeIDs))
+	attendees := make([]meetingarchive.Person, 0, len(attendeeIDs))
+	resolved := make([]resolvedUser, 0, len(attendeeIDs))
+	seenEmails := make(map[string]struct{}, len(attendeeIDs))
+	seenResolvedIDs := make(map[string]struct{}, len(attendeeIDs))
+	restored := 0
+	for index, id := range attendeeIDs {
+		label := id
+		if index < len(meeting.AttendeeLabels) && strings.TrimSpace(meeting.AttendeeLabels[index]) != "" {
+			label = strings.TrimSpace(meeting.AttendeeLabels[index])
+		}
+
+		user, ok := currentByID[id]
+		if !ok {
+			if _, isUnresolved := unresolved[id]; isUnresolved {
+				user, ok = archivedByID[id]
+				if ok {
+					restored++
+					delete(unresolved, id)
+				}
+			}
+		}
+		if !ok {
+			labels = append(labels, label)
+			continue
+		}
+
+		user.ID = strings.TrimSpace(user.ID)
+		user.Name = strings.TrimSpace(user.Name)
+		user.Email = strings.ToLower(strings.TrimSpace(user.Email))
+		if user.Name != "" {
+			label = user.Name
+		}
+		labels = append(labels, label)
+		if user.Email == "" || !user.EmailVerified {
+			continue
+		}
+		if _, seen := seenResolvedIDs[user.ID]; !seen {
+			resolved = append(resolved, user)
+			seenResolvedIDs[user.ID] = struct{}{}
+		}
+		if _, seen := seenEmails[user.Email]; seen {
+			continue
+		}
+		attendees = append(attendees, meetingarchive.Person{Name: user.Name, Email: user.Email})
+		seenEmails[user.Email] = struct{}{}
+	}
+	if restored == 0 {
+		return
+	}
+
+	remainingUnresolved := make([]string, 0, len(meeting.UnresolvedAttendeeIDs))
+	for _, id := range meeting.UnresolvedAttendeeIDs {
+		if _, remains := unresolved[id]; remains {
+			remainingUnresolved = append(remainingUnresolved, id)
+		}
+	}
+	meeting.AttendeeLabels = labels
+	meeting.Attendees = attendees
+	meeting.ResolvedUsers = resolved
+	meeting.UnresolvedAttendeeIDs = remainingUnresolved
+	meeting.Warnings = append(meeting.Warnings, "user directory lookup failed; preserved previously verified attendees from archived evidence")
+}
+
+func preserveArchivedAttendeeRelationships(
+	meeting *HydratedMeeting,
+	archived []store.MessageRecipient,
+	archivedUsers []resolvedUser,
+) {
+	if meeting == nil || len(archived) == 0 {
+		return
+	}
+	currentByID := make(map[string]int, len(meeting.ResolvedUsers))
+	emailUsers := make(map[string]map[int]struct{}, len(meeting.ResolvedUsers))
+	addEmailUser := func(email string, userIndex int) {
+		email = strings.ToLower(strings.TrimSpace(email))
+		if email == "" {
+			return
+		}
+		users := emailUsers[email]
+		if users == nil {
+			users = make(map[int]struct{})
+			emailUsers[email] = users
+		}
+		users[userIndex] = struct{}{}
+	}
+	addAlias := func(userIndex int, email string) {
+		email = strings.ToLower(strings.TrimSpace(email))
+		user := &meeting.ResolvedUsers[userIndex]
+		if email == "" || email == strings.ToLower(strings.TrimSpace(user.Email)) {
+			return
+		}
+		for _, alias := range user.EmailAliases {
+			if strings.EqualFold(strings.TrimSpace(alias), email) {
+				return
+			}
+		}
+		user.EmailAliases = append(user.EmailAliases, email)
+	}
+	for index := range meeting.ResolvedUsers {
+		user := &meeting.ResolvedUsers[index]
+		id := strings.TrimSpace(user.ID)
+		email := strings.ToLower(strings.TrimSpace(user.Email))
+		if id == "" || email == "" || !user.EmailVerified {
+			continue
+		}
+		user.ID = id
+		user.Email = email
+		currentByID[id] = index
+		addEmailUser(email, index)
+		for _, alias := range user.EmailAliases {
+			addEmailUser(alias, index)
+		}
+	}
+	for _, user := range archivedUsers {
+		index, current := currentByID[strings.TrimSpace(user.ID)]
+		if !current || !user.EmailVerified {
+			continue
+		}
+		for _, email := range append([]string{user.Email}, user.EmailAliases...) {
+			addEmailUser(email, index)
+			addAlias(index, email)
+		}
+	}
+	if len(emailUsers) == 0 {
+		return
+	}
+	currentParticipants := make(map[int64]map[int]struct{}, len(emailUsers))
+	for _, recipient := range archived {
+		email := strings.ToLower(strings.TrimSpace(recipient.EmailAddress))
+		users := emailUsers[email]
+		if len(users) == 0 {
+			continue
+		}
+		participantUsers := currentParticipants[recipient.ParticipantID]
+		if participantUsers == nil {
+			participantUsers = make(map[int]struct{})
+			currentParticipants[recipient.ParticipantID] = participantUsers
+		}
+		for index := range users {
+			participantUsers[index] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(meeting.Attendees)+len(archived))
+	for _, attendee := range meeting.Attendees {
+		email := strings.ToLower(strings.TrimSpace(attendee.Email))
+		if email != "" {
+			seen[email] = struct{}{}
+		}
+	}
+	restored := 0
+	for _, recipient := range archived {
+		users := currentParticipants[recipient.ParticipantID]
+		if len(users) == 0 {
+			continue
+		}
+		email := strings.ToLower(strings.TrimSpace(recipient.EmailAddress))
+		if email == "" {
+			continue
+		}
+		for index := range users {
+			addAlias(index, email)
+		}
+		if _, ok := seen[email]; ok {
+			continue
+		}
+		meeting.Attendees = append(meeting.Attendees, meetingarchive.Person{
+			Name: strings.TrimSpace(recipient.DisplayName), Email: email,
+		})
+		seen[email] = struct{}{}
+		restored++
+	}
+	if restored > 0 {
+		meeting.Warnings = append(meeting.Warnings,
+			"user directory lookup failed; preserved previously verified attendees from archived relationships")
+	}
+}
+
+func coverageFor(result *QueryResult, limited bool) Coverage {
+	coverage := Coverage{HasMore: result.HasMore, Returned: len(result.Results), Limited: limited}
+	for _, meeting := range result.Results {
+		value := meeting.LastEditedTime
+		if value == "" {
+			continue
+		}
+		if coverage.OldestEdit == "" || value < coverage.OldestEdit {
+			coverage.OldestEdit = value
+		}
+		if coverage.NewestEdit == "" || value > coverage.NewestEdit {
+			coverage.NewestEdit = value
+		}
+	}
+	return coverage
+}
+
+func candidateTime(meeting MeetingNote) time.Time {
+	for _, value := range []string{
+		meeting.MeetingNotes.CalendarEvent.StartTime,
+		meeting.MeetingNotes.Recording.StartTime,
+		meeting.CreatedTime,
+	} {
+		if parsed := parseNotionTime(value); !parsed.IsZero() {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func schedulePending(meeting *HydratedMeeting, now time.Time, previous pendingTranscript, hasPrevious bool) (pendingTranscript, bool) {
+	_, endedAt := meeting.times()
+	retryUntil := time.Time{}
+	if hasPrevious {
+		retryUntil, _ = time.Parse(time.RFC3339, previous.RetryUntil)
+	}
+	if !endedAt.IsZero() {
+		deadline := endedAt.Add(transcriptRetryWindow)
+		if deadline.After(retryUntil) {
+			retryUntil = deadline
+		}
+	} else if retryUntil.IsZero() {
+		retryUntil = now.Add(unknownTranscriptRetrySpan)
+	}
+	if !retryUntil.After(now) {
+		return pendingTranscript{}, false
+	}
+	next := now.Add(transcriptRetryCadence)
+	if next.After(retryUntil) {
+		next = retryUntil
+	}
+	return pendingTranscript{
+		BlockID:       meeting.Discovery.ID,
+		NextAttemptAt: next.UTC().Format(time.RFC3339),
+		RetryUntil:    retryUntil.UTC().Format(time.RFC3339),
+	}, true
+}
+
+func pendingDue(pending pendingTranscript, now time.Time) bool {
+	next, err := time.Parse(time.RFC3339, pending.NextAttemptAt)
+	return err != nil || !next.After(now)
+}
+
+func pendingExpired(pending pendingTranscript, now time.Time) bool {
+	until, err := time.Parse(time.RFC3339, pending.RetryUntil)
+	return err == nil && !until.After(now)
+}
+
+func terminalStatus(status string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	return strings.Contains(normalized, "fail") || strings.Contains(normalized, "delete")
+}
+
+func checksumBytes(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}

--- a/internal/notionmeetings/importer_test.go
+++ b/internal/notionmeetings/importer_test.go
@@ -154,7 +154,9 @@ func TestImporterFullRepairsDerivedArchiveData(t *testing.T) {
 	metadata, err := st.GetMessageMetadata(messageID)
 	require.NoError(err)
 	assert.True(metadata.Valid)
-	assert.Contains(metadata.String, `"platform":"notion_meetings"`)
+	var repairedMetadata map[string]any
+	require.NoError(json.Unmarshal([]byte(metadata.String), &repairedMetadata))
+	assert.Equal("notion_meetings", repairedMetadata["platform"])
 	var envelope, rawFormat string
 	require.NoError(st.DB().QueryRow(st.Rebind(`
 		SELECT mr.email_address, raw.raw_format

--- a/internal/notionmeetings/importer_test.go
+++ b/internal/notionmeetings/importer_test.go
@@ -1,0 +1,1146 @@
+package notionmeetings
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type fakeImportSource struct {
+	*fakeHydrationSource
+
+	query    *QueryResult
+	queryErr error
+}
+
+func (f *fakeImportSource) QueryMeetingNotes(context.Context, int) (*QueryResult, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.query, nil
+}
+
+func newImporterFixture(t *testing.T) (*store.Store, *fakeImportSource, *Importer) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	_, err := st.GetOrCreateSource(SourceType, "work")
+	require.NoError(t, err)
+	source := &fakeImportSource{
+		fakeHydrationSource: completeHydrationSource(),
+		query:               &QueryResult{Results: []MeetingNote{hydrationMeeting()}},
+	}
+	imp := NewImporter(st, source)
+	imp.now = func() time.Time { return time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC) }
+	return st, source, imp
+}
+
+func lastNotionState(t *testing.T, st *store.Store, sourceID int64) syncState {
+	t.Helper()
+	run, err := st.GetLastSuccessfulSync(sourceID)
+	require.NoError(t, err)
+	require.True(t, run.CursorAfter.Valid)
+	var state syncState
+	require.NoError(t, json.Unmarshal([]byte(run.CursorAfter.String), &state))
+	return state
+}
+
+func lastTranscriptRetryUntil(t *testing.T, st *store.Store, sourceID int64) map[string]string {
+	t.Helper()
+	run, err := st.GetLastSuccessfulSync(sourceID)
+	require.NoError(t, err)
+	require.True(t, run.CursorAfter.Valid)
+	var cursor struct {
+		TranscriptRetryUntil map[string]string `json:"transcript_retry_until"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(run.CursorAfter.String), &cursor))
+	return cursor.TranscriptRetryUntil
+}
+
+func TestImporterCreatesUpdatesAndVerifiesVisibleMeetings(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+
+	first, err := imp.Import(context.Background(), ImportOptions{
+		Identifier: "work", AccountEmail: "user@example.com",
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+	assert.Equal(int64(1), first.MeetingsProcessed)
+	state := lastNotionState(t, st, first.SourceID)
+	assert.Equal(syncStateVersion, state.Version)
+	require.Contains(state.Known, "meeting-1")
+	assert.Equal("2026-08-29T10:35:00Z", state.Known["meeting-1"].LastEditedTime)
+
+	second, err := imp.Import(context.Background(), ImportOptions{
+		Identifier: "work", AccountEmail: "user@example.com",
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MeetingsProcessed)
+	assert.Zero(second.MeetingsUpdated)
+
+	meeting := hydrationMeeting()
+	meeting.LastEditedTime = "2026-08-29T12:30:00Z"
+	source.query.Results = []MeetingNote{meeting}
+	updated := paragraph("summary-1", "Ship the edited release scope.", false)
+	source.blocks["summary-1"] = &updated
+	third, err := imp.Import(context.Background(), ImportOptions{
+		Identifier: "work", AccountEmail: "user@example.com",
+	})
+	require.NoError(err)
+	assert.Equal(int64(1), third.MeetingsUpdated)
+
+	var body string
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "Ship the edited release scope.")
+	var sender sql.NullInt64
+	require.NoError(st.DB().QueryRow(`SELECT sender_id FROM messages`).Scan(&sender))
+	assert.False(sender.Valid, "Notion created_by must not become organizer")
+	var attendee string
+	require.NoError(st.DB().QueryRow(`
+		SELECT p.email_address
+		FROM message_recipients mr
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE mr.recipient_type = 'to'
+	`).Scan(&attendee))
+	assert.Equal("attendee@example.com", attendee)
+	_, hits, err := st.SearchMessages("edited", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), hits)
+}
+
+func TestImporterFullRepairsDerivedArchiveData(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, _, imp := newImporterFixture(t)
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`,
+	), "meeting-1").Scan(&messageID))
+	for _, query := range []string{
+		`UPDATE message_recipients SET email_address = NULL WHERE message_id = ?`,
+		`DELETE FROM conversation_participants
+		 WHERE conversation_id = (SELECT conversation_id FROM messages WHERE id = ?)`,
+		`DELETE FROM message_bodies WHERE message_id = ?`,
+		`UPDATE messages SET metadata = NULL WHERE id = ?`,
+		`UPDATE message_raw SET raw_format = 'stale' WHERE message_id = ?`,
+	} {
+		_, err = st.DB().Exec(st.Rebind(query), messageID)
+		require.NoError(err)
+	}
+
+	repaired, err := imp.Import(context.Background(), ImportOptions{Identifier: "work", Full: true})
+	require.NoError(err)
+	assert.Equal(int64(1), repaired.MeetingsUpdated)
+
+	body, err := st.GetMessageBodyText(messageID)
+	require.NoError(err)
+	assert.Contains(body, "Decide the release scope.")
+	metadata, err := st.GetMessageMetadata(messageID)
+	require.NoError(err)
+	assert.True(metadata.Valid)
+	assert.Contains(metadata.String, `"platform":"notion_meetings"`)
+	var envelope, rawFormat string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mr.email_address, raw.raw_format
+		FROM message_recipients mr
+		JOIN message_raw raw ON raw.message_id = mr.message_id
+		WHERE mr.message_id = ? AND mr.recipient_type = 'to'
+	`), messageID).Scan(&envelope, &rawFormat))
+	assert.Equal("attendee@example.com", envelope)
+	assert.Equal(RawFormat, rawFormat)
+	var conversationParticipants int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM conversation_participants
+		WHERE conversation_id = (SELECT conversation_id FROM messages WHERE id = ?)
+	`), messageID).Scan(&conversationParticipants))
+	assert.Equal(1, conversationParticipants)
+}
+
+func TestImporterRestoresMissingArchiveForKnownSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, _, imp := newImporterFixture(t)
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+	_, err = st.DB().Exec(st.Rebind("DELETE FROM messages WHERE source_id = ?"), first.SourceID)
+	require.NoError(err)
+
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MeetingsAdded)
+
+	var body string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT mb.body_text
+		FROM messages m
+		JOIN message_bodies mb ON mb.message_id = m.id
+		WHERE m.source_id = ? AND m.source_message_id = 'meeting-1'
+	`), first.SourceID).Scan(&body))
+	assert.Contains(body, "Decide the release scope.")
+}
+
+func TestImporterRepairsUnavailableRawEvidence(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *store.Store, int64)
+	}{
+		{
+			name: "missing",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				_, err := st.DB().Exec(st.Rebind("DELETE FROM message_raw WHERE message_id = ?"), messageID)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "malformed",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				require.NoError(t, st.UpsertMessageRawWithFormat(messageID, []byte("{"), RawFormat))
+			},
+		},
+		{
+			name: "empty object",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				require.NoError(t, st.UpsertMessageRawWithFormat(messageID, []byte(`{}`), RawFormat))
+			},
+		},
+		{
+			name: "corrupt compression",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				_, err := st.DB().Exec(st.Rebind(`
+					UPDATE message_raw SET raw_data = ?, compression = 'zlib'
+					WHERE message_id = ?
+				`), []byte("not zlib"), messageID)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, _, imp := newImporterFixture(t)
+			first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+
+			var messageID int64
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT id FROM messages
+				WHERE source_id = ? AND source_message_id = 'meeting-1'
+			`), first.SourceID).Scan(&messageID))
+			tt.mutate(t, st, messageID)
+
+			second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), second.MeetingsUpdated)
+
+			raw, err := st.GetMessageRaw(messageID)
+			require.NoError(err)
+			var evidence rawEvidence
+			require.NoError(json.Unmarshal(raw, &evidence))
+			assert.Contains(evidence.Canonical.Summary, "Decide the release scope.")
+		})
+	}
+}
+
+func TestImporterDetectsHydratedSnapshotChangesWithoutDiscoveryEdit(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*fakeImportSource)
+		wantBody string
+		wantRaw  string
+	}{
+		{
+			name: "summary child",
+			mutate: func(source *fakeImportSource) {
+				updated := paragraph("summary-1", "Ship the revised release scope.", false)
+				source.blocks["summary-1"] = &updated
+			},
+			wantBody: "Ship the revised release scope.",
+		},
+		{
+			name: "nested child",
+			mutate: func(source *fakeImportSource) {
+				updated := paragraph("nested-1", "Revised nested action item.", false)
+				source.children["notes-1"][""] = &BlockPage{
+					Results: []Block{updated},
+					Raw:     json.RawMessage(`{"results":[{"id":"nested-1","text":"Revised nested action item."}],"has_more":false}`),
+				}
+			},
+			wantBody: "Revised nested action item.",
+		},
+		{
+			name: "page Markdown",
+			mutate: func(source *fakeImportSource) {
+				source.markdown.Markdown = "# Weekly planning\n\nRevised page context.\n\n## Transcript\nTest Speaker: Ready to ship."
+				source.markdown.Raw = json.RawMessage(`{"object":"page_markdown","id":"page-1","markdown":"Revised page context."}`)
+			},
+			wantRaw: "Revised page context.",
+		},
+		{
+			name: "attendee display label",
+			mutate: func(source *fakeImportSource) {
+				source.users[""].Results[1].Name = "Renamed Unresolved Attendee"
+			},
+			wantBody: "Attendees: Test Attendee, Renamed Unresolved Attendee",
+			wantRaw:  `"attendee_labels":["Test Attendee","Renamed Unresolved Attendee"]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, source, imp := newImporterFixture(t)
+
+			first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), first.MeetingsAdded)
+
+			tt.mutate(source)
+			second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), second.MeetingsProcessed)
+			assert.Equal(int64(1), second.MeetingsUpdated)
+
+			var messageID int64
+			var body string
+			require.NoError(st.DB().QueryRow(`
+				SELECT m.id, mb.body_text
+				FROM messages m
+				JOIN message_bodies mb ON mb.message_id = m.id
+				WHERE m.source_message_id = 'meeting-1'
+			`).Scan(&messageID, &body))
+			if tt.wantBody != "" {
+				assert.Contains(body, tt.wantBody)
+			}
+			if tt.wantRaw != "" {
+				raw, rawErr := st.GetMessageRaw(messageID)
+				require.NoError(rawErr)
+				assert.Contains(string(raw), tt.wantRaw)
+			}
+
+			third, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), third.MeetingsProcessed)
+			assert.Zero(third.MeetingsAdded)
+			assert.Zero(third.MeetingsUpdated)
+		})
+	}
+}
+
+func TestImporterKeepsMatchingMeetingIDsIsolatedBySource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, firstImporter := newImporterFixture(t)
+	first, err := firstImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	_, err = st.GetOrCreateSource(SourceType, "personal")
+	require.NoError(err)
+	secondImporter := NewImporter(st, source)
+	secondImporter.now = firstImporter.now
+	second, err := secondImporter.Import(context.Background(), ImportOptions{Identifier: "personal"})
+	require.NoError(err)
+	assert.NotEqual(first.SourceID, second.SourceID)
+
+	var count int
+	require.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages WHERE source_message_id = 'meeting-1'`,
+	).Scan(&count))
+	assert.Equal(2, count)
+}
+
+func TestImporterLimitAndAfterRemainLocalVisibleSetBounds(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	second := hydrationMeeting()
+	second.ID = "meeting-2"
+	second.LastEditedTime = "2026-08-29T10:35:00Z"
+	source.query.Results = []MeetingNote{hydrationMeeting(), second}
+
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work", Limit: 1})
+	require.NoError(err)
+	state := lastNotionState(t, st, summary.SourceID)
+	assert.True(state.Coverage.Limited)
+	assert.Contains(state.Known, "meeting-1")
+	assert.NotContains(state.Known, "meeting-2")
+
+	otherStore, otherSource, otherImporter := newImporterFixture(t)
+	otherSource.query.Results = []MeetingNote{hydrationMeeting()}
+	after, err := otherImporter.Import(context.Background(), ImportOptions{
+		Identifier: "work", CreatedAfter: time.Date(2026, 8, 30, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+	assert.Zero(after.MeetingsProcessed)
+	afterState := lastNotionState(t, otherStore, after.SourceID)
+	assert.Empty(afterState.Known)
+}
+
+func TestImporterRecordsPartialCoverageWithoutLooping(t *testing.T) {
+	assert := assert.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.query.HasMore = true
+
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(t, err)
+	state := lastNotionState(t, st, summary.SourceID)
+	assert.True(state.Coverage.HasMore)
+	assert.Equal(1, state.Coverage.Returned)
+	assert.True(summary.PartialCoverage)
+}
+
+func TestImporterHardFailureRetainsLastSuccessfulState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	before := lastNotionState(t, st, first.SourceID)
+
+	meeting := hydrationMeeting()
+	meeting.LastEditedTime = "2026-08-29T13:00:00Z"
+	source.query.Results = []MeetingNote{meeting}
+	delete(source.blocks, "summary-1")
+	failed, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.Error(err)
+	assert.Equal(int64(1), failed.Errors)
+	after := lastNotionState(t, st, first.SourceID)
+	assert.Equal(before, after)
+}
+
+func TestImporterReportsWriteCommittedBeforeConversationStatsFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, _, imp := newImporterFixture(t)
+	if st.IsPostgreSQL() {
+		_, err := st.DB().Exec(`
+			CREATE FUNCTION fail_notion_meeting_stats() RETURNS trigger AS $$
+			BEGIN
+				RAISE EXCEPTION 'forced Notion meeting stats failure';
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER fail_notion_meeting_stats
+			BEFORE UPDATE OF message_count ON conversations
+			FOR EACH ROW EXECUTE FUNCTION fail_notion_meeting_stats();
+		`)
+		require.NoError(err)
+	} else {
+		_, err := st.DB().Exec(`
+			CREATE TRIGGER fail_notion_meeting_stats
+			BEFORE UPDATE OF message_count ON conversations
+			BEGIN
+				SELECT RAISE(ABORT, 'forced Notion meeting stats failure');
+			END
+		`)
+		require.NoError(err)
+	}
+
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.Error(err)
+	assert.Equal(int64(1), summary.MeetingsAdded)
+	assert.Equal(int64(1), summary.Errors)
+
+	var messages int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&messages))
+	assert.Equal(1, messages)
+}
+
+func TestImporterRetriesPendingTranscriptOutsideVisibleLimit(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.blockErrs = map[string]error{
+		"transcript-1": &APIError{Kind: ErrProvider, Status: 404, Code: "object_not_found"},
+	}
+	source.markdown.Markdown = "# Weekly planning"
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work", Limit: 1})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+	state := lastNotionState(t, st, first.SourceID)
+	require.Len(state.Pending, 1)
+	assert.Equal("meeting-1", state.Pending[0].BlockID)
+	var body string
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "Decide the release scope.")
+	assert.NotContains(body, "Transcript:")
+
+	fullDiscovery, err := json.Marshal(hydrationMeeting())
+	require.NoError(err)
+	source.blocks["meeting-1"].Raw = fullDiscovery
+	source.query.Results = nil
+	delete(source.blockErrs, "transcript-1")
+	late := paragraph("transcript-1", "Test Speaker: Transcript arrived.", false)
+	source.blocks["transcript-1"] = &late
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Transcript arrived."
+	imp.now = func() time.Time { return time.Date(2026, 8, 29, 18, 1, 0, 0, time.UTC) }
+
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work", Limit: 1})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MaintenanceRetries)
+	state = lastNotionState(t, st, second.SourceID)
+	assert.Empty(state.Pending)
+
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "Transcript arrived.")
+}
+
+func TestImporterRetriesTruncatedMarkdownTranscriptUntilComplete(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Partial transcript."
+	source.markdown.Truncated = true
+	source.markdown.Raw = json.RawMessage(`{"object":"page_markdown","id":"page-1","truncated":true}`)
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state := lastNotionState(t, st, first.SourceID)
+	require.Len(state.Pending, 1)
+	assert.Equal("meeting-1", state.Pending[0].BlockID)
+	var body string
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.NotContains(body, "Partial transcript.")
+
+	fullDiscovery, err := json.Marshal(hydrationMeeting())
+	require.NoError(err)
+	source.blocks["meeting-1"].Raw = fullDiscovery
+	source.query.Results = nil
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Complete transcript."
+	source.markdown.Truncated = false
+	source.markdown.Raw = json.RawMessage(`{"object":"page_markdown","id":"page-1","truncated":false}`)
+	imp.now = func() time.Time { return time.Date(2026, 8, 29, 18, 1, 0, 0, time.UTC) }
+
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MaintenanceRetries)
+	assert.Equal(int64(1), second.MeetingsUpdated)
+	state = lastNotionState(t, st, second.SourceID)
+	assert.Empty(state.Pending)
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "Complete transcript.")
+}
+
+func TestImporterDoesNotRenewExpiredUnknownEndTranscriptRetry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	meeting := hydrationMeeting()
+	meeting.MeetingNotes.CalendarEvent.EndTime = ""
+	meeting.MeetingNotes.Recording.EndTime = ""
+	source.query.Results = []MeetingNote{meeting}
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning"
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state := lastNotionState(t, st, first.SourceID)
+	require.Len(state.Pending, 1)
+	assert.Equal("2026-08-31T12:00:00Z", state.Pending[0].RetryUntil)
+
+	expiredImporter := NewImporter(st, source)
+	expiredImporter.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	second, err := expiredImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state = lastNotionState(t, st, second.SourceID)
+	assert.Empty(state.Pending)
+	assert.Equal("2026-08-31T12:00:00Z", lastTranscriptRetryUntil(t, st, second.SourceID)["meeting-1"])
+
+	muchLaterImporter := NewImporter(st, source)
+	muchLaterImporter.now = func() time.Time { return time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC) }
+	third, err := muchLaterImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state = lastNotionState(t, st, third.SourceID)
+	assert.Empty(state.Pending)
+	assert.Equal("2026-08-31T12:00:00Z", lastTranscriptRetryUntil(t, st, third.SourceID)["meeting-1"])
+
+	updated := paragraph("summary-1", "Ship the post-expiry release scope.", false)
+	source.blocks["summary-1"] = &updated
+	editImporter := NewImporter(st, source)
+	editImporter.now = func() time.Time { return time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC) }
+	edited, err := editImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), edited.MeetingsUpdated)
+	state = lastNotionState(t, st, edited.SourceID)
+	assert.Empty(state.Pending)
+	var body string
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "post-expiry release scope")
+
+	late := paragraph("transcript-1", "Test Speaker: Transcript arrived after expiry.", false)
+	source.blocks["transcript-1"] = &late
+	source.markdown.Markdown = "# Weekly planning\n\n## Transcript\nTest Speaker: Transcript arrived after expiry."
+	lateImporter := NewImporter(st, source)
+	lateImporter.now = func() time.Time { return time.Date(2026, 9, 2, 14, 0, 0, 0, time.UTC) }
+	lateSummary, err := lateImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), lateSummary.MeetingsUpdated)
+	state = lastNotionState(t, st, lateSummary.SourceID)
+	assert.Empty(state.Pending)
+	require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+	assert.Contains(body, "Transcript arrived after expiry.")
+}
+
+func TestImporterMigratesPendingRetryDeadlineFromVersionOneCursor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	meeting := hydrationMeeting()
+	meeting.MeetingNotes.CalendarEvent.EndTime = ""
+	source.query.Results = []MeetingNote{meeting}
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning"
+
+	sourceRecord, err := st.GetSourceByTypeAndIdentifier(SourceType, "work")
+	require.NoError(err)
+	syncID, err := st.StartSync(sourceRecord.ID, SourceType)
+	require.NoError(err)
+	require.NoError(st.CompleteSync(syncID, `{"version":1,"last_query_at":"2026-08-29T12:00:00Z","known":{},"pending":[{"block_id":"meeting-1","next_attempt_at":"2026-08-29T18:00:00Z","retry_until":"2026-08-31T12:00:00Z"}],"coverage":{"has_more":false,"returned":1}}`))
+
+	imp.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state := lastNotionState(t, st, summary.SourceID)
+	assert.Empty(state.Pending)
+	assert.Equal("2026-08-31T12:00:00Z", lastTranscriptRetryUntil(t, st, summary.SourceID)["meeting-1"])
+}
+
+func TestImporterReopensExpiredTranscriptRetryForLaterUsableEnd(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	meeting := hydrationMeeting()
+	meeting.MeetingNotes.CalendarEvent.EndTime = ""
+	source.query.Results = []MeetingNote{meeting}
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning"
+
+	_, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	expiredImporter := NewImporter(st, source)
+	expiredImporter.now = func() time.Time { return time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC) }
+	_, err = expiredImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+
+	meeting.MeetingNotes.CalendarEvent.EndTime = "2026-09-01T12:00:00Z"
+	source.query.Results = []MeetingNote{meeting}
+	extendedImporter := NewImporter(st, source)
+	extendedImporter.now = func() time.Time { return time.Date(2026, 9, 1, 13, 0, 0, 0, time.UTC) }
+	extended, err := extendedImporter.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state := lastNotionState(t, st, extended.SourceID)
+	require.Len(state.Pending, 1)
+	assert.Equal("2026-09-08T12:00:00Z", state.Pending[0].RetryUntil)
+	assert.Equal("2026-09-08T12:00:00Z", lastTranscriptRetryUntil(t, st, extended.SourceID)["meeting-1"])
+}
+
+func TestSyncStateRejectsInvalidTranscriptRetryDeadline(t *testing.T) {
+	var state syncState
+	require.NoError(t, json.Unmarshal([]byte(`{"version":1,"known":{},"transcript_retry_until":{"meeting-1":"not-a-time"}}`), &state))
+
+	err := state.validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `transcript retry deadline "meeting-1" is invalid`)
+}
+
+func TestImporterContinuesWhenUserListingFailsTransiently(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.usersErr = errors.New("rate limit exceeded")
+
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MeetingsAdded)
+	assert.Zero(summary.Errors)
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = 'meeting-1'`,
+	).Scan(&messageID))
+	raw, err := st.GetMessageRaw(messageID)
+	require.NoError(err)
+	assert.Contains(string(raw), "Notion User Information lookup failed: rate limit exceeded")
+	var participants int
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT COUNT(*) FROM message_recipients WHERE message_id = ?`), messageID,
+	).Scan(&participants))
+	assert.Zero(participants)
+}
+
+func TestImporterPreservesVerifiedAttendeesWhenUserListingFailsTransiently(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.users[""].Results[0].Person.Email = "durableaddress@example.com"
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+
+	var messageID, recipientID int64
+	var recipientEmail, recipientName, envelopeEmail string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT m.id, mr.participant_id, p.email_address, mr.display_name,
+		       COALESCE(mr.email_address, '')
+		FROM messages m
+		JOIN message_recipients mr ON mr.message_id = m.id
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE m.source_message_id = ? AND mr.recipient_type = 'to'
+	`), "meeting-1").Scan(
+		&messageID, &recipientID, &recipientEmail, &recipientName, &envelopeEmail,
+	))
+	assert.Equal("durableaddress@example.com", recipientEmail)
+	assert.Equal("Test Attendee", recipientName)
+	assert.Equal("durableaddress@example.com", envelopeEmail)
+
+	var conversationParticipants int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM messages m
+		JOIN conversation_participants cp ON cp.conversation_id = m.conversation_id
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE m.id = ? AND p.email_address = ?
+	`), messageID, "durableaddress@example.com").Scan(&conversationParticipants))
+	assert.Equal(1, conversationParticipants)
+	_, hits, err := st.SearchMessages("durableaddress", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), hits)
+
+	survivorID, err := st.EnsureParticipant(
+		"mergedaddress@example.com", "Merged Participant", "example.com",
+	)
+	require.NoError(err)
+	require.NoError(st.MergeParticipants(recipientID, survivorID))
+
+	source.usersErr = errors.New("rate limit exceeded")
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE message_raw SET raw_data = ?, compression = 'zlib'
+		WHERE message_id = ?
+	`), []byte("not zlib"), messageID)
+	require.NoError(err)
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MeetingsUpdated)
+
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT p.email_address, mr.display_name, COALESCE(mr.email_address, '')
+		FROM message_recipients mr
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE mr.message_id = ? AND mr.recipient_type = 'to'
+	`), messageID).Scan(&recipientEmail, &recipientName, &envelopeEmail))
+	assert.Equal("durableaddress@example.com", recipientEmail)
+	assert.Equal("Test Attendee", recipientName)
+	assert.Equal("durableaddress@example.com", envelopeEmail)
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*)
+		FROM conversation_participants cp
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE cp.conversation_id = (SELECT conversation_id FROM messages WHERE id = ?)
+		  AND p.email_address = ?
+	`), messageID, "durableaddress@example.com").Scan(&conversationParticipants))
+	assert.Equal(1, conversationParticipants)
+	_, hits, err = st.SearchMessages("durableaddress", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), hits)
+
+	raw, err := st.GetMessageRaw(messageID)
+	require.NoError(err)
+	_, validEvidence := decodeArchivedEvidence(raw, "meeting-1")
+	assert.True(validEvidence)
+	assert.Contains(string(raw), "preserved previously verified attendees from archived evidence")
+}
+
+func TestImporterDegradedAttendeeRecoveryDropsRemovedUsers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.users[""].Results[0].Person.Email = "retained@example.com"
+	source.users[""].Results[1].Person.Email = "removed@example.com"
+	source.users[""].Results[1].Person.EmailVerified = true
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+
+	meeting := hydrationMeeting()
+	meeting.MeetingNotes.CalendarEvent.Attendees = []string{"user-1"}
+	source.query.Results = []MeetingNote{meeting}
+	source.usersErr = errors.New("rate limit exceeded")
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), second.MeetingsUpdated)
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`,
+	), "meeting-1").Scan(&messageID))
+	for email, want := range map[string]int{
+		"retained@example.com": 1,
+		"removed@example.com":  0,
+	} {
+		var recipients int
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COUNT(*)
+			FROM message_recipients mr
+			WHERE mr.message_id = ? AND mr.email_address = ?
+		`), messageID, email).Scan(&recipients))
+		assert.Equal(want, recipients, email)
+	}
+	_, hits, err := st.SearchMessages("retained", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), hits)
+	_, hits, err = st.SearchMessages("removed", 0, 10)
+	require.NoError(err)
+	assert.Zero(hits)
+}
+
+func TestImporterPreservesRenamedAttendeeAliasesDuringDegradedLookup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	source.users[""].Results[0].Person.Email = "original@example.com"
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), first.MeetingsAdded)
+
+	renamed := source.users[""].Results[0]
+	renamed.Person.Email = "renamed@example.com"
+	source.users = map[string]*UserPage{
+		"": {
+			Results:    []User{renamed},
+			HasMore:    true,
+			NextCursor: "next",
+		},
+	}
+	source.userErrs = map[string]error{"next": errors.New("rate limit exceeded")}
+
+	for range 2 {
+		_, err = imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+		require.NoError(err)
+	}
+
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`,
+	), "meeting-1").Scan(&messageID))
+	for _, email := range []string{"original@example.com", "renamed@example.com"} {
+		var recipients int
+		require.NoError(st.DB().QueryRow(st.Rebind(`
+			SELECT COUNT(*)
+			FROM message_recipients
+			WHERE message_id = ? AND email_address = ?
+		`), messageID, email).Scan(&recipients))
+		assert.Equal(1, recipients, email)
+		_, hits, err := st.SearchMessages(strings.TrimSuffix(email, "@example.com"), 0, 10)
+		require.NoError(err)
+		assert.Equal(int64(1), hits, email)
+	}
+}
+
+func TestImporterHealthyAttendeeResolutionRemainsAuthoritative(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*fakeImportSource)
+	}{
+		{
+			name: "removed from event",
+			mutate: func(source *fakeImportSource) {
+				meeting := hydrationMeeting()
+				meeting.MeetingNotes.CalendarEvent.Attendees = []string{"user-2"}
+				source.query.Results = []MeetingNote{meeting}
+			},
+		},
+		{
+			name: "now unverified",
+			mutate: func(source *fakeImportSource) {
+				source.users[""].Results[0].Person.EmailVerified = false
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, source, imp := newImporterFixture(t)
+			source.users[""].Results[0].Person.Email = "authoritativeaddress@example.com"
+
+			first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), first.MeetingsAdded)
+
+			tt.mutate(source)
+			second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), second.MeetingsUpdated)
+
+			var messageID int64
+			require.NoError(st.DB().QueryRow(st.Rebind(
+				`SELECT id FROM messages WHERE source_message_id = ?`,
+			), "meeting-1").Scan(&messageID))
+			var recipients int
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COUNT(*)
+				FROM message_recipients mr
+				JOIN participants p ON p.id = mr.participant_id
+				WHERE mr.message_id = ? AND p.email_address = ?
+			`), messageID, "authoritativeaddress@example.com").Scan(&recipients))
+			assert.Zero(recipients)
+			var conversationParticipants int
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT COUNT(*)
+				FROM conversation_participants cp
+				JOIN participants p ON p.id = cp.participant_id
+				WHERE cp.conversation_id = (SELECT conversation_id FROM messages WHERE id = ?)
+				  AND p.email_address = ?
+			`), messageID, "authoritativeaddress@example.com").Scan(&conversationParticipants))
+			assert.Zero(conversationParticipants)
+			_, hits, err := st.SearchMessages("authoritativeaddress", 0, 10)
+			require.NoError(err)
+			assert.Zero(hits)
+			raw, err := st.GetMessageRaw(messageID)
+			require.NoError(err)
+			assert.NotContains(string(raw), "authoritativeaddress@example.com")
+		})
+	}
+}
+
+func TestImporterContinuesVisibleWorkWhenPendingMeetingCannotBeLoaded(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	empty := paragraph("transcript-1", "", false)
+	source.blocks["transcript-1"] = &empty
+	source.markdown.Markdown = "# Weekly planning"
+
+	first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	state := lastNotionState(t, st, first.SourceID)
+	require.Len(state.Pending, 1)
+
+	source.blockErrs = map[string]error{
+		"meeting-1": &APIError{Kind: ErrRateLimited, Status: 503, Code: "service_unavailable"},
+	}
+	visible := hydrationMeeting()
+	visible.ID = "meeting-2"
+	visible.LastEditedTime = "2026-08-29T18:01:00Z"
+	visibleRaw, err := json.Marshal(visible)
+	require.NoError(err)
+	source.blocks["meeting-2"] = &Block{
+		Object: "block", ID: "meeting-2", Type: "meeting_notes", Raw: visibleRaw,
+	}
+	transcript := paragraph("transcript-1", "Test Speaker: New visible meeting.", false)
+	source.blocks["transcript-1"] = &transcript
+	source.query.Results = []MeetingNote{visible}
+	imp.now = func() time.Time { return time.Date(2026, 8, 29, 18, 1, 0, 0, time.UTC) }
+
+	second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), second.Errors)
+	assert.Equal(int64(1), second.MeetingsAdded)
+	state = lastNotionState(t, st, second.SourceID)
+	require.Len(state.Pending, 1)
+	assert.Equal("meeting-1", state.Pending[0].BlockID)
+	assert.Equal("2026-08-30T00:01:00Z", state.Pending[0].NextAttemptAt)
+}
+
+func TestImporterSurfacesPermanentPendingMeetingLoadFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "unauthorized", err: &APIError{Kind: ErrUnauthorized, Status: 401, Code: "unauthorized"}},
+		{name: "content access", err: &APIError{Kind: ErrReadContent, Status: 403, Code: "restricted_resource"}},
+		{name: "malformed response", err: fmt.Errorf("%w: invalid block", ErrMalformedResponse)},
+		{name: "context canceled", err: context.Canceled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, source, imp := newImporterFixture(t)
+			empty := paragraph("transcript-1", "", false)
+			source.blocks["transcript-1"] = &empty
+			source.markdown.Markdown = "# Weekly planning"
+
+			first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			before := lastNotionState(t, st, first.SourceID)
+			require.Len(before.Pending, 1)
+
+			source.query.Results = nil
+			source.blockErrs = map[string]error{"meeting-1": tt.err}
+			imp.now = func() time.Time { return time.Date(2026, 8, 29, 18, 1, 0, 0, time.UTC) }
+			summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.Error(err)
+			require.ErrorIs(err, tt.err)
+			assert.Equal(int64(1), summary.Errors)
+
+			after := lastNotionState(t, st, first.SourceID)
+			assert.Equal(before.LastQueryAt, after.LastQueryAt)
+			assert.Equal(before.Pending, after.Pending)
+		})
+	}
+}
+
+func TestImporterArchivesMetadataWhileContentIsPending(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, source, imp := newImporterFixture(t)
+	for _, id := range []string{"summary-1", "notes-1", "transcript-1"} {
+		empty := paragraph(id, "", false)
+		source.blocks[id] = &empty
+	}
+	source.markdown.Markdown = "# Weekly planning"
+
+	summary, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MeetingsAdded)
+	state := lastNotionState(t, st, summary.SourceID)
+	require.Contains(state.Known, "meeting-1")
+	assert.NotEmpty(state.Known["meeting-1"].SnapshotSHA256)
+
+	var body string
+	require.NoError(st.DB().QueryRow(`
+		SELECT mb.body_text
+		FROM messages m
+		JOIN message_bodies mb ON mb.message_id = m.id
+		WHERE m.source_message_id = 'meeting-1'
+	`).Scan(&body))
+	assert.Contains(body, "Weekly planning")
+	assert.Contains(body, "When: 2026-08-29 10:00 - 10:30")
+	assert.NotContains(body, "Summary:")
+	assert.NotContains(body, "Notes:")
+	assert.NotContains(body, "Transcript:")
+}
+
+func TestImporterPreservesArchivedTranscriptOnTemporaryOmission(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *store.Store, int64)
+	}{
+		{name: "valid evidence"},
+		{
+			name: "missing evidence",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				_, err := st.DB().Exec(st.Rebind("DELETE FROM message_raw WHERE message_id = ?"), messageID)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "malformed evidence",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				require.NoError(t, st.UpsertMessageRawWithFormat(messageID, []byte("{"), RawFormat))
+			},
+		},
+		{
+			name: "corrupt compression",
+			mutate: func(t *testing.T, st *store.Store, messageID int64) {
+				t.Helper()
+				_, err := st.DB().Exec(st.Rebind(`
+					UPDATE message_raw SET raw_data = ?, compression = 'zlib'
+					WHERE message_id = ?
+				`), []byte("not zlib"), messageID)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			st, source, imp := newImporterFixture(t)
+			first, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+
+			var messageID int64
+			require.NoError(st.DB().QueryRow(st.Rebind(`
+				SELECT id FROM messages
+				WHERE source_id = ? AND source_message_id = 'meeting-1'
+			`), first.SourceID).Scan(&messageID))
+			if tt.mutate != nil {
+				tt.mutate(t, st, messageID)
+			}
+
+			meeting := hydrationMeeting()
+			meeting.LastEditedTime = "2026-08-29T14:00:00Z"
+			source.query.Results = []MeetingNote{meeting}
+			empty := paragraph("transcript-1", "", false)
+			source.blocks["transcript-1"] = &empty
+			source.markdown.Markdown = "# Weekly planning"
+			second, err := imp.Import(context.Background(), ImportOptions{Identifier: "work"})
+			require.NoError(err)
+			assert.Equal(int64(1), second.MeetingsUpdated)
+
+			var body string
+			require.NoError(st.DB().QueryRow(`SELECT body_text FROM message_bodies`).Scan(&body))
+			assert.Contains(body, "Test Speaker: Ready to ship.")
+			state := lastNotionState(t, st, first.SourceID)
+			require.Len(state.Pending, 1)
+		})
+	}
+}
+
+func TestImporterRequiresRegisteredSource(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	source := &fakeImportSource{fakeHydrationSource: completeHydrationSource(), query: &QueryResult{}}
+	_, err := NewImporter(st, source).Import(context.Background(), ImportOptions{Identifier: "removed"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, store.ErrSourceNotFound)
+}
+
+func TestPendingTranscriptCadenceAndExpiry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	hydrated := &HydratedMeeting{Discovery: hydrationMeeting()}
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	pending, keep := schedulePending(hydrated, now, pendingTranscript{}, false)
+	require.True(keep)
+	assert.Equal("2026-08-29T18:00:00Z", pending.NextAttemptAt)
+	assert.Equal("2026-09-05T10:30:00Z", pending.RetryUntil)
+	assert.False(pendingDue(pending, now))
+	assert.True(pendingDue(pending, now.Add(transcriptRetryCadence)))
+	assert.True(pendingExpired(pending, time.Date(2026, 9, 5, 10, 30, 0, 0, time.UTC)))
+
+	hydrated.Discovery.MeetingNotes.CalendarEvent.EndTime = ""
+	hydrated.Discovery.MeetingNotes.Recording.EndTime = ""
+	unknown, keep := schedulePending(hydrated, now, pendingTranscript{}, false)
+	require.True(keep)
+	assert.Equal("2026-08-31T12:00:00Z", unknown.RetryUntil)
+}

--- a/internal/notionmeetings/types.go
+++ b/internal/notionmeetings/types.go
@@ -112,22 +112,31 @@ type RichTextBlock struct {
 	RichText []RichText `json:"rich_text"`
 }
 
+type blockContent struct {
+	RichText   []RichText      `json:"rich_text"`
+	Caption    []RichText      `json:"caption"`
+	Title      json.RawMessage `json:"title"`
+	Expression string          `json:"expression"`
+	Cells      [][]RichText    `json:"cells"`
+}
+
 type Block struct {
-	Object           string          `json:"object"`
-	ID               string          `json:"id"`
-	Type             string          `json:"type"`
-	Parent           Parent          `json:"parent"`
-	HasChildren      bool            `json:"has_children"`
-	Paragraph        RichTextBlock   `json:"paragraph"`
-	Heading1         RichTextBlock   `json:"heading_1"`
-	Heading2         RichTextBlock   `json:"heading_2"`
-	Heading3         RichTextBlock   `json:"heading_3"`
-	BulletedListItem RichTextBlock   `json:"bulleted_list_item"`
-	NumberedListItem RichTextBlock   `json:"numbered_list_item"`
-	Quote            RichTextBlock   `json:"quote"`
-	Callout          RichTextBlock   `json:"callout"`
-	Toggle           RichTextBlock   `json:"toggle"`
-	ToDo             RichTextBlock   `json:"to_do"`
+	Object           string        `json:"object"`
+	ID               string        `json:"id"`
+	Type             string        `json:"type"`
+	Parent           Parent        `json:"parent"`
+	HasChildren      bool          `json:"has_children"`
+	Paragraph        RichTextBlock `json:"paragraph"`
+	Heading1         RichTextBlock `json:"heading_1"`
+	Heading2         RichTextBlock `json:"heading_2"`
+	Heading3         RichTextBlock `json:"heading_3"`
+	BulletedListItem RichTextBlock `json:"bulleted_list_item"`
+	NumberedListItem RichTextBlock `json:"numbered_list_item"`
+	Quote            RichTextBlock `json:"quote"`
+	Callout          RichTextBlock `json:"callout"`
+	Toggle           RichTextBlock `json:"toggle"`
+	ToDo             RichTextBlock `json:"to_do"`
+	content          blockContent
 	Raw              json.RawMessage `json:"-"`
 }
 
@@ -138,6 +147,15 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*b = Block(decoded)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if payload := fields[b.Type]; len(payload) > 0 {
+		if err := json.Unmarshal(payload, &b.content); err != nil {
+			return err
+		}
+	}
 	b.Raw = append(b.Raw[:0], data...)
 	return nil
 }
@@ -165,7 +183,44 @@ func (b Block) PlainText() string {
 		parts = b.Toggle.RichText
 	case "to_do":
 		parts = b.ToDo.RichText
+	default:
+		return b.content.plainText()
 	}
+	return richTextPlainText(parts)
+}
+
+func (c blockContent) plainText() string {
+	lines := make([]string, 0, 2+len(c.Cells))
+	appendRichText := func(parts []RichText) {
+		if text := richTextPlainText(parts); text != "" {
+			lines = append(lines, text)
+		}
+	}
+	appendRichText(c.RichText)
+	appendRichText(c.Caption)
+	if len(c.Title) > 0 {
+		var title string
+		if json.Unmarshal(c.Title, &title) == nil {
+			if title = strings.TrimSpace(title); title != "" {
+				lines = append(lines, title)
+			}
+		} else {
+			var titleParts []RichText
+			if json.Unmarshal(c.Title, &titleParts) == nil {
+				appendRichText(titleParts)
+			}
+		}
+	}
+	if expression := strings.TrimSpace(c.Expression); expression != "" {
+		lines = append(lines, expression)
+	}
+	for _, cell := range c.Cells {
+		appendRichText(cell)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func richTextPlainText(parts []RichText) string {
 	var text strings.Builder
 	for _, part := range parts {
 		text.WriteString(part.PlainText)

--- a/internal/notionmeetings/types.go
+++ b/internal/notionmeetings/types.go
@@ -1,0 +1,224 @@
+// Package notionmeetings imports Notion AI Meeting Notes into the canonical
+// msgvault meeting archive.
+package notionmeetings
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const (
+	SourceType       = "notion_meetings"
+	ConversationType = "meeting"
+	MessageType      = "meeting_transcript"
+	RawFormat        = "notion_meeting_json"
+	APIVersion       = "2026-03-11"
+	DefaultBaseURL   = "https://api.notion.com"
+)
+
+type RichText struct {
+	PlainText string `json:"plain_text"`
+}
+
+type UserRef struct {
+	Object string `json:"object"`
+	ID     string `json:"id"`
+}
+
+type Parent struct {
+	Type   string `json:"type"`
+	PageID string `json:"page_id"`
+}
+
+type MeetingChildren struct {
+	SummaryBlockID    string `json:"summary_block_id"`
+	NotesBlockID      string `json:"notes_block_id"`
+	TranscriptBlockID string `json:"transcript_block_id"`
+}
+
+type MeetingCalendarEvent struct {
+	StartTime string   `json:"start_time"`
+	EndTime   string   `json:"end_time"`
+	Attendees []string `json:"attendees"`
+}
+
+type MeetingRecording struct {
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+}
+
+type MeetingNotesData struct {
+	Title         []RichText           `json:"title"`
+	Status        string               `json:"status"`
+	Children      MeetingChildren      `json:"children"`
+	CalendarEvent MeetingCalendarEvent `json:"calendar_event"`
+	Recording     MeetingRecording     `json:"recording"`
+}
+
+type MeetingNote struct {
+	Object         string                     `json:"object"`
+	ID             string                     `json:"id"`
+	Type           string                     `json:"type"`
+	MeetingNotes   MeetingNotesData           `json:"meeting_notes"`
+	CreatedTime    string                     `json:"created_time"`
+	LastEditedTime string                     `json:"last_edited_time"`
+	CreatedBy      UserRef                    `json:"created_by"`
+	LastEditedBy   UserRef                    `json:"last_edited_by"`
+	Parent         Parent                     `json:"parent"`
+	HasChildren    bool                       `json:"has_children"`
+	InTrash        bool                       `json:"in_trash"`
+	Extra          map[string]json.RawMessage `json:"-"`
+	Raw            json.RawMessage            `json:"-"`
+}
+
+func (m *MeetingNote) UnmarshalJSON(data []byte) error {
+	type plain MeetingNote
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var extra map[string]json.RawMessage
+	if err := json.Unmarshal(data, &extra); err != nil {
+		return err
+	}
+	for _, key := range []string{
+		"object", "id", "type", "meeting_notes", "created_time",
+		"last_edited_time", "created_by", "last_edited_by", "parent",
+		"has_children", "in_trash",
+	} {
+		delete(extra, key)
+	}
+	*m = MeetingNote(decoded)
+	m.Extra = extra
+	m.Raw = append(m.Raw[:0], data...)
+	return nil
+}
+
+func (m MeetingNote) Title() string {
+	var title strings.Builder
+	for _, part := range m.MeetingNotes.Title {
+		title.WriteString(part.PlainText)
+	}
+	return title.String()
+}
+
+type QueryResult struct {
+	Results []MeetingNote   `json:"results"`
+	HasMore bool            `json:"has_more"`
+	Raw     json.RawMessage `json:"-"`
+}
+
+type RichTextBlock struct {
+	RichText []RichText `json:"rich_text"`
+}
+
+type Block struct {
+	Object           string          `json:"object"`
+	ID               string          `json:"id"`
+	Type             string          `json:"type"`
+	Parent           Parent          `json:"parent"`
+	HasChildren      bool            `json:"has_children"`
+	Paragraph        RichTextBlock   `json:"paragraph"`
+	Heading1         RichTextBlock   `json:"heading_1"`
+	Heading2         RichTextBlock   `json:"heading_2"`
+	Heading3         RichTextBlock   `json:"heading_3"`
+	BulletedListItem RichTextBlock   `json:"bulleted_list_item"`
+	NumberedListItem RichTextBlock   `json:"numbered_list_item"`
+	Quote            RichTextBlock   `json:"quote"`
+	Callout          RichTextBlock   `json:"callout"`
+	Toggle           RichTextBlock   `json:"toggle"`
+	ToDo             RichTextBlock   `json:"to_do"`
+	Raw              json.RawMessage `json:"-"`
+}
+
+func (b *Block) UnmarshalJSON(data []byte) error {
+	type plain Block
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*b = Block(decoded)
+	b.Raw = append(b.Raw[:0], data...)
+	return nil
+}
+
+func (b Block) PlainText() string {
+	var parts []RichText
+	switch b.Type {
+	case "paragraph":
+		parts = b.Paragraph.RichText
+	case "heading_1":
+		parts = b.Heading1.RichText
+	case "heading_2":
+		parts = b.Heading2.RichText
+	case "heading_3":
+		parts = b.Heading3.RichText
+	case "bulleted_list_item":
+		parts = b.BulletedListItem.RichText
+	case "numbered_list_item":
+		parts = b.NumberedListItem.RichText
+	case "quote":
+		parts = b.Quote.RichText
+	case "callout":
+		parts = b.Callout.RichText
+	case "toggle":
+		parts = b.Toggle.RichText
+	case "to_do":
+		parts = b.ToDo.RichText
+	}
+	var text strings.Builder
+	for _, part := range parts {
+		text.WriteString(part.PlainText)
+	}
+	return text.String()
+}
+
+type BlockPage struct {
+	Object     string          `json:"object"`
+	Results    []Block         `json:"results"`
+	NextCursor string          `json:"next_cursor"`
+	HasMore    bool            `json:"has_more"`
+	Raw        json.RawMessage `json:"-"`
+}
+
+type MarkdownPage struct {
+	Object          string          `json:"object"`
+	ID              string          `json:"id"`
+	Markdown        string          `json:"markdown"`
+	Truncated       bool            `json:"truncated"`
+	UnknownBlockIDs []string        `json:"unknown_block_ids"`
+	Raw             json.RawMessage `json:"-"`
+}
+
+type UserPerson struct {
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+}
+
+type User struct {
+	Object string          `json:"object"`
+	ID     string          `json:"id"`
+	Name   string          `json:"name"`
+	Type   string          `json:"type"`
+	Person UserPerson      `json:"person"`
+	Raw    json.RawMessage `json:"-"`
+}
+
+func (u *User) UnmarshalJSON(data []byte) error {
+	type plain User
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*u = User(decoded)
+	u.Raw = append(u.Raw[:0], data...)
+	return nil
+}
+
+type UserPage struct {
+	Object     string          `json:"object"`
+	Results    []User          `json:"results"`
+	NextCursor string          `json:"next_cursor"`
+	HasMore    bool            `json:"has_more"`
+	Raw        json.RawMessage `json:"-"`
+}

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -76,6 +76,16 @@ type APIMessage struct {
 	Attachments          []APIAttachment
 }
 
+// MessageRecipient is one archived message-recipient relationship.
+// EmailAddress comes from the immutable message envelope when available,
+// rather than from a participant that may be merged. ParticipantID groups
+// historical envelope aliases that now resolve to the same participant.
+type MessageRecipient struct {
+	ParticipantID int64
+	EmailAddress  string
+	DisplayName   string
+}
+
 // APIAttachment represents attachment metadata for API responses.
 type APIAttachment struct {
 	ID          int64
@@ -1176,6 +1186,45 @@ func (s *Store) getRecipients(ctx context.Context, messageID int64, recipientTyp
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate recipients: %w", err)
+	}
+	return recipients, nil
+}
+
+// GetMessageRecipientsContext returns structured recipient relationships for a
+// message. Importers use this when provider identity lookup is temporarily
+// degraded and replacing an already verified relationship would lose data.
+func (s *Store) GetMessageRecipientsContext(
+	ctx context.Context, messageID int64, recipientType string,
+) ([]MessageRecipient, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			mr.participant_id,
+			COALESCE(NULLIF(mr.email_address, ''), NULLIF(p.email_address, ''), ''),
+			COALESCE(NULLIF(TRIM(mr.display_name), ''), NULLIF(TRIM(p.display_name), ''), '')
+		FROM message_recipients mr
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE mr.message_id = ? AND mr.recipient_type = ?
+		ORDER BY mr.id
+	`, messageID, recipientType)
+	if err != nil {
+		return nil, fmt.Errorf("get structured recipients: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var recipients []MessageRecipient
+	for rows.Next() {
+		var recipient MessageRecipient
+		if err := rows.Scan(
+			&recipient.ParticipantID, &recipient.EmailAddress, &recipient.DisplayName,
+		); err != nil {
+			return nil, fmt.Errorf("scan structured recipient: %w", err)
+		}
+		if strings.TrimSpace(recipient.EmailAddress) != "" {
+			recipients = append(recipients, recipient)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate structured recipients: %w", err)
 	}
 	return recipients, nil
 }

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -1226,6 +1226,9 @@ func upsertMessageRawWithFormat(q querier, messageID int64, rawData []byte, form
 	return err
 }
 
+// ErrInvalidMessageRaw marks raw message data that cannot be decompressed.
+var ErrInvalidMessageRaw = errors.New("invalid message raw data")
+
 // GetMessageRaw retrieves and decompresses the raw MIME data for a message.
 func (s *Store) GetMessageRaw(messageID int64) ([]byte, error) {
 	var compressed []byte
@@ -1241,21 +1244,37 @@ func (s *Store) GetMessageRaw(messageID int64) ([]byte, error) {
 	return decodeMessageRaw(compressed, compression)
 }
 
+// GetMessageBodyText returns the archived plain-text body for one message.
+// A message without a body returns an empty string.
+func (s *Store) GetMessageBodyText(messageID int64) (string, error) {
+	var body sql.NullString
+	err := s.db.QueryRow(`
+		SELECT body_text FROM message_bodies WHERE message_id = ?
+	`, messageID).Scan(&body)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return nullStringValue(body), nil
+}
+
 func decodeMessageRaw(compressed []byte, compression sql.NullString) ([]byte, error) {
 	if !compression.Valid || compression.String != "zlib" {
 		return compressed, nil
 	}
 	r, err := zlib.NewReader(bytes.NewReader(compressed))
 	if err != nil {
-		return nil, fmt.Errorf("zlib reader: %w", err)
+		return nil, fmt.Errorf("%w: zlib reader: %w", ErrInvalidMessageRaw, err)
 	}
 	data, readErr := io.ReadAll(r)
 	closeErr := r.Close()
 	if readErr != nil {
-		return nil, readErr
+		return nil, fmt.Errorf("%w: read zlib data: %w", ErrInvalidMessageRaw, readErr)
 	}
 	if closeErr != nil {
-		return nil, fmt.Errorf("close zlib reader: %w", closeErr)
+		return nil, fmt.Errorf("%w: close zlib reader: %w", ErrInvalidMessageRaw, closeErr)
 	}
 	return data, nil
 }

--- a/internal/tui/meeting_mode_test.go
+++ b/internal/tui/meeting_mode_test.go
@@ -98,15 +98,17 @@ func TestMeetingAccountsExcludeUnrelatedSources(t *testing.T) {
 		query.AccountInfo{ID: 3, SourceType: meetingSourceCircleback, Identifier: "team-meetings"},
 		query.AccountInfo{ID: 4, SourceType: "teams", Identifier: "team-chat"},
 		query.AccountInfo{ID: 5, SourceType: meetingSourceImported, Identifier: "local-meetings"},
+		query.AccountInfo{ID: 6, SourceType: meetingSourceNotion, Identifier: "notion-notes"},
 	).Build()
 
 	accounts := model.meetingAccounts()
 
-	require.Len(t, accounts, 3)
-	assert.Equal(t, []string{"work-notes", "team-meetings", "local-meetings"}, []string{
+	require.Len(t, accounts, 4)
+	assert.Equal(t, []string{"work-notes", "team-meetings", "local-meetings", "notion-notes"}, []string{
 		accounts[0].Identifier,
 		accounts[1].Identifier,
 		accounts[2].Identifier,
+		accounts[3].Identifier,
 	})
 }
 

--- a/internal/tui/meeting_state.go
+++ b/internal/tui/meeting_state.go
@@ -12,6 +12,7 @@ const meetingMessageType = "meeting_transcript"
 const (
 	meetingSourceGranola    = "granola"
 	meetingSourceCircleback = "circleback"
+	meetingSourceNotion     = "notion_meetings"
 	meetingSourceImported   = "meeting_import"
 )
 
@@ -77,7 +78,7 @@ func (m Model) meetingAccounts() []query.AccountInfo {
 	accounts := make([]query.AccountInfo, 0, len(m.accounts))
 	for _, account := range m.accounts {
 		switch strings.ToLower(strings.TrimSpace(account.SourceType)) {
-		case meetingSourceGranola, meetingSourceCircleback, meetingSourceImported:
+		case meetingSourceGranola, meetingSourceCircleback, meetingSourceNotion, meetingSourceImported:
 			accounts = append(accounts, account)
 		}
 	}

--- a/internal/tui/meeting_view.go
+++ b/internal/tui/meeting_view.go
@@ -60,6 +60,8 @@ func (m Model) meetingSourceLabel(sourceID int64) string {
 			return "Granola"
 		case meetingSourceCircleback:
 			return "Circleback"
+		case meetingSourceNotion:
+			return "Notion"
 		case meetingSourceImported:
 			if account.DisplayName != "" {
 				return textutil.SanitizeTerminal(account.DisplayName)

--- a/internal/tui/meeting_view_test.go
+++ b/internal/tui/meeting_view_test.go
@@ -54,6 +54,21 @@ func TestMeetingListViewUsesPlaceholderForUnknownSource(t *testing.T) {
 	assert.Contains(t, view, "—")
 }
 
+func TestMeetingViewLabelsNotionSource(t *testing.T) {
+	model := NewBuilder().WithAccounts(
+		query.AccountInfo{ID: 8, SourceType: meetingSourceNotion, Identifier: "notion-notes"},
+	).WithSize(100, 24).Build()
+	model.mode = modeMeetings
+	model.loading = false
+	model.meetingState.messages = []query.MessageSummary{{
+		ID: 11, SourceID: 8, Subject: "Notion meeting", SentAt: time.Now(),
+	}}
+
+	view := stripANSI(model.renderView())
+	assert.Contains(t, view, "Notion")
+	assert.Equal(t, "Notion", model.meetingSourceLabel(8))
+}
+
 func TestMeetingEmptyStateGuidesSourceSetup(t *testing.T) {
 	model := NewBuilder().WithSize(100, 24).Build()
 	model.mode = modeMeetings

--- a/internal/vector/embed/assemble_meeting_test.go
+++ b/internal/vector/embed/assemble_meeting_test.go
@@ -89,6 +89,23 @@ func TestAssembleMeetingDocument_PlainTranscriptUsesStrictGenericFallback(t *tes
 	assertNonOverlappingDense(t, doc.Chunks)
 }
 
+func TestAssembleMeetingDocument_NotionCanonicalSectionsRemainSearchable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	body := "Notion planning\nWhen: 2026-08-29 10:00 - 10:30\nAttendees: Test Attendee\n\nSummary:\nRelease scope agreed.\n\nNotes:\nOwner prepares rollout.\n\nTranscript:\nTest Speaker: Ready to ship."
+	doc, err := embed.AssembleMeetingDocument(meetingRow(18, body), embed.AssemblyPolicy{MaxChunkRunes: 500})
+	require.NoError(err)
+	require.NotEmpty(doc.Chunks)
+	joined := concatenateMeetingSource(body, doc.Chunks)
+	assert.Contains(joined, "Release scope agreed.")
+	assert.Contains(joined, "Owner prepares rollout.")
+	assert.Contains(joined, "Test Speaker: Ready to ship.")
+	for _, chunk := range doc.Chunks {
+		assert.Contains(chunk.Text, "Notion planning")
+		assert.Equal(vector.SourceBasisBody, chunk.SourceBasis)
+	}
+}
+
 func TestAssembleMeetingDocument_IncompleteSpeakerContractFallsBackForTranscriptRegion(t *testing.T) {
 	transcript := "[00:01] Alice: Complete.\nBob: missing timestamp."
 	body := "Strict parser\nWhen: 2026-08-08 09:00\n\nTranscript:\n" + transcript


### PR DESCRIPTION
## What changed

Adds native, read-only Notion AI Meeting Notes sync to msgvault.

- Adds `[[notion_meetings]]` configuration plus `add-notion-meetings` and `sync-notion-meetings` commands.
- Imports the title, time, attendees, summary, notes, and transcript into the canonical meeting archive used by Granola and Circleback.
- Tracks visible meetings incrementally, retries pending transcripts, and reports Notion's partial 50-meeting discovery window.
- Wires the source into daemon scheduling, account removal, meeting views, search, and embedding paths.

## Why

Notion AI Meeting Notes were only available through manual export. This makes them a first-class meeting source without introducing a separate archive shape or a dependency on the Notion CLI.

## Usage

```toml
[[notion_meetings]]
identifier = "notion-personal"
account_email = "you@example.com"
token = "ntn_..."
enabled = true
# schedule = "15 */6 * * *"
```

```bash
msgvault add-notion-meetings notion-personal
msgvault sync-notion-meetings notion-personal
```

Use `sync-notion-meetings notion-personal --probe` to check API capabilities without printing meeting content.

Closes #615
