### PR TITLE
feat(api): add asynchronous historical import jobs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4823,6 +4823,105 @@ components:
       required:
         - identifier
       type: object
+    ImportJobRequest:
+      additionalProperties: false
+      properties:
+        account:
+          minLength: 1
+          type: string
+        after:
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+          type: string
+        before:
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+          type: string
+        limit:
+          format: int64
+          minimum: 0
+          type: integer
+        noresume:
+          type: boolean
+        query:
+          type: string
+      required:
+        - account
+      type: object
+    ImportJobResponse:
+      additionalProperties: true
+      properties:
+        account:
+          type: string
+        added:
+          format: int64
+          type: integer
+        created_at:
+          format: date-time
+          type: string
+        error:
+          type: string
+        finished_at:
+          format: date-time
+          type:
+            - string
+            - "null"
+        job_id:
+          type: string
+        processed:
+          format: int64
+          type: integer
+        skipped:
+          format: int64
+          type: integer
+        started_at:
+          format: date-time
+          type:
+            - string
+            - "null"
+        status:
+          enum:
+            - queued
+            - running
+            - done
+            - failed
+          type: string
+        summary:
+          $ref: "#/components/schemas/ImportJobSummary"
+      required:
+        - job_id
+        - account
+        - status
+        - processed
+        - added
+        - skipped
+        - created_at
+        - started_at
+        - finished_at
+      type: object
+    ImportJobSummary:
+      additionalProperties: true
+      properties:
+        added:
+          format: int64
+          type: integer
+        errors:
+          format: int64
+          type: integer
+        processed:
+          format: int64
+          type: integer
+        skipped:
+          format: int64
+          type: integer
+        updated:
+          format: int64
+          type: integer
+      required:
+        - processed
+        - added
+        - updated
+        - skipped
+        - errors
+      type: object
     ImportRequest:
       additionalProperties: false
       properties:
@@ -11245,7 +11344,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.12.0
+  version: 2.13.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -16310,6 +16409,133 @@ paths:
       security:
         - apiKey: []
       summary: Import one meeting
+      tags:
+        - API
+  /api/v1/imports:
+    post:
+      operationId: createImportJob
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportJobRequest"
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportJobResponse"
+          description: Accepted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "413":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "415":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Start a bounded historical import
+      tags:
+        - API
+  /api/v1/imports/{job_id}:
+    get:
+      operationId: getImportJob
+      parameters:
+        - description: Historical import job ID
+          in: path
+          name: job_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportJobResponse"
+          description: OK
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get historical import status
       tags:
         - API
   /api/v1/integrations/tasks/search:

