### PR TITLE
test(imap): cover server-side date filtering

### DIFF
--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -216,6 +216,23 @@ func TestListMessages_DateFilterDisablesFolderTracking(t *testing.T) {
 		"date-filtered runs must not record folder states")
 }
 
+func TestListMessages_DateFilterLimitsResults(t *testing.T) {
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 0})
+	testutil.AppendIMAPMessageAt(t, user, "INBOX", "before window",
+		time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC))
+	testutil.AppendIMAPMessageAt(t, user, "INBOX", "inside window",
+		time.Date(2026, time.January, 15, 12, 0, 0, 0, time.UTC))
+	testutil.AppendIMAPMessageAt(t, user, "INBOX", "after window",
+		time.Date(2026, time.February, 1, 12, 0, 0, 0, time.UTC))
+
+	client := newTestClient(t, addr, WithDateFilter(
+		time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, time.February, 1, 0, 0, 0, 0, time.UTC),
+	))
+
+	assert.Equal(t, []string{"INBOX|2"}, listAllMessages(t, client))
+}
+
 func TestListMessages_AllMailboxUnsupportedQresyncUsesFullFallback(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sort"
 	"testing"
+	"time"
 
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -122,11 +123,26 @@ func AppendIMAPMessageWithoutMessageID(
 	messageBody string,
 ) {
 	t.Helper()
+	AppendIMAPMessageAt(t, user, mailbox, messageBody, time.Time{})
+}
+
+// AppendIMAPMessageAt appends one synthetic RFC822 message with the supplied
+// body and internal date to a mailbox of an in-memory IMAP test user.
+func AppendIMAPMessageAt(
+	t *testing.T,
+	user *imapmemserver.User,
+	mailbox string,
+	messageBody string,
+	internalDate time.Time,
+) {
+	t.Helper()
 	body := fmt.Appendf(nil,
 		"From: alice@example.com\r\nTo: bob@example.com\r\n\r\n%s\r\n",
 		messageBody,
 	)
-	_, err := user.Append(mailbox, imapLiteral{bytes.NewReader(body)}, &imap.AppendOptions{})
+	_, err := user.Append(mailbox, imapLiteral{bytes.NewReader(body)}, &imap.AppendOptions{
+		Time: internalDate,
+	})
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## What changed

- Added an IMAP integration test with three explicit `INTERNALDATE` values.
- Asserted that the server-side `SINCE` / `BEFORE` window returns only the in-range message.
- Extended the in-memory IMAP helper to append messages at a specific internal date.

## Why

#195's implementation landed in #222, but its original tests only covered malformed flags. This closes the remaining behavioral coverage gap by exercising the native IMAP date filter end to end.

## Review boundaries

Test-only. No production behavior changes.

Closes #195
