### PR TITLE
test(imap): cover malformed envelope fetch regression

### DIFF
--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -1,8 +1,14 @@
 package imap
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
 	"testing"
 
 	imapapi "github.com/emersion/go-imap/v2"
@@ -153,6 +159,33 @@ func TestRawBatchFetchRecordsMembershipBeforeDedup(t *testing.T) {
 	assert.Equal("Archive|1", observed[1].SourceMessageID)
 	assert.Equal(messageID, observed[1].RFC822MessageID)
 	assert.Equal([]string{"\\Flagged"}, observed[1].Flags)
+}
+
+func TestRawBatchFetchDoesNotRequestMalformedEnvelope(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	raw := []byte("Message-ID: <tencent-914@example.test>\r\nSubject: archived message\r\n\r\nbody")
+	addr, fetchCommand := startMalformedEnvelopeIMAPServer(t, raw)
+	host, portText, err := net.SplitHostPort(addr)
+	require.NoError(err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(err)
+	client := NewClient(&Config{
+		Host:     host,
+		Port:     port,
+		Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword)
+	t.Cleanup(func() { _ = client.Close() })
+
+	results, err := client.GetMessagesRawBatchWithErrors(
+		t.Context(), []string{"INBOX|914"})
+
+	require.NoError(err)
+	require.Len(results, 1)
+	require.NoError(results[0].Err)
+	require.NotNil(results[0].Message)
+	assert.Equal(raw, results[0].Message.Raw)
+	assert.NotContains(<-fetchCommand, "ENVELOPE")
 }
 
 func TestLabelOnlyFetchRecordsCanonicalMembershipFlags(t *testing.T) {
@@ -671,4 +704,57 @@ func fetchMessageBufferWithoutEnvelope(raw []byte) *imapclient.FetchMessageBuffe
 			{Bytes: raw},
 		},
 	}
+}
+
+func startMalformedEnvelopeIMAPServer(t *testing.T, raw []byte) (string, <-chan string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	fetchCommand := make(chan string, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = io.WriteString(conn, "* OK [CAPABILITY IMAP4rev1] synthetic server ready\r\n")
+		reader := bufio.NewReader(conn)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				return
+			}
+			line = strings.TrimSpace(line)
+			tag, command, _ := strings.Cut(line, " ")
+			upper := strings.ToUpper(command)
+			switch {
+			case strings.HasPrefix(upper, "LOGIN"):
+				_, _ = fmt.Fprintf(conn, "%s OK LOGIN completed\r\n", tag)
+			case strings.HasPrefix(upper, "SELECT"):
+				_, _ = io.WriteString(conn,
+					"* FLAGS (\\Seen)\r\n* 1 EXISTS\r\n* OK [UIDVALIDITY 1]\r\n* OK [UIDNEXT 915]\r\n")
+				_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
+			case strings.HasPrefix(upper, "UID FETCH"):
+				fetchCommand <- upper
+				if strings.Contains(upper, "ENVELOPE") {
+					_, _ = io.WriteString(conn, "* 1 FETCH (UID 914 ENVELOPE BROKEN)\r\n")
+				} else {
+					_, _ = fmt.Fprintf(conn,
+						"* 1 FETCH (UID 914 FLAGS () INTERNALDATE \"01-Jan-2026 00:00:00 +0000\" RFC822.SIZE %d BODY[] {%d}\r\n",
+						len(raw), len(raw))
+					_, _ = conn.Write(raw)
+					_, _ = io.WriteString(conn, ")\r\n")
+				}
+				_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
+			case strings.HasPrefix(upper, "LOGOUT"):
+				_, _ = fmt.Fprintf(conn, "* BYE closing\r\n%s OK LOGOUT completed\r\n", tag)
+				return
+			default:
+				_, _ = fmt.Fprintf(conn, "%s BAD unsupported synthetic command\r\n", tag)
+			}
+		}
+	}()
+	return listener.Addr().String(), fetchCommand
 }


### PR DESCRIPTION
## What changed

- Added a protocol-level regression that exercises raw IMAP batch fetches through the real client path.
- Made the scripted server return a malformed `ENVELOPE` response if the client requests one, while serving the raw MIME body normally otherwise.

## Why

Older raw fetches requested `ENVELOPE`, so a malformed server response could fail before the message body arrived and surface as a nil fetch result. The production behavior is already fixed on `main`; this locks it in against regressions.

## Usage

No usage change.

Closes #362