--- a/internal/api/import_jobs.go
+++ b/internal/api/import_jobs.go
@@ -1,0 +1,594 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const (
+	importJobsEndpointPath = "/api/v1/imports"
+	maxImportRequestBytes  = 16 << 10
+	maxImportJobs          = 16
+
+	importJobStatusQueued  = "queued"
+	importJobStatusRunning = "running"
+	importJobStatusDone    = "done"
+	importJobStatusFailed  = "failed"
+)
+
+var (
+	errImportJobQueueFull    = errors.New("import job queue is full")
+	errImportJobsClosed      = errors.New("import jobs are shut down")
+	errImportAlreadyActive   = errors.New("import already active")
+	errImportAmbiguousSource = errors.New("import account is ambiguous")
+	errImportUnsyncable      = errors.New("import account is not syncable")
+)
+
+// ImportJobRequest describes one bounded historical Gmail or IMAP import.
+type ImportJobRequest struct {
+	Account  string `json:"account" minLength:"1"`
+	After    string `json:"after,omitempty" pattern:"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"`
+	Before   string `json:"before,omitempty" pattern:"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"`
+	Limit    int    `json:"limit,omitempty" minimum:"0"`
+	Query    string `json:"query,omitempty"`
+	NoResume bool   `json:"noresume,omitempty"`
+}
+
+// ImportJobSummary contains the final archive counters for a completed job.
+type ImportJobSummary struct {
+	Processed int64 `json:"processed"`
+	Added     int64 `json:"added"`
+	Updated   int64 `json:"updated"`
+	Skipped   int64 `json:"skipped"`
+	Errors    int64 `json:"errors"`
+}
+
+// ImportJobResponse is the current in-memory state of a historical import.
+type ImportJobResponse struct {
+	JobID      string            `json:"job_id"`
+	Account    string            `json:"account"`
+	Status     string            `json:"status" enum:"queued,running,done,failed"`
+	Processed  int64             `json:"processed"`
+	Added      int64             `json:"added"`
+	Skipped    int64             `json:"skipped"`
+	Error      string            `json:"error,omitempty"`
+	CreatedAt  time.Time         `json:"created_at"`
+	StartedAt  *time.Time        `json:"started_at"`
+	FinishedAt *time.Time        `json:"finished_at"`
+	Summary    *ImportJobSummary `json:"summary,omitempty"`
+}
+
+type importJobStore interface {
+	GetSourcesByIdentifierOrDisplayName(query string) ([]*store.Source, error)
+	GetActiveSync(sourceID int64) (*store.SyncRun, error)
+	GetLatestSync(sourceID int64) (*store.SyncRun, error)
+}
+
+type importJob struct {
+	ImportJobResponse
+
+	sourceID       int64
+	baselineRunID  int64
+	resumableRunID int64
+}
+
+type importJobManager struct {
+	mu     sync.RWMutex
+	jobs   map[string]*importJob
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	closed bool
+}
+
+func newImportJobManager() *importJobManager {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &importJobManager{
+		jobs:   make(map[string]*importJob),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (m *importJobManager) create(
+	now time.Time,
+	account string,
+	sourceID int64,
+	baselineRunID int64,
+	resumableRunID int64,
+) (ImportJobResponse, error) {
+	id, err := newImportJobID()
+	if err != nil {
+		return ImportJobResponse{}, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return ImportJobResponse{}, errImportJobsClosed
+	}
+	for _, job := range m.jobs {
+		if job.sourceID == sourceID &&
+			(job.Status == importJobStatusQueued || job.Status == importJobStatusRunning) {
+			return ImportJobResponse{}, fmt.Errorf("%w as job %s", errImportAlreadyActive, job.JobID)
+		}
+	}
+	m.pruneTerminalJobsLocked()
+	if len(m.jobs) >= maxImportJobs {
+		return ImportJobResponse{}, errImportJobQueueFull
+	}
+
+	job := &importJob{ //nolint:modernize // Keep the private sibling fields keyed by name.
+		ImportJobResponse: ImportJobResponse{
+			JobID:     id,
+			Account:   account,
+			Status:    importJobStatusQueued,
+			CreatedAt: now.UTC(),
+		},
+		sourceID:       sourceID,
+		baselineRunID:  baselineRunID,
+		resumableRunID: resumableRunID,
+	}
+	m.jobs[id] = job
+	m.wg.Add(1)
+	return cloneImportJobResponse(job.ImportJobResponse), nil
+}
+
+func (m *importJobManager) pruneTerminalJobsLocked() {
+	for len(m.jobs) >= maxImportJobs {
+		var oldestID string
+		var oldestTime time.Time
+		for id, job := range m.jobs {
+			if job.Status == importJobStatusQueued || job.Status == importJobStatusRunning {
+				continue
+			}
+			if oldestID == "" || job.CreatedAt.Before(oldestTime) {
+				oldestID = id
+				oldestTime = job.CreatedAt
+			}
+		}
+		if oldestID == "" {
+			return
+		}
+		delete(m.jobs, oldestID)
+	}
+}
+
+func (m *importJobManager) get(id string) (ImportJobResponse, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	job, ok := m.jobs[id]
+	if !ok {
+		return ImportJobResponse{}, false
+	}
+	return cloneImportJobResponse(job.ImportJobResponse), true
+}
+
+func (m *importJobManager) markRunning(id string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	if !ok || job.Status != importJobStatusQueued {
+		return
+	}
+	startedAt := now.UTC()
+	job.Status = importJobStatusRunning
+	job.StartedAt = &startedAt
+}
+
+func (m *importJobManager) updateProgress(id string, run *store.SyncRun) {
+	if run == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	if !ok || job.Status != importJobStatusRunning || !job.acceptsRun(run) {
+		return
+	}
+	job.Processed, job.Added, job.Skipped = importRunCounts(run)
+}
+
+func (j *importJob) acceptsRun(run *store.SyncRun) bool {
+	if j == nil || run == nil || run.SourceID != j.sourceID {
+		return false
+	}
+	if j.resumableRunID > 0 && run.ID == j.resumableRunID {
+		return true
+	}
+	if run.ID <= j.baselineRunID {
+		return false
+	}
+	// SQLite records sync timestamps with one-second precision. Compare at the
+	// same precision so a run created during the job's starting second is not
+	// rejected merely because the in-memory job timestamp has nanoseconds.
+	return j.StartedAt == nil || !run.StartedAt.Before(j.StartedAt.Truncate(time.Second))
+}
+
+func (m *importJobManager) acceptsRun(id string, run *store.SyncRun) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.jobs[id].acceptsRun(run)
+}
+
+func (m *importJobManager) markDone(id string, run *store.SyncRun, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	if !ok || !job.acceptsRun(run) {
+		return
+	}
+	processed, added, skipped := importRunCounts(run)
+	updated := run.MessagesUpdated
+	finishedAt := now.UTC()
+	if run.CompletedAt.Valid {
+		finishedAt = run.CompletedAt.Time.UTC()
+	}
+	job.Status = importJobStatusDone
+	job.Processed = processed
+	job.Added = added
+	job.Skipped = skipped
+	job.Error = ""
+	job.FinishedAt = &finishedAt
+	job.Summary = &ImportJobSummary{
+		Processed: processed,
+		Added:     added,
+		Updated:   updated,
+		Skipped:   skipped,
+		Errors:    run.ErrorsCount,
+	}
+}
+
+func (m *importJobManager) markFailed(id string, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.jobs[id]
+	if !ok || job.Status == importJobStatusDone || job.Status == importJobStatusFailed {
+		return
+	}
+	finishedAt := now.UTC()
+	job.Status = importJobStatusFailed
+	job.Error = "import failed"
+	job.FinishedAt = &finishedAt
+}
+
+func (m *importJobManager) shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	m.closed = true
+	m.cancel()
+	m.mu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func cloneImportJobResponse(in ImportJobResponse) ImportJobResponse {
+	out := in
+	if in.StartedAt != nil {
+		startedAt := *in.StartedAt
+		out.StartedAt = &startedAt
+	}
+	if in.FinishedAt != nil {
+		finishedAt := *in.FinishedAt
+		out.FinishedAt = &finishedAt
+	}
+	if in.Summary != nil {
+		summary := *in.Summary
+		out.Summary = &summary
+	}
+	return out
+}
+
+func newImportJobID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate import job id: %w", err)
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func importRunCounts(run *store.SyncRun) (processed, added, skipped int64) {
+	processed = run.MessagesProcessed
+	added = run.MessagesAdded
+	skipped = max(processed-added-run.MessagesUpdated, 0)
+	return processed, added, skipped
+}
+
+func (s *Server) registerImportJobRoutes(api huma.API) {
+	createOp := rawAPIV1Operation(
+		"createImportJob",
+		http.MethodPost,
+		"/imports",
+		"Start a bounded historical import",
+	)
+	createOp.RequestBody = jsonRequestBodyFor[ImportJobRequest](api)
+	createOp.Responses = jsonResponsesFor[ImportJobResponse](api, http.StatusAccepted)
+	addErrorResponses(api, createOp.Responses,
+		http.StatusBadRequest,
+		http.StatusConflict,
+		http.StatusNotFound,
+		http.StatusRequestEntityTooLarge,
+		http.StatusTooManyRequests,
+		http.StatusUnauthorized,
+		http.StatusUnsupportedMediaType,
+		http.StatusUnprocessableEntity,
+		http.StatusInternalServerError,
+		http.StatusServiceUnavailable,
+	)
+	registerRawHumaRoute(api, createOp, s.handleCreateImportJob)
+
+	getOp := rawAPIV1Operation(
+		"getImportJob",
+		http.MethodGet,
+		"/imports/{job_id}",
+		"Get historical import status",
+	)
+	getOp.Responses = jsonResponsesFor[ImportJobResponse](api)
+	addErrorResponses(api, getOp.Responses, http.StatusNotFound, http.StatusUnauthorized)
+	registerRawHumaRoute(api, getOp, s.handleGetImportJob)
+}
+
+func (s *Server) handleCreateImportJob(w http.ResponseWriter, r *http.Request) {
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != applicationJSONMediaType {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type",
+			"Content-Type must be application/json")
+		return
+	}
+
+	var req ImportJobRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxImportRequestBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large",
+				"Import request exceeds 16 KiB")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid import request JSON")
+		return
+	}
+	if !requireSingleJSONValue(w, decoder, "bad_request") {
+		return
+	}
+	req.Account = strings.TrimSpace(req.Account)
+	if validationErr := validateImportJobRequest(req); validationErr != "" {
+		writeError(w, http.StatusUnprocessableEntity, "validation_failed", validationErr)
+		return
+	}
+
+	runner, runnerOK := s.store.(CLISyncRunner)
+	jobStore, storeOK := s.store.(importJobStore)
+	if !runnerOK || !storeOK || s.importJobs == nil {
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable",
+			"Historical imports are unavailable")
+		return
+	}
+	sources, err := jobStore.GetSourcesByIdentifierOrDisplayName(req.Account)
+	if err != nil {
+		s.logger.Error("failed to resolve historical import account", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error",
+			"Failed to resolve import account")
+		return
+	}
+	source, err := resolveExactImportSource(sources, req.Account)
+	if errors.Is(err, errImportAmbiguousSource) {
+		writeError(w, http.StatusConflict, "ambiguous_account",
+			"Import account matches multiple syncable sources")
+		return
+	}
+	if errors.Is(err, errImportUnsyncable) {
+		writeError(w, http.StatusUnprocessableEntity, "account_not_syncable",
+			"Import account must be a Gmail or IMAP source")
+		return
+	}
+	if err != nil || source == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Import account not found")
+		return
+	}
+	baselineRunID := int64(0)
+	resumableRunID := int64(0)
+	latest, err := jobStore.GetLatestSync(source.ID)
+	if err == nil {
+		baselineRunID = latest.ID
+		if !req.NoResume && latest.Status == store.SyncStatusRunning {
+			resumableRunID = latest.ID
+		}
+	} else if !errors.Is(err, store.ErrSyncRunNotFound) {
+		s.logger.Error("failed to read historical import baseline", "source_id", source.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error",
+			"Failed to prepare import job")
+		return
+	}
+
+	runReq := CLISyncRequest{
+		Full:        true,
+		SourceID:    source.ID,
+		SourceIDSet: true,
+		Query:       req.Query,
+		NoResume:    req.NoResume,
+		Before:      req.Before,
+		After:       req.After,
+		Limit:       req.Limit,
+	}
+	job, err := s.importJobs.create(
+		s.clockNow(), source.Identifier, source.ID, baselineRunID, resumableRunID,
+	)
+	if err != nil {
+		if errors.Is(err, errImportJobQueueFull) {
+			writeError(w, http.StatusTooManyRequests, "import_queue_full",
+				"Historical import queue is full")
+			return
+		}
+		if errors.Is(err, errImportAlreadyActive) {
+			writeError(w, http.StatusConflict, "import_already_active", err.Error())
+			return
+		}
+		if errors.Is(err, errImportJobsClosed) {
+			writeError(w, http.StatusServiceUnavailable, "service_unavailable",
+				"Historical imports are unavailable")
+			return
+		}
+		s.logger.Error("failed to create historical import job", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error",
+			"Failed to create import job")
+		return
+	}
+
+	go func() {
+		defer s.importJobs.wg.Done()
+		s.runImportJob(job.JobID, runner, jobStore, runReq)
+	}()
+	writeJSON(w, http.StatusAccepted, job)
+}
+
+func validateImportJobRequest(req ImportJobRequest) string {
+	if req.Account == "" {
+		return "account is required"
+	}
+	if req.Limit < 0 {
+		return "limit must be a non-negative integer"
+	}
+	after, afterSet, err := parseImportDate(req.After)
+	if err != nil {
+		return "after must use YYYY-MM-DD"
+	}
+	before, beforeSet, err := parseImportDate(req.Before)
+	if err != nil {
+		return "before must use YYYY-MM-DD"
+	}
+	if afterSet && beforeSet && !after.Before(before) {
+		return "after must be earlier than before"
+	}
+	return ""
+}
+
+func parseImportDate(raw string) (time.Time, bool, error) {
+	if raw == "" {
+		return time.Time{}, false, nil
+	}
+	parsed, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return time.Time{}, true, fmt.Errorf("parse import date: %w", err)
+	}
+	return parsed, true, nil
+}
+
+func resolveExactImportSource(sources []*store.Source, account string) (*store.Source, error) {
+	var match *store.Source
+	selectorFound := false
+	for _, source := range sources {
+		if source == nil {
+			continue
+		}
+		matchesIdentifier := strings.EqualFold(source.Identifier, account)
+		matchesDisplayName := source.DisplayName.Valid &&
+			strings.EqualFold(source.DisplayName.String, account)
+		if !matchesIdentifier && !matchesDisplayName {
+			continue
+		}
+		selectorFound = true
+		if source.SourceType != "gmail" && source.SourceType != "imap" {
+			continue
+		}
+		if match != nil {
+			return nil, errImportAmbiguousSource
+		}
+		match = source
+	}
+	if match != nil {
+		return match, nil
+	}
+	if selectorFound {
+		return nil, errImportUnsyncable
+	}
+	return nil, store.ErrSourceNotFound
+}
+
+func (s *Server) runImportJob(
+	jobID string,
+	runner CLISyncRunner,
+	jobStore importJobStore,
+	req CLISyncRequest,
+) {
+	ctx := s.importJobs.ctx
+	done, ok := s.beginBackgroundOperationGateWork(ctx, "msgvault historical import")
+	if !ok {
+		s.importJobs.markFailed(jobID, s.clockNow())
+		return
+	}
+	defer done()
+
+	s.importJobs.markRunning(jobID, s.clockNow())
+	if err := runner.RunCLISync(ctx, req, func(CLISyncEvent) error { return nil }); err != nil {
+		s.importJobs.markFailed(jobID, s.clockNow())
+		s.logger.Error("historical import job failed", "job_id", jobID, "error", err)
+		return
+	}
+	latest, err := jobStore.GetLatestSync(req.SourceID)
+	if err != nil || latest == nil || latest.Status != store.SyncStatusCompleted ||
+		!s.importJobs.acceptsRun(jobID, latest) {
+		s.importJobs.markFailed(jobID, s.clockNow())
+		s.logger.Error("historical import job completed without a final sync summary",
+			"job_id", jobID, "error", err)
+		return
+	}
+	s.importJobs.markDone(jobID, latest, s.clockNow())
+}
+
+func (s *Server) handleGetImportJob(w http.ResponseWriter, r *http.Request) {
+	if s.importJobs == nil {
+		writeError(w, http.StatusServiceUnavailable, "service_unavailable",
+			"Historical imports are unavailable")
+		return
+	}
+	jobID := r.PathValue("job_id")
+	job, ok := s.importJobs.get(jobID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "not_found", "Import job not found")
+		return
+	}
+	if job.Status == importJobStatusRunning {
+		if jobStore, ok := s.store.(importJobStore); ok {
+			active, err := jobStore.GetActiveSync(s.importJobSourceID(jobID))
+			if err == nil && s.importJobs.acceptsRun(jobID, active) {
+				s.importJobs.updateProgress(jobID, active)
+				job, _ = s.importJobs.get(jobID)
+			} else if !errors.Is(err, store.ErrSyncRunNotFound) {
+				s.logger.Warn("failed to refresh historical import progress",
+					"job_id", jobID, "error", err)
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, job)
+}
+
+func (s *Server) importJobSourceID(jobID string) int64 {
+	s.importJobs.mu.RLock()
+	defer s.importJobs.mu.RUnlock()
+	job := s.importJobs.jobs[jobID]
+	if job == nil {
+		return 0
+	}
+	return job.sourceID
+}

--- a/internal/api/import_jobs_test.go
+++ b/internal/api/import_jobs_test.go
@@ -1,0 +1,626 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type importJobTestStore struct {
+	*mockStore
+
+	mu        sync.Mutex
+	active    *store.SyncRun
+	latest    *store.SyncRun
+	runErr    error
+	started   chan CLISyncRequest
+	release   chan struct{}
+	releaseMu sync.Once
+}
+
+func newImportJobTestStore() *importJobTestStore {
+	return &importJobTestStore{
+		mockStore: &mockStore{
+			sourcesByLookup: map[string][]*store.Source{
+				"archive@example.com": {{
+					ID:         42,
+					SourceType: "gmail",
+					Identifier: "archive@example.com",
+				}},
+			},
+		},
+		started: make(chan CLISyncRequest, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *importJobTestStore) RunCLISync(
+	ctx context.Context,
+	req CLISyncRequest,
+	_ func(CLISyncEvent) error,
+) error {
+	select {
+	case s.started <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-s.release:
+		return s.runErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *importJobTestStore) GetActiveSync(sourceID int64) (*store.SyncRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.active == nil || s.active.SourceID != sourceID {
+		return nil, store.ErrSyncRunNotFound
+	}
+	clone := *s.active
+	return &clone, nil
+}
+
+func (s *importJobTestStore) GetLatestSync(sourceID int64) (*store.SyncRun, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latest == nil || s.latest.SourceID != sourceID {
+		return nil, store.ErrSyncRunNotFound
+	}
+	clone := *s.latest
+	return &clone, nil
+}
+
+func (s *importJobTestStore) setActive(run *store.SyncRun) {
+	s.mu.Lock()
+	s.active = run
+	s.mu.Unlock()
+}
+
+func (s *importJobTestStore) setLatest(run *store.SyncRun) {
+	s.mu.Lock()
+	s.latest = run
+	s.mu.Unlock()
+}
+
+func (s *importJobTestStore) finish() {
+	s.releaseMu.Do(func() { close(s.release) })
+}
+
+type importJobTestResponse struct {
+	JobID      string                `json:"job_id"`
+	Account    string                `json:"account"`
+	Status     string                `json:"status"`
+	Processed  int64                 `json:"processed"`
+	Added      int64                 `json:"added"`
+	Skipped    int64                 `json:"skipped"`
+	Error      string                `json:"error"`
+	CreatedAt  time.Time             `json:"created_at"`
+	StartedAt  *time.Time            `json:"started_at"`
+	FinishedAt *time.Time            `json:"finished_at"`
+	Summary    *importJobTestSummary `json:"summary"`
+}
+
+type importJobTestSummary struct {
+	Processed int64 `json:"processed"`
+	Added     int64 `json:"added"`
+	Updated   int64 `json:"updated"`
+	Skipped   int64 `json:"skipped"`
+	Errors    int64 `json:"errors"`
+}
+
+func submitImportJob(t *testing.T, srv *Server, body string, apiKey string) importJobTestResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", applicationJSONMediaType)
+	if apiKey != "" {
+		req.Header.Set("X-Api-Key", apiKey)
+	}
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	require.Equal(t, http.StatusAccepted, resp.Code, resp.Body.String())
+
+	var result importJobTestResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	require.NotEmpty(t, result.JobID)
+	return result
+}
+
+func getImportJob(t *testing.T, srv *Server, jobID string) (int, importJobTestResponse, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/imports/"+jobID, nil)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+
+	var result importJobTestResponse
+	if resp.Code == http.StatusOK {
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	}
+	return resp.Code, result, resp.Body.String()
+}
+
+func TestImportJobLifecycleQueuesBehindArchiveWorkAndReportsTypedProgress(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newImportJobTestStore()
+	t.Cleanup(st.finish)
+	gate := NewSerialOperationGate()
+	releaseGate, ok := gate.BeginLabeledWorkContext(t.Context(), "another archive operation")
+	require.True(ok)
+
+	srv := NewServerWithOptions(ServerOptions{
+		Config:        &config.Config{},
+		Store:         st,
+		OperationGate: gate,
+		Logger:        testLogger(),
+	})
+
+	created := submitImportJob(t, srv, `{
+		"account":"archive@example.com",
+		"after":"2024-01-01",
+		"before":"2024-02-01",
+		"limit":25,
+		"query":"has:attachment",
+		"noresume":true
+	}`, "")
+	assert.Equal("archive@example.com", created.Account)
+	assert.Equal("queued", created.Status)
+	assert.False(created.CreatedAt.IsZero())
+	assert.Nil(created.StartedAt)
+	assert.Nil(created.FinishedAt)
+
+	select {
+	case req := <-st.started:
+		require.FailNowf("import started while gate held", "request=%+v", req)
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	releaseGate()
+	var runReq CLISyncRequest
+	require.Eventually(func() bool {
+		select {
+		case runReq = <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	assert.True(runReq.Full)
+	assert.Empty(runReq.Email)
+	assert.Equal(int64(42), runReq.SourceID)
+	assert.True(runReq.SourceIDSet)
+	assert.Equal("2024-01-01", runReq.After)
+	assert.Equal("2024-02-01", runReq.Before)
+	assert.Equal(25, runReq.Limit)
+	assert.Equal("has:attachment", runReq.Query)
+	assert.True(runReq.NoResume)
+
+	code, runningBeforeProgress, body := getImportJob(t, srv, created.JobID)
+	require.Equal(http.StatusOK, code, body)
+	require.Equal("running", runningBeforeProgress.Status)
+	require.NotNil(runningBeforeProgress.StartedAt)
+	startedAt := runningBeforeProgress.StartedAt.Truncate(time.Second)
+	st.setActive(&store.SyncRun{
+		ID:                100,
+		SourceID:          42,
+		StartedAt:         startedAt,
+		Status:            store.SyncStatusRunning,
+		MessagesProcessed: 12,
+		MessagesAdded:     7,
+		MessagesUpdated:   2,
+		ErrorsCount:       1,
+	})
+
+	require.Eventually(func() bool {
+		code, running, _ := getImportJob(t, srv, created.JobID)
+		return code == http.StatusOK && running.Status == "running" &&
+			running.Processed == 12 && running.Added == 7 && running.Skipped == 3
+	}, time.Second, 10*time.Millisecond)
+
+	finishedAt := time.Now().UTC().Add(time.Second)
+	st.setLatest(&store.SyncRun{
+		ID:                100,
+		SourceID:          42,
+		StartedAt:         startedAt,
+		CompletedAt:       sql.NullTime{Time: finishedAt, Valid: true},
+		Status:            store.SyncStatusCompleted,
+		MessagesProcessed: 20,
+		MessagesAdded:     11,
+		MessagesUpdated:   3,
+		ErrorsCount:       2,
+	})
+	st.finish()
+
+	var done importJobTestResponse
+	require.Eventually(func() bool {
+		code, result, _ := getImportJob(t, srv, created.JobID)
+		done = result
+		return code == http.StatusOK && result.Status == "done"
+	}, time.Second, 10*time.Millisecond)
+	require.NotNil(done.Summary)
+	assert.Equal(int64(20), done.Processed)
+	assert.Equal(int64(11), done.Added)
+	assert.Equal(int64(6), done.Skipped)
+	assert.Equal(int64(20), done.Summary.Processed)
+	assert.Equal(int64(11), done.Summary.Added)
+	assert.Equal(int64(3), done.Summary.Updated)
+	assert.Equal(int64(6), done.Summary.Skipped)
+	assert.Equal(int64(2), done.Summary.Errors)
+	assert.NotNil(done.StartedAt)
+	assert.NotNil(done.FinishedAt)
+}
+
+func TestImportJobCanCompleteResumedBaselineRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newImportJobTestStore()
+	baselineStartedAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	st.setLatest(&store.SyncRun{
+		ID:        99,
+		SourceID:  42,
+		StartedAt: baselineStartedAt,
+		Status:    store.SyncStatusRunning,
+	})
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	created := submitImportJob(t, srv, `{"account":"archive@example.com"}`, "")
+	var runReq CLISyncRequest
+	require.Eventually(func() bool {
+		select {
+		case runReq = <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	assert.False(runReq.NoResume)
+
+	finishedAt := time.Now().UTC()
+	st.setLatest(&store.SyncRun{
+		ID:                99,
+		SourceID:          42,
+		StartedAt:         baselineStartedAt,
+		CompletedAt:       sql.NullTime{Time: finishedAt, Valid: true},
+		Status:            store.SyncStatusCompleted,
+		MessagesProcessed: 10,
+		MessagesAdded:     7,
+		MessagesUpdated:   1,
+	})
+	st.finish()
+
+	var done importJobTestResponse
+	require.Eventually(func() bool {
+		code, result, _ := getImportJob(t, srv, created.JobID)
+		done = result
+		return code == http.StatusOK && result.Status == "done"
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(int64(10), done.Processed)
+	assert.Equal(int64(7), done.Added)
+	require.NotNil(done.Summary)
+	assert.Equal(int64(1), done.Summary.Updated)
+}
+
+func TestImportJobFailureDoesNotExposeRunnerError(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newImportJobTestStore()
+	st.runErr = errors.New("oauth token secret-value was rejected")
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	created := submitImportJob(t, srv, `{"account":"archive@example.com"}`, "")
+	require.Eventually(func() bool {
+		select {
+		case <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	st.finish()
+
+	var failed importJobTestResponse
+	require.Eventually(func() bool {
+		code, result, _ := getImportJob(t, srv, created.JobID)
+		failed = result
+		return code == http.StatusOK && result.Status == "failed"
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal("import failed", failed.Error)
+	assert.NotContains(failed.Error, "secret-value")
+	assert.Nil(failed.Summary)
+	assert.NotNil(failed.FinishedAt)
+}
+
+func TestImportJobOutlivesSubmitRequest(t *testing.T) {
+	require := require.New(t)
+	st := newImportJobTestStore()
+	t.Cleanup(st.finish)
+	gate := NewSerialOperationGate()
+	releaseGate, ok := gate.BeginLabeledWorkContext(t.Context(), "another archive operation")
+	require.True(ok)
+	var releaseGateOnce sync.Once
+	releaseHeldGate := func() { releaseGateOnce.Do(releaseGate) }
+	t.Cleanup(releaseHeldGate)
+
+	srv := NewServerWithOptions(ServerOptions{
+		Config:        &config.Config{},
+		Store:         st,
+		OperationGate: gate,
+		Logger:        testLogger(),
+	})
+
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports",
+		strings.NewReader(`{"account":"archive@example.com"}`)).WithContext(requestCtx)
+	req.Header.Set("Content-Type", applicationJSONMediaType)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	require.Equal(http.StatusAccepted, resp.Code, resp.Body.String())
+
+	var created importJobTestResponse
+	require.NoError(json.NewDecoder(resp.Body).Decode(&created))
+	cancelRequest()
+	releaseHeldGate()
+
+	require.Eventually(func() bool {
+		select {
+		case <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, "background import must not inherit request cancellation")
+
+	finishedAt := time.Now().UTC()
+	st.setLatest(&store.SyncRun{
+		ID:          101,
+		SourceID:    42,
+		StartedAt:   finishedAt,
+		CompletedAt: sql.NullTime{Time: finishedAt, Valid: true},
+		Status:      store.SyncStatusCompleted,
+	})
+	st.finish()
+	require.Eventually(func() bool {
+		code, result, _ := getImportJob(t, srv, created.JobID)
+		return code == http.StatusOK && result.Status == "done"
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestImportJobDoesNotAdoptStaleLatestRun(t *testing.T) {
+	st := newImportJobTestStore()
+	oldStartedAt := time.Now().UTC().Add(-time.Hour)
+	st.setLatest(&store.SyncRun{
+		ID:                7,
+		SourceID:          42,
+		StartedAt:         oldStartedAt,
+		CompletedAt:       sql.NullTime{Time: oldStartedAt.Add(time.Minute), Valid: true},
+		Status:            store.SyncStatusCompleted,
+		MessagesProcessed: 900,
+		MessagesAdded:     800,
+	})
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	created := submitImportJob(t, srv, `{"account":"archive@example.com"}`, "")
+	require.Eventually(t, func() bool {
+		select {
+		case <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	st.finish()
+
+	require.Eventually(t, func() bool {
+		code, result, _ := getImportJob(t, srv, created.JobID)
+		return code == http.StatusOK && result.Status == "failed" &&
+			result.Processed == 0 && result.Added == 0 && result.Summary == nil
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestImportJobShutdownCancelsRunningJob(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := newImportJobTestStore()
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	created := submitImportJob(t, srv, `{"account":"archive@example.com"}`, "")
+	require.Eventually(func() bool {
+		select {
+		case <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(srv.Shutdown(shutdownCtx))
+
+	code, failed, body := getImportJob(t, srv, created.JobID)
+	require.Equal(http.StatusOK, code, body)
+	assert.Equal("failed", failed.Status)
+	assert.Equal("import failed", failed.Error)
+	assert.NotNil(failed.FinishedAt)
+}
+
+func TestImportJobAcceptsAccountDisplayName(t *testing.T) {
+	st := newImportJobTestStore()
+	st.sourcesByLookup["Work Archive"] = []*store.Source{{
+		ID:          54,
+		SourceType:  "imap",
+		Identifier:  "work@example.com",
+		DisplayName: sql.NullString{String: "Work Archive", Valid: true},
+	}}
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	created := submitImportJob(t, srv, `{"account":"Work Archive"}`, "")
+	assert.Equal(t, "work@example.com", created.Account)
+
+	var runReq CLISyncRequest
+	require.Eventually(t, func() bool {
+		select {
+		case runReq = <-st.started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int64(54), runReq.SourceID)
+}
+
+func TestImportJobsRequireAPIAuthentication(t *testing.T) {
+	const apiKey = "import-test-api-key"
+	st := newImportJobTestStore()
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIKey: apiKey}}, st, nil, testLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports",
+		strings.NewReader(`{"account":"archive@example.com"}`))
+	req.Header.Set("Content-Type", applicationJSONMediaType)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusUnauthorized, resp.Code, resp.Body.String())
+
+	created := submitImportJob(t, srv, `{"account":"archive@example.com"}`, apiKey)
+	code, _, body := getImportJob(t, srv, created.JobID)
+	assert.Equal(t, http.StatusUnauthorized, code, body)
+}
+
+func TestImportJobRequestValidation(t *testing.T) {
+	st := newImportJobTestStore()
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	tests := []struct {
+		name        string
+		body        string
+		contentType string
+		wantStatus  int
+	}{
+		{name: "content type required", body: `{}`, wantStatus: http.StatusUnsupportedMediaType},
+		{name: "malformed JSON", body: `{`, contentType: applicationJSONMediaType, wantStatus: http.StatusBadRequest},
+		{name: "account required", body: `{}`, contentType: applicationJSONMediaType, wantStatus: http.StatusUnprocessableEntity},
+		{name: "after is a date", body: `{"account":"archive@example.com","after":"yesterday"}`, contentType: applicationJSONMediaType, wantStatus: http.StatusUnprocessableEntity},
+		{name: "before is a date", body: `{"account":"archive@example.com","before":"tomorrow"}`, contentType: applicationJSONMediaType, wantStatus: http.StatusUnprocessableEntity},
+		{name: "window is ordered", body: `{"account":"archive@example.com","after":"2024-02-01","before":"2024-01-01"}`, contentType: applicationJSONMediaType, wantStatus: http.StatusUnprocessableEntity},
+		{name: "limit is nonnegative", body: `{"account":"archive@example.com","limit":-1}`, contentType: applicationJSONMediaType, wantStatus: http.StatusUnprocessableEntity},
+		{name: "unknown account", body: `{"account":"missing@example.com"}`, contentType: applicationJSONMediaType, wantStatus: http.StatusNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/imports", strings.NewReader(tt.body))
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, req)
+			assert.Equal(t, tt.wantStatus, resp.Code, resp.Body.String())
+		})
+	}
+}
+
+func TestImportJobRejectsAmbiguousAndUnsyncableSources(t *testing.T) {
+	st := newImportJobTestStore()
+	st.sourcesByLookup["ambiguous@example.com"] = []*store.Source{
+		{ID: 51, SourceType: "gmail", Identifier: "ambiguous@example.com"},
+		{ID: 52, SourceType: "imap", Identifier: "ambiguous@example.com"},
+	}
+	st.sourcesByLookup["calendar@example.com"] = []*store.Source{
+		{ID: 53, SourceType: "gcal", Identifier: "calendar@example.com"},
+	}
+	t.Cleanup(st.finish)
+	srv := NewServer(&config.Config{}, st, nil, testLogger())
+
+	tests := []struct {
+		account    string
+		wantStatus int
+	}{
+		{account: "ambiguous@example.com", wantStatus: http.StatusConflict},
+		{account: "calendar@example.com", wantStatus: http.StatusUnprocessableEntity},
+	}
+	for _, tt := range tests {
+		t.Run(tt.account, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/imports",
+				strings.NewReader(fmt.Sprintf(`{"account":%q}`, tt.account)))
+			req.Header.Set("Content-Type", applicationJSONMediaType)
+			resp := httptest.NewRecorder()
+			srv.Router().ServeHTTP(resp, req)
+			assert.Equal(t, tt.wantStatus, resp.Code, resp.Body.String())
+		})
+	}
+}
+
+func TestImportJobAdmissionIsBounded(t *testing.T) {
+	st := newImportJobTestStore()
+	gate := NewSerialOperationGate()
+	releaseGate, ok := gate.BeginLabeledWorkContext(t.Context(), "another archive operation")
+	require.True(t, ok)
+
+	srv := NewServerWithOptions(ServerOptions{
+		Config:        &config.Config{},
+		Store:         st,
+		OperationGate: gate,
+		Logger:        testLogger(),
+	})
+	t.Cleanup(func() {
+		st.finish()
+		releaseGate()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(shutdownCtx))
+	})
+
+	for i := range 16 {
+		account := fmt.Sprintf("archive-%02d@example.com", i)
+		st.sourcesByLookup[account] = []*store.Source{{
+			ID: int64(100 + i), SourceType: "gmail", Identifier: account,
+		}}
+		submitImportJob(t, srv, fmt.Sprintf(`{"account":%q}`, account), "")
+	}
+
+	overflowAccount := "archive-overflow@example.com"
+	st.sourcesByLookup[overflowAccount] = []*store.Source{{
+		ID: 999, SourceType: "gmail", Identifier: overflowAccount,
+	}}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports",
+		strings.NewReader(fmt.Sprintf(`{"account":%q}`, overflowAccount)))
+	req.Header.Set("Content-Type", applicationJSONMediaType)
+	resp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(resp, req)
+	assert.Equal(t, http.StatusTooManyRequests, resp.Code, resp.Body.String())
+
+	duplicate := httptest.NewRequest(http.MethodPost, "/api/v1/imports",
+		strings.NewReader(`{"account":"archive-00@example.com"}`))
+	duplicate.Header.Set("Content-Type", applicationJSONMediaType)
+	duplicateResp := httptest.NewRecorder()
+	srv.Router().ServeHTTP(duplicateResp, duplicate)
+	assert.Equal(t, http.StatusConflict, duplicateResp.Code, duplicateResp.Body.String())
+}
+
+func TestGetImportJobReturnsNotFoundForUnknownID(t *testing.T) {
+	srv := NewServer(&config.Config{}, newImportJobTestStore(), nil, testLogger())
+	code, _, body := getImportJob(t, srv, "missing")
+	assert.Equal(t, http.StatusNotFound, code, body)
+}

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -240,7 +240,10 @@ import (
 // 2.12.0 adds deletion_scope=active|deleted|any to GET /api/v1/cli/search.
 // Omission preserves the active-only default. Additive (minor bump): existing
 // clients continue to receive the same result population.
-const APISchemaVersion = "2.12.0"
+// 2.13.0 adds authenticated asynchronous historical import jobs at
+// POST /api/v1/imports and GET /api/v1/imports/{job_id}. Existing synchronous
+// CLI sync routes and source-status responses are unchanged.
+const APISchemaVersion = "2.13.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -34,8 +34,41 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 	assert.NotEmpty(t, doc.Paths, "paths")
 }
 
-func TestOpenAPISchemaVersionSearchDeletionScopeIs2120(t *testing.T) {
-	assert.Equal(t, "2.12.0", APISchemaVersion)
+func TestOpenAPISchemaVersionAsyncImportsIs2130(t *testing.T) {
+	assert.Equal(t, "2.13.0", APISchemaVersion)
+}
+
+func TestOpenAPIImportJobContract(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	doc := OpenAPIDocument()
+
+	createPath := doc.Paths["/api/v1/imports"]
+	require.NotNil(createPath, "import collection path")
+	require.NotNil(createPath.Post, "create import operation")
+	assert.Equal("createImportJob", createPath.Post.OperationID)
+	require.Len(createPath.Post.Security, 1)
+	_, secured := createPath.Post.Security[0][apiKeySecurityScheme]
+	assert.True(secured, "create import requires API-key security")
+	require.NotNil(createPath.Post.RequestBody)
+	requestMedia := createPath.Post.RequestBody.Content[applicationJSONMediaType]
+	require.NotNil(requestMedia)
+	assert.Equal("#/components/schemas/ImportJobRequest", requestMedia.Schema.Ref)
+	accepted := createPath.Post.Responses["202"]
+	require.NotNil(accepted, "create import documents 202")
+	acceptedMedia := accepted.Content[applicationJSONMediaType]
+	require.NotNil(acceptedMedia)
+	assert.Equal("#/components/schemas/ImportJobResponse", acceptedMedia.Schema.Ref)
+	assert.Contains(createPath.Post.Responses, "429", "bounded admission is documented")
+
+	statusPath := doc.Paths["/api/v1/imports/{job_id}"]
+	require.NotNil(statusPath, "import status path")
+	require.NotNil(statusPath.Get, "get import operation")
+	assert.Equal("getImportJob", statusPath.Get.OperationID)
+	require.Len(statusPath.Get.Parameters, 1)
+	assert.Equal("job_id", statusPath.Get.Parameters[0].Name)
+	assert.Equal("path", statusPath.Get.Parameters[0].In)
+	assert.True(statusPath.Get.Parameters[0].Required)
 }
 
 func TestCLISearchOpenAPIDocumentsDeletionScope(t *testing.T) {
@@ -133,7 +166,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.12.0", APISchemaVersion)
+	assert.Equal("2.13.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -155,11 +188,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.12.0", APISchemaVersion)
+	assert.Equal(t, "2.13.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.12.0", APISchemaVersion)
+	assert.Equal(t, "2.13.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -183,7 +216,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.12.0", APISchemaVersion,
+	assert.Equal(t, "2.13.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -494,7 +527,7 @@ func TestOpenAPIFastSearchDocumentsSourceIDs(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.12.0", APISchemaVersion,
+	assert.Equal("2.13.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -608,7 +641,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.12.0", APISchemaVersion,
+	assertions.Equal("2.13.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -628,7 +661,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.12.0", APISchemaVersion,
+	assert.Equal("2.13.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -656,7 +689,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.12.0", APISchemaVersion,
+	assertions.Equal("2.13.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -703,8 +736,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// 2.5.0. Person search in 2.6.0, structured filters in 2.7.0, CardDAV routes
 	// in 2.8.0, person merge/split operations in 2.9.0, and relationship
 	// calendars in 2.10.0, person fact diagnostics in 2.11.0, and lexical
-	// deletion scope in 2.12.0 did not touch it.
-	assert.Equal("2.12.0", APISchemaVersion, "meeting import is an additive schema release")
+	// deletion scope in 2.12.0 and historical import jobs in 2.13.0 did not
+	// touch it.
+	assert.Equal("2.13.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -344,7 +344,8 @@ func writeOperationGateBusy(w http.ResponseWriter, gate OperationGate) {
 // NOT exempt: its subprocess opens the store read-write and runs schema
 // init/migrations.
 //
-// Backup freeze begin and meeting import coordinate the gate in their handlers.
+// Backup freeze begin, meeting import, and historical import jobs coordinate
+// the gate in their handlers.
 // Meeting import first reads and validates its bounded request body so a slow
 // authenticated upload cannot hold the gate. Backup freeze end bypasses the
 // gate so it can release the freeze held by begin. Routing these through the
@@ -353,6 +354,7 @@ var operationGateExemptPaths = map[string]bool{
 	queryEndpointPath:                true,
 	sessionPath:                      true,
 	sessionLoginPath:                 true,
+	importJobsEndpointPath:           true,
 	meetingImportEndpointPath:        true,
 	"/api/v1/cli/add-calendar/plan":  true,
 	"/api/v1/cli/delete-staged/plan": true,

--- a/internal/api/relationship_calendar_test.go
+++ b/internal/api/relationship_calendar_test.go
@@ -177,7 +177,7 @@ func TestRelationshipCalendarRequestRejectsTrailingJSON(t *testing.T) {
 func TestRelationshipCalendarOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.Equal("2.12.0", APISchemaVersion)
+	assert.Equal("2.13.0", APISchemaVersion)
 	document := OpenAPIDocument()
 	path := document.Paths["/api/v1/relationships/{id}/calendar"]
 	require.NotNil(path)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -224,6 +224,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	}, s.handleDaemonShutdown)
 
 	registerAPIV1RawHumaJSONRoute[StatsResponse](apiV1, "getStats", http.MethodGet, "/stats", "Get archive statistics", s.handleStats)
+	s.registerImportJobRoutes(apiV1)
 	s.registerSettingsRoutes(apiV1)
 	s.registerCardDAVRoutes(apiV1)
 	s.registerSavedViewRoutes(apiV1)
@@ -612,6 +613,8 @@ func rawRouteParameters(operationID string) []*huma.Param {
 	switch operationID {
 	case "getCLIStats":
 		return scopeParams()
+	case "getImportJob":
+		return []*huma.Param{pathStringParam("job_id", "Historical import job ID")}
 	case "searchCLI":
 		return append([]*huma.Param{
 			queryStringParam("q", "Search query", true),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -270,6 +270,7 @@ type Server struct {
 	visualCoverageRateLimiter *RateLimiter
 	idleTracker               *IdleTracker
 	operationGate             OperationGate
+	importJobs                *importJobManager
 	// ftsIndexComplete memoizes that the FTS index is fully populated so
 	// handleCLISearch stops probing on every request. NeedsFTSBackfill runs an
 	// anti-join that scans every message when the index is complete (the
@@ -540,6 +541,7 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		daemonVersion:            opts.DaemonVersion,
 		idleTracker:              opts.IdleTracker,
 		operationGate:            opts.OperationGate,
+		importJobs:               newImportJobManager(),
 		blobStore:                opts.BlobStore,
 		remoteImages:             newRemoteImageFetcher(),
 		inlineCache:              newInlineParseCache(inlineCacheMaxEntries, inlineCacheMaxBytes),
@@ -777,6 +779,10 @@ func (s *Server) StartOnListener(ln net.Listener) error {
 
 // Shutdown gracefully shuts down the server.
 func (s *Server) Shutdown(ctx context.Context) error {
+	var importJobsErr error
+	if s.importJobs != nil {
+		importJobsErr = s.importJobs.shutdown(ctx)
+	}
 	if s.rateLimiter != nil {
 		s.rateLimiter.Close()
 	}
@@ -796,10 +802,10 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	server := s.server
 	s.serverMu.RUnlock()
 	if server == nil {
-		return nil
+		return importJobsErr
 	}
 	s.logger.Info("shutting down API server")
-	return server.Shutdown(ctx)
+	return errors.Join(importJobsErr, server.Shutdown(ctx))
 }
 
 // Router returns the HTTP router for testing.

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -451,6 +451,14 @@ type ClientInterface interface {
 	ImportMeeting(ctx context.Context, options *ImportMeetingRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportMeetingResponseJSON, error)
 	ImportMeetingWithResponse(ctx context.Context, options *ImportMeetingRequestOptions, reqEditors ...runtime.RequestEditorFn) (*ImportMeetingResp, error)
 
+	// CreateImportJob Start a bounded historical import
+	CreateImportJob(ctx context.Context, options *CreateImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateImportJobResponse, error)
+	CreateImportJobWithResponse(ctx context.Context, options *CreateImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateImportJobResp, error)
+
+	// GetImportJob Get historical import status
+	GetImportJob(ctx context.Context, options *GetImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetImportJobResponse, error)
+	GetImportJobWithResponse(ctx context.Context, options *GetImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetImportJobResp, error)
+
 	// SearchIntegrationTasks Search tasks in the configured project
 	SearchIntegrationTasks(ctx context.Context, options *SearchIntegrationTasksRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchIntegrationTasksResponse, error)
 	SearchIntegrationTasksWithResponse(ctx context.Context, options *SearchIntegrationTasksRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchIntegrationTasksResp, error)
@@ -7329,6 +7337,133 @@ func (c *Client) ImportMeeting(ctx context.Context, options *ImportMeetingReques
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/import/meeting")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// CreateImportJob Start a bounded historical import
+func (c *Client) CreateImportJob(ctx context.Context, options *CreateImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateImportJobResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/imports",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*CreateImportJobResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 202 {
+			target := new(CreateImportJobErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "CreateImportJobErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(CreateImportJobResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "CreateImportJobResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/imports")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// GetImportJob Get historical import status
+func (c *Client) GetImportJob(ctx context.Context, options *GetImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetImportJobResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/imports/{job_id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*GetImportJobResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(GetImportJobErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "GetImportJobErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		target := new(GetImportJobResponse)
+		// Handle empty response body gracefully
+		if len(bodyBytes) == 0 {
+			return target, nil
+		}
+		if err = json.Unmarshal(bodyBytes, target); err != nil {
+			return nil, &runtime.ResponseDecodeError{
+				StatusCode:    resp.StatusCode,
+				ContentType:   resp.Headers.Get("Content-Type"),
+				ContentLength: len(bodyBytes),
+				TargetType:    "GetImportJobResponse",
+				Body:          bodyBytes,
+				Err:           err,
+			}
+		}
+		return target, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/imports/{job_id}")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -4217,6 +4217,94 @@ func (o *ImportMeetingRequestOptions) GetHeader() (map[string]string, error) {
 	return nil, nil
 }
 
+// CreateImportJobRequestOptions is the options needed to make a request to CreateImportJob.
+type CreateImportJobRequestOptions struct {
+	Body *CreateImportJobBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *CreateImportJobRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *CreateImportJobRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *CreateImportJobRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *CreateImportJobRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *CreateImportJobRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
+// GetImportJobRequestOptions is the options needed to make a request to GetImportJob.
+type GetImportJobRequestOptions struct {
+	PathParams *GetImportJobPath
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *GetImportJobRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.PathParams != nil {
+		if v, ok := any(o.PathParams).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("PathParams", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *GetImportJobRequestOptions) GetPathParams() (map[string]any, error) {
+	return runtime.AsMap[any](o.PathParams)
+}
+
+// GetQuery returns the query params as a map.
+func (o *GetImportJobRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *GetImportJobRequestOptions) GetBody() any {
+	return nil
+}
+
+// GetHeader returns the headers as a map.
+func (o *GetImportJobRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // SearchIntegrationTasksRequestOptions is the options needed to make a request to SearchIntegrationTasks.
 type SearchIntegrationTasksRequestOptions struct {
 	Query *SearchIntegrationTasksQuery

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -9025,6 +9025,293 @@ func (c *Client) ImportMeetingWithResponse(ctx context.Context, options *ImportM
 	}
 }
 
+// CreateImportJob Start a bounded historical import
+func (c *Client) CreateImportJobWithResponse(ctx context.Context, options *CreateImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*CreateImportJobResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/imports",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/imports")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &CreateImportJobResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 202:
+		out.JSON202 = new(CreateImportJobResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON202); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 400:
+		out.JSON400 = new(CreateImportJobErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON400); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 401:
+		out.JSON401 = new(CreateImportJobErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON401); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(CreateImportJobErrorResponseJSON404)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON404",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 409:
+		out.JSON409 = new(CreateImportJobErrorResponseJSON409)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON409); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON409",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 413:
+		out.JSON413 = new(CreateImportJobErrorResponseJSON413)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON413); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON413",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 415:
+		out.JSON415 = new(CreateImportJobErrorResponseJSON415)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON415); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON415",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 422:
+		out.JSON422 = new(CreateImportJobErrorResponseJSON422)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON422); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON422",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 429:
+		out.JSON429 = new(CreateImportJobErrorResponseJSON429)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON429); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON429",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 500:
+		out.JSON500 = new(CreateImportJobErrorResponseJSON500)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON500); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON500",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 503:
+		out.JSON503 = new(CreateImportJobErrorResponseJSON503)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON503); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "CreateImportJobErrorResponseJSON503",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
+// GetImportJob Get historical import status
+func (c *Client) GetImportJobWithResponse(ctx context.Context, options *GetImportJobRequestOptions, reqEditors ...runtime.RequestEditorFn) (*GetImportJobResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL: c.apiClient.GetBaseURL() + "/api/v1/imports/{job_id}",
+		Method:     "GET",
+		Options:    options,
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/imports/{job_id}")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &GetImportJobResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		out.JSON200 = new(GetImportJobResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON200); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetImportJobResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, nil
+	case 401:
+		out.JSON401 = new(GetImportJobErrorResponse)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON401); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetImportJobErrorResponse",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	case 404:
+		out.JSON404 = new(GetImportJobErrorResponseJSON)
+		bodyBytes := resp.Content
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, out.JSON404); err != nil {
+				return out, &runtime.ResponseDecodeError{
+					StatusCode:    resp.StatusCode,
+					ContentType:   resp.Headers.Get("Content-Type"),
+					ContentLength: len(bodyBytes),
+					TargetType:    "GetImportJobErrorResponseJSON",
+					Body:          bodyBytes,
+					Err:           err,
+				}
+			}
+		}
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // SearchIntegrationTasks Search tasks in the configured project
 func (c *Client) SearchIntegrationTasksWithResponse(ctx context.Context, options *SearchIntegrationTasksRequestOptions, reqEditors ...runtime.RequestEditorFn) (*SearchIntegrationTasksResp, error) {
 	var err error

--- a/pkg/client/generated/enums.go
+++ b/pkg/client/generated/enums.go
@@ -556,6 +556,25 @@ func (i IdentitySearchSortField) Validate() error {
 	}
 }
 
+type ImportJobResponseStatus string
+
+const (
+	Done    ImportJobResponseStatus = "done"
+	Failed  ImportJobResponseStatus = "failed"
+	Queued  ImportJobResponseStatus = "queued"
+	Running ImportJobResponseStatus = "running"
+)
+
+// Validate checks if the ImportJobResponseStatus value is valid
+func (i ImportJobResponseStatus) Validate() error {
+	switch i {
+	case Done, Failed, Queued, Running:
+		return nil
+	default:
+		return runtime.NewValidationErrorsFromString("Enum", fmt.Sprintf("must be a valid ImportJobResponseStatus value, got: %v", i))
+	}
+}
+
 type MeetingImportResponseStatus string
 
 const (

--- a/pkg/client/generated/paths.go
+++ b/pkg/client/generated/paths.go
@@ -259,6 +259,15 @@ type RejectIdentityMatchCandidatePath struct {
 	ID int64 `json:"id"`
 }
 
+type GetImportJobPath struct {
+	// JobID Historical import job ID
+	JobID string `json:"job_id" validate:"required"`
+}
+
+func (g GetImportJobPath) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(g))
+}
+
 type GetMessagePath struct {
 	// ID Message ID
 	ID int64 `json:"id"`

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -100,6 +100,8 @@ type UnlinkIdentityParticipantsBody = IdentityLinkRequest
 
 type ImportMeetingBody = MeetingImportRequest
 
+type CreateImportJobBody = ImportJobRequest
+
 type CreateOrLinkMessageTaskBody = TaskLinkMutationRequest
 
 type StartVisualAttachmentBuildBody = VisualBuildRequest

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -1323,6 +1323,34 @@ type ImportMeetingResponseJSON = MeetingImportResponse
 
 type ImportMeetingErrorResponse = ErrorResponse
 
+type CreateImportJobResponse = ImportJobResponse
+
+type CreateImportJobErrorResponse = ErrorResponse
+
+type CreateImportJobErrorResponseJSON = ErrorResponse
+
+type CreateImportJobErrorResponseJSON404 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON409 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON413 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON415 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON422 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON429 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON500 = ErrorResponse
+
+type CreateImportJobErrorResponseJSON503 = ErrorResponse
+
+type GetImportJobResponse = ImportJobResponse
+
+type GetImportJobErrorResponse = ErrorResponse
+
+type GetImportJobErrorResponseJSON = ErrorResponse
+
 type SearchIntegrationTasksResponse = TaskSearchResponse
 
 type SearchIntegrationTasksErrorResponse = ErrorResponse
@@ -3684,6 +3712,32 @@ type ImportMeetingResp struct {
 	StatusCode   int
 	JSON200      *ImportMeetingResponse
 	JSON201      *ImportMeetingResponseJSON
+}
+
+type CreateImportJobResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON202      *CreateImportJobResponse
+	JSON400      *CreateImportJobErrorResponse
+	JSON401      *CreateImportJobErrorResponseJSON
+	JSON404      *CreateImportJobErrorResponseJSON404
+	JSON409      *CreateImportJobErrorResponseJSON409
+	JSON413      *CreateImportJobErrorResponseJSON413
+	JSON415      *CreateImportJobErrorResponseJSON415
+	JSON422      *CreateImportJobErrorResponseJSON422
+	JSON429      *CreateImportJobErrorResponseJSON429
+	JSON500      *CreateImportJobErrorResponseJSON500
+	JSON503      *CreateImportJobErrorResponseJSON503
+}
+
+type GetImportJobResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+	JSON200      *GetImportJobResponse
+	JSON401      *GetImportJobErrorResponse
+	JSON404      *GetImportJobErrorResponseJSON
 }
 
 type SearchIntegrationTasksResp struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -4129,6 +4129,80 @@ func (i ImportEntry) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(i))
 }
 
+type ImportJobRequest struct {
+	Account  string  `json:"account" validate:"required,min=1"`
+	After    *string `json:"after,omitempty"`
+	Before   *string `json:"before,omitempty"`
+	Limit    *int64  `json:"limit,omitempty" validate:"omitempty,gte=0"`
+	Noresume *bool   `json:"noresume,omitempty"`
+	Query    *string `json:"query,omitempty"`
+}
+
+func (i ImportJobRequest) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(i))
+}
+
+type ImportJobResponse struct {
+	Account    string                  `json:"account" validate:"required"`
+	Added      int64                   `json:"added"`
+	CreatedAt  time.Time               `json:"created_at" validate:"required"`
+	ErrorData  *string                 `json:"error,omitempty"`
+	FinishedAt *time.Time              `json:"finished_at,omitempty" validate:"required"`
+	JobID      string                  `json:"job_id" validate:"required"`
+	Processed  int64                   `json:"processed"`
+	Skipped    int64                   `json:"skipped"`
+	StartedAt  *time.Time              `json:"started_at,omitempty" validate:"required"`
+	Status     ImportJobResponseStatus `json:"status" validate:"required"`
+	Summary    *ImportJobSummary       `json:"summary,omitempty"`
+}
+
+func (i ImportJobResponse) Validate() error {
+	var errors runtime.ValidationErrors
+	if err := typesValidator.Var(i.Account, "required"); err != nil {
+		errors = errors.Append("Account", err)
+	}
+	if err := typesValidator.Var(i.CreatedAt, "required"); err != nil {
+		errors = errors.Append("CreatedAt", err)
+	}
+	if i.FinishedAt != nil {
+		if err := typesValidator.Var(i.FinishedAt, "required"); err != nil {
+			errors = errors.Append("FinishedAt", err)
+		}
+	}
+	if err := typesValidator.Var(i.JobID, "required"); err != nil {
+		errors = errors.Append("JobID", err)
+	}
+	if i.StartedAt != nil {
+		if err := typesValidator.Var(i.StartedAt, "required"); err != nil {
+			errors = errors.Append("StartedAt", err)
+		}
+	}
+	if v, ok := any(i.Status).(runtime.Validator); ok {
+		if err := v.Validate(); err != nil {
+			errors = errors.Append("Status", err)
+		}
+	}
+	if i.Summary != nil {
+		if v, ok := any(i.Summary).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Summary", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+	return errors
+}
+
+type ImportJobSummary struct {
+	Added     int64 `json:"added"`
+	Errors    int64 `json:"errors"`
+	Processed int64 `json:"processed"`
+	Skipped   int64 `json:"skipped"`
+	Updated   int64 `json:"updated"`
+}
+
 type ImportRequest struct {
 	Account  *string       `json:"account,omitempty"`
 	Apply    *bool         `json:"apply,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -4664,6 +4664,101 @@ components:
       required:
         - identifier
       type: object
+    ImportJobRequest:
+      additionalProperties: false
+      properties:
+        account:
+          minLength: 1
+          type: string
+        after:
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+          type: string
+        before:
+          pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+          type: string
+        limit:
+          format: int64
+          minimum: 0
+          type: integer
+        noresume:
+          type: boolean
+        query:
+          type: string
+      required:
+        - account
+      type: object
+    ImportJobResponse:
+      properties:
+        account:
+          type: string
+        added:
+          format: int64
+          type: integer
+        created_at:
+          format: date-time
+          type: string
+        error:
+          type: string
+        finished_at:
+          format: date-time
+          nullable: true
+          type: string
+        job_id:
+          type: string
+        processed:
+          format: int64
+          type: integer
+        skipped:
+          format: int64
+          type: integer
+        started_at:
+          format: date-time
+          nullable: true
+          type: string
+        status:
+          enum:
+            - queued
+            - running
+            - done
+            - failed
+          type: string
+        summary:
+          $ref: "#/components/schemas/ImportJobSummary"
+      required:
+        - job_id
+        - account
+        - status
+        - processed
+        - added
+        - skipped
+        - created_at
+        - started_at
+        - finished_at
+      type: object
+    ImportJobSummary:
+      properties:
+        added:
+          format: int64
+          type: integer
+        errors:
+          format: int64
+          type: integer
+        processed:
+          format: int64
+          type: integer
+        skipped:
+          format: int64
+          type: integer
+        updated:
+          format: int64
+          type: integer
+      required:
+        - processed
+        - added
+        - updated
+        - skipped
+        - errors
+      type: object
     ImportRequest:
       additionalProperties: false
       properties:
@@ -10652,7 +10747,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.12.0
+  version: 2.13.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -15717,6 +15812,133 @@ paths:
       security:
         - apiKey: []
       summary: Import one meeting
+      tags:
+        - API
+  /api/v1/imports:
+    post:
+      operationId: createImportJob
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportJobRequest"
+        required: true
+      responses:
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportJobResponse"
+          description: Accepted
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "413":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "415":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "503":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Start a bounded historical import
+      tags:
+        - API
+  /api/v1/imports/{job_id}:
+    get:
+      operationId: getImportJob
+      parameters:
+        - description: Historical import job ID
+          in: path
+          name: job_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportJobResponse"
+          description: OK
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Get historical import status
       tags:
         - API
   /api/v1/integrations/tasks/search:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -1532,6 +1532,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/imports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Start a bounded historical import */
+        post: operations["createImportJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/imports/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get historical import status */
+        get: operations["getImportJob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/integrations/tasks/search": {
         parameters: {
             query?: never;
@@ -5305,6 +5339,51 @@ export interface components {
         ImportEntry: {
             identifier: string;
             state?: string;
+        };
+        ImportJobRequest: {
+            account: string;
+            after?: string;
+            before?: string;
+            /** Format: int64 */
+            limit?: number;
+            noresume?: boolean;
+            query?: string;
+        };
+        ImportJobResponse: {
+            account: string;
+            /** Format: int64 */
+            added: number;
+            /** Format: date-time */
+            created_at: string;
+            error?: string;
+            /** Format: date-time */
+            finished_at: string | null;
+            job_id: string;
+            /** Format: int64 */
+            processed: number;
+            /** Format: int64 */
+            skipped: number;
+            /** Format: date-time */
+            started_at: string | null;
+            /** @enum {string} */
+            status: "queued" | "running" | "done" | "failed";
+            summary?: components["schemas"]["ImportJobSummary"];
+        } & {
+            [key: string]: unknown;
+        };
+        ImportJobSummary: {
+            /** Format: int64 */
+            added: number;
+            /** Format: int64 */
+            errors: number;
+            /** Format: int64 */
+            processed: number;
+            /** Format: int64 */
+            skipped: number;
+            /** Format: int64 */
+            updated: number;
+        } & {
+            [key: string]: unknown;
         };
         ImportRequest: {
             account?: string;
@@ -13818,6 +13897,179 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MeetingImportResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    createImportJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImportJobRequest"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportJobResponse"];
+                };
+            };
+            /** @description Error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            415: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    getImportJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Historical import job ID */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportJobResponse"];
+                };
+            };
+            /** @description Error */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Error */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
## What changed

- Add authenticated `POST /api/v1/imports` and `GET /api/v1/imports/{job_id}` endpoints for bounded Gmail and IMAP historical imports.
- Queue imports behind the daemon's archive-operation gate, with process-local status, progress, final counts, timestamps, and sanitized failures.
- Handle SQLite timestamp precision and resumed sync runs when attributing progress and completion to a job.
- Publish schema 2.13.0 and regenerate the Go and TypeScript clients.

## Why

Remote deployments can inspect and schedule accounts over HTTP, but starting a bounded initial import still requires a local `msgvault sync-full` bridge. This adds the missing async primitive for operator UIs without exposing arbitrary commands or provider tokens.

## Usage

```bash
curl http://localhost:8080/api/v1/imports \
  -H "Authorization: Bearer $MSGVAULT_API_KEY" \
  -H "Content-Type: application/json" \
  --data '{"account":"you@example.com","after":"2024-01-01","limit":5000}'
```

Poll `GET /api/v1/imports/{job_id}` until the job reaches `done` or `failed`.

Closes #378
