### PR TITLE
Improve TUI search, deletion, and export workflows

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2504,10 +2504,16 @@ components:
           type: string
         scope:
           type: string
+        stats:
+          $ref: "#/components/schemas/TotalStatsResponse"
+        total_count:
+          format: int64
+          type: integer
       required:
         - query
         - messages
         - count
+        - total_count
         - has_more
         - offset
         - limit
@@ -4553,6 +4559,10 @@ components:
           items:
             type: string
           type: array
+        search_mode:
+          type: string
+        search_query:
+          type: string
         targets:
           items:
             $ref: "#/components/schemas/DeletionTarget"
@@ -17548,6 +17558,26 @@ paths:
           name: direction
           schema:
             type: string
+        - description: Structured search query
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: "Search mode: fast, deep, or aggregate; required with q"
+          in: query
+          name: search_mode
+          schema:
+            type: string
+        - description: Aggregate view type; required for aggregate search
+          in: query
+          name: view_type
+          schema:
+            type: string
+        - description: Displayed aggregate row key; required for aggregate search
+          in: query
+          name: aggregate_key
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -22915,47 +22945,47 @@ paths:
           name: scope
           schema:
             type: string
-        - description: Sender email/address filter
+        - description: Sender email/address filter; not supported when scope=body
           in: query
           name: sender
           schema:
             type: string
-        - description: Sender display-name filter; not supported by deep search
+        - description: Sender display-name filter; not supported when scope=body
           in: query
           name: sender_name
           schema:
             type: string
-        - description: Recipient email/address filter
+        - description: Recipient email/address filter; not supported when scope=body
           in: query
           name: recipient
           schema:
             type: string
-        - description: Recipient display-name filter; not supported by deep search
+        - description: Recipient display-name filter; not supported when scope=body
           in: query
           name: recipient_name
           schema:
             type: string
-        - description: Domain filter
+        - description: Domain filter; not supported when scope=body
           in: query
           name: domain
           schema:
             type: string
-        - description: Label filter
+        - description: Label filter; not supported when scope=body
           in: query
           name: label
           schema:
             type: string
-        - description: Exact case-insensitive RFC 2919 List-Id filter; not supported by deep search
+        - description: Exact case-insensitive RFC 2919 List-Id filter; not supported when scope=body
           in: query
           name: list_id
           schema:
             type: string
-        - description: Message type filter; not supported by deep search
+        - description: Message type filter; not supported when scope=body
           in: query
           name: message_type
           schema:
             type: string
-        - description: Named time period; not supported by deep search
+        - description: Named time period; not supported when scope=body
           in: query
           name: time_period
           schema:
@@ -22965,7 +22995,7 @@ paths:
           name: time_granularity
           schema:
             type: string
-        - description: Conversation ID; not supported by deep search
+        - description: Conversation ID; not supported when scope=body
           in: query
           name: conversation_id
           schema:
@@ -22997,7 +23027,7 @@ paths:
           name: before
           schema:
             type: string
-        - description: Comma-separated aggregate view names to match empty values; not supported by deep search
+        - description: Comma-separated aggregate view names to match empty values; not supported when scope=body
           in: query
           name: empty_targets
           schema:
@@ -23706,12 +23736,6 @@ paths:
     get:
       operationId: getTotalStats
       parameters:
-        - description: Source ID
-          in: query
-          name: source_id
-          schema:
-            format: int64
-            type: integer
         - description: Source IDs; repeat the parameter for multiple sources
           in: query
           name: source_ids
@@ -23720,16 +23744,6 @@ paths:
               format: int64
               type: integer
             type: array
-        - description: Only include messages with attachments
-          in: query
-          name: attachments_only
-          schema:
-            type: boolean
-        - description: Exclude deleted messages
-          in: query
-          name: hide_deleted
-          schema:
-            type: boolean
         - description: Search query
           in: query
           name: search_query
@@ -23743,6 +23757,93 @@ paths:
         - description: Aggregate view type for grouping
           in: query
           name: group_by
+          schema:
+            type: string
+        - description: Sender email/address filter
+          in: query
+          name: sender
+          schema:
+            type: string
+        - description: Sender display-name filter
+          in: query
+          name: sender_name
+          schema:
+            type: string
+        - description: Recipient email/address filter
+          in: query
+          name: recipient
+          schema:
+            type: string
+        - description: Recipient display-name filter
+          in: query
+          name: recipient_name
+          schema:
+            type: string
+        - description: Domain filter
+          in: query
+          name: domain
+          schema:
+            type: string
+        - description: Label filter
+          in: query
+          name: label
+          schema:
+            type: string
+        - description: Exact case-insensitive RFC 2919 List-Id filter
+          in: query
+          name: list_id
+          schema:
+            type: string
+        - description: Message type filter
+          in: query
+          name: message_type
+          schema:
+            type: string
+        - description: Named time period
+          in: query
+          name: time_period
+          schema:
+            type: string
+        - description: Time bucket granularity
+          in: query
+          name: time_granularity
+          schema:
+            type: string
+        - description: Conversation ID
+          in: query
+          name: conversation_id
+          schema:
+            format: int64
+            type: integer
+        - description: Source ID
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
+        - description: Only include messages with attachments
+          in: query
+          name: attachments_only
+          schema:
+            type: boolean
+        - description: Exclude deleted messages
+          in: query
+          name: hide_deleted
+          schema:
+            type: boolean
+        - description: Lower date/time bound (RFC3339 or YYYY-MM-DD)
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Upper date/time bound (RFC3339 or YYYY-MM-DD)
+          in: query
+          name: before
+          schema:
+            type: string
+        - description: Comma-separated aggregate view names to match empty values
+          in: query
+          name: empty_targets
           schema:
             type: string
       responses:

--- a/cmd/msgvault/cmd/daemon_runtime.go
+++ b/cmd/msgvault/cmd/daemon_runtime.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/msgvault/internal/api"
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/daemonauth"
+	"go.kenn.io/msgvault/internal/daemonclient"
 	"go.kenn.io/msgvault/internal/update"
 	"golang.org/x/crypto/argon2"
 )
@@ -33,6 +34,7 @@ const (
 	runtimeCreateTime               = "create_time"
 	runtimeShutdownToken            = "shutdown_token"
 	runtimeStartupPhase             = "startup_phase"
+	minimumDaemonAPISchemaVersion   = "2.14.0"
 	runtimeStartupCacheBuildOutcome = "startup_cache_build_outcome"
 	daemonProbeTick                 = 250 * time.Millisecond
 )
@@ -368,6 +370,12 @@ func apiSchemaCompatibilityError(peerVersion string) error {
 		return fmt.Errorf(
 			"daemon API schema version %q is incompatible with client API schema version %q",
 			peerVersion, api.APISchemaVersion,
+		)
+	}
+	if !daemonclient.APISchemaVersionAtLeast(peerVersion, minimumDaemonAPISchemaVersion) {
+		return fmt.Errorf(
+			"daemon API schema version %q is incompatible: this CLI requires API schema %s or newer",
+			peerVersion, minimumDaemonAPISchemaVersion,
 		)
 	}
 	return nil

--- a/cmd/msgvault/cmd/export_eml_test.go
+++ b/cmd/msgvault/cmd/export_eml_test.go
@@ -89,6 +89,37 @@ func TestExportEMLHTTPNotFoundPreservesCLIError(t *testing.T) {
 	assert.NotContains(err.Error(), "API error", "transport details")
 }
 
+func TestWriteExportedEMLDefaultsToSourceMessageIDFilename(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	outputDir := t.TempDir()
+	t.Chdir(outputDir)
+	raw := []byte("From: alice@example.com\r\nSubject: Raw\r\n\r\nBody")
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "export-eml"}
+	cmd.SetOut(&out)
+
+	err := writeExportedEML(cmd, "gmail-raw", "", raw)
+	require.NoError(err)
+
+	outputPath := filepath.Join(outputDir, "gmail-raw.eml")
+	got, err := os.ReadFile(outputPath)
+	require.NoError(err)
+	assert.Equal(raw, got)
+	assert.Contains(out.String(), "Exported message to: gmail-raw.eml")
+}
+
+func TestWriteExportedEMLWritesRawBytesToStdout(t *testing.T) {
+	raw := []byte("From: alice@example.com\r\nSubject: Raw\r\n\r\nBody")
+	var out bytes.Buffer
+	cmd := &cobra.Command{Use: "export-eml"}
+	cmd.SetOut(&out)
+
+	err := writeExportedEML(cmd, "gmail-raw", stdoutSentinel, raw)
+	require.NoError(t, err)
+	assert.Equal(t, raw, out.Bytes())
+}
+
 func emlHTTPDaemon(t *testing.T, raw []byte) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 	requests := &atomic.Int32{}

--- a/cmd/msgvault/cmd/store_resolver_remote_schema_test.go
+++ b/cmd/msgvault/cmd/store_resolver_remote_schema_test.go
@@ -73,6 +73,36 @@ func TestOpenRemoteStoreRejectsAPISchemaMajorMismatch(t *testing.T) {
 	require.ErrorContains(err, `daemon API schema version "1.44.0" is incompatible`)
 }
 
+func TestOpenRemoteStoreRejectsOlderMinorSchema(t *testing.T) {
+	require := require.New(t)
+	_ = remoteSchemaStub(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "api_schema_version": "2.13.0",
+		})
+	})
+
+	client, _, err := OpenHTTPStore(t.Context())
+	if client != nil {
+		t.Cleanup(func() { _ = client.Close() })
+	}
+	require.ErrorContains(err, "requires API schema 2.14.0 or newer")
+}
+
+func TestOpenRemoteStoreAcceptsCompatiblePreviousMinorSchema(t *testing.T) {
+	healthRequests := remoteSchemaStub(t, func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok", "api_schema_version": "2.15.0",
+		})
+	})
+
+	client, _, err := OpenHTTPStore(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+	assert.Equal(t, int32(1), healthRequests.Load())
+}
+
 func TestOpenRemoteStoreRejectsDaemonWithoutSchemaVersion(t *testing.T) {
 	require := require.New(t)
 	_ = remoteSchemaStub(t, func(w http.ResponseWriter) {
@@ -109,4 +139,11 @@ func TestDaemonRuntimeCompatibilityRejectsLegacyRecordWithoutSchemaVersion(t *te
 	previousMajor := &DaemonRuntime{API: daemonAPIVersion, APISchemaVersion: "1.44.0"}
 	require.ErrorContains(daemonRuntimeCompatibilityError(previousMajor),
 		`daemon API schema version "1.44.0" is incompatible`)
+
+	previousSupportedMinor := &DaemonRuntime{API: daemonAPIVersion, APISchemaVersion: "2.15.0"}
+	require.NoError(daemonRuntimeCompatibilityError(previousSupportedMinor))
+
+	previousMinor := &DaemonRuntime{API: daemonAPIVersion, APISchemaVersion: "2.13.0"}
+	require.ErrorContains(daemonRuntimeCompatibilityError(previousMinor),
+		"requires API schema 2.14.0 or newer")
 }

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -59,7 +59,8 @@ Navigation:
 Email selection:
   Space       Toggle selection
   x           Clear selection
-  d           Stage selected messages for deletion
+  d           Stage selected/current messages for deletion
+  D           Stage all current row/filter matches for deletion
 
 Meeting browsing is read-only; selection and deletion keys are disabled.
 Press '?' in any mode for its complete key reference, or 'q' to quit.
@@ -97,6 +98,7 @@ HTTP Mode:
 		semanticSearch := tuiSemanticSearcher(cmd.Context(), backend.client, backend.engine)
 		model := tui.New(backend.engine, tui.Options{
 			DataDir:          cfg.Data.DataDir,
+			ExportDir:        cfg.ExportDir(),
 			Version:          Version,
 			TextEngine:       textEngine,
 			PeopleBackend:    peopleBackend,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -223,6 +223,12 @@ and streams the daemon's stdout/stderr back to the terminal. This keeps local
 and remote full sync behavior aligned and avoids running a separate direct
 SQLite writer beside `msgvault serve`.
 
+`sync-full` does not infer source deletion from messages absent from its result
+set. This is especially important with `--query`, `--limit`, or date filters,
+where the listing is intentionally incomplete. Gmail source-deletion
+reconciliation happens only during the complete mailbox recovery described
+under [`sync`](#sync).
+
 ---
 
 ## sync
@@ -245,6 +251,19 @@ daemon serializes this work with other archive mutations.
 
 Folder filters are applied only to IMAP accounts. See
 [IMAP Folder Sync](/docs/usage/imap/) for examples and matching rules.
+
+For Gmail, normal incremental sync consumes History API deletion events and
+marks those messages as deleted from the source. If Gmail says the saved history
+cursor has expired, msgvault recovers with an unfiltered, unlimited snapshot of
+the complete mailbox, then consumes changes made while that snapshot was in
+progress. Only a successfully completed snapshot is used to mark missing
+messages as source-deleted; interrupted or partial listings do not reconcile
+absence.
+
+Source deletion updates archive metadata rather than deleting local message or
+raw MIME data. Search excludes source-deleted messages by default; use
+`msgvault search ... --deletion-scope deleted` or `--deletion-scope any` to find
+retained history. See [Source-Deleted Messages](/docs/usage/searching/#source-deleted-messages).
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,9 @@ Override the data directory with the `MSGVAULT_HOME` environment variable or the
 # Base data directory (default: ~/.msgvault)
 data_dir = "/path/to/msgvault/data"
 
+# User-requested exports (default: {data_dir}/exports)
+export_dir = "/path/to/msgvault/exports"
+
 # Database URL (default: {data_dir}/msgvault.db; PostgreSQL DSN supported)
 database_url = "/path/to/msgvault.db"
 
@@ -345,6 +348,7 @@ client_secrets = 'C:\Users\you\Downloads\client_secret.json'
 | Key | Default | Description |
 |---|---|---|
 | `data_dir` | `~/.msgvault` | Base directory for all data |
+| `export_dir` | `{data_dir}/exports` | Directory for attachment ZIPs, downloads, and files opened from the TUI |
 | `database_url` | `{data_dir}/msgvault.db` | SQLite database path or PostgreSQL DSN |
 | `loose_attachments` | `false` | Keep attachments as loose files and reject pack/repack commands instead of creating immutable packs |
 

--- a/docs/usage/exporting.md
+++ b/docs/usage/exporting.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-30"
 title: Exporting Data
 description: Export bounded message windows, .eml files, and attachments.
 ---
@@ -68,22 +69,21 @@ Export a single message as a standard `.eml` file:
 
 ```bash
 # By internal message ID
-msgvault export-eml --message-id 12345 --output message.eml
+msgvault export-eml 12345 --output message.eml
 
-# By Gmail message ID
-msgvault export-eml --gmail-id 18abc123def --output message.eml
+# By source message ID
+msgvault export-eml 18abc123def --output message.eml
 
 # Output to stdout
-msgvault export-eml --gmail-id 18abc123def
+msgvault export-eml 18abc123def --output -
 ```
 
-| Flag | Description |
+| Argument or flag | Description |
 |---|---|
-| `--message-id` | Internal database message ID |
-| `--gmail-id` | Gmail message ID (hex string) |
-| `--output` | Output file path (default: stdout) |
+| `<id>` | Internal message ID or source message ID |
+| `-o`, `--output` | Output file path (default: `<source-message-id>.eml`; use `-` for stdout) |
 
-The exported `.eml` file contains the original raw MIME data, decompressed from the zlib-compressed storage in the database.
+The exported `.eml` contains the original raw MIME bytes preserved during sync.
 
 ---
 

--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -1,4 +1,5 @@
 ---
+last_edited: "2026-08-30"
 title: Searching
 description: Gmail-like search syntax with full-text search and JSON output.
 ---
@@ -133,6 +134,14 @@ applies to source deletion (`deleted_from_source_at`); rows hidden internally by
 deduplication are never returned. It is available only with `--mode fts` because
 the vector index intentionally covers active messages only. Vector and hybrid
 search reject non-active deletion scopes instead of returning incomplete results.
+
+Gmail incremental sync records History API deletion events. When the saved
+history cursor has expired, msgvault reconciles deletion metadata only after an
+unfiltered, unlimited snapshot of the complete mailbox succeeds. A regular
+`sync-full` result, including one narrowed by a query, limit, or date range, is
+not treated as proof that omitted messages were deleted. In either path, the
+archive retains the message and raw MIME data; only its source-presence metadata
+changes.
 
 HTTP clients can pass the same values as `deletion_scope` on
 `GET /api/v1/cli/search`.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -234,8 +234,10 @@ type FilteredMessagesResponse struct {
 }
 
 type GmailIDsResponse struct {
-	GmailIDs []string               `json:"gmail_ids"`
-	Targets  []query.DeletionTarget `json:"targets,omitempty"`
+	GmailIDs    []string               `json:"gmail_ids"`
+	Targets     []query.DeletionTarget `json:"targets,omitempty"`
+	SearchQuery string                 `json:"search_query,omitempty"`
+	SearchMode  string                 `json:"search_mode,omitempty"`
 }
 
 type DeepSearchResponse struct {
@@ -244,6 +246,8 @@ type DeepSearchResponse struct {
 	Messages     []MessageSummary    `json:"messages"`
 	BodyContexts []BodySearchContext `json:"body_contexts,omitempty"`
 	Count        int                 `json:"count"`
+	TotalCount   int64               `json:"total_count"`
+	Stats        *TotalStatsResponse `json:"stats,omitempty"`
 	HasMore      bool                `json:"has_more"`
 	Offset       int                 `json:"offset"`
 	Limit        int                 `json:"limit"`
@@ -3163,8 +3167,58 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 		s.rejectBadParam(w, err)
 		return
 	}
-	targets, err := engine.GetDeletionTargetsByFilter(r.Context(), filter)
+	searchQuery := strings.TrimSpace(r.URL.Query().Get("q"))
+	searchMode := strings.TrimSpace(r.URL.Query().Get("search_mode"))
+	var targets []query.DeletionTarget
+	if searchQuery == "" {
+		if searchMode != "" {
+			writeError(w, http.StatusBadRequest, "invalid_search", "search_mode requires q")
+			return
+		}
+		targets, err = engine.GetDeletionTargetsByFilter(r.Context(), filter)
+	} else {
+		parsed := search.Parse(searchQuery)
+		if parseErr := parsed.Err(); parseErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid_search", parseErr.Error())
+			return
+		}
+		switch searchMode {
+		case string(query.DeletionSearchFast), string(query.DeletionSearchDeep):
+			resolver, ok := engine.(query.DeletionTargetSearchResolver)
+			if !ok {
+				writeError(w, http.StatusServiceUnavailable, "search_unavailable", "Search-aware deletion resolution is not available")
+				return
+			}
+			targets, err = resolver.GetDeletionTargetsBySearch(
+				r.Context(), parsed, filter, query.DeletionSearchMode(searchMode),
+			)
+		case string(query.DeletionSearchAggregate):
+			viewType, ok := parseViewType(r.URL.Query().Get("view_type"))
+			if !ok {
+				writeError(w, http.StatusBadRequest, "invalid_view_type", "aggregate search requires a valid view_type")
+				return
+			}
+			if !r.URL.Query().Has("aggregate_key") {
+				writeError(w, http.StatusBadRequest, "missing_aggregate_key", "aggregate search requires aggregate_key")
+				return
+			}
+			resolver, ok := engine.(query.DeletionTargetAggregateSearchResolver)
+			if !ok {
+				writeError(w, http.StatusServiceUnavailable, "search_unavailable", "Aggregate search deletion resolution is not available")
+				return
+			}
+			targets, err = resolver.GetDeletionTargetsByAggregateSearch(
+				r.Context(), searchQuery, filter, viewType, r.URL.Query().Get("aggregate_key"),
+			)
+		default:
+			writeError(w, http.StatusBadRequest, "invalid_search_mode", "search_mode must be fast, deep, or aggregate")
+			return
+		}
+	}
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		s.logger.Error("gmail id filter query failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
 		return
@@ -3174,6 +3228,7 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 	}
 	writeJSON(w, http.StatusOK, GmailIDsResponse{
 		GmailIDs: deletion.SourceMessageIDs(targets), Targets: targets,
+		SearchQuery: searchQuery, SearchMode: searchMode,
 	})
 }
 
@@ -3472,7 +3527,21 @@ func (s *Server) handleTotalStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filter, err := parseMessageFilter(r)
+	if err != nil {
+		s.rejectBadParam(w, err)
+		return
+	}
 	var opts query.StatsOptions
+	for _, name := range []string{
+		"sender", "sender_name", recipientParam, "recipient_name", "domain", "label", "list_id",
+		"message_type", "time_period", "time_granularity", "conversation_id", "after", "before", "empty_targets",
+	} {
+		if _, present := r.URL.Query()[name]; present {
+			opts.Filter = &filter
+			break
+		}
+	}
 
 	if id, ok, err := queryInt64(r, "source_id"); err != nil {
 		s.rejectBadParam(w, err)
@@ -3584,19 +3653,6 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject filter fields that the search engines cannot honor.
-	// SenderName/RecipientName use display names that aren't indexed
-	// for search, and EmptyValueTargets is an aggregate-only concept. The parsed
-	// message_type: operator is honored by the query engine; the
-	// filter parameter form is still list-search-only.
-	if filter.SenderName != "" || filter.RecipientName != "" ||
-		filter.HasEmptyTargets() || filter.MessageType != "" {
-		writeError(w, http.StatusBadRequest, "unsupported_filter",
-			"Fast search does not support sender_name, recipient_name, "+
-				"empty_targets, or message_type filters")
-		return
-	}
-
 	// Get view type for stats grouping (optional, defaults to senders)
 	var statsGroupBy query.ViewType
 	if v := r.URL.Query().Get("view_type"); v != "" {
@@ -3679,17 +3735,18 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Reject filter fields that this deep-search engine path cannot
-	// honor. Without this check the parameters parse
-	// successfully but silently do nothing, letting deep search
-	// escape the current drill-down scope.
-	if filter.SenderName != "" || filter.RecipientName != "" ||
+	// Exact body-only search rejects view filters whose exact MessageFilter
+	// semantics cannot be preserved through search.Query. Generic Deep search
+	// below keeps the complete filter independent from user-entered operators.
+	if scope == "body" && (filter.Sender != "" || filter.SenderName != "" ||
+		filter.Recipient != "" || filter.RecipientName != "" ||
+		filter.Domain != "" || filter.Label != "" ||
 		filter.TimeRange.Period != "" || filter.HasEmptyTargets() ||
-		filter.MessageType != "" || filter.ListID != "" {
+		filter.MessageType != "" || filter.ListID != "") {
 		writeError(w, http.StatusBadRequest, "unsupported_filter",
-			"Deep search does not support sender_name, recipient_name, "+
-				"time_period, empty_targets, message_type, "+
-				"or list_id filters")
+			"Body search does not support sender, sender_name, recipient, "+
+				"recipient_name, domain, label, time_period, empty_targets, "+
+				"message_type, or list_id filters")
 		return
 	}
 
@@ -3704,18 +3761,19 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		limit = 100
 	}
 
-	merged := query.MergeFilterIntoQuery(q, filter)
-	if filter.HideDeletedFromSource {
-		merged.DeletionScope = search.DeletionScopeActive
-	} else {
-		// Preserve the pre-2.12 deep-search contract: omitted or false
-		// hide_deleted includes retained source-deleted messages.
-		merged.DeletionScope = search.DeletionScopeAny
-	}
-
 	// Fetch one extra row to determine has_more accurately.
 	var messages []query.MessageSummary
+	var totalCount int64
+	var stats *query.TotalStats
 	if scope == "body" {
+		merged := query.MergeFilterIntoQuery(q, filter)
+		if filter.HideDeletedFromSource {
+			merged.DeletionScope = search.DeletionScopeActive
+		} else {
+			// Preserve the pre-2.12 deep-search contract: omitted or false
+			// hide_deleted includes retained source-deleted messages.
+			merged.DeletionScope = search.DeletionScopeAny
+		}
 		bodySearcher, ok := engine.(query.MessageBodySearcher)
 		if !ok {
 			writeError(w, http.StatusNotImplemented, "body_search_unavailable",
@@ -3724,7 +3782,21 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		messages, err = bodySearcher.SearchMessageBodies(r.Context(), merged, limit+1, offset)
 	} else {
-		messages, err = engine.Search(r.Context(), merged, limit+1, offset)
+		searchScope := *q
+		if filter.HideDeletedFromSource {
+			searchScope.DeletionScope = search.DeletionScopeActive
+		} else {
+			// Preserve the pre-2.12 deep-search contract: omitted or false
+			// hide_deleted includes retained source-deleted messages.
+			searchScope.DeletionScope = search.DeletionScopeAny
+		}
+		var result *query.SearchFastResult
+		result, err = engine.SearchDeepWithStats(r.Context(), &searchScope, filter, limit+1, offset)
+		if err == nil {
+			messages = result.Messages
+			totalCount = result.TotalCount
+			stats = result.Stats
+		}
 	}
 	if err != nil {
 		if s.writeIfContextError(w, err) {
@@ -3748,6 +3820,15 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	if hasMore {
 		messages = messages[:limit]
 	}
+	if scope == "body" {
+		if hasMore || (offset > 0 && len(messages) == 0) {
+			totalCount = -1
+		} else {
+			totalCount = int64(offset + len(messages))
+		}
+	} else if totalCount >= 0 {
+		hasMore = totalCount > int64(offset+len(messages))
+	}
 
 	summaries := make([]MessageSummary, len(messages))
 	for i, m := range messages {
@@ -3767,6 +3848,8 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 		Messages:     summaries,
 		BodyContexts: bodyContexts,
 		Count:        len(summaries),
+		TotalCount:   totalCount,
+		Stats:        toTotalStatsResponse(stats),
 		HasMore:      hasMore,
 		Offset:       offset,
 		Limit:        limit,

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5117,6 +5117,67 @@ func TestHandleGmailIDsByFilterUsesQueryEngine(t *testing.T) {
 	assert.Equal([]string{"gm-1", "gm-2"}, resp.GmailIDs, "gmail_ids")
 }
 
+func TestHandleGmailIDsByFilterResolvesSearchAndFilterTogether(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var calls int
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsBySearchFunc: func(_ context.Context, parsed *search.Query, filter query.MessageFilter, mode query.DeletionSearchMode) ([]query.DeletionTarget, error) {
+			calls++
+			assertions.Equal([]string{"invoice"}, parsed.TextTerms)
+			assertions.Equal("alice@example.com", filter.Sender)
+			assertions.Equal(query.DeletionSearchDeep, mode)
+			return []query.DeletionTarget{{
+				MessageID: 1, SourceID: 1, SourceType: "gmail",
+				SourceIdentifier: "user@example.com", SourceMessageID: "gm-1",
+			}}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/messages/gmail-ids?sender=alice@example.com&q=invoice&search_mode=deep", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	requirements.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	var resp GmailIDsResponse
+	requirements.NoError(json.NewDecoder(w.Body).Decode(&resp))
+	assertions.Equal(1, calls)
+	assertions.Equal([]string{"gm-1"}, resp.GmailIDs)
+	assertions.Equal("invoice", resp.SearchQuery)
+	assertions.Equal("deep", resp.SearchMode)
+}
+
+func TestHandleGmailIDsByFilterResolvesDisplayedAggregateSearch(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByAggregateSearchFunc: func(
+			_ context.Context, raw string, filter query.MessageFilter, view query.ViewType, key string,
+		) ([]query.DeletionTarget, error) {
+			assertions.Equal("invoice", raw)
+			assertions.Equal("alice@example.com", filter.Sender)
+			assertions.Equal(query.ViewSenders, view)
+			assertions.Equal("alice@example.com", key)
+			return []query.DeletionTarget{{
+				MessageID: 1, SourceID: 1, SourceType: "gmail",
+				SourceIdentifier: "user@example.com", SourceMessageID: "gm-1",
+			}}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/messages/gmail-ids?sender=alice@example.com&q=invoice&search_mode=aggregate&view_type=senders&aggregate_key=alice@example.com", nil)
+	w := httptest.NewRecorder()
+	srv.Router().ServeHTTP(w, req)
+
+	requirements.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	var resp GmailIDsResponse
+	requirements.NoError(json.NewDecoder(w.Body).Decode(&resp))
+	assertions.Equal([]string{"gm-1"}, resp.GmailIDs)
+	assertions.Equal("aggregate", resp.SearchMode)
+}
+
 func TestHandleGetAttachmentUsesQueryEngine(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -5358,7 +5419,7 @@ func TestHandleTotalStatsSearchScope(t *testing.T) {
 	}{
 		{
 			name:            "search scope enabled",
-			target:          "/api/v1/stats/total?search_query=meeting&search_scope=true&source_ids=8&source_ids=7&source_ids=8",
+			target:          "/api/v1/stats/total?search_query=meeting&search_scope=true&source_ids=8&source_ids=7&source_ids=8&sender_name=Alice&recipient_name=Bob&domain=example.com&label=Work&message_type=email&conversation_id=42&empty_targets=labels",
 			wantSearchScope: true,
 			wantSourceIDs:   []int64{7, 8},
 			wantEchoScope:   true,
@@ -5391,6 +5452,19 @@ func TestHandleTotalStatsSearchScope(t *testing.T) {
 			assert.Equal("meeting", gotOpts.SearchQuery, "search query")
 			assert.Equal(tt.wantSearchScope, gotOpts.SearchScope, "search scope")
 			assert.Equal(tt.wantSourceIDs, gotOpts.SourceIDs, "source IDs")
+			if tt.wantSearchScope {
+				require.NotNil(gotOpts.Filter)
+				assert.Equal("Alice", gotOpts.Filter.SenderName)
+				assert.Equal("Bob", gotOpts.Filter.RecipientName)
+				assert.Equal("example.com", gotOpts.Filter.Domain)
+				assert.Equal("Work", gotOpts.Filter.Label)
+				assert.Equal("email", gotOpts.Filter.MessageType)
+				require.NotNil(gotOpts.Filter.ConversationID)
+				assert.Equal(int64(42), *gotOpts.Filter.ConversationID)
+				assert.True(gotOpts.Filter.MatchesEmpty(query.ViewLabels))
+			} else {
+				assert.Nil(gotOpts.Filter)
+			}
 
 			var response map[string]any
 			require.NoError(json.NewDecoder(w.Body).Decode(&response), "decode response")
@@ -5511,20 +5585,48 @@ func TestHandleFastSearchInvalidViewType(t *testing.T) {
 	assert.Equal(t, "invalid_view_type", errResp["error"], "error")
 }
 
-// TestSearchRejectsMessageTypeFilterParam guards against silently dropping
-// the message_type filter parameter. Fast/deep search support the parsed
-// message_type: operator, but parseMessageFilter's parameter form is still
-// list-search-only and must not be accepted as a no-op.
-func TestSearchRejectsMessageTypeFilterParam(t *testing.T) {
-	for _, path := range []string{
-		"/api/v1/search/fast?q=hello&message_type=sms",
-		"/api/v1/search/deep?q=hello&message_type=sms",
-	} {
-		t.Run(path, func(t *testing.T) {
-			engine := &querytest.MockEngine{}
-			srv := newTestServerWithEngine(t, engine)
+func TestFastSearchPreservesCompleteMessageFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var gotFilter query.MessageFilter
+	engine := &querytest.MockEngine{
+		SearchFastWithStatsFunc: func(
+			_ context.Context, _ *search.Query, _ string, filter query.MessageFilter,
+			_ query.ViewType, _, _ int,
+		) (*query.SearchFastResult, error) {
+			gotFilter = filter
+			return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/search/fast?q=hello&sender_name=Alice&recipient_name=Bob&message_type=email&empty_targets=labels", nil)
+	w := httptest.NewRecorder()
 
-			req := httptest.NewRequest(http.MethodGet, path, nil)
+	srv.Router().ServeHTTP(w, req)
+
+	requirements.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assertions.Equal("Alice", gotFilter.SenderName)
+	assertions.Equal("Bob", gotFilter.RecipientName)
+	assertions.Equal("email", gotFilter.MessageType)
+	assertions.True(gotFilter.MatchesEmpty(query.ViewLabels))
+}
+
+func TestDeepBodySearchRejectsUnsupportedFilterParams(t *testing.T) {
+	tests := []struct {
+		name  string
+		param string
+	}{
+		{name: "recipient", param: "recipient=alice%40example.com"},
+		{name: "label", param: "label=Work"},
+		{name: "domain wildcard", param: "domain=exa%25mple.com"},
+		{name: "list ID", param: "list_id=%3Cdev%40example.test%3E"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServerWithEngine(t, &querytest.MockEngine{})
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/search/deep?q=hello&scope=body&"+tt.param, nil)
 			w := httptest.NewRecorder()
 
 			srv.Router().ServeHTTP(w, req)
@@ -5535,21 +5637,6 @@ func TestSearchRejectsMessageTypeFilterParam(t *testing.T) {
 			require.Equal(t, "unsupported_filter", errResp["error"], "error")
 		})
 	}
-}
-
-func TestDeepSearchRejectsListIDFilterParam(t *testing.T) {
-	engine := &querytest.MockEngine{}
-	srv := newTestServerWithEngine(t, engine)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/search/deep?q=hello&list_id=%3Cdev%40example.test%3E", nil)
-	w := httptest.NewRecorder()
-
-	srv.Router().ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusBadRequest, w.Code, "status (body: %s)", w.Body.String())
-	var errResp map[string]string
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&errResp), "decode error")
-	require.Equal(t, "unsupported_filter", errResp["error"], "error")
 }
 
 func TestDaemonAdapterListIDScopeReachesServerQueryEngine(t *testing.T) {
@@ -5631,6 +5718,12 @@ func TestSearchConversationIDFilterParamReachesEngine(t *testing.T) {
 				},
 				SearchFunc: func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
 					gotConversationIDs = append([]int64(nil), q.ConversationIDs...)
+					return nil, nil
+				},
+				SearchDeepFunc: func(_ context.Context, _ *search.Query, filter query.MessageFilter, _, _ int) ([]query.MessageSummary, error) {
+					if filter.ConversationID != nil {
+						gotConversationIDs = []int64{*filter.ConversationID}
+					}
 					return nil, nil
 				},
 			}
@@ -5945,7 +6038,10 @@ func TestRemoteSearchParsedMessageTypeThroughAPI(t *testing.T) {
 }
 
 func TestHandleDeepSearch(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
 	engine := &querytest.MockEngine{
+		Stats: &query.TotalStats{MessageCount: 1, TotalSize: 250},
 		SearchResults: []query.MessageSummary{
 			{
 				ID:        1,
@@ -5962,12 +6058,38 @@ func TestHandleDeepSearch(t *testing.T) {
 
 	srv.Router().ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
+	assertions.Equal(http.StatusOK, w.Code, "status (body: %s)", w.Body.String())
 
 	var resp map[string]any
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
+	requirements.NoError(json.NewDecoder(w.Body).Decode(&resp), "failed to decode response")
 
-	assert.Equal(t, "agenda", resp["query"], "query")
+	assertions.Equal("agenda", resp["query"], "query")
+	assertions.InDelta(1, resp["total_count"], 0, "total count")
+	requirements.NotNil(resp["stats"], "stats")
+}
+
+func TestHandleDeepSearchPreservesCompleteViewFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var gotFilter query.MessageFilter
+	engine := &querytest.MockEngine{
+		SearchDeepFunc: func(
+			_ context.Context, _ *search.Query, filter query.MessageFilter, _, _ int,
+		) ([]query.MessageSummary, error) {
+			gotFilter = filter
+			return nil, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet,
+		"/api/v1/search/deep?q=agenda&sender_name=Alice&recipient_name=Bob&message_type=email&empty_targets=labels", nil))
+
+	requirements.Equal(http.StatusOK, response.Code, response.Body.String())
+	assertions.Equal("Alice", gotFilter.SenderName)
+	assertions.Equal("Bob", gotFilter.RecipientName)
+	assertions.Equal("email", gotFilter.MessageType)
+	assertions.True(gotFilter.MatchesEmpty(query.ViewLabels))
 }
 
 func TestHandleDeepSearchPreservesHideDeletedCompatibility(t *testing.T) {
@@ -6065,6 +6187,23 @@ func TestHandleDeepSearchBodyScope(t *testing.T) {
 	assert.InDelta(float64(2), bodyContext["message_id"], 0, "body context message ID")
 	assert.Equal([]any{"exact body context"}, bodyContext["context_snippets"])
 	assert.Equal(true, bodyContext["context_snippets_truncated"])
+}
+
+func TestHandleDeepSearchBodyScopeEmptyPageHasUnknownTotal(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	srv := newTestServerWithEngine(t, &querytest.MockEngine{})
+	response := httptest.NewRecorder()
+	srv.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet,
+		"/api/v1/search/deep?q=bodyneedle&scope=body&limit=10&offset=20", nil))
+
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	var body DeepSearchResponse
+	require.NoError(json.NewDecoder(response.Body).Decode(&body))
+	assert.Empty(body.Messages)
+	assert.False(body.HasMore)
+	assert.Equal(int64(-1), body.TotalCount)
 }
 
 func TestHandleDeepSearchScopeValidation(t *testing.T) {

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -257,12 +257,17 @@ import (
 // infrastructure identifiers. That shape change lands inside the unreleased 2.x
 // line: nothing after the released 1.36.0 contract has shipped yet, so it does
 // not open a new major version.
+// Existing filtered target requests are unchanged.
 // 2.15.0 adds POST /api/v1/cli/repair-message with a dedicated request and
 // streaming event contract for Gmail snapshot repair and audit operations.
 // Additive (minor bump): existing CLI routes and clients remain unchanged.
-// 2.16.0 adds authenticated asynchronous historical import jobs at
+// 2.16.0 adds complete MessageFilter parameters to total statistics and adds
+// result totals and statistics to deep search. Search-aware deletion query
+// parameters introduced with these TUI contracts are also covered by 2.16.0.
+// It also adds authenticated asynchronous historical import jobs at
 // POST /api/v1/imports and GET /api/v1/imports/{job_id}. Existing synchronous
-// CLI sync routes and source-status responses are unchanged.
+// CLI sync routes, source-status responses, unfiltered statistics, search, and
+// deletion requests are unchanged.
 const APISchemaVersion = "2.16.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
@@ -674,6 +679,15 @@ func applyClientCodegenExtensions(doc *huma.OpenAPI) {
 			}
 			snapshot.Extensions["x-go-type"] = "json.RawMessage"
 			snapshot.Extensions["x-go-type-import"] = map[string]any{pathKey: "encoding/json"}
+		}
+	}
+	if manifest := schemas["Manifest"]; manifest != nil {
+		if rawFilter := manifest.Properties["raw_filter"]; rawFilter != nil {
+			if rawFilter.Extensions == nil {
+				rawFilter.Extensions = map[string]any{}
+			}
+			rawFilter.Extensions["x-go-type"] = "json.RawMessage"
+			rawFilter.Extensions["x-go-type-import"] = map[string]any{pathKey: "encoding/json"}
 		}
 	}
 	for schemaName, properties := range map[string][]string{

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -101,12 +101,12 @@ func TestCLISearchOpenAPIDocumentsDeletionScope(t *testing.T) {
 	assertions.Fail("deletion_scope query parameter is not documented")
 }
 
-func TestOpenAPIDeepSearchDocumentsUnsupportedListIDParameter(t *testing.T) {
+func TestOpenAPIDeepSearchDocumentsBodyScopeListIDRestriction(t *testing.T) {
 	operation := OpenAPIDocument().Paths["/api/v1/search/deep"].Get
 	require.NotNil(t, operation)
 	for _, parameter := range operation.Parameters {
 		if parameter.Name == "list_id" {
-			assert.Contains(t, parameter.Description, "not supported by deep search")
+			assert.Contains(t, parameter.Description, "not supported when scope=body")
 			return
 		}
 	}
@@ -777,7 +777,8 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// calendars in 2.10.0, person fact diagnostics in 2.11.0, lexical deletion
 	// scope in 2.12.0, Directory people and deduplicate planning in 2.13.0,
 	// CardDAV status and run history plus List-ID filtering in 2.14.0, Gmail
-	// repair in 2.15.0, and historical import jobs in 2.16.0 did not touch it.
+	// repair in 2.15.0, and complete TUI search and statistics contracts plus
+	// historical import jobs in 2.16.0 did not touch it.
 	assert.Equal("2.16.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -846,7 +846,12 @@ func rawRouteParameters(operationID string) []*huma.Param {
 	case "listChangedMessages":
 		return changesParams()
 	case "getGmailIDsByFilter":
-		return messageFilterParams()
+		return append(messageFilterParams(),
+			queryStringParam("q", "Structured search query", false),
+			queryStringParam("search_mode", "Search mode: fast, deep, or aggregate; required with q", false),
+			queryStringParam("view_type", "Aggregate view type; required for aggregate search", false),
+			queryStringParam("aggregate_key", "Displayed aggregate row key; required for aggregate search", false),
+		)
 	case "searchMessagesByDomains":
 		return []*huma.Param{
 			queryStringParam("domains", "Comma-separated participant domains", true),
@@ -866,15 +871,12 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryBooleanParam("has_attachment", "Only include messages with attachments"),
 		}
 	case "getTotalStats":
-		return []*huma.Param{
-			queryIntegerParam("source_id", "Source ID"),
+		return mergeParams([]*huma.Param{
 			queryIntegerArrayParam("source_ids", "Source IDs; repeat the parameter for multiple sources"),
-			queryBooleanParam("attachments_only", "Only include messages with attachments"),
-			queryBooleanParam("hide_deleted", "Exclude deleted messages"),
 			queryStringParam("search_query", "Search query", false),
 			queryBooleanParam("search_scope", "Include all message types when the search has no explicit message_type"),
 			queryStringParam("group_by", "Aggregate view type for grouping", false),
-		}
+		}, messageFilterScopeParams())
 	case "fastSearch":
 		params := append([]*huma.Param{
 			queryStringParam("q", "Search query", true),
@@ -887,9 +889,10 @@ func rawRouteParameters(operationID string) []*huma.Param {
 		filterParams := messageFilterParams()
 		for _, parameter := range filterParams {
 			switch parameter.Name {
-			case "sender_name", "recipient_name", "time_period", "conversation_id",
+			case "sender", "sender_name", recipientParam, "recipient_name", "domain", "label",
+				"time_period", "conversation_id",
 				"empty_targets", "message_type", "list_id":
-				parameter.Description += "; not supported by deep search"
+				parameter.Description += "; not supported when scope=body"
 			}
 		}
 		return append([]*huma.Param{
@@ -980,6 +983,15 @@ func aggregateOptionParams() []*huma.Param {
 }
 
 func messageFilterParams() []*huma.Param {
+	return append(messageFilterScopeParams(),
+		queryIntegerParam("offset", "Zero-based row offset"),
+		queryIntegerParam(limitParam, "Maximum number of rows to return (default and max 500; larger values are clamped)"),
+		queryStringParam("sort", "Sort field: date, size, or subject", false),
+		queryStringParam("direction", "Sort direction: asc or desc", false),
+	)
+}
+
+func messageFilterScopeParams() []*huma.Param {
 	return []*huma.Param{
 		queryStringParam("sender", "Sender email/address filter", false),
 		queryStringParam("sender_name", "Sender display-name filter", false),
@@ -998,10 +1010,6 @@ func messageFilterParams() []*huma.Param {
 		queryStringParam("after", "Lower date/time bound (RFC3339 or YYYY-MM-DD)", false),
 		queryStringParam("before", "Upper date/time bound (RFC3339 or YYYY-MM-DD)", false),
 		queryStringParam("empty_targets", "Comma-separated aggregate view names to match empty values", false),
-		queryIntegerParam("offset", "Zero-based row offset"),
-		queryIntegerParam(limitParam, "Maximum number of rows to return (default and max 500; larger values are clamped)"),
-		queryStringParam("sort", "Sort field: date, size, or subject", false),
-		queryStringParam("direction", "Sort direction: asc or desc", false),
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -550,6 +550,7 @@ type LogConfig struct {
 // DataConfig holds data storage configuration.
 type DataConfig struct {
 	DataDir          string `toml:"data_dir"`
+	ExportDir        string `toml:"export_dir"`
 	DatabaseURL      string `toml:"database_url"`
 	LooseAttachments bool   `toml:"loose_attachments"`
 }
@@ -822,6 +823,7 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 
 	// Expand ~ in paths
 	cfg.Data.DataDir = expandPath(cfg.Data.DataDir)
+	cfg.Data.ExportDir = expandPath(cfg.Data.ExportDir)
 	cfg.Log.Dir = expandPath(cfg.Log.Dir)
 	cfg.OAuth.ClientSecrets = expandPath(cfg.OAuth.ClientSecrets)
 	cfg.OAuth.ServiceAccountKey = expandPath(cfg.OAuth.ServiceAccountKey)
@@ -838,6 +840,7 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	// directory so behavior doesn't depend on the working directory.
 	if explicit {
 		cfg.Data.DataDir = resolveRelative(cfg.Data.DataDir, cfg.HomeDir)
+		cfg.Data.ExportDir = resolveRelative(cfg.Data.ExportDir, cfg.HomeDir)
 		cfg.Log.Dir = resolveRelative(cfg.Log.Dir, cfg.HomeDir)
 		cfg.OAuth.ClientSecrets = resolveRelative(cfg.OAuth.ClientSecrets, cfg.HomeDir)
 		cfg.OAuth.ServiceAccountKey = resolveRelative(cfg.OAuth.ServiceAccountKey, cfg.HomeDir)
@@ -1090,6 +1093,14 @@ func (c *Config) DatabasePath() (string, error) {
 // AttachmentsDir returns the path to the attachments directory.
 func (c *Config) AttachmentsDir() string {
 	return filepath.Join(c.Data.DataDir, "attachments")
+}
+
+// ExportDir returns the directory used for user-requested file exports.
+func (c *Config) ExportDir() string {
+	if c.Data.ExportDir != "" {
+		return c.Data.ExportDir
+	}
+	return filepath.Join(c.Data.DataDir, "exports")
 }
 
 // TokensDir returns the path to the OAuth tokens directory.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -821,6 +821,7 @@ func TestLoadEmptyPath(t *testing.T) {
 	// Verify default values
 	assert.Equal(tmpDir, cfg.HomeDir)
 	assert.Equal(tmpDir, cfg.Data.DataDir)
+	assert.Equal(filepath.Join(tmpDir, "exports"), cfg.ExportDir())
 	assert.Equal(5, cfg.Sync.RateLimitQPS)
 
 	// DatabaseDSN should return default path
@@ -840,6 +841,7 @@ func TestLoadWithConfigFile(t *testing.T) {
 	configContent := `
 [data]
 data_dir = "~/custom/data"
+export_dir = "~/custom/exports"
 
 [oauth]
 client_secrets = "~/secrets/client.json"
@@ -858,6 +860,7 @@ rate_limit_qps = 10
 	// Verify paths were expanded
 	expectedDataDir := filepath.Join(home, "custom/data")
 	assert.Equal(expectedDataDir, cfg.Data.DataDir)
+	assert.Equal(filepath.Join(home, "custom/exports"), cfg.ExportDir())
 
 	expectedSecrets := filepath.Join(home, "secrets/client.json")
 	assert.Equal(expectedSecrets, cfg.OAuth.ClientSecrets)
@@ -940,6 +943,7 @@ func TestLoadExplicitPathRelativePaths(t *testing.T) {
 	configContent := `
 [data]
 data_dir = "data"
+export_dir = "exports"
 
 [oauth]
 client_secrets = "secrets/client.json"
@@ -951,6 +955,7 @@ client_secrets = "secrets/client.json"
 
 	expectedDataDir := filepath.Join(tmpDir, "data")
 	assert.Equal(expectedDataDir, cfg.Data.DataDir)
+	assert.Equal(filepath.Join(tmpDir, "exports"), cfg.ExportDir())
 
 	expectedSecrets := filepath.Join(tmpDir, "secrets/client.json")
 	assert.Equal(expectedSecrets, cfg.OAuth.ClientSecrets)

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -515,6 +515,12 @@ func apiSchemaVersionAtLeast(version, minimum string) bool {
 	return true
 }
 
+// APISchemaVersionAtLeast reports whether version satisfies an additive API
+// contract minimum. Missing and malformed versions fail closed.
+func APISchemaVersionAtLeast(version, minimum string) bool {
+	return apiSchemaVersionAtLeast(version, minimum)
+}
+
 func (c *Client) RunCLIVerify(
 	ctx context.Context,
 	req CLIVerifyRequest,

--- a/internal/daemonclient/convert.go
+++ b/internal/daemonclient/convert.go
@@ -1,6 +1,7 @@
 package daemonclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -137,6 +138,10 @@ func cliDeletionManifestToGenerated(manifest *deletion.Manifest) generated.Creat
 		ID:          manifest.ID,
 		Status:      string(manifest.Status),
 		Version:     int64(manifest.Version),
+	}
+	if len(manifest.RawFilter) > 0 {
+		rawFilter := append(json.RawMessage(nil), manifest.RawFilter...)
+		out.RawFilter = &rawFilter
 	}
 	if manifest.Execution != nil {
 		out.Execution = cliDeletionExecutionToGenerated(manifest.Execution)

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -39,6 +39,10 @@ var _ query.Engine = (*Engine)(nil)
 var _ query.TextEngine = (*Engine)(nil)
 var _ query.MessageBodySearcher = (*Engine)(nil)
 var _ query.SemanticMessageSearcher = (*Engine)(nil)
+var _ query.DeletionTargetSearchResolver = (*Engine)(nil)
+var _ query.DeletionTargetAggregateSearchResolver = (*Engine)(nil)
+
+const tuiSearchContractMinAPISchemaVersion = "2.16.0"
 
 // NewEngine creates a new daemon-backed query engine.
 func NewEngine(cfg Config) (*Engine, error) {
@@ -81,22 +85,36 @@ func (e *Engine) SearchSemanticMessages(
 	if !query.SemanticMessageSearchSupportsFilter(filter) {
 		return nil, errors.New("semantic TUI search cannot preserve the current display-name or empty-value scope")
 	}
-	parsed := search.Parse(request.Query)
-	if err := parsed.Err(); err != nil {
-		return nil, err
-	}
-	if len(parsed.TextTerms) == 0 {
+	transportQuery := strings.TrimSpace(request.Query)
+	if transportQuery == "" {
 		return nil, errors.New("semantic search requires a query")
 	}
-	messageTypes, noMessageTypeMatches := query.ScopedMessageTypes(parsed.MessageTypes, filter.MessageType)
+
+	parsedQuery := search.Parse(transportQuery)
+	parseErr := parsedQuery.Err()
+	queryMessageTypes := parsedQuery.MessageTypes
+	if parseErr != nil {
+		// Semantic input is natural language. Quote the complete input so the
+		// daemon parser treats operator-shaped text literally instead of
+		// rejecting it before hybrid search can embed it.
+		transportQuery = search.Format(&search.Query{TextTerms: []string{transportQuery}})
+		queryMessageTypes = nil
+	}
+
+	messageTypes, noMessageTypeMatches := query.ScopedMessageTypes(queryMessageTypes, filter.MessageType)
 	if noMessageTypeMatches {
 		return &query.SemanticMessageSearchResult{}, nil
 	}
-	// Carry the canonical intersection as the HTTP parameter and remove the
-	// user-authored operators from q. Leaving both in place would make the
-	// hybrid backend OR them and widen an Email-mode query back to SMS/MMS.
-	parsed.MessageTypes = nil
-	transportQuery := search.Format(parsed)
+	if parseErr == nil && len(parsedQuery.TextTerms) == 0 {
+		return nil, errors.New("semantic search requires free text")
+	}
+	if parseErr == nil {
+		// Carry message types through the structured API parameter after
+		// intersecting them with the TUI view. Removing them from q prevents
+		// the daemon from combining the query and view scopes as a union.
+		parsedQuery.MessageTypes = nil
+		transportQuery = search.Format(parsedQuery)
+	}
 
 	response, err := e.store.GetCLIHybridSearch(ctx, CLIHybridSearchRequest{
 		Query:        transportQuery,
@@ -307,7 +325,16 @@ func generatedFilterMessagesQuery(filter query.MessageFilter, paginated bool) ge
 
 func gmailIDsFilterQuery(filter query.MessageFilter) *generated.GetGmailIDsByFilterQuery {
 	base := generatedFilterMessagesQuery(filter, false)
-	out := generated.GetGmailIDsByFilterQuery(base)
+	out := generated.GetGmailIDsByFilterQuery{
+		Sender: base.Sender, SenderName: base.SenderName,
+		Recipient: base.Recipient, RecipientName: base.RecipientName,
+		Domain: base.Domain, Label: base.Label, ListID: base.ListID, MessageType: base.MessageType,
+		TimePeriod: base.TimePeriod, TimeGranularity: base.TimeGranularity,
+		ConversationID: base.ConversationID, SourceID: base.SourceID,
+		AttachmentsOnly: base.AttachmentsOnly, HideDeleted: base.HideDeleted,
+		After: base.After, Before: base.Before, EmptyTargets: base.EmptyTargets,
+		Offset: base.Offset, Sort: base.Sort, Direction: base.Direction,
+	}
 	out.Limit = optionalPositiveInt64(filter.Pagination.Limit)
 	return &out
 }
@@ -900,6 +927,90 @@ func (e *Engine) Search(ctx context.Context, q *search.Query, limit, offset int)
 	return messageSummariesFromGenerated(resp.JSON200.Messages), nil
 }
 
+// SearchDeep preserves the TUI's complete view filter across the daemon
+// boundary instead of reducing it to search.Query fields.
+func (e *Engine) SearchDeep(
+	ctx context.Context, q *search.Query, filter query.MessageFilter, limit, offset int,
+) ([]query.MessageSummary, error) {
+	result, err := e.SearchDeepWithStats(ctx, q, filter, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return result.Messages, nil
+}
+
+// SearchDeepWithStats preserves the TUI's complete view filter and returns the
+// daemon's metrics for that same match set.
+func (e *Engine) SearchDeepWithStats(
+	ctx context.Context, q *search.Query, filter query.MessageFilter, limit, offset int,
+) (*query.SearchFastResult, error) {
+	compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("check deep-search capability: %w", err)
+	}
+	if !compatible {
+		return nil, fmt.Errorf("deep search with statistics requires daemon API schema %s or newer", tuiSearchContractMinAPISchemaVersion)
+	}
+	if err := e.requireListIDCapability(ctx, q, filter); err != nil {
+		return nil, err
+	}
+	if err := validateParsedSearchQuery(q); err != nil {
+		return nil, err
+	}
+	if filter.SourceIDs != nil {
+		if len(filter.SourceIDs) == 0 {
+			return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
+		}
+		if len(filter.SourceIDs) > 1 {
+			return nil, errors.New("daemon deep search does not support multiple source IDs")
+		}
+		filter.SourceID = &filter.SourceIDs[0]
+		filter.SourceIDs = nil
+	}
+
+	transportScope := query.MergeFilterIntoQuery(q, filter)
+	if hasExplicitEmptyAccountScope(transportScope) {
+		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
+	}
+	queryStr := search.Format(q)
+	if queryStr == "" {
+		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
+	}
+	queryParams, err := deepSearchQuery(queryStr, transportScope, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	fields := generatedFilterMessagesQuery(filter, false)
+	queryParams.Sender = fields.Sender
+	queryParams.SenderName = fields.SenderName
+	queryParams.Recipient = fields.Recipient
+	queryParams.RecipientName = fields.RecipientName
+	queryParams.Domain = fields.Domain
+	queryParams.Label = fields.Label
+	queryParams.ListID = fields.ListID
+	queryParams.MessageType = fields.MessageType
+	queryParams.TimePeriod = fields.TimePeriod
+	queryParams.TimeGranularity = fields.TimeGranularity
+	queryParams.ConversationID = fields.ConversationID
+	queryParams.AttachmentsOnly = fields.AttachmentsOnly
+	queryParams.HideDeleted = optionalBool(q.HideDeleted || filter.HideDeletedFromSource)
+	queryParams.After = fields.After
+	queryParams.Before = fields.Before
+	queryParams.EmptyTargets = fields.EmptyTargets
+
+	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.DeepSearchResp, error) {
+		return client.DeepSearchWithResponse(ctx, &generated.DeepSearchRequestOptions{Query: queryParams})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &query.SearchFastResult{
+		Messages:   messageSummariesFromGenerated(resp.JSON200.Messages),
+		TotalCount: resp.JSON200.TotalCount,
+		Stats:      totalStatsFromGenerated(resp.JSON200.Stats),
+	}, nil
+}
+
 // SearchMessageBodies requests the daemon's exact body-only search scope and
 // requires the response to echo that scope. Requiring the echo fails closed
 // against older daemons that ignore the additive query parameter and would
@@ -968,6 +1079,15 @@ func (e *Engine) SearchFastWithStats(ctx context.Context, q *search.Query, query
 	if filter.SourceIDs != nil && len(filter.SourceIDs) == 0 {
 		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
 	}
+	if filter.SenderName != "" || filter.RecipientName != "" || filter.HasEmptyTargets() {
+		compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
+		if err != nil {
+			return nil, fmt.Errorf("check complete fast-search filter capability: %w", err)
+		}
+		if !compatible {
+			return nil, fmt.Errorf("fast search with complete filters requires daemon API schema %s or newer", tuiSearchContractMinAPISchemaVersion)
+		}
+	}
 	scopedQueryStr, noMatches := fastSearchScopedQueryString(q, queryStr, filter)
 	if noMatches {
 		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
@@ -1004,11 +1124,93 @@ func (e *Engine) GetDeletionTargetsByFilter(ctx context.Context, filter query.Me
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.JSON200.Targets) == 0 && len(resp.JSON200.GmailIds) > 0 {
+	return deletionTargetsFromGenerated(resp.JSON200)
+}
+
+func (e *Engine) GetDeletionTargetsBySearch(
+	ctx context.Context,
+	searchQuery *search.Query,
+	filter query.MessageFilter,
+	mode query.DeletionSearchMode,
+) ([]query.DeletionTarget, error) {
+	if err := validateParsedSearchQuery(searchQuery); err != nil {
+		return nil, err
+	}
+	queryString := search.Format(searchQuery)
+	if queryString == "" {
+		return e.GetDeletionTargetsByFilter(ctx, filter)
+	}
+	compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("check daemon search-aware deletion capability: %w", err)
+	}
+	if !compatible {
+		return nil, fmt.Errorf("search-aware deletion resolution requires daemon API schema %s or newer", tuiSearchContractMinAPISchemaVersion)
+	}
+	modeString := string(mode)
+	params := gmailIDsFilterQuery(filter)
+	params.Q = &queryString
+	params.SearchMode = &modeString
+	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.GetGmailIDsByFilterResp, error) {
+		return client.GetGmailIDsByFilterWithResponse(ctx, &generated.GetGmailIDsByFilterRequestOptions{Query: params})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if stringValue(resp.JSON200.SearchQuery) != queryString || stringValue(resp.JSON200.SearchMode) != modeString {
+		return nil, errors.New("daemon did not confirm the deletion search scope; upgrade the daemon and retry")
+	}
+	return deletionTargetsFromGenerated(resp.JSON200)
+}
+
+func (e *Engine) GetDeletionTargetsByAggregateSearch(
+	ctx context.Context,
+	searchQuery string,
+	filter query.MessageFilter,
+	groupBy query.ViewType,
+	key string,
+) ([]query.DeletionTarget, error) {
+	parsed := search.Parse(searchQuery)
+	if err := validateParsedSearchQuery(parsed); err != nil {
+		return nil, err
+	}
+	queryString := search.Format(parsed)
+	if queryString == "" {
+		return e.GetDeletionTargetsByFilter(ctx, filter)
+	}
+	compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
+	if err != nil {
+		return nil, fmt.Errorf("check daemon aggregate deletion capability: %w", err)
+	}
+	if !compatible {
+		return nil, fmt.Errorf("aggregate deletion resolution requires daemon API schema %s or newer", tuiSearchContractMinAPISchemaVersion)
+	}
+
+	modeString := string(query.DeletionSearchAggregate)
+	viewType := viewTypeToString(groupBy)
+	params := gmailIDsFilterQuery(filter)
+	params.Q = &queryString
+	params.SearchMode = &modeString
+	params.ViewType = &viewType
+	params.AggregateKey = &key
+	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.GetGmailIDsByFilterResp, error) {
+		return client.GetGmailIDsByFilterWithResponse(ctx, &generated.GetGmailIDsByFilterRequestOptions{Query: params})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if stringValue(resp.JSON200.SearchQuery) != queryString || stringValue(resp.JSON200.SearchMode) != modeString {
+		return nil, errors.New("daemon did not confirm the aggregate deletion search scope; upgrade the daemon and retry")
+	}
+	return deletionTargetsFromGenerated(resp.JSON200)
+}
+
+func deletionTargetsFromGenerated(resp *generated.GmailIDsResponse) ([]query.DeletionTarget, error) {
+	if len(resp.Targets) == 0 && len(resp.GmailIds) > 0 {
 		return nil, errors.New("daemon did not return deletion source provenance; upgrade the daemon and retry")
 	}
-	targets := make([]query.DeletionTarget, len(resp.JSON200.Targets))
-	for i, target := range resp.JSON200.Targets {
+	targets := make([]query.DeletionTarget, len(resp.Targets))
+	for i, target := range resp.Targets {
 		targets[i] = query.DeletionTarget{
 			MessageID: target.MessageID, SourceID: target.SourceID,
 			SourceType: target.SourceType, SourceIdentifier: target.SourceIdentifier,
@@ -1154,20 +1356,60 @@ func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*q
 	if opts.SourceIDs != nil && len(opts.SourceIDs) == 0 {
 		return &query.TotalStats{}, nil
 	}
-	if err := e.requireListIDCapability(ctx, search.Parse(opts.SearchQuery), query.MessageFilter{}, opts.GroupBy); err != nil {
+	if opts.SourceIDs == nil && opts.Filter != nil && opts.Filter.SourceIDs != nil && len(opts.Filter.SourceIDs) == 0 {
+		return &query.TotalStats{}, nil
+	}
+	var filter query.MessageFilter
+	if opts.Filter != nil {
+		filter = opts.Filter.Clone()
+		compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
+		if err != nil {
+			return nil, fmt.Errorf("check filtered-stats capability: %w", err)
+		}
+		if !compatible {
+			return nil, fmt.Errorf("complete filtered statistics require daemon API schema %s or newer", tuiSearchContractMinAPISchemaVersion)
+		}
+	}
+	if err := e.requireListIDCapability(ctx, search.Parse(opts.SearchQuery), filter, opts.GroupBy); err != nil {
 		return nil, err
+	}
+	params := &generated.GetTotalStatsQuery{
+		SourceID:        opts.SourceID,
+		SourceIds:       append([]int64(nil), opts.SourceIDs...),
+		AttachmentsOnly: optionalBool(opts.WithAttachmentsOnly),
+		HideDeleted:     optionalBool(opts.HideDeletedFromSource),
+		SearchQuery:     optionalString(opts.SearchQuery),
+		SearchScope:     optionalBool(opts.SearchScope),
+		GroupBy:         optionalStatsGroupBy(opts.GroupBy),
+	}
+	if opts.Filter != nil {
+		fields := generatedFilterMessagesQuery(filter, false)
+		params.Sender = fields.Sender
+		params.SenderName = fields.SenderName
+		params.Recipient = fields.Recipient
+		params.RecipientName = fields.RecipientName
+		params.Domain = fields.Domain
+		params.Label = fields.Label
+		params.ListID = fields.ListID
+		params.MessageType = fields.MessageType
+		params.TimePeriod = fields.TimePeriod
+		params.TimeGranularity = fields.TimeGranularity
+		params.ConversationID = fields.ConversationID
+		params.After = fields.After
+		params.Before = fields.Before
+		params.EmptyTargets = fields.EmptyTargets
+		if opts.SourceIDs == nil && opts.SourceID == nil && filter.SourceIDs != nil {
+			params.SourceIds = append([]int64(nil), filter.SourceIDs...)
+		}
+		if opts.SourceIDs == nil && params.SourceID == nil {
+			params.SourceID = fields.SourceID
+		}
+		params.AttachmentsOnly = optionalBool(opts.WithAttachmentsOnly || filter.WithAttachmentsOnly)
+		params.HideDeleted = optionalBool(opts.HideDeletedFromSource || filter.HideDeletedFromSource)
 	}
 	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.GetTotalStatsResp, error) {
 		return client.GetTotalStatsWithResponse(ctx, &generated.GetTotalStatsRequestOptions{
-			Query: &generated.GetTotalStatsQuery{
-				SourceID:        opts.SourceID,
-				SourceIds:       append([]int64(nil), opts.SourceIDs...),
-				AttachmentsOnly: optionalBool(opts.WithAttachmentsOnly),
-				HideDeleted:     optionalBool(opts.HideDeletedFromSource),
-				SearchQuery:     optionalString(opts.SearchQuery),
-				SearchScope:     optionalBool(opts.SearchScope),
-				GroupBy:         optionalStatsGroupBy(opts.GroupBy),
-			},
+			Query: params,
 		})
 	})
 	if err != nil {

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -176,16 +176,17 @@ func TestEngineSemanticSearchRejectsScopesItCannotPreserve(t *testing.T) {
 	}
 }
 
-func TestEngineSemanticSearchIntersectsMessageTypeScope(t *testing.T) {
+func TestEngineSemanticSearchQuotesInvalidOperatorsForDaemon(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	var requests int
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		assert.Equal("email", r.URL.Query().Get("message_type"))
-		assert.Equal("invoice", r.URL.Query().Get("q"), "message_type operator is carried only by the exact parameter")
+		assert.Equal(`"before:not-a-date message_type:sms invoice"`, r.URL.Query().Get("q"))
+		assert.NoError(search.Parse(r.URL.Query().Get("q")).Err())
 		writeJSONResponse(t, w, map[string]any{
-			"query": "invoice", "mode": "hybrid", "returned": 0,
+			"query": "before:not-a-date message_type:sms invoice", "mode": "hybrid", "returned": 0,
 			"pool_saturated": false, "has_more": false, "took_ms": 1,
 			"generation": map[string]any{
 				"id": 9, "model": "test-model", "dimension": 4,
@@ -198,21 +199,72 @@ func TestEngineSemanticSearchIntersectsMessageTypeScope(t *testing.T) {
 
 	engine := NewEngineAdapter(newTestStore(srv, ""))
 	result, err := engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
-		Query:  "message_type:email invoice",
+		Query:  "before:not-a-date message_type:sms invoice",
 		Filter: query.MessageFilter{MessageType: "email"},
 	})
 	require.NoError(err)
 	assert.Empty(result.Messages)
 	assert.Equal(1, requests)
+}
 
-	result, err = engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
-		Query:  "message_type:sms invoice",
+func TestEngineSemanticSearchIntersectsQueryAndViewMessageTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		wantRequests int
+		wantQuery    string
+	}{
+		{name: "matching scope", query: "message_type:email invoice", wantRequests: 1, wantQuery: "invoice"},
+		{name: "disjoint scope", query: "message_type:sms invoice", wantRequests: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests int
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				assert.Equal(t, "email", r.URL.Query().Get("message_type"))
+				assert.Equal(t, tt.wantQuery, r.URL.Query().Get("q"))
+				writeJSONResponse(t, w, map[string]any{
+					"query": tt.wantQuery, "mode": "hybrid", "returned": 0,
+					"pool_saturated": false, "has_more": false, "took_ms": 1,
+					"generation": map[string]any{
+						"id": 9, "model": "test-model", "dimension": 4,
+						"fingerprint": "test:4", "state": "active",
+					},
+					"results": []any{},
+				})
+			}))
+			t.Cleanup(srv.Close)
+
+			engine := NewEngineAdapter(newTestStore(srv, ""))
+			result, err := engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
+				Query:  tt.query,
+				Filter: query.MessageFilter{MessageType: "email"},
+			})
+			require.NoError(t, err)
+			assert.Empty(t, result.Messages)
+			assert.Equal(t, tt.wantRequests, requests)
+		})
+	}
+}
+
+func TestEngineSemanticSearchRejectsMessageTypeWithoutFreeText(t *testing.T) {
+	var requests int
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		http.Error(w, "unexpected request", http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	engine := NewEngineAdapter(newTestStore(srv, ""))
+	_, err := engine.SearchSemanticMessages(t.Context(), query.SemanticMessageSearchRequest{
+		Query:  "message_type:email",
 		Filter: query.MessageFilter{MessageType: "email"},
 	})
-	require.NoError(err)
-	assert.Empty(result.Messages)
-	assert.False(result.HasMore)
-	assert.Equal(1, requests, "disjoint scope must fail closed without an HTTP search")
+
+	require.ErrorContains(t, err, "semantic search requires free text")
+	assert.Zero(t, requests)
 }
 
 func TestEngineListMessagesUsesGeneratedClientAdapter(t *testing.T) {
@@ -917,6 +969,139 @@ func TestEngineRejectsListIDFilterAgainstOlderDaemonBeforeScopedRequest(t *testi
 	}
 }
 
+func TestEngineGetDeletionTargetsBySearchUsesVersionedExactScope(t *testing.T) {
+	var targetRequests int
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+		case "/api/v1/messages/gmail-ids":
+			targetRequests++
+			assert.Equal(t, "invoice", r.URL.Query().Get("q"))
+			assert.Equal(t, "deep", r.URL.Query().Get("search_mode"))
+			assert.Equal(t, "alice@example.com", r.URL.Query().Get("sender"))
+			writeJSONResponse(t, w, map[string]any{
+				"gmail_ids": []string{"gm-1"}, "search_query": "invoice", "search_mode": "deep",
+				"targets": []map[string]any{{
+					"message_id": 1, "source_id": 7, "source_type": "gmail",
+					"source_identifier": "account@example.invalid", "source_message_id": "gm-1",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	targets, err := NewEngineAdapter(store).GetDeletionTargetsBySearch(t.Context(), search.Parse("invoice"), query.MessageFilter{
+		Sender: "alice@example.com",
+	}, query.DeletionSearchDeep)
+	require.NoError(t, err)
+	assert.Equal(t, 1, targetRequests)
+	assert.Equal(t, []query.DeletionTarget{{
+		MessageID: 1, SourceID: 7, SourceType: "gmail",
+		SourceIdentifier: "account@example.invalid", SourceMessageID: "gm-1",
+	}}, targets)
+}
+
+func TestEngineGetDeletionTargetsByAggregateSearchForwardsDisplayedRow(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+		case "/api/v1/messages/gmail-ids":
+			assertions.Equal("invoice", r.URL.Query().Get("q"))
+			assertions.Equal("aggregate", r.URL.Query().Get("search_mode"))
+			assertions.Equal("senders", r.URL.Query().Get("view_type"))
+			assertions.Equal("alice@example.com", r.URL.Query().Get("aggregate_key"))
+			writeJSONResponse(t, w, map[string]any{
+				"gmail_ids": []string{"gm-1"}, "search_query": "invoice", "search_mode": "aggregate",
+				"targets": []map[string]any{{
+					"message_id": 1, "source_id": 7, "source_type": "gmail",
+					"source_identifier": "account@example.invalid", "source_message_id": "gm-1",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	targets, err := NewEngineAdapter(store).GetDeletionTargetsByAggregateSearch(
+		t.Context(), "invoice", query.MessageFilter{Sender: "alice@example.com"},
+		query.ViewSenders, "alice@example.com")
+	requirements.NoError(err)
+	assertions.Equal([]query.DeletionTarget{{
+		MessageID: 1, SourceID: 7, SourceType: "gmail",
+		SourceIdentifier: "account@example.invalid", SourceMessageID: "gm-1",
+	}}, targets)
+}
+
+func TestEngineGetDeletionTargetsBySearchRejectsPreSearchAwareDaemon(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var healthRequests, targetRequests int
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			healthRequests++
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.15.0"})
+		case "/api/v1/messages/gmail-ids":
+			targetRequests++
+			writeJSONResponse(t, w, map[string]any{
+				"gmail_ids": []string{}, "search_query": "invoice", "search_mode": "fast",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_, err := NewEngineAdapter(store).GetDeletionTargetsBySearch(
+		t.Context(), search.Parse("invoice"), query.MessageFilter{}, query.DeletionSearchFast)
+
+	requirements.ErrorContains(err, "requires daemon API schema 2.16.0 or newer")
+	assertions.Equal(1, healthRequests)
+	assertions.Zero(targetRequests)
+}
+
+func TestEngineGetDeletionTargetsBySearchTreatsCanonicalEmptyAsFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var healthRequests, targetRequests int
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			healthRequests++
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.13.0"})
+		case "/api/v1/messages/gmail-ids":
+			targetRequests++
+			assertions.Empty(r.URL.Query().Get("q"))
+			assertions.Empty(r.URL.Query().Get("search_mode"))
+			writeJSONResponse(t, w, map[string]any{
+				"gmail_ids": []string{"gm-1"},
+				"targets": []map[string]any{{
+					"message_id": 1, "source_id": 7, "source_type": "gmail",
+					"source_identifier": "account@example.invalid", "source_message_id": "gm-1",
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	targets, err := NewEngineAdapter(store).GetDeletionTargetsBySearch(
+		t.Context(), search.Parse("subject:"), query.MessageFilter{Sender: "alice@example.com"},
+		query.DeletionSearchDeep)
+
+	requirements.NoError(err)
+	assertions.Zero(healthRequests)
+	assertions.Equal(1, targetRequests)
+	assertions.Equal([]query.DeletionTarget{{
+		MessageID: 1, SourceID: 7, SourceType: "gmail",
+		SourceIdentifier: "account@example.invalid", SourceMessageID: "gm-1",
+	}}, targets)
+}
+
 func TestEngineSearchByDomainsUsesGeneratedClientAdapter(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1185,6 +1370,10 @@ func TestEngineGetTotalStatsUsesGeneratedClientAdapter(t *testing.T) {
 	sourceID := int64(7)
 
 	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+			return
+		}
 		assert.Equal("/api/v1/stats/total", r.URL.Path, "path")
 		assert.Equal("7", r.URL.Query().Get("source_id"), "source_id")
 		assert.Equal("true", r.URL.Query().Get("attachments_only"), "attachments_only")
@@ -1192,6 +1381,11 @@ func TestEngineGetTotalStatsUsesGeneratedClientAdapter(t *testing.T) {
 		assert.Equal("urgent", r.URL.Query().Get("search_query"), "search_query")
 		assert.Equal("true", r.URL.Query().Get("search_scope"), "search_scope")
 		assert.Equal("labels", r.URL.Query().Get("group_by"), "group_by")
+		assert.Equal("Alice", r.URL.Query().Get("sender_name"), "sender_name")
+		assert.Equal("Bob", r.URL.Query().Get("recipient_name"), "recipient_name")
+		assert.Equal("example.com", r.URL.Query().Get("domain"), "domain")
+		assert.Equal("Work", r.URL.Query().Get("label"), "label")
+		assert.Equal("labels", r.URL.Query().Get("empty_targets"), "empty_targets")
 		writeJSONResponse(t, w, map[string]any{
 			"message_count":           5,
 			"active_messages":         4,
@@ -1208,6 +1402,13 @@ func TestEngineGetTotalStatsUsesGeneratedClientAdapter(t *testing.T) {
 	engine := NewEngineAdapter(store)
 
 	stats, err := engine.GetTotalStats(context.Background(), query.StatsOptions{
+		Filter: &query.MessageFilter{
+			SenderName:        "Alice",
+			RecipientName:     "Bob",
+			Domain:            "example.com",
+			Label:             "Work",
+			EmptyValueTargets: map[query.ViewType]bool{query.ViewLabels: true},
+		},
 		SourceID:              &sourceID,
 		WithAttachmentsOnly:   true,
 		HideDeletedFromSource: true,
@@ -1222,6 +1423,19 @@ func TestEngineGetTotalStatsUsesGeneratedClientAdapter(t *testing.T) {
 	assert.Equal(int64(1), stats.SourceDeletedMessageCount, "source-deleted breakdown must survive the adapter")
 	assert.Equal(int64(25), stats.AttachmentSize)
 	assert.Equal(int64(1), stats.AccountCount)
+}
+
+func TestEngineGetTotalStatsRejectsCompleteFilterAgainstOlderDaemon(t *testing.T) {
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/health", r.URL.Path)
+		writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.15.0"})
+	})
+
+	stats, err := NewEngineAdapter(store).GetTotalStats(t.Context(), query.StatsOptions{
+		Filter: &query.MessageFilter{MessageType: "email"},
+	})
+	require.ErrorContains(t, err, "API schema 2.16.0 or newer")
+	assert.Nil(t, stats)
 }
 
 func TestEngineGetTotalStatsOmitsSearchScopeByDefault(t *testing.T) {
@@ -1445,6 +1659,51 @@ func TestEngineSearchSerializesMessageTypes(t *testing.T) {
 	}, 10, 0)
 	require.NoError(err, "Search")
 }
+
+func TestEngineSearchDeepForwardsCompleteViewFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	sourceID := int64(7)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+			return
+		}
+		assertions.Equal("/api/v1/search/deep", r.URL.Path)
+		assertions.Equal("needle", r.URL.Query().Get("q"))
+		assertions.Equal("Alice", r.URL.Query().Get("sender_name"))
+		assertions.Equal("Bob", r.URL.Query().Get("recipient_name"))
+		assertions.Equal("example.com", r.URL.Query().Get("domain"))
+		assertions.Equal("<dev@example.test>", r.URL.Query().Get("list_id"))
+		assertions.Equal("labels", r.URL.Query().Get("empty_targets"))
+		assertions.Equal("7", r.URL.Query().Get("source_id"))
+		writeJSONResponse(t, w, map[string]any{
+			"query": "needle", "messages": []map[string]any{}, "count": 0,
+			"total_count": 2,
+			"stats": map[string]any{
+				"message_count": 2, "active_messages": 2, "source_deleted_messages": 0,
+				"total_size": 300, "attachment_count": 0, "attachment_size": 0,
+				"label_count": 0, "account_count": 1,
+			},
+			"has_more": false, "offset": 0, "limit": 10,
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	result, err := engine.SearchDeepWithStats(context.Background(), search.Parse("needle"), query.MessageFilter{
+		SenderName:        "Alice",
+		RecipientName:     "Bob",
+		Domain:            "example.com",
+		ListID:            "<dev@example.test>",
+		SourceID:          &sourceID,
+		EmptyValueTargets: map[query.ViewType]bool{query.ViewLabels: true},
+	}, 10, 0)
+	requirements.NoError(err)
+	requirements.NotNil(result.Stats)
+	assertions.Equal(int64(2), result.TotalCount)
+	assertions.Equal(int64(300), result.Stats.TotalSize)
+}
+
 func TestEngineSearchForwardsMessageTypeOnlyTerms(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1948,6 +2207,47 @@ func TestEngineSearchFastWithStatsUsesGeneratedClientAdapter(t *testing.T) {
 	require.NotNil(result.Stats, "stats")
 	assert.Equal(int64(2048), result.Stats.TotalSize)
 	assert.Equal(int64(512), result.Stats.AttachmentSize)
+}
+
+func TestEngineSearchFastWithStatsRejectsCompleteFilterAgainstOlderDaemon(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter query.MessageFilter
+	}{
+		{name: "sender name", filter: query.MessageFilter{SenderName: "Alice"}},
+		{name: "recipient name", filter: query.MessageFilter{RecipientName: "Bob"}},
+		{
+			name: "empty target",
+			filter: query.MessageFilter{
+				EmptyValueTargets: map[query.ViewType]bool{query.ViewLabels: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/health" {
+					writeJSONResponse(t, w, map[string]any{
+						"status": "ok", "api_schema_version": "2.15.0",
+					})
+					return
+				}
+				http.NotFound(w, r)
+			})
+
+			result, err := NewEngineAdapter(store).SearchFastWithStats(
+				t.Context(), search.Parse("needle"), "needle", tt.filter,
+				query.ViewSenders, 10, 0,
+			)
+			require.Error(err)
+			assert.Nil(result)
+			assert.ErrorContains(err, "requires daemon API schema 2.16.0 or newer")
+		})
+	}
 }
 
 func TestEngineSearchFastWithStatsForwardsSourceIDs(t *testing.T) {

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -536,6 +536,7 @@ func TestCreateCLIDeletionManifestUsesGeneratedClientAdapter(t *testing.T) {
 	})
 	manifest.CreatedBy = "tui"
 	manifest.Filters.ListIDs = []string{"announce.example.org"}
+	manifest.RawFilter = json.RawMessage(`{"scope":"all_matches","search_query":"invoice","match_filter":{"attachments_only":true}}`)
 
 	s := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/health" {
@@ -553,6 +554,7 @@ func TestCreateCLIDeletionManifestUsesGeneratedClientAdapter(t *testing.T) {
 		assert.Equal("tui", body.CreatedBy, "created by")
 		assert.Equal([]string{"gid1", "gid2"}, body.GmailIDs, "gmail ids")
 		assert.Equal([]string{"announce.example.org"}, body.Filters.ListIDs, "list ids")
+		assert.JSONEq(string(manifest.RawFilter), string(body.RawFilter), "raw filter")
 		if !assert.NotNil(body.Source) {
 			http.Error(w, "missing source", http.StatusBadRequest)
 			return

--- a/internal/deletion/manifest.go
+++ b/internal/deletion/manifest.go
@@ -118,10 +118,10 @@ type Manifest struct {
 	Status      Status           `json:"status"`
 	Execution   *Execution       `json:"execution,omitempty"`
 	Source      *SourceReference `json:"source,omitempty"`
-	// RawFilter records the serialized HTTP API staging request fields for
-	// provenance — Filters cannot represent every request field
-	// (sender_name, recipient_name, source_id). Absent on manifests created
-	// by the TUI/CLI.
+	// RawFilter records the serialized staging criteria for provenance. Filters
+	// cannot represent every request field (search query, sender_name,
+	// recipient_name, source_id), so API and all-match TUI staging preserve the
+	// complete input here. It remains absent for explicit TUI/CLI selections.
 	RawFilter json.RawMessage `json:"raw_filter,omitempty"`
 }
 

--- a/internal/export/attachments.go
+++ b/internal/export/attachments.go
@@ -109,8 +109,10 @@ func AttachmentsWithOpener(zipFilename string, attachments []query.AttachmentInf
 		return stats
 	}
 
-	cwd, _ := os.Getwd()
-	stats.ZipPath = filepath.Join(cwd, zipFilename)
+	stats.ZipPath = zipFilename
+	if absolutePath, err := filepath.Abs(zipFilename); err == nil {
+		stats.ZipPath = absolutePath
+	}
 	return stats
 }
 

--- a/internal/mime/parse_test.go
+++ b/internal/mime/parse_test.go
@@ -172,6 +172,19 @@ func TestParse_InvalidTextPartContentTypeDefaultsToBody(t *testing.T) {
 	assert.Contains(msg.Errors[0], "invalid Content-Type treated as text/plain")
 }
 
+func TestParse_TextPlainContentTypeWithTrailingSemicolon(t *testing.T) {
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: trailing semicolon\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/plain;\r\n\r\n" +
+		"searchable body\r\n")
+
+	msg := mustParse(t, raw)
+	assert.Equal(t, "searchable body", strings.TrimSpace(msg.BodyText))
+	assert.Empty(t, msg.Attachments)
+}
+
 func TestParse_InvalidPartContentTypePreservesNameParameter(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -812,6 +812,20 @@ func escapeILIKE(s string) string {
 	return s
 }
 
+func aggregateTextSearchParts(termPattern string) ([]string, []any) {
+	return []string{
+		`msg.subject ILIKE ? ESCAPE '\'`,
+		`COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\'`,
+		`EXISTS (
+			SELECT 1 FROM mr mr_search
+			JOIN p p_search ON p_search.id = mr_search.participant_id
+			WHERE mr_search.message_id = msg.id
+			  AND mr_search.recipient_type = 'from'
+			  AND (p_search.email_address ILIKE ? ESCAPE '\' OR COALESCE(p_search.display_name, '') ILIKE ? ESCAPE '\')
+		)`,
+	}, []any{termPattern, termPattern, termPattern, termPattern}
+}
+
 // buildWhereClause builds WHERE conditions for Parquet queries.
 // Column references use msg. prefix to be explicit since aggregate queries join multiple CTEs.
 // buildAggregateSearchConditions builds SQL conditions for a search query in aggregate views.
@@ -835,24 +849,13 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 	// Uses ILIKE for performance on Parquet scans.
 	for _, term := range q.TextTerms {
 		termPattern := "%" + escapeILIKE(term) + "%"
-		var parts []string
-		parts = append(parts, `msg.subject ILIKE ? ESCAPE '\'`)
-		args = append(args, termPattern)
-		parts = append(parts, `COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\'`)
-		args = append(args, termPattern)
-		parts = append(parts, `EXISTS (
-			SELECT 1 FROM mr mr_search
-			JOIN p p_search ON p_search.id = mr_search.participant_id
-			WHERE mr_search.message_id = msg.id
-			  AND mr_search.recipient_type = 'from'
-			  AND (p_search.email_address ILIKE ? ESCAPE '\' OR COALESCE(p_search.display_name, '') ILIKE ? ESCAPE '\')
-		)`)
-		args = append(args, termPattern, termPattern)
+		parts, termArgs := aggregateTextSearchParts(termPattern)
 		for _, col := range keyColumns {
 			parts = append(parts, col+` ILIKE ? ESCAPE '\'`)
-			args = append(args, termPattern)
+			termArgs = append(termArgs, termPattern)
 		}
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
+		args = append(args, termArgs...)
 	}
 
 	// Append non-text filters (from:, to:, subject:, label:, has:, dates, sizes).
@@ -864,7 +867,7 @@ func (e *DuckDBEngine) buildAggregateSearchConditions(searchQuery string, keyCol
 }
 
 // buildNonTextSearchConditions builds WHERE conditions for the non-text
-// portion of a parsed search query (from:, to:, subject:, label:, has:,
+// portion of a parsed search query (from:, to:, cc:, bcc:, subject:, label:, has:,
 // date/size filters). Extracted from buildAggregateSearchConditions so
 // callers that handle text terms themselves (e.g. buildStatsSearchConditions)
 // can append non-text filters without having to compute how many args
@@ -897,18 +900,9 @@ func (e *DuckDBEngine) buildNonTextSearchConditions(q *search.Query, keyColumns 
 		args = append(args, fromPattern)
 	}
 
-	// to: filter - match recipient email (to or cc, consistent with SearchFast)
-	for _, to := range q.ToAddrs {
-		toPattern := "%" + escapeILIKE(to) + "%"
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM mr mr_to
-			JOIN p p_to ON p_to.id = mr_to.participant_id
-			WHERE mr_to.message_id = msg.id
-			  AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p_to.email_address ILIKE ? ESCAPE '\'
-		)`)
-		args = append(args, toPattern)
-	}
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.ToAddrs, "to")
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.CcAddrs, "cc")
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.BccAddrs, "bcc")
 
 	// subject: filter
 	for _, subj := range q.SubjectTerms {
@@ -998,9 +992,8 @@ func (e *DuckDBEngine) buildNonTextSearchConditions(q *search.Query, keyColumns 
 
 // buildWhereClause builds WHERE conditions for aggregate queries.
 // buildStatsSearchConditions builds search conditions for GetTotalStats.
-// For 1:N views (Recipients, RecipientNames, Labels), text terms filter via
-// EXISTS subqueries on the grouping dimension so stats match visible rows.
-// For 1:1 views, falls back to the default subject+sender search.
+// For 1:N views (Recipients, RecipientNames, Labels), text terms also filter
+// via EXISTS subqueries on the grouping dimension so stats match visible rows.
 func (e *DuckDBEngine) buildStatsSearchConditions(searchQuery string, groupBy ViewType) ([]string, []any) {
 	if searchQuery == "" {
 		return nil, nil
@@ -1010,44 +1003,76 @@ func (e *DuckDBEngine) buildStatsSearchConditions(searchQuery string, groupBy Vi
 
 	var conditions []string
 	var args []any
+	if groupBy == ViewLabels && (len(q.Labels) > 0 || len(q.TextTerms) > 0) {
+		var labelRowConditions []string
+		var labelRowArgs []any
+		if len(q.Labels) > 0 {
+			labelParts := make([]string, 0, len(q.Labels))
+			for _, label := range q.Labels {
+				labelParts = append(labelParts, `lbl_rs.name ILIKE ? ESCAPE '\'`)
+				labelRowArgs = append(labelRowArgs, "%"+escapeILIKE(label)+"%")
+			}
+			labelRowConditions = append(labelRowConditions,
+				"("+strings.Join(labelParts, " OR ")+")")
+			q.Labels = nil
+		}
+		for _, term := range q.TextTerms {
+			termPattern := "%" + escapeILIKE(term) + "%"
+			parts, termArgs := aggregateTextSearchParts(termPattern)
+			parts = append(parts, `lbl_rs.name ILIKE ? ESCAPE '\'`)
+			termArgs = append(termArgs, termPattern)
+			labelRowConditions = append(labelRowConditions,
+				"("+strings.Join(parts, " OR ")+")")
+			labelRowArgs = append(labelRowArgs, termArgs...)
+		}
+		q.TextTerms = nil
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM ml ml_rs
+			JOIN lbl lbl_rs ON lbl_rs.id = ml_rs.label_id
+			WHERE ml_rs.message_id = msg.id
+			  AND (`+strings.Join(labelRowConditions, " AND ")+`)
+		)`)
+		args = append(args, labelRowArgs...)
+	}
 
-	// Text terms — use EXISTS for 1:N views since the stats query has no
+	// Text terms always search subject, snippet, and sender. For 1:N views,
+	// also use EXISTS for the grouping key because the stats query has no
 	// participant/label joins.
 	for _, term := range q.TextTerms {
 		termPattern := "%" + escapeILIKE(term) + "%"
+		parts, termArgs := aggregateTextSearchParts(termPattern)
 		switch groupBy {
-		case ViewRecipients, ViewRecipientNames:
-			conditions = append(conditions, `EXISTS (
+		case ViewSenderNames, ViewRecipientNames:
+			recipientTypeCondition := "mr_rs.recipient_type = 'from'"
+			if groupBy == ViewRecipientNames {
+				recipientTypeCondition = "mr_rs.recipient_type IN ('to', 'cc', 'bcc')"
+			}
+			var keyParts []string
+			for _, col := range aggregateNameKeyColumns("mr_rs", "p_rs") {
+				keyParts = append(keyParts, "COALESCE("+col+", '') ILIKE ? ESCAPE '\\'")
+				termArgs = append(termArgs, termPattern)
+			}
+			parts = append(parts, fmt.Sprintf(`EXISTS (
+				SELECT 1 FROM mr mr_rs
+				JOIN p p_rs ON p_rs.id = mr_rs.participant_id
+				WHERE mr_rs.message_id = msg.id
+				  AND %s
+				  AND (%s)
+			)`, recipientTypeCondition, strings.Join(keyParts, " OR ")))
+		case ViewRecipients:
+			parts = append(parts, `EXISTS (
 				SELECT 1 FROM mr mr_rs
 				JOIN p p_rs ON p_rs.id = mr_rs.participant_id
 				WHERE mr_rs.message_id = msg.id
 				  AND mr_rs.recipient_type IN ('to', 'cc', 'bcc')
 				  AND (p_rs.email_address ILIKE ? ESCAPE '\' OR p_rs.display_name ILIKE ? ESCAPE '\')
 			)`)
-			args = append(args, termPattern, termPattern)
-		case ViewLabels:
-			conditions = append(conditions, `EXISTS (
-				SELECT 1 FROM ml ml_rs
-				JOIN lbl lbl_rs ON lbl_rs.id = ml_rs.label_id
-				WHERE ml_rs.message_id = msg.id
-				  AND lbl_rs.name ILIKE ? ESCAPE '\'
-			)`)
-			args = append(args, termPattern)
+			termArgs = append(termArgs, termPattern, termPattern)
 		default:
-			// Default: search subject, snippet, and sender
-			conditions = append(conditions, `(
-				msg.subject ILIKE ? ESCAPE '\' OR
-				COALESCE(msg.snippet, '') ILIKE ? ESCAPE '\' OR
-				EXISTS (
-					SELECT 1 FROM mr mr_search
-					JOIN p p_search ON p_search.id = mr_search.participant_id
-					WHERE mr_search.message_id = msg.id
-					  AND mr_search.recipient_type = 'from'
-					  AND (p_search.email_address ILIKE ? ESCAPE '\' OR p_search.display_name ILIKE ? ESCAPE '\')
-				)
-			)`)
-			args = append(args, termPattern, termPattern, termPattern, termPattern)
+			// Other views use only the shared message and sender predicates.
 		}
+		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
+		args = append(args, termArgs...)
 	}
 
 	// Non-text filters (from:, to:, subject:, label:, etc.) are the same
@@ -1119,6 +1144,15 @@ type aggViewDef struct {
 	keyColumns []string
 }
 
+func aggregateNameKeyColumns(mrAlias, pAlias string) []string {
+	return []string{
+		mrAlias + ".display_name",
+		pAlias + ".email_address",
+		pAlias + ".display_name",
+		pAlias + ".phone_number",
+	}
+}
+
 // getViewDef returns the aggregate query definition for a given view type.
 // The tablePrefix is used to alias tables in SubAggregate to avoid conflicts
 // with CTE names used in filter conditions. Pass "" for top-level aggregates.
@@ -1149,7 +1183,7 @@ func getViewDef(view ViewType, granularity TimeGranularity, tablePrefix string) 
 			keyExpr:    nameExpr,
 			joinClause: fmt.Sprintf("JOIN mr %s ON %s.message_id = msg.id AND %s.recipient_type = 'from'\n\t\t\t\tJOIN p %s ON %s.id = %s.participant_id", mrAlias, mrAlias, mrAlias, pAlias, pAlias, mrAlias),
 			nullGuard:  nameExpr + " != ''",
-			keyColumns: []string{mrAlias + ".display_name", pAlias + ".email_address", pAlias + ".display_name", pAlias + ".phone_number"},
+			keyColumns: aggregateNameKeyColumns(mrAlias, pAlias),
 		}, nil
 	case ViewRecipients:
 		return aggViewDef{
@@ -1164,7 +1198,7 @@ func getViewDef(view ViewType, granularity TimeGranularity, tablePrefix string) 
 			keyExpr:    nameExpr,
 			joinClause: fmt.Sprintf("JOIN mr %s ON %s.message_id = msg.id AND %s.recipient_type IN ('to', 'cc', 'bcc')\n\t\t\t\tJOIN p %s ON %s.id = %s.participant_id", mrAlias, mrAlias, mrAlias, pAlias, pAlias, mrAlias),
 			nullGuard:  nameExpr + " != ''",
-			keyColumns: []string{mrAlias + ".display_name", pAlias + ".email_address", pAlias + ".display_name", pAlias + ".phone_number"},
+			keyColumns: aggregateNameKeyColumns(mrAlias, pAlias),
 		}, nil
 	case ViewDomains:
 		return aggViewDef{
@@ -1414,19 +1448,19 @@ func (e *DuckDBEngine) buildFilterConditions(filter MessageFilter) (string, []an
 			JOIN p ON p.id = mr.participant_id
 			WHERE mr.message_id = msg.id
 			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p.email_address = ?
+			  AND (p.email_address = ? OR p.phone_number = ?)
 			  AND %s = ?
 		)`, recipientNameExpr("mr", "p")))
-		args = append(args, filter.Recipient, filter.RecipientName)
+		args = append(args, filter.Recipient, filter.Recipient, filter.RecipientName)
 	} else if filter.Recipient != "" {
 		conditions = append(conditions, `EXISTS (
 			SELECT 1 FROM mr
 			JOIN p ON p.id = mr.participant_id
 			WHERE mr.message_id = msg.id
 			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p.email_address = ?
+			  AND (p.email_address = ? OR p.phone_number = ?)
 		)`)
-		args = append(args, filter.Recipient)
+		args = append(args, filter.Recipient, filter.Recipient)
 	} else if filter.MatchesEmpty(ViewRecipients) {
 		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM mr WHERE mr.message_id = msg.id AND mr.recipient_type IN ('to', 'cc', 'bcc'))")
 	}
@@ -1460,9 +1494,9 @@ func (e *DuckDBEngine) buildFilterConditions(filter MessageFilter) (string, []an
 			JOIN p ON p.id = mr.participant_id
 			WHERE mr.message_id = msg.id
 			  AND mr.recipient_type = 'from'
-			  AND p.domain = ?
+			  AND LOWER(p.domain) = ?
 		)`)
-		args = append(args, filter.Domain)
+		args = append(args, strings.ToLower(filter.Domain))
 	} else if filter.MatchesEmpty(ViewDomains) {
 		conditions = append(conditions, `NOT EXISTS (
 			SELECT 1 FROM mr
@@ -1516,6 +1550,13 @@ func inferTimeGranularity(base TimeGranularity, period string) TimeGranularity {
 // SubAggregate performs aggregation on a filtered subset of messages.
 // This is used for sub-grouping after drill-down.
 func (e *DuckDBEngine) SubAggregate(ctx context.Context, filter MessageFilter, groupBy ViewType, opts AggregateOptions) ([]AggregateRow, error) {
+	// SQLite owns body-aware aggregate search. Keep rendering on the same
+	// predicate used by aggregate deletion resolution so a body-only match
+	// cannot be staged from a row that DuckDB omitted.
+	if strings.TrimSpace(opts.SearchQuery) != "" && e.sqliteEngine != nil {
+		return e.sqliteEngine.SubAggregate(ctx, filter, groupBy, opts)
+	}
+
 	release, err := e.acquireQuerySlot(ctx)
 	if err != nil {
 		return nil, err
@@ -1621,16 +1662,27 @@ func (e *DuckDBEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 
 	var conditions []string
 	var args []any
-	// Generic analytics default to email; search-result stats opt into the
-	// broader search scope. NULL and '' are legacy email rows.
-	if shouldDefaultStatsToEmail(opts) {
-		conditions = append(conditions, emailOnlyFilterMsg)
-	}
-	conditions = append(conditions, store.LiveMessagesWhere("msg", opts.HideDeletedFromSource))
-	conditions, args = appendSourceFilter(conditions, args, "msg.", opts.SourceID, opts.SourceIDs)
+	if filter := effectiveStatsFilter(opts); filter != nil {
+		filterCondition, filterArgs := e.buildFilterConditions(*filter)
+		if filterCondition != "" {
+			conditions = append(conditions, filterCondition)
+			args = append(args, filterArgs...)
+		}
+		if filter.MessageType == "" && shouldDefaultStatsToEmail(opts) {
+			conditions = append(conditions, emailOnlyFilterMsg)
+		}
+	} else {
+		// Generic analytics default to email; search-result stats opt into the
+		// broader search scope. NULL and '' are legacy email rows.
+		if shouldDefaultStatsToEmail(opts) {
+			conditions = append(conditions, emailOnlyFilterMsg)
+		}
+		conditions = append(conditions, store.LiveMessagesWhere("msg", opts.HideDeletedFromSource))
+		conditions, args = appendSourceFilter(conditions, args, "msg.", opts.SourceID, opts.SourceIDs)
 
-	if opts.WithAttachmentsOnly {
-		conditions = append(conditions, "msg.has_attachments = 1")
+		if opts.WithAttachmentsOnly {
+			conditions = append(conditions, "msg.has_attachments = 1")
+		}
 	}
 
 	// Search filter — uses EXISTS subqueries so no row multiplication.
@@ -2268,6 +2320,28 @@ func (e *DuckDBEngine) Search(ctx context.Context, q *search.Query, limit, offse
 	return results, nil
 }
 
+// SearchDeep delegates complete filtered full-text search to the direct
+// transactional engine. The Parquet cache does not contain message bodies.
+func (e *DuckDBEngine) SearchDeep(
+	ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int,
+) ([]MessageSummary, error) {
+	if e.sqliteEngine == nil {
+		return nil, errors.New("SearchDeep requires a direct SQLite engine")
+	}
+	return e.sqliteEngine.SearchDeep(ctx, q, filter, limit, offset)
+}
+
+// SearchDeepWithStats delegates to SQLite because the Parquet cache does not
+// contain message bodies.
+func (e *DuckDBEngine) SearchDeepWithStats(
+	ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int,
+) (*SearchFastResult, error) {
+	if e.sqliteEngine == nil {
+		return nil, errors.New("SearchDeepWithStats requires a direct SQLite engine")
+	}
+	return e.sqliteEngine.SearchDeepWithStats(ctx, q, filter, limit, offset)
+}
+
 // SearchMessageBodies delegates to the direct SQLite engine so FTS5 can scope
 // MATCH to the indexed body column. The sqlite_scanner fallback is
 // intentionally unsupported: exact body search must never scan message_bodies.
@@ -2291,8 +2365,6 @@ func (e *DuckDBEngine) SearchByDomains(ctx context.Context, domains []string, af
 }
 
 func (e *DuckDBEngine) GetDeletionTargetsByFilter(ctx context.Context, filter MessageFilter) ([]DeletionTarget, error) {
-	// Delegate to SQLite for authoritative deletion status.
-	// Parquet cache may be stale if deletions occurred after the last build.
 	if e.sqliteEngine != nil {
 		return e.sqliteEngine.GetDeletionTargetsByFilter(ctx, filter)
 	}
@@ -2307,155 +2379,11 @@ func (e *DuckDBEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 	}
 	defer release()
 
-	var conditions []string
-	var args []any
-
-	// Always exclude deleted messages.
-	// Always pass true: this surface feeds remote-deletion staging and
-	// must never honor an opt-in.
-	conditions = append(conditions, store.LiveMessagesWhere("msg", true))
-	conditions, args = appendSourceFilter(conditions, args, "msg.", filter.SourceID, filter.SourceIDs)
-	if filter.ConversationID != nil {
-		conditions = append(conditions, "msg.conversation_id = ?")
-		args = append(args, *filter.ConversationID)
-	}
-	if filter.MessageType != "" {
-		condition, conditionArgs := duckDBMessageTypeCondition("msg", []string{filter.MessageType})
-		if condition != "" {
-			conditions = append(conditions, condition)
-			args = append(args, conditionArgs...)
-		}
-	}
-	if filter.ListID != "" {
-		conditions = append(conditions, "LOWER(msg.list_id) = LOWER(?)")
-		args = append(args, filter.ListID)
-	}
-
-	// Use EXISTS subqueries for filtering (becomes semi-joins, no duplicates).
-	// When BOTH the email and the display name are filtered, they must match
-	// the SAME from-row (or the SAME direct sender), not two independent
-	// EXISTS that a multi-author message could satisfy via different rows.
-	if filter.Sender != "" && filter.SenderName != "" {
-		conditions = append(conditions, fmt.Sprintf(`(EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type = 'from'
-			  AND (p.email_address = ? OR p.phone_number = ?)
-			  AND %s = ?
-		) OR EXISTS (
-			SELECT 1 FROM p
-			WHERE p.id = msg.sender_id
-			  AND (p.email_address = ? OR p.phone_number = ?)
-			  AND %s = ?
-		))`, recipientNameExpr("mr", "p"), participantNameExpr("p")))
-		args = append(args, filter.Sender, filter.Sender, filter.SenderName, filter.Sender, filter.Sender, filter.SenderName)
-	} else if filter.Sender != "" {
-		conditions = append(conditions, `(EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type = 'from'
-			  AND (p.email_address = ? OR p.phone_number = ?)
-		) OR EXISTS (
-			SELECT 1 FROM p
-			WHERE p.id = msg.sender_id
-			  AND (p.email_address = ? OR p.phone_number = ?)
-		))`)
-		args = append(args, filter.Sender, filter.Sender, filter.Sender, filter.Sender)
-	} else if filter.SenderName != "" {
-		conditions = append(conditions, fmt.Sprintf(`(EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type = 'from'
-			  AND %s = ?
-		) OR EXISTS (
-			SELECT 1 FROM p
-			WHERE p.id = msg.sender_id
-			  AND %s = ?
-		))`, recipientNameExpr("mr", "p"), participantNameExpr("p")))
-		args = append(args, filter.SenderName, filter.SenderName)
-	}
-
-	// When BOTH the recipient email and the display name are filtered, they
-	// must match the SAME to/cc/bcc row, not two independent EXISTS that a
-	// multi-recipient message could satisfy via different rows.
-	if filter.Recipient != "" && filter.RecipientName != "" {
-		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p.email_address = ?
-			  AND %s = ?
-		)`, recipientNameExpr("mr", "p")))
-		args = append(args, filter.Recipient, filter.RecipientName)
-	} else if filter.Recipient != "" {
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p.email_address = ?
-		)`)
-		args = append(args, filter.Recipient)
-	} else if filter.RecipientName != "" {
-		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND %s = ?
-		)`, recipientNameExpr("mr", "p")))
-		args = append(args, filter.RecipientName)
-	}
-
-	if filter.Domain != "" {
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type = 'from'
-			  AND p.domain = ?
-		)`)
-		args = append(args, filter.Domain)
-	}
-
-	if filter.Label != "" {
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM ml
-			JOIN lbl ON lbl.id = ml.label_id
-			WHERE ml.message_id = msg.id
-			  AND lbl.name ILIKE ? ESCAPE '\'
-		)`)
-		args = append(args, escapeILIKE(filter.Label))
-	}
-
-	if filter.TimeRange.Period != "" {
-		granularity := inferTimeGranularity(filter.TimeRange.Granularity, filter.TimeRange.Period)
-		// GetDeletionTargetsByFilter uses strftime for time filtering (no year/month columns)
-		var te string
-		switch granularity {
-		case TimeYear:
-			te = "strftime(msg.sent_at, '%Y')"
-		case TimeDay:
-			te = "strftime(msg.sent_at, '%Y-%m-%d')"
-		default:
-			te = "strftime(msg.sent_at, '%Y-%m')"
-		}
-		conditions = append(conditions, te+" = ?")
-		args = append(args, filter.TimeRange.Period)
-	}
-
-	if filter.After != nil {
-		conditions = append(conditions, "msg.sent_at >= CAST(? AS TIMESTAMP)")
-		args = append(args, queryTimeUTC(*filter.After))
-	}
-	if filter.Before != nil {
-		conditions = append(conditions, "msg.sent_at < CAST(? AS TIMESTAMP)")
-		args = append(args, queryTimeUTC(*filter.Before))
-	}
+	// This surface feeds remote-deletion staging, so it always excludes
+	// source-deleted messages. Reuse the complete Parquet filter rather than
+	// maintaining a second, partial copy for the fallback path.
+	filter.HideDeletedFromSource = true
+	where, args := e.buildFilterConditions(filter)
 
 	// Build query — JOIN src to scope to Gmail sources authoritatively.
 	query := fmt.Sprintf(`
@@ -2465,7 +2393,7 @@ func (e *DuckDBEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 		JOIN src ON src.id = msg.source_id AND COALESCE(src.source_type, 'gmail') = 'gmail'
 		WHERE %s
 		ORDER BY msg.sent_at DESC, msg.id DESC
-	`, e.parquetCTEs(), strings.Join(conditions, " AND "))
+	`, e.parquetCTEs(), where)
 
 	// Only add LIMIT if explicitly set (0 means no limit)
 	if filter.Pagination.Limit > 0 {
@@ -2480,6 +2408,35 @@ func (e *DuckDBEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 	defer func() { _ = rows.Close() }()
 
 	return collectDeletionTargets(rows)
+}
+
+func (e *DuckDBEngine) GetDeletionTargetsBySearch(
+	ctx context.Context,
+	searchQuery *search.Query,
+	filter MessageFilter,
+	mode DeletionSearchMode,
+) ([]DeletionTarget, error) {
+	// Search deletion eligibility is authoritative transactional state. The
+	// daemon opens DuckDB with this direct SQLite engine in normal operation.
+	if e.sqliteEngine == nil {
+		return nil, errors.New("GetDeletionTargetsBySearch requires a direct SQLite engine")
+	}
+	return e.sqliteEngine.GetDeletionTargetsBySearch(ctx, searchQuery, filter, mode)
+}
+
+// GetDeletionTargetsByAggregateSearch resolves the complete aggregate scope
+// against authoritative SQLite state.
+func (e *DuckDBEngine) GetDeletionTargetsByAggregateSearch(
+	ctx context.Context,
+	searchQuery string,
+	filter MessageFilter,
+	groupBy ViewType,
+	key string,
+) ([]DeletionTarget, error) {
+	if e.sqliteEngine == nil {
+		return nil, errors.New("GetDeletionTargetsByAggregateSearch requires a direct SQLite engine")
+	}
+	return e.sqliteEngine.GetDeletionTargetsByAggregateSearch(ctx, searchQuery, filter, groupBy, key)
 }
 
 func (e *DuckDBEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error) {
@@ -3037,89 +2994,9 @@ func (e *DuckDBEngine) SearchFastWithStats(ctx context.Context, q *search.Query,
 // Shared by SearchFast and SearchFastCount.
 // Note: These conditions reference msg and ms (msg_sender) CTEs.
 func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilter) ([]string, []any) {
-	var conditions []string
-	var args []any
-
-	// Apply basic filter conditions (ignoring join flags for search - we handle those differently)
-	conditions = append(conditions,
-		store.LiveMessagesWhere("msg", filter.HideDeletedFromSource),
-	)
-	messageTypes, noMessageTypeMatches := ScopedMessageTypes(q.MessageTypes, filter.MessageType)
-	switch {
-	case noMessageTypeMatches:
-		conditions = append(conditions, "1=0")
-	case len(messageTypes) > 0:
-		condition, conditionArgs := duckDBMessageTypeCondition("msg", messageTypes)
-		if condition != "" {
-			conditions = append(conditions, condition)
-			args = append(args, conditionArgs...)
-		}
-	}
-	conditions, args = appendSourceFilter(conditions, args, "msg.", filter.SourceID, filter.SourceIDs)
-	if filter.ConversationID != nil {
-		conditions = append(conditions, "msg.conversation_id = ?")
-		args = append(args, *filter.ConversationID)
-	}
-	if filter.After != nil {
-		conditions = append(conditions, "msg.sent_at >= CAST(? AS TIMESTAMP)")
-		args = append(args, duckDBDateParam(*filter.After))
-	}
-	if filter.Before != nil {
-		conditions = append(conditions, "msg.sent_at < CAST(? AS TIMESTAMP)")
-		args = append(args, duckDBDateParam(*filter.Before))
-	}
-	if filter.WithAttachmentsOnly {
-		conditions = append(conditions, "msg.has_attachments = true")
-	}
-	if filter.ListID != "" {
-		conditions = append(conditions, "LOWER(msg.list_id) = LOWER(?)")
-		args = append(args, filter.ListID)
-	}
-	// Sender filter - check both message_recipients (email/phone) and direct sender_id (WhatsApp/chat)
-	if filter.Sender != "" {
-		conditions = append(conditions, `(EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type = 'from'
-			  AND (p.email_address = ? OR p.phone_number = ?)
-		) OR EXISTS (
-			SELECT 1 FROM p
-			WHERE p.id = msg.sender_id
-			  AND (p.email_address = ? OR p.phone_number = ?)
-		))`)
-		args = append(args, filter.Sender, filter.Sender, filter.Sender, filter.Sender)
-	}
-	if filter.Domain != "" {
-		conditions = append(conditions, "ms.from_email ILIKE ?")
-		args = append(args, "%@"+filter.Domain)
-	}
-	// Recipient filter - use EXISTS subquery for drill-down context (checks email and phone)
-	if filter.Recipient != "" {
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM mr
-			JOIN p ON p.id = mr.participant_id
-			WHERE mr.message_id = msg.id
-			  AND mr.recipient_type IN ('to', 'cc', 'bcc')
-			  AND (p.email_address = ? OR p.phone_number = ?)
-		)`)
-		args = append(args, filter.Recipient, filter.Recipient)
-	}
-	// Label filter - use EXISTS subquery for drill-down context
-	if filter.Label != "" {
-		conditions = append(conditions, `EXISTS (
-			SELECT 1 FROM ml
-			JOIN lbl ON lbl.id = ml.label_id
-			WHERE ml.message_id = msg.id
-			  AND lbl.name ILIKE ? ESCAPE '\'
-		)`)
-		args = append(args, escapeILIKE(filter.Label))
-	}
-	if filter.TimeRange.Period != "" {
-		granularity := inferTimeGranularity(filter.TimeRange.Granularity, filter.TimeRange.Period)
-		conditions = append(conditions, timeExpr(granularity)+" = ?")
-		args = append(args, filter.TimeRange.Period)
-	}
+	filterWhere, filterArgs := e.buildFilterConditions(filter)
+	conditions := []string{filterWhere}
+	args := append([]any(nil), filterArgs...)
 
 	// Text search terms - search subject, snippet, and every participant row
 	// without consulting message bodies (fast path). The EXISTS branch includes
@@ -3173,19 +3050,9 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 		}
 	}
 
-	// To filter - use EXISTS subquery to check recipients (email and phone)
-	if len(q.ToAddrs) > 0 {
-		for _, addr := range q.ToAddrs {
-			pattern := "%" + escapeILIKE(addr) + "%"
-			conditions = append(conditions, `EXISTS (
-				SELECT 1 FROM mr
-				JOIN p ON p.id = mr.participant_id
-				WHERE mr.message_id = msg.id AND mr.recipient_type IN ('to', 'cc', 'bcc')
-				AND (p.email_address ILIKE ? ESCAPE '\' OR p.phone_number ILIKE ? ESCAPE '\')
-			)`)
-			args = append(args, pattern, pattern)
-		}
-	}
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.ToAddrs, "to")
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.CcAddrs, "cc")
+	conditions, args = appendDuckDBRecipientSearchCondition(conditions, args, q.BccAddrs, "bcc")
 
 	// Subject filter
 	if len(q.SubjectTerms) > 0 {
@@ -3260,5 +3127,39 @@ func (e *DuckDBEngine) buildSearchConditions(q *search.Query, filter MessageFilt
 		conditions = append(conditions, "1=1")
 	}
 
+	return conditions, args
+}
+
+func appendDuckDBRecipientSearchCondition(
+	conditions []string,
+	args []any,
+	addresses []string,
+	recipientType string,
+) ([]string, []any) {
+	if len(addresses) == 0 {
+		return conditions, args
+	}
+
+	addressParts := make([]string, 0, len(addresses))
+	recipientArgs := []any{recipientType}
+	for _, address := range addresses {
+		address = strings.ToLower(address)
+		if strings.HasPrefix(address, "@") {
+			addressParts = append(addressParts, `LOWER(p_recipient.email_address) LIKE ? ESCAPE '\'`)
+			recipientArgs = append(recipientArgs, "%"+escapeILIKE(address))
+		} else {
+			addressParts = append(addressParts,
+				"(LOWER(p_recipient.email_address) = ? OR p_recipient.phone_number = ?)")
+			recipientArgs = append(recipientArgs, address, address)
+		}
+	}
+	conditions = append(conditions, fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM mr mr_recipient
+		JOIN p p_recipient ON p_recipient.id = mr_recipient.participant_id
+		WHERE mr_recipient.message_id = msg.id
+		  AND mr_recipient.recipient_type = ?
+		  AND (%s)
+	)`, strings.Join(addressParts, " OR ")))
+	args = append(args, recipientArgs...)
 	return conditions, args
 }

--- a/internal/query/duckdb_search_scope_test.go
+++ b/internal/query/duckdb_search_scope_test.go
@@ -55,6 +55,60 @@ func TestDuckDBSearchFast_AllFromParticipantsMetadata(t *testing.T) {
 	assert.Equal(int64(len(messages)), count, "result/count agreement")
 }
 
+func TestDuckDBSearchFast_DomainFilterTreatsWildcardsLiterally(t *testing.T) {
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@example.com")
+	wantedSenderID := b.AddParticipant("sender@team_ops.example", "team_ops.example", "Wanted Sender")
+	otherSenderID := b.AddParticipant("sender@teamXops.example", "teamXops.example", "Other Sender")
+	wantedMessageID := b.AddMessage(MessageOpt{Subject: "domain filter needle"})
+	otherMessageID := b.AddMessage(MessageOpt{Subject: "domain filter needle"})
+	secondaryMatchMessageID := b.AddMessage(MessageOpt{Subject: "domain filter needle"})
+	b.AddFrom(wantedMessageID, wantedSenderID, "Wanted Sender")
+	b.AddFrom(otherMessageID, otherSenderID, "Other Sender")
+	b.AddFrom(secondaryMatchMessageID, otherSenderID, "Other Sender")
+	b.AddFrom(secondaryMatchMessageID, wantedSenderID, "Wanted Sender")
+	engine := b.BuildEngine()
+
+	messages, err := engine.SearchFast(context.Background(), search.Parse("domain filter needle"), MessageFilter{
+		Domain: "team_ops.example",
+	}, 50, 0)
+	require.NoError(t, err)
+	gotIDs := make([]int64, len(messages))
+	for i := range messages {
+		gotIDs[i] = messages[i].ID
+	}
+	assert.ElementsMatch(t, []int64{wantedMessageID, secondaryMatchMessageID}, gotIDs)
+}
+
+func TestDuckDBSearchFast_AppliesCompleteViewFilter(t *testing.T) {
+	t.Run("sender name", func(t *testing.T) {
+		engine := newParquetEngine(t)
+		messages, err := engine.SearchFast(context.Background(), search.Parse("Preview"), MessageFilter{
+			SenderName: "Alice",
+		}, 50, 0)
+		require.NoError(t, err)
+		assertMessageIDs(t, messages, []int64{1, 2, 3})
+	})
+
+	t.Run("recipient name", func(t *testing.T) {
+		engine := newParquetEngine(t)
+		messages, err := engine.SearchFast(context.Background(), search.Parse("Preview"), MessageFilter{
+			RecipientName: "Bob",
+		}, 50, 0)
+		require.NoError(t, err)
+		assertMessageIDs(t, messages, []int64{1, 2, 3})
+	})
+
+	t.Run("empty sender", func(t *testing.T) {
+		engine := newEmptyBucketsEngine(t)
+		messages, err := engine.SearchFast(context.Background(), search.Parse("No"), MessageFilter{
+			EmptyValueTargets: map[ViewType]bool{ViewSenders: true},
+		}, 50, 0)
+		require.NoError(t, err)
+		assertMessageIDs(t, messages, []int64{3})
+	})
+}
+
 func TestDuckDBSearchFast_UnscopedIncludesCachedMessageTypes(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -900,6 +900,37 @@ func TestDuckDBEngine_RecipientEmailAndName_SameToRow(t *testing.T) {
 		"same-row recipient email+name must still match in GetDeletionTargetsByFilter")
 }
 
+func TestDuckDBEngine_RecipientPhoneFilter(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@gmail.com")
+	recipient := b.AddPhoneParticipant("+15551234567", "Phone Recipient")
+	messageID := b.AddMessage(MessageOpt{Subject: "Phone recipient", SentAt: makeDate(6, 10), SizeEstimate: 1000})
+	b.AddTo(messageID, recipient, "Phone Recipient")
+	b.SetEmptyAttachments()
+	engine := b.BuildEngine()
+
+	for _, filter := range []MessageFilter{
+		{Recipient: "+15551234567"},
+		{Recipient: "+15551234567", RecipientName: "Phone Recipient"},
+	} {
+		messages, err := engine.SearchFast(ctx, &search.Query{}, filter, 100, 0)
+		require.NoError(err, "SearchFast")
+		assertMessageIDs(t, messages, []int64{messageID})
+
+		count, err := engine.SearchFastCount(ctx, &search.Query{}, filter)
+		require.NoError(err, "SearchFastCount")
+		assert.Equal(t, int64(1), count)
+
+		targets, err := engine.GetDeletionTargetsByFilter(ctx, filter)
+		require.NoError(err, "GetDeletionTargetsByFilter")
+		require.Len(targets, 1)
+		assert.Equal(t, messageID, targets[0].MessageID)
+	}
+}
+
 func TestDuckDBEngine_GetDeletionTargetsByFilter_SenderName(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()
@@ -1359,8 +1390,6 @@ func TestDuckDBEngine_SearchFast(t *testing.T) {
 		{"LabelFilter_CaseInsensitive", "label:work", MessageFilter{}, []string{"Hello World", "Question"}},
 		{"LabelFilter_Substring", "label:wor", MessageFilter{}, []string{"Hello World", "Question"}},
 		{"HasAttachment", "has:attachment", MessageFilter{}, []string{"Re: Hello", "Question"}},
-		{"ToFilter_Bob", "to:bob", MessageFilter{}, []string{"Hello World", "Re: Hello", "Follow up"}},
-		{"ToFilter_Carol", "to:carol", MessageFilter{}, []string{"Hello World"}},
 
 		// Context filters (search + MessageFilter)
 		{"ContextFilter_SenderAlice", "Hello", MessageFilter{Sender: "alice@example.com"}, []string{"Hello World", "Re: Hello"}},
@@ -1410,6 +1439,82 @@ func TestDuckDBEngine_SearchFast(t *testing.T) {
 		}
 		assert.True(t, foundFromBob, "expected at least one message from bob@company.org")
 	})
+}
+
+func TestDuckDBEngine_SearchFastRecipientOperatorParity(t *testing.T) {
+	requirements := require.New(t)
+	ctx := t.Context()
+
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	_, err := tdb.DB.Exec(`
+		INSERT INTO participants (id, email_address, display_name, domain)
+		VALUES (4, 'recipient@example.net', 'Test Recipient', 'example.net');
+		INSERT INTO participants (id, phone_number, display_name)
+		VALUES (5, '+15551234567', 'Phone Recipient');
+		INSERT INTO message_recipients (message_id, participant_id, recipient_type, display_name)
+		VALUES (1, 4, 'to', 'Test Recipient'),
+		       (2, 4, 'cc', 'Test Recipient'),
+		       (3, 4, 'bcc', 'Test Recipient'),
+		       (1, 5, 'to', 'Phone Recipient'),
+		       (2, 5, 'cc', 'Phone Recipient'),
+		       (3, 5, 'bcc', 'Phone Recipient');
+	`)
+	requirements.NoError(err)
+	sqliteEngine := NewSQLiteEngine(tdb.DB)
+
+	builder := buildStandardTestData(t)
+	recipientID := builder.AddParticipant("recipient@example.net", "example.net", "Test Recipient")
+	phoneRecipientID := builder.AddPhoneParticipant("+15551234567", "Phone Recipient")
+	builder.AddTo(1, recipientID, "Test Recipient")
+	builder.AddCc(2, recipientID, "Test Recipient")
+	builder.AddRecipient(3, recipientID, "bcc", "Test Recipient")
+	builder.AddTo(1, phoneRecipientID, "Phone Recipient")
+	builder.AddCc(2, phoneRecipientID, "Phone Recipient")
+	builder.AddRecipient(3, phoneRecipientID, "bcc", "Phone Recipient")
+	duckDBEngine := builder.BuildEngine()
+
+	for _, testCase := range []struct {
+		query string
+		want  []int64
+	}{
+		{query: "to:recipient@example.net", want: []int64{1}},
+		{query: "cc:recipient@example.net", want: []int64{2}},
+		{query: "bcc:recipient@example.net", want: []int64{3}},
+		{query: "to:example.net", want: []int64{1}},
+		{query: "cc:example.net", want: []int64{2}},
+		{query: "bcc:example.net", want: []int64{3}},
+		{query: "to:+15551234567", want: []int64{1}},
+		{query: "cc:+15551234567", want: []int64{2}},
+		{query: "bcc:+15551234567", want: []int64{3}},
+	} {
+		t.Run(testCase.query, func(t *testing.T) {
+			requirements := require.New(t)
+			parsed := search.Parse(testCase.query)
+			sqliteResults, err := sqliteEngine.SearchFast(ctx, parsed, MessageFilter{}, 100, 0)
+			requirements.NoError(err)
+			duckDBResults, err := duckDBEngine.SearchFast(ctx, parsed, MessageFilter{}, 100, 0)
+			requirements.NoError(err)
+			sqliteCount, err := sqliteEngine.SearchFastCount(ctx, parsed, MessageFilter{})
+			requirements.NoError(err)
+			duckDBCount, err := duckDBEngine.SearchFastCount(ctx, parsed, MessageFilter{})
+			requirements.NoError(err)
+			deletionTargets, err := sqliteEngine.GetDeletionTargetsBySearch(
+				ctx, parsed, MessageFilter{}, DeletionSearchFast,
+			)
+			requirements.NoError(err)
+
+			assertMessageIDs(t, sqliteResults, testCase.want)
+			assertMessageIDs(t, duckDBResults, testCase.want)
+			assert.Equal(t, int64(len(testCase.want)), sqliteCount)
+			assert.Equal(t, int64(len(testCase.want)), duckDBCount)
+			deletionIDs := make([]int64, len(deletionTargets))
+			for i, target := range deletionTargets {
+				deletionIDs[i] = target.MessageID
+			}
+			assertSetEqual(t, deletionIDs, testCase.want)
+		})
+	}
 }
 
 func TestDuckDBEngine_SearchFast_MessageTypeFilter(t *testing.T) {
@@ -2285,6 +2390,11 @@ func TestDuckDBEngine_GetDeletionTargetsByFilter(t *testing.T) {
 			wantIDs: []string{"msg1", "msg2"},
 		},
 		{
+			name:    "attachments",
+			filter:  MessageFilter{WithAttachmentsOnly: true},
+			wantIDs: []string{"msg2", "msg4"},
+		},
+		{
 			name:    "time_period=2024-01",
 			filter:  MessageFilter{TimeRange: TimeRange{Period: "2024-01", Granularity: TimeMonth}},
 			wantIDs: []string{"msg1", "msg2"},
@@ -2327,6 +2437,140 @@ func TestDuckDBEngine_GetDeletionTargetsByFilter_MessageTypeEmailIncludesLegacy(
 		[]string{fmt.Sprintf("msg%d", typedEmailID), fmt.Sprintf("msg%d", legacyEmailID)},
 		ids,
 	)
+}
+
+func TestDuckDBEngine_GetDeletionTargetsByAggregateSearch(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	builder := buildStandardTestData(t)
+	listID := "<dev@example.test>"
+	builder.messages[0].ListID = &listID
+	builder.messages[1].ListID = &listID
+	analyticsDir, cleanup := builder.Build()
+	t.Cleanup(cleanup)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	_, err := tdb.DB.Exec(`UPDATE messages SET list_id = ? WHERE id IN (1, 2)`, listID)
+	requirements.NoError(err)
+	engine, err := NewDuckDBEngine(analyticsDir, "", tdb.DB)
+	requirements.NoError(err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	filter := MessageFilter{Sender: "alice@example.com", MessageType: messageTypeEmail}
+	rows, err := engine.SubAggregate(t.Context(), MessageFilter{MessageType: messageTypeEmail}, ViewSenders,
+		AggregateOptions{SearchQuery: "Hello"})
+	requirements.NoError(err)
+	requirements.NotEmpty(rows)
+
+	targets, err := engine.GetDeletionTargetsByAggregateSearch(
+		t.Context(), "Hello", filter, ViewSenders, "alice@example.com")
+	requirements.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.ElementsMatch([]string{"msg1", "msg2"}, ids)
+
+	targets, err = engine.GetDeletionTargetsByAggregateSearch(
+		t.Context(), "Hello", MessageFilter{MessageType: messageTypeEmail}, ViewLists, listID)
+	requirements.NoError(err)
+	ids, err = deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.ElementsMatch([]string{"msg1", "msg2"}, ids)
+}
+
+func TestDuckDBEngine_AggregateSearchAndDeletionShareBodyScope(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	builder := buildStandardTestData(t)
+	analyticsDir, cleanup := builder.Build()
+	t.Cleanup(cleanup)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	_, err := tdb.DB.Exec(`UPDATE message_bodies SET body_text = 'aggregatebodyneedle' WHERE message_id = 1`)
+	requirements.NoError(err)
+	tdb.EnableFTS()
+	engine, err := NewDuckDBEngine(analyticsDir, "", tdb.DB)
+	requirements.NoError(err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	filter := MessageFilter{MessageType: messageTypeEmail}
+	rows, err := engine.SubAggregate(t.Context(), filter, ViewSenders,
+		AggregateOptions{SearchQuery: "aggregatebodyneedle"})
+	requirements.NoError(err)
+	requirements.Len(rows, 1)
+	assertions.Equal("alice@example.com", rows[0].Key)
+	assertions.Equal(int64(1), rows[0].Count)
+
+	filter.Sender = rows[0].Key
+	targets, err := engine.GetDeletionTargetsByAggregateSearch(
+		t.Context(), "aggregatebodyneedle", filter, ViewSenders, rows[0].Key)
+	requirements.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg1"}, ids)
+}
+
+func TestDuckDBEngine_GetDeletionTargetsUseAuthoritativeSQLiteScope(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	builder := buildStandardTestData(t)
+	analyticsDir, cleanup := builder.Build()
+	t.Cleanup(cleanup)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	engine, err := NewDuckDBEngine(analyticsDir, "", tdb.DB)
+	requirements.NoError(err)
+	t.Cleanup(func() { _ = engine.Close() })
+
+	_, err = tdb.DB.Exec(`UPDATE messages SET
+		subject = CASE id
+			WHEN 1 THEN 'No longer matches'
+			WHEN 2 THEN 'No longer matches either'
+			WHEN 3 THEN 'Hello from live SQLite'
+			ELSE subject END,
+		has_attachments = CASE id
+			WHEN 1 THEN 1
+			WHEN 2 THEN 0
+			WHEN 4 THEN 0
+			ELSE has_attachments END,
+		deleted_from_source_at = CASE id
+			WHEN 5 THEN '2026-09-03 12:00:00'
+			ELSE deleted_from_source_at END`)
+	requirements.NoError(err)
+	q := search.Parse("Hello")
+	filter := MessageFilter{MessageType: messageTypeEmail}
+
+	visible, err := engine.SearchFast(t.Context(), q, filter, 100, 0)
+	requirements.NoError(err)
+	requirements.Len(visible, 2)
+	assertions.ElementsMatch([]int64{1, 2}, []int64{visible[0].ID, visible[1].ID})
+
+	targets, err := engine.GetDeletionTargetsBySearch(t.Context(), q, filter, DeletionSearchFast)
+	requirements.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg3"}, ids)
+
+	attachmentFilter := MessageFilter{MessageType: messageTypeEmail, WithAttachmentsOnly: true}
+	visible, err = engine.ListMessages(t.Context(), attachmentFilter)
+	requirements.NoError(err)
+	requirements.Len(visible, 2)
+	assertions.ElementsMatch([]int64{2, 4}, []int64{visible[0].ID, visible[1].ID})
+
+	targets, err = engine.GetDeletionTargetsByFilter(t.Context(), attachmentFilter)
+	requirements.NoError(err)
+	ids, err = deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg1"}, ids)
+
+	limitedFilter := MessageFilter{
+		MessageType: messageTypeEmail,
+		Pagination:  Pagination{Limit: 1},
+	}
+	targets, err = engine.GetDeletionTargetsByFilter(t.Context(), limitedFilter)
+	requirements.NoError(err)
+	ids, err = deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg4"}, ids)
 }
 
 // buildEmptyBucketsTestData creates a TestDataBuilder with messages that have
@@ -2675,6 +2919,33 @@ func TestDuckDBEngine_GetDeletionTargetsByFilter_EmptyFilter(t *testing.T) {
 	assertSetEqual(t, ids, []string{"msg1", "msg2", "msg3", "msg4", "msg5"})
 }
 
+func TestDuckDBEngine_GetDeletionTargetsByFilter_EmptyBuckets(t *testing.T) {
+	engine := newEmptyBucketsEngine(t)
+
+	tests := []struct {
+		name string
+		view ViewType
+		want []string
+	}{
+		{name: "sender", view: ViewSenders, want: []string{"msg3"}},
+		{name: "sender name", view: ViewSenderNames, want: []string{"msg3"}},
+		{name: "recipient", view: ViewRecipients, want: []string{"msg4"}},
+		{name: "recipient name", view: ViewRecipientNames, want: []string{"msg4"}},
+		{name: "domain", view: ViewDomains, want: []string{"msg3", "msg6"}},
+		{name: "label", view: ViewLabels, want: []string{"msg5"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids, err := deletionTargetSourceMessageIDs(engine.GetDeletionTargetsByFilter(
+				context.Background(), MessageFilter{EmptyValueTargets: map[ViewType]bool{tt.view: true}},
+			))
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, ids)
+		})
+	}
+}
+
 // TestDuckDBEngine_GetDeletionTargetsByFilter_CombinedNoMatch verifies empty results for
 // combined filters that match nothing.
 func TestDuckDBEngine_GetDeletionTargetsByFilter_CombinedNoMatch(t *testing.T) {
@@ -2766,8 +3037,8 @@ func TestBuildWhereClause_SearchOperators(t *testing.T) {
 		},
 		{
 			name:        "to operator",
-			searchQuery: "to:bob",
-			wantClauses: []string{"recipient_type IN ('to', 'cc', 'bcc')", "email_address ILIKE"},
+			searchQuery: "to:recipient@example.net",
+			wantClauses: []string{"recipient_type = ?", "LOWER(p_recipient.email_address) = ?"},
 		},
 		{
 			name:        "subject operator",
@@ -2943,6 +3214,29 @@ func TestAggregateByLabel_WithLabelSearch(t *testing.T) {
 	assert.Len(rows, 1, "expected 1 label row")
 }
 
+func TestDuckDBEngine_AggregateLabelSearchStatsCorrelateFilterAndText(t *testing.T) {
+	b := buildStandardTestData(t)
+	needle := b.AddLabel("Needle")
+	b.AddMessageLabel(1, needle)
+	workNeedle := b.AddLabel("Work Needle")
+	b.AddMessageLabel(2, workNeedle)
+	engine := b.BuildEngine()
+	ctx := context.Background()
+	searchQuery := "label:Work Needle"
+
+	rows, err := engine.Aggregate(ctx, ViewLabels,
+		AggregateOptions{SearchQuery: searchQuery})
+	require.NoError(t, err)
+	assertAggregateCounts(t, rows, map[string]int64{"Work Needle": 1})
+
+	stats, err := engine.GetTotalStats(ctx, StatsOptions{
+		SearchQuery: searchQuery,
+		GroupBy:     ViewLabels,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.MessageCount)
+}
+
 // TestBuildSearchConditions_EscapedWildcards verifies that buildSearchConditions
 // escapes wildcards: ILIKE ESCAPE for TextTerms and operators.
 func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
@@ -2969,14 +3263,6 @@ func TestBuildSearchConditions_EscapedWildcards(t *testing.T) {
 			},
 			wantClauses: []string{"p.email_address ILIKE", "ESCAPE"},
 			wantInArgs:  []string{"test\\_user\\%"},
-		},
-		{
-			name: "to: with wildcards",
-			query: &search.Query{
-				ToAddrs: []string{"bob_smith%"},
-			},
-			wantClauses: []string{"email_address ILIKE", "ESCAPE"},
-			wantInArgs:  []string{"bob\\_smith\\%"},
 		},
 		{
 			name: "subject: with wildcards",
@@ -3251,14 +3537,15 @@ func TestDuckDBEngine_GetTotalStats_GroupByRecipients(t *testing.T) {
 	}
 	engine := newParquetEngine(t)
 
-	// Search "bob" with GroupBy=ViewRecipients should search recipient key columns.
-	// Bob is a recipient (to) on msgs 1,2,3 — searching "bob" should match those.
+	// Search "bob" with GroupBy=ViewRecipients should search message metadata and
+	// recipient key columns. Bob is the recipient on msgs 1,2,3 and the sender on
+	// msgs 4,5, so all five messages match the displayed aggregate scope.
 	stats, err := engine.GetTotalStats(context.Background(), StatsOptions{
 		SearchQuery: "bob",
 		GroupBy:     ViewRecipients,
 	})
 	require.NoError(t, err, "GetTotalStats")
-	assert.Equal(t, int64(3), stats.MessageCount, "recipient search 'bob'")
+	assert.Equal(t, int64(5), stats.MessageCount, "recipient search 'bob'")
 }
 
 func TestDuckDBEngine_GetTotalStats_GroupByLabels(t *testing.T) {
@@ -3290,6 +3577,111 @@ func TestDuckDBEngine_GetTotalStats_GroupByDefault(t *testing.T) {
 	})
 	require.NoError(t, err, "GetTotalStats")
 	assert.Equal(t, int64(3), stats.MessageCount, "sender search 'alice'")
+}
+
+func TestDuckDBEngine_GetTotalStats_GroupedSearchMatchesVisibleRows(t *testing.T) {
+	tests := []struct {
+		name             string
+		query            string
+		groupBy          ViewType
+		wantRow          string
+		wantRowCount     int64
+		wantMessageCount int64
+	}{
+		{
+			name:             "recipient view subject match",
+			query:            "follow",
+			groupBy:          ViewRecipients,
+			wantRow:          "bob@company.org",
+			wantRowCount:     1,
+			wantMessageCount: 1,
+		},
+		{
+			name:             "label view sender match",
+			query:            "alice",
+			groupBy:          ViewLabels,
+			wantRow:          "INBOX",
+			wantRowCount:     3,
+			wantMessageCount: 3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			engine := newParquetEngine(t)
+			ctx := context.Background()
+			opts := DefaultAggregateOptions()
+			opts.SearchQuery = tc.query
+
+			rows, err := engine.Aggregate(ctx, tc.groupBy, opts)
+			require.NoError(err, "Aggregate")
+			assert.Equal(tc.wantRowCount, requireAggregateRow(t, rows, tc.wantRow).Count)
+
+			stats, err := engine.GetTotalStats(ctx, StatsOptions{
+				SearchQuery: tc.query,
+				GroupBy:     tc.groupBy,
+			})
+			require.NoError(err, "GetTotalStats")
+			assert.Equal(tc.wantMessageCount, stats.MessageCount)
+		})
+	}
+}
+
+func TestDuckDBEngine_GetTotalStats_NameGroupSearchMatchesVisibleRows(t *testing.T) {
+	b := NewTestDataBuilder(t)
+	b.AddSource("test@gmail.com")
+	listSender := b.AddParticipant("list@example.org", "example.org", "List Sender")
+	phoneRecipient := b.AddPhoneParticipant("+15551234567", "")
+
+	senderNameMessage := b.AddMessage(MessageOpt{Subject: "Sender name", SizeEstimate: 1000})
+	b.AddFrom(senderNameMessage, listSender, "Alice via List")
+	recipientNameMessage := b.AddMessage(MessageOpt{Subject: "Recipient name", SizeEstimate: 2000})
+	b.AddTo(recipientNameMessage, phoneRecipient, "")
+	b.SetEmptyAttachments()
+	engine := b.BuildEngine()
+
+	tests := []struct {
+		name    string
+		query   string
+		groupBy ViewType
+		wantRow string
+	}{
+		{
+			name:    "sender per-message display name",
+			query:   "Alice via List",
+			groupBy: ViewSenderNames,
+			wantRow: "Alice via List",
+		},
+		{
+			name:    "recipient phone fallback",
+			query:   "+15551234567",
+			groupBy: ViewRecipientNames,
+			wantRow: "+15551234567",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			ctx := context.Background()
+			opts := DefaultAggregateOptions()
+			opts.SearchQuery = tc.query
+
+			rows, err := engine.Aggregate(ctx, tc.groupBy, opts)
+			require.NoError(err, "Aggregate")
+			assert.Equal(int64(1), requireAggregateRow(t, rows, tc.wantRow).Count)
+
+			stats, err := engine.GetTotalStats(ctx, StatsOptions{
+				SearchQuery: tc.query,
+				GroupBy:     tc.groupBy,
+			})
+			require.NoError(err, "GetTotalStats")
+			assert.Equal(int64(1), stats.MessageCount)
+		})
+	}
 }
 
 // TestBuildStatsSearchConditions_PlaceholderArgCount is a regression test for

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -62,6 +62,13 @@ type Engine interface {
 	// Search - full-text search using FTS5 (includes message body)
 	Search(ctx context.Context, query *search.Query, limit, offset int) ([]MessageSummary, error)
 
+	// SearchDeep runs body-aware search within a complete view filter.
+	SearchDeep(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error)
+
+	// SearchDeepWithStats returns deep-search messages, total count, and stats
+	// from the same complete view filter.
+	SearchDeepWithStats(ctx context.Context, query *search.Query, filter MessageFilter, limit, offset int) (*SearchFastResult, error)
+
 	// SearchFast searches message metadata only (no body text).
 	// This is much faster for large archives as it queries Parquet files directly.
 	// Free text searches subject, snippet, and sender/recipient metadata
@@ -100,6 +107,41 @@ type Engine interface {
 
 	// Close releases any resources held by the engine.
 	Close() error
+}
+
+// DeletionSearchMode selects the search predicate used while resolving an
+// exact, source-bound deletion target set.
+type DeletionSearchMode string
+
+const (
+	DeletionSearchFast      DeletionSearchMode = "fast"
+	DeletionSearchDeep      DeletionSearchMode = "deep"
+	DeletionSearchAggregate DeletionSearchMode = "aggregate"
+)
+
+// DeletionTargetSearchResolver resolves a filtered search and source deletion
+// eligibility in one backend query. Keeping this capability separate from
+// Engine lets callers fail closed when a backend cannot provide a stable
+// all-match snapshot.
+type DeletionTargetSearchResolver interface {
+	GetDeletionTargetsBySearch(
+		ctx context.Context,
+		searchQuery *search.Query,
+		filter MessageFilter,
+		mode DeletionSearchMode,
+	) ([]DeletionTarget, error)
+}
+
+// DeletionTargetAggregateSearchResolver resolves the exact message population
+// that contributed to one displayed aggregate row.
+type DeletionTargetAggregateSearchResolver interface {
+	GetDeletionTargetsByAggregateSearch(
+		ctx context.Context,
+		searchQuery string,
+		filter MessageFilter,
+		groupBy ViewType,
+		key string,
+	) ([]DeletionTarget, error)
 }
 
 // SemanticMessageSearcher is an optional engine capability for ranked

--- a/internal/query/models.go
+++ b/internal/query/models.go
@@ -311,7 +311,8 @@ func (f *MessageFilter) Clone() MessageFilter {
 		maps.Copy(clone.EmptyValueTargets, f.EmptyValueTargets)
 	}
 	if f.SourceIDs != nil {
-		clone.SourceIDs = append([]int64(nil), f.SourceIDs...)
+		clone.SourceIDs = make([]int64, len(f.SourceIDs))
+		copy(clone.SourceIDs, f.SourceIDs)
 	}
 	return clone
 }
@@ -364,11 +365,12 @@ type AccountInfo struct {
 
 // StatsOptions configures a stats query.
 type StatsOptions struct {
-	SourceID              *int64   // nil means all accounts
-	SourceIDs             []int64  // multi-source filter (collections)
-	WithAttachmentsOnly   bool     // only count messages with attachments
-	HideDeletedFromSource bool     // exclude messages where deleted_from_source_at IS NOT NULL
-	SearchQuery           string   // when set, stats reflect only messages matching this search
-	SearchScope           bool     // include all message types when SearchQuery has no explicit message_type
-	GroupBy               ViewType // when set, search filters on this view's key columns instead of subject+sender
+	Filter                *MessageFilter // complete message scope; nil preserves legacy top-level filtering
+	SourceID              *int64         // nil means all accounts
+	SourceIDs             []int64        // multi-source filter (collections)
+	WithAttachmentsOnly   bool           // only count messages with attachments
+	HideDeletedFromSource bool           // exclude messages where deleted_from_source_at IS NOT NULL
+	SearchQuery           string         // when set, stats reflect only messages matching this search
+	SearchScope           bool           // include all message types when SearchQuery has no explicit message_type
+	GroupBy               ViewType       // when set, search filters on this view's key columns instead of subject+sender
 }

--- a/internal/query/postgres.go
+++ b/internal/query/postgres.go
@@ -34,6 +34,8 @@ type pgEngine struct {
 }
 
 var _ MessageBodySearcher = (*pgEngine)(nil)
+var _ DeletionTargetSearchResolver = (*pgEngine)(nil)
+var _ DeletionTargetAggregateSearchResolver = (*pgEngine)(nil)
 
 type deletionTargetsByMessageIDsResolver interface {
 	GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int64) ([]DeletionTarget, error)
@@ -45,6 +47,33 @@ func (e *pgEngine) GetDeletionTargetsByMessageIDs(ctx context.Context, ids []int
 		return nil, ErrNotImplemented
 	}
 	return resolver.GetDeletionTargetsByMessageIDs(ctx, ids)
+}
+
+func (e *pgEngine) GetDeletionTargetsBySearch(
+	ctx context.Context,
+	searchQuery *search.Query,
+	filter MessageFilter,
+	mode DeletionSearchMode,
+) ([]DeletionTarget, error) {
+	resolver, ok := e.Engine.(DeletionTargetSearchResolver)
+	if !ok {
+		return nil, ErrNotImplemented
+	}
+	return resolver.GetDeletionTargetsBySearch(ctx, searchQuery, filter, mode)
+}
+
+func (e *pgEngine) GetDeletionTargetsByAggregateSearch(
+	ctx context.Context,
+	searchQuery string,
+	filter MessageFilter,
+	groupBy ViewType,
+	key string,
+) ([]DeletionTarget, error) {
+	resolver, ok := e.Engine.(DeletionTargetAggregateSearchResolver)
+	if !ok {
+		return nil, ErrNotImplemented
+	}
+	return resolver.GetDeletionTargetsByAggregateSearch(ctx, searchQuery, filter, groupBy, key)
 }
 
 // SearchMessageBodies forwards exact body-only search through the PostgreSQL

--- a/internal/query/postgres_test.go
+++ b/internal/query/postgres_test.go
@@ -39,6 +39,14 @@ func TestPostgresEngineHidesTextEngine(t *testing.T) {
 	require.True(t, ok, "SQLite engine should satisfy TextEngine")
 }
 
+func TestPostgresEngineExposesAggregateDeletionResolver(t *testing.T) {
+	requirements := require.New(t)
+	engine := NewPostgreSQLEngine(nil)
+
+	_, ok := engine.(DeletionTargetAggregateSearchResolver)
+	requirements.True(ok, "PostgreSQL engine must forward aggregate deletion resolution")
+}
+
 // TestPostgresTimeTruncExpression verifies the PostgreSQL time truncation expressions.
 func TestPostgresTimeTruncExpression(t *testing.T) {
 	d := PostgreSQLQueryDialect{}

--- a/internal/query/querytest/mock_engine.go
+++ b/internal/query/querytest/mock_engine.go
@@ -30,20 +30,24 @@ type MockEngine struct {
 	MessagesBySourceID map[string]*query.MessageDetail
 
 	// Optional overrides — set these to customise behavior per-test.
-	SearchFastFunc                     func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
-	SearchFunc                         func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
-	SearchMessageBodiesFunc            func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
-	GetMessageFunc                     func(context.Context, int64) (*query.MessageDetail, error)
-	GetMessageBySourceIDFunc           func(context.Context, string) (*query.MessageDetail, error)
-	GetTotalStatsFunc                  func(context.Context, query.StatsOptions) (*query.TotalStats, error)
-	ListMessagesFunc                   func(context.Context, query.MessageFilter) ([]query.MessageSummary, error)
-	SearchFastCountFunc                func(context.Context, *search.Query, query.MessageFilter) (int64, error)
-	GetDeletionTargetsByFilterFunc     func(context.Context, query.MessageFilter) ([]query.DeletionTarget, error)
-	GetDeletionTargetsByMessageIDsFunc func(context.Context, []int64) ([]query.DeletionTarget, error)
-	SearchByDomainsFunc                func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
-	SearchFastWithStatsFunc            func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
-	GetMessageRawFunc                  func(context.Context, int64) ([]byte, error)
-	GetMessageSummariesByIDsFunc       func(context.Context, []int64) ([]query.MessageSummary, error)
+	SearchFastFunc                          func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
+	SearchFunc                              func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+	SearchDeepFunc                          func(context.Context, *search.Query, query.MessageFilter, int, int) ([]query.MessageSummary, error)
+	SearchDeepWithStatsFunc                 func(context.Context, *search.Query, query.MessageFilter, int, int) (*query.SearchFastResult, error)
+	SearchMessageBodiesFunc                 func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error)
+	GetMessageFunc                          func(context.Context, int64) (*query.MessageDetail, error)
+	GetMessageBySourceIDFunc                func(context.Context, string) (*query.MessageDetail, error)
+	GetTotalStatsFunc                       func(context.Context, query.StatsOptions) (*query.TotalStats, error)
+	ListMessagesFunc                        func(context.Context, query.MessageFilter) ([]query.MessageSummary, error)
+	SearchFastCountFunc                     func(context.Context, *search.Query, query.MessageFilter) (int64, error)
+	GetDeletionTargetsByFilterFunc          func(context.Context, query.MessageFilter) ([]query.DeletionTarget, error)
+	GetDeletionTargetsByMessageIDsFunc      func(context.Context, []int64) ([]query.DeletionTarget, error)
+	GetDeletionTargetsBySearchFunc          func(context.Context, *search.Query, query.MessageFilter, query.DeletionSearchMode) ([]query.DeletionTarget, error)
+	GetDeletionTargetsByAggregateSearchFunc func(context.Context, string, query.MessageFilter, query.ViewType, string) ([]query.DeletionTarget, error)
+	SearchByDomainsFunc                     func(context.Context, []string, *time.Time, *time.Time, int, int) ([]query.MessageSummary, error)
+	SearchFastWithStatsFunc                 func(context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int) (*query.SearchFastResult, error)
+	GetMessageRawFunc                       func(context.Context, int64) ([]byte, error)
+	GetMessageSummariesByIDsFunc            func(context.Context, []int64) ([]query.MessageSummary, error)
 
 	RawMessages map[int64][]byte
 }
@@ -160,6 +164,35 @@ func (m *MockEngine) Search(ctx context.Context, q *search.Query, limit, offset 
 	return m.SearchResults, nil
 }
 
+func (m *MockEngine) SearchDeep(
+	ctx context.Context, q *search.Query, filter query.MessageFilter, limit, offset int,
+) ([]query.MessageSummary, error) {
+	if m.SearchDeepFunc != nil {
+		return m.SearchDeepFunc(ctx, q, filter, limit, offset)
+	}
+	if m.SearchFunc != nil {
+		return m.SearchFunc(ctx, q, limit, offset)
+	}
+	return m.SearchResults, nil
+}
+
+func (m *MockEngine) SearchDeepWithStats(
+	ctx context.Context, q *search.Query, filter query.MessageFilter, limit, offset int,
+) (*query.SearchFastResult, error) {
+	if m.SearchDeepWithStatsFunc != nil {
+		return m.SearchDeepWithStatsFunc(ctx, q, filter, limit, offset)
+	}
+	messages, err := m.SearchDeep(ctx, q, filter, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	return &query.SearchFastResult{
+		Messages:   messages,
+		TotalCount: int64(len(messages)),
+		Stats:      m.Stats,
+	}, nil
+}
+
 func (m *MockEngine) SearchMessageBodies(ctx context.Context, q *search.Query, limit, offset int) ([]query.MessageSummary, error) {
 	if m.SearchMessageBodiesFunc != nil {
 		return m.SearchMessageBodiesFunc(ctx, q, limit, offset)
@@ -198,6 +231,27 @@ func (m *MockEngine) GetDeletionTargetsByFilter(ctx context.Context, filter quer
 		return m.GetDeletionTargetsByFilterFunc(ctx, filter)
 	}
 	return m.defaultDeletionTargets(), nil
+}
+
+func (m *MockEngine) GetDeletionTargetsBySearch(
+	ctx context.Context,
+	searchQuery *search.Query,
+	filter query.MessageFilter,
+	mode query.DeletionSearchMode,
+) ([]query.DeletionTarget, error) {
+	if m.GetDeletionTargetsBySearchFunc != nil {
+		return m.GetDeletionTargetsBySearchFunc(ctx, searchQuery, filter, mode)
+	}
+	return nil, nil
+}
+
+func (m *MockEngine) GetDeletionTargetsByAggregateSearch(
+	ctx context.Context, searchQuery string, filter query.MessageFilter, groupBy query.ViewType, key string,
+) ([]query.DeletionTarget, error) {
+	if m.GetDeletionTargetsByAggregateSearchFunc != nil {
+		return m.GetDeletionTargetsByAggregateSearchFunc(ctx, searchQuery, filter, groupBy, key)
+	}
+	return nil, nil
 }
 
 func (m *MockEngine) defaultDeletionTargets() []query.DeletionTarget {

--- a/internal/query/shared.go
+++ b/internal/query/shared.go
@@ -73,6 +73,29 @@ func shouldDefaultStatsToEmail(opts StatsOptions) bool {
 	return !opts.SearchScope && !hasExplicitMessageTypeSearch(opts.SearchQuery)
 }
 
+// effectiveStatsFilter returns the complete message scope for a stats query.
+// Legacy top-level options remain authoritative so existing callers can add a
+// full filter without changing their source, attachment, or deletion scope.
+func effectiveStatsFilter(opts StatsOptions) *MessageFilter {
+	if opts.Filter == nil {
+		return nil
+	}
+	filter := opts.Filter.Clone()
+	if opts.SourceIDs != nil {
+		filter.SourceIDs = make([]int64, len(opts.SourceIDs))
+		copy(filter.SourceIDs, opts.SourceIDs)
+		filter.SourceID = nil
+	} else if opts.SourceID != nil {
+		filter.SourceID = opts.SourceID
+		filter.SourceIDs = nil
+	}
+	filter.WithAttachmentsOnly = filter.WithAttachmentsOnly || opts.WithAttachmentsOnly
+	filter.HideDeletedFromSource = filter.HideDeletedFromSource || opts.HideDeletedFromSource
+	filter.Pagination = Pagination{}
+	filter.Sorting = MessageSorting{}
+	return &filter
+}
+
 // participantNameExpr returns the SQL expression for a participant's display
 // label, falling back through display_name → phone_number → email_address.
 // Used by name-based aggregates and filters so phone-only participants

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -314,7 +314,7 @@ func sortClause(opts AggregateOptions) (string, error) {
 // buildFilterJoinsAndConditions builds JOIN and WHERE clauses from a MessageFilter.
 // Returns joinClauses (already joined by \n), conditions (slice), and args.
 // This is used for SubAggregate to apply drill-down filters before sub-grouping.
-func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, tableAlias string) (string, []string, []any) {
+func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter) (string, []string, []any) {
 	// Every structured filter below resolves through an EXISTS / NOT EXISTS
 	// correlated subquery, so this builder emits no JOIN of its own. The
 	// empty join slot is preserved in the return shape because callers
@@ -322,16 +322,13 @@ func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, table
 	var conditions []string
 	var args []any
 
-	prefix := ""
-	if tableAlias != "" {
-		prefix = tableAlias + "."
-	}
+	const prefix = "m."
 
 	// Include all messages (deleted messages shown with indicator in TUI)
 
 	// Always exclude rows soft-deleted by deduplicate; gate
 	// source-deleted on filter.HideDeletedFromSource via the helper.
-	conditions = append(conditions, store.LiveMessagesWhere(strings.TrimSuffix(prefix, "."), filter.HideDeletedFromSource))
+	conditions = append(conditions, store.LiveMessagesWhere("m", filter.HideDeletedFromSource))
 
 	conditions, args = appendSourceFilter(
 		conditions, args, prefix, filter.SourceID, filter.SourceIDs,
@@ -357,15 +354,13 @@ func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, table
 	}
 
 	if filter.MessageType != "" {
-		condition, conditionArgs := sqliteMessageTypeCondition(tableAlias, []string{filter.MessageType})
+		condition, conditionArgs := sqliteMessageTypeCondition("m", []string{filter.MessageType})
 		if condition != "" {
 			conditions = append(conditions, condition)
 			args = append(args, conditionArgs...)
 		}
 	}
-
-	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, tableAlias+".list_id", filter.ListID)
-
+	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, prefix+"list_id", filter.ListID)
 	// Sender + sender-name filters — check both message_recipients (email)
 	// and direct sender_id (WhatsApp/chat). Also checks phone_number for
 	// phone-based lookups (e.g., from:+447...). Uses EXISTS (not a plain
@@ -470,19 +465,19 @@ func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, table
 			JOIN participants p_filter_to ON p_filter_to.id = mr_filter_to.participant_id
 			WHERE mr_filter_to.message_id = m.id
 			  AND mr_filter_to.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p_filter_to.email_address = ?
+			  AND (p_filter_to.email_address = ? OR p_filter_to.phone_number = ?)
 			  AND %s = ?
 		)`, recipientNameExpr("mr_filter_to", "p_filter_to")))
-		args = append(args, filter.Recipient, filter.RecipientName)
+		args = append(args, filter.Recipient, filter.Recipient, filter.RecipientName)
 	} else if filter.Recipient != "" {
 		conditions = append(conditions, `EXISTS (
 			SELECT 1 FROM message_recipients mr_filter_to
 			JOIN participants p_filter_to ON p_filter_to.id = mr_filter_to.participant_id
 			WHERE mr_filter_to.message_id = m.id
 			  AND mr_filter_to.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p_filter_to.email_address = ?
+			  AND (p_filter_to.email_address = ? OR p_filter_to.phone_number = ?)
 		)`)
-		args = append(args, filter.Recipient)
+		args = append(args, filter.Recipient, filter.Recipient)
 	} else if filter.MatchesEmpty(ViewRecipients) {
 		conditions = append(conditions, `NOT EXISTS (
 			SELECT 1 FROM message_recipients mr_filter_to
@@ -521,9 +516,9 @@ func (e *SQLiteEngine) buildFilterJoinsAndConditions(filter MessageFilter, table
 			JOIN participants p_filter_from ON p_filter_from.id = mr_filter_from.participant_id
 			WHERE mr_filter_from.message_id = m.id
 			  AND mr_filter_from.recipient_type = 'from'
-			  AND p_filter_from.domain = ?
+			  AND LOWER(p_filter_from.domain) = ?
 		)`)
-		args = append(args, filter.Domain)
+		args = append(args, strings.ToLower(filter.Domain))
 	} else if filter.MatchesEmpty(ViewDomains) {
 		// A message has an "empty domain" only if it has no from-recipient with a
 		// non-empty domain. NOT EXISTS keeps the predicate message-scoped.
@@ -605,7 +600,7 @@ func (e *SQLiteEngine) SubAggregate(ctx context.Context, filter MessageFilter, g
 	if opts.HideDeletedFromSource {
 		filter.HideDeletedFromSource = true
 	}
-	filterJoins, filterConditions, args := e.buildFilterJoinsAndConditions(filter, "m")
+	filterJoins, filterConditions, args := e.buildFilterJoinsAndConditions(filter)
 
 	// Add opts-based conditions. Note: optsToFilterConditions emits
 	// its own LiveMessagesWhere clause (correct for the Aggregate
@@ -730,6 +725,19 @@ func (e *SQLiteEngine) buildAggregateSearchParts(
 		q.Labels = nil
 	}
 
+	keyCondition := aggregateSearchKeyCondition(e.dialect, groupBy, "mr", "p", "l")
+	if len(q.TextTerms) > 0 && keyCondition != "" {
+		textTerms := q.TextTerms
+		q.TextTerms = nil
+		searchConds, searchArgs, ftsJoin := e.buildSearchQueryParts(ctx, q)
+		conditions = append(conditions, searchConds...)
+		args = append(args, searchArgs...)
+		textConds, textArgs := e.buildAggregateTextSearchConditions(ctx, textTerms, keyCondition)
+		conditions = append(conditions, textConds...)
+		args = append(args, textArgs...)
+		return ftsJoin, conditions, args
+	}
+
 	searchConds, searchArgs, ftsJoin :=
 		e.buildSearchQueryParts(ctx, q)
 	conditions = append(conditions, searchConds...)
@@ -738,6 +746,134 @@ func (e *SQLiteEngine) buildAggregateSearchParts(
 	// The only join buildSearchQueryParts emits is the optional FTS join;
 	// all structured filters are EXISTS subqueries.
 	return ftsJoin, conditions, args
+}
+
+func aggregateSearchKeyCondition(
+	d Dialect, groupBy ViewType, recipientAlias, participantAlias, labelAlias string,
+) string {
+	switch groupBy {
+	case ViewSenderNames, ViewRecipientNames:
+		return metadataContainsExpression(d, recipientNameExpr(recipientAlias, participantAlias))
+	case ViewLabels:
+		return metadataContainsExpression(d, labelAlias+".name")
+	default:
+		return ""
+	}
+}
+
+func aggregateStatsSearchKeyCondition(groupBy ViewType, keyConditions string) string {
+	switch groupBy {
+	case ViewSenderNames:
+		return fmt.Sprintf(`EXISTS (
+			SELECT 1 FROM message_recipients mr_key
+			JOIN participants p_key ON p_key.id = mr_key.participant_id
+			WHERE mr_key.message_id = m.id
+			  AND mr_key.recipient_type = 'from'
+			  AND (%s)
+		)`, keyConditions)
+	case ViewRecipientNames:
+		return fmt.Sprintf(`EXISTS (
+			SELECT 1 FROM message_recipients mr_key
+			JOIN participants p_key ON p_key.id = mr_key.participant_id
+			WHERE mr_key.message_id = m.id
+			  AND mr_key.recipient_type IN ('to', 'cc', 'bcc')
+			  AND (%s)
+		)`, keyConditions)
+	case ViewLabels:
+		return fmt.Sprintf(`EXISTS (
+			SELECT 1 FROM message_labels ml_key
+			JOIN labels l_key ON l_key.id = ml_key.label_id
+			WHERE ml_key.message_id = m.id AND (%s)
+		)`, keyConditions)
+	default:
+		return ""
+	}
+}
+
+func (e *SQLiteEngine) buildAggregateTextSearchConditions(
+	ctx context.Context, terms []string, keyCondition string,
+) ([]string, []any) {
+	conditions := make([]string, 0, len(terms))
+	var args []any
+	hasFTS := e.hasFTSTable(ctx)
+	for _, term := range terms {
+		var textCondition string
+		var textArgs []any
+		if hasFTS {
+			expr, arg := e.dialect.BuildFTSTerm([]string{term})
+			if e.dialect.FTSJoin() != "" {
+				expr = "m.id IN (SELECT rowid FROM messages_fts WHERE " + expr + ")"
+			}
+			textCondition = expr
+			if arg != "" {
+				textArgs = append(textArgs, arg)
+			}
+		} else {
+			textCondition = `(LOWER(m.subject) LIKE LOWER(?) ESCAPE '\' OR LOWER(m.snippet) LIKE LOWER(?) ESCAPE '\')`
+			pattern := "%" + escapeSQLiteLike(term) + "%"
+			textArgs = append(textArgs, pattern, pattern)
+		}
+
+		conditions = append(conditions, "("+textCondition+" OR "+keyCondition+")")
+		args = append(args, textArgs...)
+		args = append(args, "%"+escapeSQLiteLike(term)+"%")
+	}
+	return conditions, args
+}
+
+func (e *SQLiteEngine) buildAggregateStatsSearchParts(
+	ctx context.Context, searchQuery string, groupBy ViewType,
+) ([]string, []any, string) {
+	q := search.Parse(searchQuery)
+	keyCondition := aggregateSearchKeyCondition(e.dialect, groupBy, "mr_key", "p_key", "l_key")
+	var conditions []string
+	var args []any
+	if groupBy == ViewLabels && (len(q.Labels) > 0 || len(q.TextTerms) > 0) {
+		var labelRowConditions []string
+		var labelRowArgs []any
+		labelParts := make([]string, 0, len(q.Labels))
+		for _, label := range q.Labels {
+			labelParts = append(labelParts, keyCondition)
+			labelRowArgs = append(labelRowArgs, "%"+escapeSQLiteLike(label)+"%")
+		}
+		if len(labelParts) > 0 {
+			labelRowConditions = append(labelRowConditions,
+				"("+strings.Join(labelParts, " OR ")+")")
+		}
+		q.Labels = nil
+
+		if len(q.TextTerms) > 0 {
+			textConditions, textArgs := e.buildAggregateTextSearchConditions(ctx, q.TextTerms, keyCondition)
+			labelRowConditions = append(labelRowConditions, textConditions...)
+			labelRowArgs = append(labelRowArgs, textArgs...)
+			q.TextTerms = nil
+		}
+
+		conditions = append(conditions,
+			aggregateStatsSearchKeyCondition(groupBy, strings.Join(labelRowConditions, " AND ")))
+		args = append(args, labelRowArgs...)
+		searchConditions, searchArgs, ftsJoin := e.buildSearchQueryParts(ctx, q)
+		conditions = append(conditions, searchConditions...)
+		args = append(args, searchArgs...)
+		return conditions, args, ftsJoin
+	}
+	if len(q.TextTerms) == 0 || keyCondition == "" {
+		searchConditions, searchArgs, ftsJoin := e.buildSearchQueryParts(ctx, q)
+		conditions = append(conditions, searchConditions...)
+		args = append(args, searchArgs...)
+		return conditions, args, ftsJoin
+	}
+
+	textTerms := q.TextTerms
+	q.TextTerms = nil
+	searchConditions, searchArgs, ftsJoin := e.buildSearchQueryParts(ctx, q)
+	conditions = append(conditions, searchConditions...)
+	args = append(args, searchArgs...)
+	textConditions, textArgs := e.buildAggregateTextSearchConditions(ctx, textTerms, keyCondition)
+	conditions = append(conditions,
+		aggregateStatsSearchKeyCondition(groupBy, strings.Join(textConditions, " AND ")))
+	args = append(args, textArgs...)
+	return conditions, args, ftsJoin
 }
 
 // executeAggregate is the shared implementation for Aggregate and SubAggregate.
@@ -794,7 +930,7 @@ func (e *SQLiteEngine) executeAggregateQuery(ctx context.Context, query string, 
 
 // ListMessages retrieves messages matching the filter.
 func (e *SQLiteEngine) ListMessages(ctx context.Context, filter MessageFilter) ([]MessageSummary, error) {
-	filterJoins, conditions, args := e.buildFilterJoinsAndConditions(filter, "m")
+	filterJoins, conditions, args := e.buildFilterJoinsAndConditions(filter)
 
 	// Build ORDER BY with validation. Every structured filter in
 	// buildFilterJoinsAndConditions resolves through an EXISTS / NOT EXISTS
@@ -1148,27 +1284,34 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 	var searchArgs []any
 	var searchFTSJoin string
 	if opts.SearchQuery != "" {
-		q := search.Parse(opts.SearchQuery)
-		searchConditions, searchArgs, searchFTSJoin = e.buildSearchQueryParts(ctx, q)
+		searchConditions, searchArgs, searchFTSJoin =
+			e.buildAggregateStatsSearchParts(ctx, opts.SearchQuery, opts.GroupBy)
 	}
 
 	// Build WHERE clause for messages — always use m. prefix since we alias
 	// the messages table for compatibility with search joins.
 	var conditions []string
 	var args []any
-	// Generic analytics default to email; search-result stats opt into the
-	// broader search scope. NULL and '' are legacy email rows.
-	// Exclude rows soft-deleted by deduplicate; gate source-deleted on
-	// opts.HideDeletedFromSource via the helper.
-	if shouldDefaultStatsToEmail(opts) {
-		conditions = append(conditions, emailOnlyFilterM)
-	}
-	conditions = append(conditions, store.LiveMessagesWhere("m", opts.HideDeletedFromSource))
-	conditions, args = appendSourceFilter(
-		conditions, args, "m.", opts.SourceID, opts.SourceIDs,
-	)
-	if opts.WithAttachmentsOnly {
-		conditions = append(conditions, e.dialect.BoolTrueExpr("m.has_attachments"))
+	if filter := effectiveStatsFilter(opts); filter != nil {
+		_, conditions, args = e.buildFilterJoinsAndConditions(*filter)
+		if filter.MessageType == "" && shouldDefaultStatsToEmail(opts) {
+			conditions = append(conditions, emailOnlyFilterM)
+		}
+	} else {
+		// Generic analytics default to email; search-result stats opt into the
+		// broader search scope. NULL and '' are legacy email rows.
+		// Exclude rows soft-deleted by deduplicate; gate source-deleted on
+		// opts.HideDeletedFromSource via the helper.
+		if shouldDefaultStatsToEmail(opts) {
+			conditions = append(conditions, emailOnlyFilterM)
+		}
+		conditions = append(conditions, store.LiveMessagesWhere("m", opts.HideDeletedFromSource))
+		conditions, args = appendSourceFilter(
+			conditions, args, "m.", opts.SourceID, opts.SourceIDs,
+		)
+		if opts.WithAttachmentsOnly {
+			conditions = append(conditions, e.dialect.BoolTrueExpr("m.has_attachments"))
+		}
 	}
 	// Merge search conditions
 	conditions = append(conditions, searchConditions...)
@@ -1285,7 +1428,8 @@ func (e *SQLiteEngine) GetTotalStats(ctx context.Context, opts StatsOptions) (*T
 }
 
 func statsUseMatchingPopulation(opts StatsOptions) bool {
-	return opts.SearchScope ||
+	return opts.Filter != nil ||
+		opts.SearchScope ||
 		opts.SourceID != nil ||
 		opts.SourceIDs != nil ||
 		opts.WithAttachmentsOnly ||
@@ -1312,6 +1456,14 @@ func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 	// Always pass true: this surface feeds remote-deletion staging and
 	// must never honor an opt-in.
 	conditions = append(conditions, store.LiveMessagesWhere("m", true))
+	if filter.HasEmptyTargets() {
+		_, emptyConditions, emptyArgs := e.buildFilterJoinsAndConditions(MessageFilter{
+			EmptyValueTargets:     filter.EmptyValueTargets,
+			HideDeletedFromSource: true,
+		})
+		conditions = append(conditions, emptyConditions...)
+		args = append(args, emptyArgs...)
+	}
 
 	conditions, args = appendSourceFilter(conditions, args, "m.", filter.SourceID, filter.SourceIDs)
 	if filter.ConversationID != nil {
@@ -1326,6 +1478,9 @@ func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 		}
 	}
 	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, "m.list_id", filter.ListID)
+	if filter.WithAttachmentsOnly {
+		conditions = append(conditions, e.dialect.BoolTrueExpr("m.has_attachments"))
+	}
 
 	// Scope to Gmail sources only — this function is used for
 	// Gmail-specific deletion/staging workflows and must not return
@@ -1395,19 +1550,19 @@ func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 			JOIN participants p_to ON p_to.id = mr_to.participant_id
 			WHERE mr_to.message_id = m.id
 			  AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p_to.email_address = ?
+			  AND (p_to.email_address = ? OR p_to.phone_number = ?)
 			  AND %s = ?
 		)`, recipientNameExpr("mr_to", "p_to")))
-		args = append(args, filter.Recipient, filter.RecipientName)
+		args = append(args, filter.Recipient, filter.Recipient, filter.RecipientName)
 	} else if filter.Recipient != "" {
 		conditions = append(conditions, `EXISTS (
 			SELECT 1 FROM message_recipients mr_to
 			JOIN participants p_to ON p_to.id = mr_to.participant_id
 			WHERE mr_to.message_id = m.id
 			  AND mr_to.recipient_type IN ('to', 'cc', 'bcc')
-			  AND p_to.email_address = ?
+			  AND (p_to.email_address = ? OR p_to.phone_number = ?)
 		)`)
-		args = append(args, filter.Recipient)
+		args = append(args, filter.Recipient, filter.Recipient)
 	} else if filter.RecipientName != "" {
 		conditions = append(conditions, fmt.Sprintf(`EXISTS (
 			SELECT 1 FROM message_recipients mr_to
@@ -1424,9 +1579,9 @@ func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 			SELECT 1 FROM message_recipients mr_from
 			JOIN participants p_from ON p_from.id = mr_from.participant_id
 			WHERE mr_from.message_id = m.id AND mr_from.recipient_type = 'from'
-			  AND p_from.domain = ?
+			  AND LOWER(p_from.domain) = ?
 		)`)
-		args = append(args, filter.Domain)
+		args = append(args, strings.ToLower(filter.Domain))
 	}
 
 	if filter.Label != "" {
@@ -1499,6 +1654,132 @@ func (e *SQLiteEngine) GetDeletionTargetsByFilter(ctx context.Context, filter Me
 	}
 	defer func() { _ = rows.Close() }()
 
+	return collectDeletionTargets(rows)
+}
+
+// GetDeletionTargetsBySearch resolves one exact filtered search population in
+// a single database query. This avoids LIMIT/OFFSET drift while a live archive
+// is receiving new messages.
+func (e *SQLiteEngine) GetDeletionTargetsBySearch(
+	ctx context.Context,
+	searchQuery *search.Query,
+	filter MessageFilter,
+	mode DeletionSearchMode,
+) ([]DeletionTarget, error) {
+	if searchQuery == nil {
+		return nil, errors.New("deletion search query is required")
+	}
+	if err := searchQuery.Err(); err != nil {
+		return nil, fmt.Errorf("invalid search query: %w", err)
+	}
+
+	filter = filter.Clone()
+	filter.Pagination = Pagination{}
+	filter.HideDeletedFromSource = true
+
+	searchScope := *searchQuery
+	searchScope.HideDeleted = true
+	searchScope.DeletionScope = search.DeletionScopeActive
+	var searchConditions []string
+	var searchArgs []any
+	var searchJoin string
+	switch mode {
+	case DeletionSearchFast:
+		// Reuse the visible fast-search composition so view filters remain
+		// exact, independent predicates rather than becoming fuzzy query
+		// operators. This also covers cc/bcc recipients consistently.
+		searchConditions, searchArgs, searchJoin = e.buildFilteredMetadataSearchQueryParts(ctx, &searchScope, filter)
+	case DeletionSearchDeep:
+		searchConditions, searchArgs, searchJoin = e.buildFilteredDeepSearchQueryParts(ctx, &searchScope, filter)
+	default:
+		return nil, fmt.Errorf("unsupported deletion search mode %q", mode)
+	}
+
+	queryText := fmt.Sprintf(`
+		SELECT m.id, m.source_id, s_gmail.source_type, s_gmail.identifier,
+		       m.source_message_id
+		FROM messages m
+		JOIN sources s_gmail ON s_gmail.id = m.source_id AND s_gmail.source_type = 'gmail'
+		%s
+		WHERE %s
+		ORDER BY m.sent_at DESC, m.id DESC
+	`, searchJoin, strings.Join(searchConditions, " AND "))
+
+	rows, err := e.queryContext(ctx, queryText, searchArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("get deletion targets by search: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return collectDeletionTargets(rows)
+}
+
+// GetDeletionTargetsByAggregateSearch resolves the message set that produced
+// one aggregate row, including the aggregate view's own search semantics.
+func (e *SQLiteEngine) GetDeletionTargetsByAggregateSearch(
+	ctx context.Context,
+	searchQuery string,
+	filter MessageFilter,
+	groupBy ViewType,
+	key string,
+) ([]DeletionTarget, error) {
+	parsed := search.Parse(searchQuery)
+	if err := parsed.Err(); err != nil {
+		return nil, fmt.Errorf("invalid aggregate search query: %w", err)
+	}
+
+	filter = filter.Clone()
+	filter.Pagination = Pagination{}
+	filter.HideDeletedFromSource = true
+	filterJoins, conditions, args := e.buildFilterJoinsAndConditions(filter)
+	timeGranularity := filter.TimeRange.Granularity
+	if groupBy == ViewTime {
+		timeGranularity = inferTimeGranularity(timeGranularity, key)
+	}
+	dim, err := aggDimensionForView(e.dialect, groupBy, timeGranularity)
+	if err != nil {
+		return nil, err
+	}
+	searchJoin, searchConditions, searchArgs := e.buildAggregateSearchParts(ctx, searchQuery, groupBy)
+	conditions = append(conditions, searchConditions...)
+	args = append(args, searchArgs...)
+	if dim.whereExpr != "" {
+		conditions = append(conditions, dim.whereExpr)
+	}
+	if groupBy == ViewLists {
+		conditions, args = appendExactListIDCondition(e.dialect, conditions, args, "m.list_id", key)
+	} else {
+		conditions = append(conditions, fmt.Sprintf("COALESCE(%s, '') = ?", dim.keyExpr))
+		args = append(args, key)
+	}
+
+	joins := dim.joins
+	if filterJoins != "" {
+		joins += "\n" + filterJoins
+	}
+	if searchJoin != "" {
+		joins += "\n" + searchJoin
+	}
+	queryText := fmt.Sprintf(`
+		SELECT m.id, m.source_id, s_gmail.source_type, s_gmail.identifier,
+		       m.source_message_id
+		FROM messages m
+		JOIN sources s_gmail ON s_gmail.id = m.source_id AND s_gmail.source_type = 'gmail'
+		WHERE m.id IN (
+			SELECT m.id
+			FROM messages m
+			%s
+			WHERE %s
+			GROUP BY m.id
+		)
+		ORDER BY m.sent_at DESC, m.id DESC
+	`, joins, strings.Join(conditions, " AND "))
+
+	rows, err := e.queryContext(ctx, queryText, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get deletion targets by aggregate search: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
 	return collectDeletionTargets(rows)
 }
 
@@ -1625,56 +1906,9 @@ func (e *SQLiteEngine) buildSearchQueryPartsWithVisibility(ctx context.Context, 
 		)`, strings.Join(fromParts, " OR ")))
 	}
 
-	// To filter - EXISTS to avoid join multiplication. The column side
-	// is wrapped in LOWER(); lowercase the bound args Go-side so the
-	// IN list also matches stored case-folded values (mirrors the
-	// From-filter convention above).
-	if len(q.ToAddrs) > 0 {
-		placeholders := make([]string, len(q.ToAddrs))
-		for i, addr := range q.ToAddrs {
-			placeholders[i] = "?"
-			args = append(args, strings.ToLower(addr))
-		}
-		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-			SELECT 1 FROM message_recipients mr_to
-			JOIN participants p_to ON p_to.id = mr_to.participant_id
-			WHERE mr_to.message_id = m.id
-			  AND mr_to.recipient_type = 'to'
-			  AND LOWER(p_to.email_address) IN (%s)
-		)`, strings.Join(placeholders, ",")))
-	}
-
-	// CC filter - EXISTS to avoid join multiplication
-	if len(q.CcAddrs) > 0 {
-		placeholders := make([]string, len(q.CcAddrs))
-		for i, addr := range q.CcAddrs {
-			placeholders[i] = "?"
-			args = append(args, strings.ToLower(addr))
-		}
-		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-			SELECT 1 FROM message_recipients mr_cc
-			JOIN participants p_cc ON p_cc.id = mr_cc.participant_id
-			WHERE mr_cc.message_id = m.id
-			  AND mr_cc.recipient_type = 'cc'
-			  AND LOWER(p_cc.email_address) IN (%s)
-		)`, strings.Join(placeholders, ",")))
-	}
-
-	// BCC filter - EXISTS to avoid join multiplication
-	if len(q.BccAddrs) > 0 {
-		placeholders := make([]string, len(q.BccAddrs))
-		for i, addr := range q.BccAddrs {
-			placeholders[i] = "?"
-			args = append(args, strings.ToLower(addr))
-		}
-		conditions = append(conditions, fmt.Sprintf(`EXISTS (
-			SELECT 1 FROM message_recipients mr_bcc
-			JOIN participants p_bcc ON p_bcc.id = mr_bcc.participant_id
-			WHERE mr_bcc.message_id = m.id
-			  AND mr_bcc.recipient_type = 'bcc'
-			  AND LOWER(p_bcc.email_address) IN (%s)
-		)`, strings.Join(placeholders, ",")))
-	}
+	conditions, args = appendSQLiteRecipientSearchCondition(conditions, args, q.ToAddrs, "to")
+	conditions, args = appendSQLiteRecipientSearchCondition(conditions, args, q.CcAddrs, "cc")
+	conditions, args = appendSQLiteRecipientSearchCondition(conditions, args, q.BccAddrs, "bcc")
 
 	// Label filter - case-insensitive substring match using EXISTS
 	// so each label term can match a different row in message_labels.
@@ -1775,6 +2009,40 @@ func (e *SQLiteEngine) buildSearchQueryPartsWithVisibility(ctx context.Context, 
 	)
 
 	return conditions, args, ftsJoin
+}
+
+func appendSQLiteRecipientSearchCondition(
+	conditions []string,
+	args []any,
+	addresses []string,
+	recipientType string,
+) ([]string, []any) {
+	if len(addresses) == 0 {
+		return conditions, args
+	}
+
+	addressParts := make([]string, 0, len(addresses))
+	recipientArgs := []any{recipientType}
+	for _, address := range addresses {
+		address = strings.ToLower(address)
+		if strings.HasPrefix(address, "@") {
+			addressParts = append(addressParts, `LOWER(p_recipient.email_address) LIKE ? ESCAPE '\'`)
+			recipientArgs = append(recipientArgs, "%"+escapeSQLiteLike(address))
+		} else {
+			addressParts = append(addressParts,
+				"(LOWER(p_recipient.email_address) = ? OR p_recipient.phone_number = ?)")
+			recipientArgs = append(recipientArgs, address, address)
+		}
+	}
+	conditions = append(conditions, fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM message_recipients mr_recipient
+		JOIN participants p_recipient ON p_recipient.id = mr_recipient.participant_id
+		WHERE mr_recipient.message_id = m.id
+		  AND mr_recipient.recipient_type = ?
+		  AND (%s)
+	)`, strings.Join(addressParts, " OR ")))
+	args = append(args, recipientArgs...)
+	return conditions, args
 }
 
 func (e *SQLiteEngine) Search(ctx context.Context, q *search.Query, limit, offset int) ([]MessageSummary, error) {
@@ -1887,12 +2155,68 @@ func (e *SQLiteEngine) buildMetadataSearchQueryParts(ctx context.Context, q *sea
 	return conditions, args, ftsJoin
 }
 
+// buildFilteredMetadataSearchQueryParts keeps view filters as exact,
+// independent predicates while user-entered operators retain their fuzzy
+// search semantics. DuckDB uses the same composition for visible fast results.
+func (e *SQLiteEngine) buildFilteredMetadataSearchQueryParts(
+	ctx context.Context, q *search.Query, filter MessageFilter,
+) ([]string, []any, string) {
+	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, q)
+	_, filterConditions, filterArgs := e.buildFilterJoinsAndConditions(filter)
+	conditions = append(filterConditions, conditions...)
+	args = append(filterArgs, args...)
+	return conditions, args, ftsJoin
+}
+
+// buildFilteredDeepSearchQueryParts keeps view filters as exact, independent
+// predicates while user-entered operators retain their search semantics.
+// Deletion resolution uses this same composition so Deep results and
+// uppercase-D stage the same visible population.
+func (e *SQLiteEngine) buildFilteredDeepSearchQueryParts(
+	ctx context.Context, searchQuery *search.Query, filter MessageFilter,
+) ([]string, []any, string) {
+	filter = filter.Clone()
+	filter.Pagination = Pagination{}
+	_, filterConditions, filterArgs := e.buildFilterJoinsAndConditions(filter)
+	searchConditions, searchArgs, searchJoin := e.buildSearchQueryParts(ctx, searchQuery)
+	searchConditions = append(filterConditions, searchConditions...)
+	searchArgs = append(filterArgs, searchArgs...)
+	return searchConditions, searchArgs, searchJoin
+}
+
+// SearchDeep runs body-aware search within the complete view filter.
+func (e *SQLiteEngine) SearchDeep(
+	ctx context.Context, searchQuery *search.Query, filter MessageFilter, limit, offset int,
+) ([]MessageSummary, error) {
+	conditions, args, ftsJoin := e.buildFilteredDeepSearchQueryParts(ctx, searchQuery, filter)
+	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
+}
+
+// SearchDeepWithStats builds the body-aware predicate once and reuses it for
+// messages, count, and stats so all three describe the same filtered set.
+func (e *SQLiteEngine) SearchDeepWithStats(
+	ctx context.Context, searchQuery *search.Query, filter MessageFilter, limit, offset int,
+) (*SearchFastResult, error) {
+	conditions, args, ftsJoin := e.buildFilteredDeepSearchQueryParts(ctx, searchQuery, filter)
+	results, err := e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	count, countErr := e.executeSearchCount(ctx, conditions, args, ftsJoin)
+	if countErr != nil {
+		log.Printf("warning: deep search count failed (using -1): %v", countErr)
+		count = -1
+	}
+	stats, _ := e.getSearchMatchStats(ctx, conditions, args, ftsJoin)
+
+	return &SearchFastResult{Messages: results, TotalCount: count, Stats: stats}, nil
+}
+
 // SearchFast searches message metadata and merges MessageFilter context into
 // the query (drill-down filters, hide-deleted, etc.).
 func (e *SQLiteEngine) SearchFast(ctx context.Context, q *search.Query, filter MessageFilter, limit, offset int) ([]MessageSummary, error) {
-	mergedQuery := MergeFilterIntoQuery(q, filter)
-	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
-	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, "m.list_id", filter.ListID)
+	conditions, args, ftsJoin := e.buildFilteredMetadataSearchQueryParts(ctx, q, filter)
 	return e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 }
 
@@ -2172,9 +2496,7 @@ func ParseTimePeriodBounds(period string) (after, before time.Time, ok bool) {
 // SearchFastCount returns the total count of messages matching a search query.
 // Uses the same query logic as SearchFast to ensure consistent counts.
 func (e *SQLiteEngine) SearchFastCount(ctx context.Context, q *search.Query, filter MessageFilter) (int64, error) {
-	mergedQuery := MergeFilterIntoQuery(q, filter)
-	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
-	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, "m.list_id", filter.ListID)
+	conditions, args, ftsJoin := e.buildFilteredMetadataSearchQueryParts(ctx, q, filter)
 	return e.executeSearchCount(ctx, conditions, args, ftsJoin)
 }
 
@@ -2270,9 +2592,7 @@ func (e *SQLiteEngine) getSearchMatchStats(ctx context.Context, conditions []str
 // for messages, count, and stats so all three describe the same match set.
 func (e *SQLiteEngine) SearchFastWithStats(ctx context.Context, q *search.Query, queryStr string,
 	filter MessageFilter, statsGroupBy ViewType, limit, offset int) (*SearchFastResult, error) {
-	mergedQuery := MergeFilterIntoQuery(q, filter)
-	conditions, args, ftsJoin := e.buildMetadataSearchQueryParts(ctx, mergedQuery)
-	conditions, args = appendExactListIDCondition(e.dialect, conditions, args, "m.list_id", filter.ListID)
+	conditions, args, ftsJoin := e.buildFilteredMetadataSearchQueryParts(ctx, q, filter)
 	results, err := e.executeSearchQuery(ctx, conditions, args, ftsJoin, limit, offset)
 	if err != nil {
 		return nil, err

--- a/internal/query/sqlite_aggregate_test.go
+++ b/internal/query/sqlite_aggregate_test.go
@@ -787,6 +787,48 @@ func TestAggregateByLabel_WithSearchQuery(t *testing.T) {
 	}
 }
 
+func TestAggregateLabelSearchStatsMatchRepeatedFilterRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	searchQuery := "label:work label:important"
+
+	rows, err := env.Engine.Aggregate(env.Ctx, ViewLabels,
+		AggregateOptions{SearchQuery: searchQuery})
+	require.NoError(err)
+	assertAggRows(t, rows, []aggExpectation{{"Work", 2}, {"IMPORTANT", 1}})
+
+	stats, err := env.Engine.GetTotalStats(env.Ctx, StatsOptions{
+		SearchQuery: searchQuery,
+		SearchScope: true,
+		GroupBy:     ViewLabels,
+	})
+	require.NoError(err)
+	assert.Equal(int64(3), stats.MessageCount)
+}
+
+func TestAggregateLabelSearchStatsCorrelateFilterAndText(t *testing.T) {
+	env := newTestEnv(t)
+	needle := env.AddLabel(dbtest.LabelOpts{Name: "Needle"})
+	env.AddMessageLabel(1, needle)
+	workNeedle := env.AddLabel(dbtest.LabelOpts{Name: "Work Needle"})
+	env.AddMessageLabel(2, workNeedle)
+	searchQuery := "label:Work Needle"
+
+	rows, err := env.Engine.Aggregate(env.Ctx, ViewLabels,
+		AggregateOptions{SearchQuery: searchQuery})
+	require.NoError(t, err)
+	assertAggRows(t, rows, []aggExpectation{{"Work Needle", 1}})
+
+	stats, err := env.Engine.GetTotalStats(env.Ctx, StatsOptions{
+		SearchQuery: searchQuery,
+		SearchScope: true,
+		GroupBy:     ViewLabels,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.MessageCount)
+}
+
 // TestSubAggregate_WithSearchQuery verifies that SubAggregate applies
 // SearchQuery to filter results (not silently dropped).
 func TestSubAggregate_WithSearchQuery(t *testing.T) {
@@ -803,6 +845,75 @@ func TestSubAggregate_WithSearchQuery(t *testing.T) {
 	// Should return exactly the "Work" label, not all labels for alice
 	require.Len(t, rows, 1, "expected 1 label row")
 	assert.Equal(t, "Work", rows[0].Key)
+}
+
+func TestAggregateSearchMatchesDisplayedKeysAndStats(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantKey string
+		view    ViewType
+		setup   func(*testEnv)
+	}{
+		{
+			name:    "label",
+			query:   "LabelOnly Needle",
+			wantKey: "LabelOnly Needle",
+			view:    ViewLabels,
+			setup: func(env *testEnv) {
+				labelID := env.AddLabel(dbtest.LabelOpts{Name: "LabelOnly Needle"})
+				env.AddMessageLabel(1, labelID)
+				env.AddMessageLabel(2, env.AddLabel(dbtest.LabelOpts{Name: "LabelOnly"}))
+				env.AddMessageLabel(2, env.AddLabel(dbtest.LabelOpts{Name: "Needle"}))
+			},
+		},
+		{
+			name:    "sender name",
+			query:   "SenderNameOnlyNeedle",
+			wantKey: "SenderNameOnlyNeedle",
+			view:    ViewSenderNames,
+			setup: func(env *testEnv) {
+				env.SetFromName(1, "SenderNameOnlyNeedle")
+			},
+		},
+		{
+			name:    "recipient name",
+			query:   "RecipientNameOnlyNeedle",
+			wantKey: "RecipientNameOnlyNeedle",
+			view:    ViewRecipientNames,
+			setup: func(env *testEnv) {
+				env.SetRecipientName(1, env.MustLookupParticipant("bob@company.org"), "RecipientNameOnlyNeedle")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+
+			env := newTestEnv(t)
+			env.EnableFTS()
+			tt.setup(env)
+			filter := MessageFilter{MessageType: messageTypeEmail}
+
+			rows, err := env.Engine.SubAggregate(env.Ctx, filter, tt.view,
+				AggregateOptions{SearchQuery: tt.query})
+			require.NoError(err)
+			require.Len(rows, 1)
+			assert.Equal(tt.wantKey, rows[0].Key)
+			assert.Equal(int64(1), rows[0].Count)
+
+			stats, err := env.Engine.GetTotalStats(env.Ctx, StatsOptions{
+				Filter:      &filter,
+				SearchQuery: tt.query,
+				SearchScope: true,
+				GroupBy:     tt.view,
+			})
+			require.NoError(err)
+			assert.Equal(int64(1), stats.MessageCount)
+		})
+	}
 }
 
 // TestEscapeSQLiteLike verifies that wildcard characters are escaped

--- a/internal/query/sqlite_crud_test.go
+++ b/internal/query/sqlite_crud_test.go
@@ -40,8 +40,9 @@ func TestMessageFilter_Clone(t *testing.T) {
 	assert := assert.New(t)
 	// Create original filter with EmptyValueTargets
 	original := MessageFilter{
-		Sender: "alice@example.com",
-		Label:  "INBOX",
+		Sender:    "alice@example.com",
+		Label:     "INBOX",
+		SourceIDs: []int64{},
 		EmptyValueTargets: map[ViewType]bool{
 			ViewSenders: true,
 		},
@@ -53,6 +54,7 @@ func TestMessageFilter_Clone(t *testing.T) {
 	// Verify scalar fields are copied
 	assert.Equal("alice@example.com", clone.Sender)
 	assert.Equal("INBOX", clone.Label)
+	assert.NotNil(clone.SourceIDs, "an explicit empty source scope must stay distinct from no scope")
 
 	// Verify EmptyValueTargets is deeply copied
 	assert.True(clone.MatchesEmpty(ViewSenders), "clone should have ViewSenders in EmptyValueTargets")
@@ -738,6 +740,19 @@ func TestGetDeletionTargetsByFilter_Label(t *testing.T) {
 	}
 }
 
+func TestGetDeletionTargetsByFilter_DomainIsCaseInsensitive(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	env := newTestEnv(t)
+
+	ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(
+		env.Ctx, MessageFilter{Domain: "EXAMPLE.COM"},
+	))
+
+	requirements.NoError(err)
+	assertions.ElementsMatch([]string{"msg1", "msg2", "msg3"}, ids)
+}
+
 func TestGetDeletionTargetsByFilter_ConversationID(t *testing.T) {
 	env := newTestEnv(t)
 	_, err := env.DB.Exec(`
@@ -791,6 +806,338 @@ func TestSQLiteEngine_ListIDScopesFastSearchAndDeletionLiterally(t *testing.T) {
 	targets, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, filter))
 	require.NoError(err)
 	assert.ElementsMatch([]string{"msg1", "msg2"}, targets)
+}
+
+func TestSQLiteEngine_GetDeletionTargetsByAggregateSearch_List(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	listID := "<dev@example.test>"
+	_, err := env.DB.Exec(`UPDATE messages SET list_id = ? WHERE id IN (1, 2)`, listID)
+	require.NoError(err)
+
+	targets, err := env.Engine.GetDeletionTargetsByAggregateSearch(
+		env.Ctx, "Hello", MessageFilter{MessageType: messageTypeEmail}, ViewLists, listID,
+	)
+	require.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
+	assert.ElementsMatch([]string{"msg1", "msg2"}, ids)
+}
+
+func TestSQLiteEngine_GetDeletionTargetsByAggregateSearch_TimeGranularity(t *testing.T) {
+	env := newTestEnv(t)
+	tests := []struct {
+		name        string
+		period      string
+		granularity TimeGranularity
+		want        []string
+	}{
+		{name: "month inferred from key", period: "2024-01", want: []string{"msg1", "msg2"}},
+		{name: "explicit year", period: "2024", granularity: TimeYear, want: []string{"msg1", "msg2"}},
+		{name: "explicit day", period: "2024-01-15", granularity: TimeDay, want: []string{"msg1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, err := env.Engine.GetDeletionTargetsByAggregateSearch(
+				env.Ctx,
+				"Hello",
+				MessageFilter{
+					MessageType: messageTypeEmail,
+					TimeRange:   TimeRange{Period: tt.period, Granularity: tt.granularity},
+				},
+				ViewTime,
+				tt.period,
+			)
+			require.NoError(t, err)
+			ids, err := deletionTargetSourceMessageIDs(targets, nil)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, ids)
+		})
+	}
+}
+
+func TestGetDeletionTargetsByFilter_EmptyBuckets(t *testing.T) {
+	env := newTestEnvWithEmptyBuckets(t)
+
+	tests := []struct {
+		name string
+		view ViewType
+		want []string
+	}{
+		{name: "sender", view: ViewSenders, want: []string{"msg100"}},
+		{name: "sender name", view: ViewSenderNames, want: []string{"msg100"}},
+		{name: "recipient", view: ViewRecipients, want: []string{"msg100", "msg101"}},
+		{name: "recipient name", view: ViewRecipientNames, want: []string{"msg100", "msg101"}},
+		{name: "domain", view: ViewDomains, want: []string{"msg100", "msg102"}},
+		{name: "label", view: ViewLabels, want: []string{"msg100", "msg101", "msg102", "msg103"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, err := env.Engine.GetDeletionTargetsByFilter(env.Ctx, MessageFilter{
+				EmptyValueTargets: emptyTargets(tt.view),
+			})
+			require.NoError(t, err)
+			ids, err := deletionTargetSourceMessageIDs(targets, nil)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.want, ids)
+		})
+	}
+}
+
+func TestGetDeletionTargetsBySearchCombinesSearchFilterAndActiveScope(t *testing.T) {
+	env := newTestEnv(t)
+	env.EnableFTS()
+	env.MarkDeletedBySourceID("msg2")
+
+	for _, mode := range []DeletionSearchMode{DeletionSearchFast, DeletionSearchDeep} {
+		t.Run(string(mode), func(t *testing.T) {
+			targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, search.Parse("Hello"), MessageFilter{
+				Sender:     "alice@example.com",
+				Pagination: Pagination{Offset: 100, Limit: 1},
+			}, mode)
+			require.NoError(t, err)
+			ids, err := deletionTargetSourceMessageIDs(targets, nil)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"msg1"}, ids)
+		})
+	}
+}
+
+func TestGetDeletionTargetsBySearchMatchesNormalFilterComposition(t *testing.T) {
+	env := newTestEnv(t)
+
+	for _, mode := range []DeletionSearchMode{DeletionSearchFast, DeletionSearchDeep} {
+		t.Run(string(mode), func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx,
+				search.Parse("from:bob@company.org"),
+				MessageFilter{Sender: "alice@example.com"}, mode)
+			requirements.NoError(err)
+			ids, err := deletionTargetSourceMessageIDs(targets, nil)
+			requirements.NoError(err)
+			assertions.Empty(ids, "view filters are independent from query operators")
+		})
+	}
+}
+
+func TestDeepSearchAndDeletionUseExactRecipientPredicates(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	env := newTestEnv(t)
+	aliceID := env.MustLookupParticipant("alice@example.com")
+	copyEmail := "copy@example.net"
+	copyName := "Copy Person"
+	copyID := env.AddParticipant(dbtest.ParticipantOpts{Email: &copyEmail, DisplayName: &copyName, Domain: "example.net"})
+	otherEmail := "other@example.net"
+	otherName := "Other Person"
+	otherID := env.AddParticipant(dbtest.ParticipantOpts{Email: &otherEmail, DisplayName: &otherName, Domain: "example.net"})
+
+	env.AddMessage(dbtest.MessageOpts{
+		Subject: "Deep recipient needle",
+		SentAt:  "2024-04-02 10:00:00",
+		FromID:  aliceID,
+		CcIDs:   []int64{copyID},
+	})
+	env.AddMessage(dbtest.MessageOpts{
+		Subject: "Deep recipient needle",
+		SentAt:  "2024-04-02 11:00:00",
+		FromID:  aliceID,
+		BccIDs:  []int64{copyID},
+	})
+	env.AddMessage(dbtest.MessageOpts{
+		Subject: "Deep recipient needle",
+		SentAt:  "2024-04-02 12:00:00",
+		FromID:  aliceID,
+		ToIDs:   []int64{copyID},
+		CcIDs:   []int64{otherID},
+	})
+	env.EnableFTS()
+
+	parsed := search.Parse("Deep recipient needle")
+	filter := MessageFilter{Recipient: copyEmail, RecipientName: copyName}
+	displayed, err := env.Engine.SearchDeep(env.Ctx, parsed, filter, 100, 0)
+	requirements.NoError(err)
+	requirements.Len(displayed, 3)
+
+	targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, parsed, filter, DeletionSearchDeep)
+	requirements.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.ElementsMatch([]string{"msg100", "msg101", "msg102"}, ids)
+
+	crossRow := MessageFilter{Recipient: copyEmail, RecipientName: otherName}
+	displayed, err = env.Engine.SearchDeep(env.Ctx, parsed, crossRow, 100, 0)
+	requirements.NoError(err)
+	assertions.Empty(displayed, "recipient email and name must match the same row")
+}
+
+func TestFastSearchAndDeletionUseExactViewPredicates(t *testing.T) {
+	env := newTestEnv(t)
+	aliceID := env.MustLookupParticipant("alice@example.com")
+
+	t.Run("recipient includes cc and bcc", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		ccEmail := "copy@example.net"
+		ccID := env.AddParticipant(dbtest.ParticipantOpts{Email: &ccEmail, Domain: "example.net"})
+		env.AddMessage(dbtest.MessageOpts{
+			Subject: "Scoped recipient needle",
+			SentAt:  "2024-04-02 10:00:00",
+			FromID:  aliceID,
+			CcIDs:   []int64{ccID},
+		})
+		env.AddMessage(dbtest.MessageOpts{
+			Subject: "Scoped recipient needle",
+			SentAt:  "2024-04-02 11:00:00",
+			FromID:  aliceID,
+			BccIDs:  []int64{ccID},
+		})
+
+		parsed := search.Parse("Scoped recipient needle")
+		filter := MessageFilter{Recipient: ccEmail}
+		displayed, err := env.Engine.SearchFast(env.Ctx, parsed, filter, 100, 0)
+		requirements.NoError(err)
+		requirements.Len(displayed, 2)
+
+		targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, parsed, filter, DeletionSearchFast)
+		requirements.NoError(err)
+		ids, err := deletionTargetSourceMessageIDs(targets, nil)
+		requirements.NoError(err)
+		assertions.ElementsMatch([]string{displayed[0].SourceMessageID, displayed[1].SourceMessageID}, ids)
+	})
+
+	t.Run("domain treats wildcard characters literally", func(t *testing.T) {
+		assertions := assert.New(t)
+		requirements := require.New(t)
+		wantedEmail := "sender@team_ops.example"
+		wantedID := env.AddParticipant(dbtest.ParticipantOpts{Email: &wantedEmail, Domain: "team_ops.example"})
+		otherEmail := "sender@teamXops.example"
+		otherID := env.AddParticipant(dbtest.ParticipantOpts{Email: &otherEmail, Domain: "teamXops.example"})
+		env.AddMessage(dbtest.MessageOpts{Subject: "Scoped domain needle", SentAt: "2024-04-03 10:00:00", FromID: wantedID})
+		env.AddMessage(dbtest.MessageOpts{Subject: "Scoped domain needle", SentAt: "2024-04-04 10:00:00", FromID: otherID})
+
+		parsed := search.Parse("Scoped domain needle")
+		filter := MessageFilter{Domain: "TEAM_OPS.EXAMPLE"}
+		displayed, err := env.Engine.SearchFast(env.Ctx, parsed, filter, 100, 0)
+		requirements.NoError(err)
+		requirements.Len(displayed, 1)
+
+		targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, parsed, filter, DeletionSearchFast)
+		requirements.NoError(err)
+		ids, err := deletionTargetSourceMessageIDs(targets, nil)
+		requirements.NoError(err)
+		assertions.Equal([]string{displayed[0].SourceMessageID}, ids)
+	})
+}
+
+func TestGetDeletionTargetsBySearchPreservesUnsupportedFilterPredicates(t *testing.T) {
+	env := newTestEnvWithEmptyBuckets(t)
+
+	targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx,
+		search.Parse("No Sender"),
+		MessageFilter{EmptyValueTargets: emptyTargets(ViewSenders)},
+		DeletionSearchFast)
+	require.NoError(t, err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(t, err)
+	assert.Len(t, ids, 1)
+}
+
+func TestFastSearchAndDeletionKeepViewLabelExact(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	aliceID := env.MustLookupParticipant("alice@example.com")
+	bobID := env.MustLookupParticipant("bob@company.org")
+	homeworkID := env.AddLabel(dbtest.LabelOpts{Name: "Homework"})
+	homeworkMessageID := env.AddMessage(dbtest.MessageOpts{
+		Subject: "Hello homework",
+		SentAt:  "2024-04-01 10:00:00",
+		FromID:  aliceID,
+		ToIDs:   []int64{bobID},
+	})
+	env.AddMessageLabel(homeworkMessageID, homeworkID)
+
+	parsed := search.Parse("Hello")
+	filter := MessageFilter{Label: "Work"}
+	displayed, err := env.Engine.SearchFast(env.Ctx, parsed, filter, 100, 0)
+	require.NoError(err)
+	require.Len(displayed, 1)
+	assert.Equal("msg1", displayed[0].SourceMessageID)
+
+	targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, parsed, filter, DeletionSearchFast)
+	require.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	require.NoError(err)
+	assert.Equal([]string{"msg1"}, ids)
+}
+
+func TestDeepSearchDeletionKeepsViewDomainExact(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	env := newTestEnv(t)
+	wantedEmail := "sender@team_ops.example"
+	wantedID := env.AddParticipant(dbtest.ParticipantOpts{Email: &wantedEmail, Domain: "team_ops.example"})
+	otherEmail := "sender@teamXops.example"
+	otherID := env.AddParticipant(dbtest.ParticipantOpts{Email: &otherEmail, Domain: "teamXops.example"})
+	env.AddMessage(dbtest.MessageOpts{Subject: "Deep domain needle", SentAt: "2024-04-03 10:00:00", FromID: wantedID})
+	env.AddMessage(dbtest.MessageOpts{Subject: "Deep domain needle", SentAt: "2024-04-04 10:00:00", FromID: otherID})
+	env.EnableFTS()
+
+	targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, search.Parse("Deep domain needle"), MessageFilter{
+		Domain: "team_ops.example",
+	}, DeletionSearchDeep)
+	requirements.NoError(err)
+	ids, err := deletionTargetSourceMessageIDs(targets, nil)
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg100"}, ids)
+}
+
+func TestDeepSearchAndDeletionKeepExactViewFilters(t *testing.T) {
+	env := newTestEnvWithEmptyBuckets(t)
+	env.EnableFTS()
+
+	tests := []struct {
+		name   string
+		query  string
+		filter MessageFilter
+		want   []string
+	}{
+		{name: "sender name", query: "Message", filter: MessageFilter{SenderName: "Alice"}, want: []string{"msg1", "msg2", "msg3"}},
+		{name: "recipient name", query: "Message", filter: MessageFilter{RecipientName: "Bob"}, want: []string{"msg1", "msg2", "msg3"}},
+		{name: "empty sender", query: "No", filter: MessageFilter{EmptyValueTargets: emptyTargets(ViewSenders)}, want: []string{"msg100"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			parsed := search.Parse(tt.query)
+			displayed, err := env.Engine.SearchDeep(env.Ctx, parsed, tt.filter, 100, 0)
+			requirements.NoError(err)
+			displayedIDs := make([]string, len(displayed))
+			for i := range displayed {
+				displayedIDs[i] = displayed[i].SourceMessageID
+			}
+			assertions.ElementsMatch(tt.want, displayedIDs)
+
+			targets, err := env.Engine.GetDeletionTargetsBySearch(env.Ctx, parsed, tt.filter, DeletionSearchDeep)
+			requirements.NoError(err)
+			targetIDs, err := deletionTargetSourceMessageIDs(targets, nil)
+			requirements.NoError(err)
+			assertions.ElementsMatch(displayedIDs, targetIDs)
+
+			result, err := env.Engine.SearchDeepWithStats(env.Ctx, parsed, tt.filter, 100, 0)
+			requirements.NoError(err)
+			requirements.NotNil(result.Stats)
+			assertions.Equal(int64(len(tt.want)), result.TotalCount)
+			assertions.Equal(int64(len(tt.want)), result.Stats.MessageCount)
+		})
+	}
 }
 
 func TestGetDeletionTargetsByFilter_SenderName(t *testing.T) {
@@ -998,6 +1345,57 @@ func TestGetDeletionTargetsByFilter_RecipientEmailAndName_SameToRow(t *testing.T
 		"same-row recipient email+name must still match")
 }
 
+func TestSQLiteRecipientPhoneFilter(t *testing.T) {
+	env := newTestEnv(t)
+	phoneID := env.AddParticipant(dbtest.ParticipantOpts{
+		Phone:       new("+15551234567"),
+		DisplayName: new("Phone Recipient"),
+	})
+	emailID := env.MustLookupParticipant("bob@company.org")
+	messageID := env.AddMessage(dbtest.MessageOpts{
+		Subject: "Phone recipient", SentAt: "2024-06-10 10:00:00",
+		ToIDs: []int64{phoneID, emailID},
+	})
+
+	for _, tc := range []struct {
+		name          string
+		recipientName string
+		wantIDs       []int64
+	}{
+		{name: "phone", wantIDs: []int64{messageID}},
+		{name: "phone and same-row name", recipientName: "Phone Recipient", wantIDs: []int64{messageID}},
+		{name: "phone and other-row name", recipientName: "Bob"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			filter := MessageFilter{Recipient: "+15551234567", RecipientName: tc.recipientName}
+			messages, err := env.Engine.ListMessages(env.Ctx, filter)
+			require.NoError(err)
+			assertMessageIDs(t, messages, tc.wantIDs)
+
+			messages, err = env.Engine.SearchFast(env.Ctx, &search.Query{}, filter, 100, 0)
+			require.NoError(err)
+			assertMessageIDs(t, messages, tc.wantIDs)
+			count, err := env.Engine.SearchFastCount(env.Ctx, &search.Query{}, filter)
+			require.NoError(err)
+			assert.Equal(int64(len(tc.wantIDs)), count)
+
+			stats, err := env.Engine.GetTotalStats(env.Ctx, StatsOptions{Filter: &filter})
+			require.NoError(err)
+			assert.Equal(int64(len(tc.wantIDs)), stats.MessageCount)
+
+			targets, err := env.Engine.GetDeletionTargetsByFilter(env.Ctx, filter)
+			require.NoError(err)
+			ids := make([]int64, 0, len(targets))
+			for _, target := range targets {
+				ids = append(ids, target.MessageID)
+			}
+			assert.ElementsMatch(tc.wantIDs, ids)
+		})
+	}
+}
+
 func TestGetDeletionTargetsByFilter_RecipientName(t *testing.T) {
 	env := newTestEnv(t)
 
@@ -1015,7 +1413,7 @@ func TestGetDeletionTargetsByFilter_RecipientName_WithMatchEmptyRecipient(t *tes
 	}
 	ids, err := deletionTargetSourceMessageIDs(env.Engine.GetDeletionTargetsByFilter(env.Ctx, filter))
 	require.NoError(t, err, "GetDeletionTargetsByFilter")
-	assert.Len(t, ids, 3, "expected 3 gmail IDs")
+	assert.Empty(t, ids, "a named recipient cannot also be in the empty-recipient bucket")
 }
 
 func TestListMessages_ConversationIDFilter(t *testing.T) {
@@ -1620,8 +2018,19 @@ func TestGetTotalStats_FilteredCountsMatchDuckDBPopulation(t *testing.T) {
 			wantMessages: 1, wantLabels: 1, wantAccounts: 1,
 		},
 		{
-			name: "explicit empty source IDs",
-			opts: StatsOptions{SourceIDs: []int64{}},
+			name: "complete message filter",
+			opts: StatsOptions{
+				SearchQuery: "filterpopulationneedle",
+				Filter:      &MessageFilter{Label: "Filtered First A"},
+			},
+			wantMessages: 1, wantLabels: 2, wantAccounts: 1,
+		},
+		{
+			name: "complete filter with explicit empty source IDs",
+			opts: StatsOptions{
+				SourceIDs: []int64{},
+				Filter:    &MessageFilter{Label: "Filtered First A"},
+			},
 		},
 	}
 	for _, tc := range tests {

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,6 +18,7 @@ import (
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/fileutil"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/textutil"
 )
 
@@ -36,6 +39,39 @@ type DeletionContext struct {
 	TimeGranularity    query.TimeGranularity
 	Messages           []query.MessageSummary
 	DrillFilter        *query.MessageFilter
+	AllMatches         bool
+	SearchQuery        string
+	SearchMode         searchModeKind
+	MatchFilter        query.MessageFilter
+	AggregateMatchKey  *string
+}
+
+type allMatchesManifestProvenance struct {
+	Scope       string                   `json:"scope"`
+	SearchQuery string                   `json:"search_query,omitempty"`
+	SearchMode  string                   `json:"search_mode,omitempty"`
+	MatchFilter allMatchesManifestFilter `json:"match_filter"`
+}
+
+type allMatchesManifestFilter struct {
+	Sender                string     `json:"sender,omitempty"`
+	SenderName            string     `json:"sender_name,omitempty"`
+	Recipient             string     `json:"recipient,omitempty"`
+	RecipientName         string     `json:"recipient_name,omitempty"`
+	Domain                string     `json:"domain,omitempty"`
+	Label                 string     `json:"label,omitempty"`
+	ListID                string     `json:"list_id,omitempty"`
+	MessageType           string     `json:"message_type,omitempty"`
+	ConversationID        *int64     `json:"conversation_id,omitempty"`
+	EmptyValueTargets     []string   `json:"empty_value_targets,omitempty"`
+	TimePeriod            string     `json:"time_period,omitempty"`
+	TimeGranularity       string     `json:"time_granularity,omitempty"`
+	SourceID              *int64     `json:"source_id,omitempty"`
+	SourceIDs             []int64    `json:"source_ids,omitempty"`
+	After                 *time.Time `json:"after,omitempty"`
+	Before                *time.Time `json:"before,omitempty"`
+	WithAttachmentsOnly   bool       `json:"attachments_only,omitempty"`
+	HideDeletedFromSource bool       `json:"hide_deleted_from_source,omitempty"`
 }
 
 // ActionController handles business logic for actions like deletion and export,
@@ -111,12 +147,25 @@ func (c *ActionController) SaveManifest(manifest *deletion.Manifest) error {
 
 // StageForDeletion prepares messages for deletion based on selection.
 func (c *ActionController) StageForDeletion(ctx DeletionContext) (*deletion.Manifest, error) {
-	targets, err := c.resolveDeletionTargets(ctx)
+	return c.StageForDeletionContext(context.Background(), ctx)
+}
+
+// StageForDeletionContext prepares messages for deletion and lets callers
+// cancel long-running all-match resolution.
+func (c *ActionController) StageForDeletionContext(
+	ctx context.Context,
+	dctx DeletionContext,
+) (*deletion.Manifest, error) {
+	dctx = normalizeEmptyDeletionSearch(dctx)
+	targets, err := c.resolveDeletionTargets(ctx, dctx)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(targets) == 0 {
+		if dctx.AllMatches {
+			return nil, errors.New("no deletable messages match the current filter or search")
+		}
 		return nil, errors.New("no messages selected")
 	}
 	source, err := deletion.SourceReferenceForTargets(targets)
@@ -128,26 +177,98 @@ func (c *ActionController) StageForDeletion(ctx DeletionContext) (*deletion.Mani
 	}
 	gmailIDs := deletion.SourceMessageIDs(targets)
 
-	description := c.buildManifestDescription(ctx)
+	description := c.buildManifestDescription(dctx)
 	manifest := deletion.NewManifestForSource(description, gmailIDs, source)
 	manifest.CreatedBy = "tui"
 
-	c.applyManifestFilters(manifest, ctx)
+	c.applyManifestFilters(manifest, dctx)
+	if dctx.AllMatches {
+		searchMode := ""
+		if dctx.SearchQuery != "" {
+			if dctx.AggregateMatchKey != nil {
+				searchMode = string(query.DeletionSearchAggregate)
+			} else {
+				searchMode = deletionSearchModeName(dctx.SearchMode)
+			}
+		}
+		rawFilter, marshalErr := json.Marshal(allMatchesManifestProvenance{
+			Scope:       "all_matches",
+			SearchQuery: dctx.SearchQuery,
+			SearchMode:  searchMode,
+			MatchFilter: manifestMatchFilter(dctx.MatchFilter),
+		})
+		if marshalErr != nil {
+			return nil, fmt.Errorf("record deletion match provenance: %w", marshalErr)
+		}
+		manifest.RawFilter = rawFilter
+	}
 
 	return manifest, nil
 }
 
+func normalizeEmptyDeletionSearch(dctx DeletionContext) DeletionContext {
+	if !dctx.AllMatches {
+		return dctx
+	}
+	queryString := strings.TrimSpace(dctx.SearchQuery)
+	if queryString == "" {
+		dctx.SearchQuery = ""
+		return dctx
+	}
+	parsed := search.Parse(queryString)
+	if parsed.Err() == nil && search.Format(parsed) == "" {
+		dctx.SearchQuery = ""
+	}
+	return dctx
+}
+
+func manifestMatchFilter(filter query.MessageFilter) allMatchesManifestFilter {
+	emptyTargets := make([]string, 0, len(filter.EmptyValueTargets))
+	for target, matchesEmpty := range filter.EmptyValueTargets {
+		if matchesEmpty {
+			emptyTargets = append(emptyTargets, target.String())
+		}
+	}
+	sort.Strings(emptyTargets)
+	return allMatchesManifestFilter{
+		Sender: filter.Sender, SenderName: filter.SenderName,
+		Recipient: filter.Recipient, RecipientName: filter.RecipientName,
+		Domain: filter.Domain, Label: filter.Label, ListID: filter.ListID, MessageType: filter.MessageType,
+		ConversationID: filter.ConversationID, EmptyValueTargets: emptyTargets,
+		TimePeriod: filter.TimeRange.Period, TimeGranularity: filter.TimeRange.Granularity.String(),
+		SourceID: filter.SourceID, SourceIDs: append([]int64(nil), filter.SourceIDs...),
+		After: filter.After, Before: filter.Before,
+		WithAttachmentsOnly:   filter.WithAttachmentsOnly,
+		HideDeletedFromSource: filter.HideDeletedFromSource,
+	}
+}
+
 // resolveGmailIDs converts selections (aggregate keys and message IDs) into Gmail IDs.
-func (c *ActionController) resolveDeletionTargets(dctx DeletionContext) ([]query.DeletionTarget, error) {
+func (c *ActionController) resolveDeletionTargets(ctx context.Context, dctx DeletionContext) ([]query.DeletionTarget, error) {
+	if dctx.AllMatches {
+		return c.resolveAllMatchingDeletionTargets(ctx, dctx)
+	}
+
 	targetsByMessageID := make(map[int64]query.DeletionTarget)
-	ctx := context.Background()
 
 	// From selected aggregates - resolve to Gmail IDs via query engine
 	if len(dctx.AggregateSelection) > 0 {
 		for key := range dctx.AggregateSelection {
 			filter := c.buildFilterForAggregate(key, dctx)
 
-			targets, err := c.queries.GetDeletionTargetsByFilter(ctx, filter)
+			var targets []query.DeletionTarget
+			var err error
+			if dctx.SearchQuery != "" {
+				resolver, ok := c.queries.(query.DeletionTargetAggregateSearchResolver)
+				if !ok {
+					return nil, errors.New("this query engine cannot resolve the displayed aggregate search safely")
+				}
+				targets, err = resolver.GetDeletionTargetsByAggregateSearch(
+					ctx, dctx.SearchQuery, filter, dctx.AggregateViewType, key,
+				)
+			} else {
+				targets, err = c.queries.GetDeletionTargetsByFilter(ctx, filter)
+			}
 			if err != nil {
 				return nil, fmt.Errorf("error loading messages: %w", err)
 			}
@@ -185,14 +306,78 @@ func (c *ActionController) resolveDeletionTargets(dctx DeletionContext) ([]query
 	return targets, nil
 }
 
+func (c *ActionController) resolveAllMatchingDeletionTargets(
+	ctx context.Context,
+	dctx DeletionContext,
+) ([]query.DeletionTarget, error) {
+	filter := emailScopedMessageFilter(dctx.MatchFilter)
+	filter.Pagination = query.Pagination{}
+	if dctx.SearchQuery == "" {
+		targets, err := c.queries.GetDeletionTargetsByFilter(ctx, filter)
+		if err != nil {
+			return nil, fmt.Errorf("error loading messages: %w", err)
+		}
+		return targets, nil
+	}
+	if dctx.AggregateMatchKey != nil {
+		resolver, ok := c.queries.(query.DeletionTargetAggregateSearchResolver)
+		if !ok {
+			return nil, errors.New("this query engine cannot resolve the displayed aggregate search safely")
+		}
+		targets, err := resolver.GetDeletionTargetsByAggregateSearch(
+			ctx, dctx.SearchQuery, filter, dctx.AggregateViewType, *dctx.AggregateMatchKey,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error loading messages: %w", err)
+		}
+		return targets, nil
+	}
+	if dctx.SearchMode == searchModeSemantic {
+		return nil, errors.New("semantic search is ranked and bounded; switch to fast or deep search to stage every match")
+	}
+	parsed := search.Parse(dctx.SearchQuery)
+	if err := parsed.Err(); err != nil {
+		return nil, fmt.Errorf("invalid search query: %w", err)
+	}
+	resolver, ok := c.queries.(query.DeletionTargetSearchResolver)
+	if !ok {
+		return nil, errors.New("this query engine cannot resolve every search match safely")
+	}
+	mode := query.DeletionSearchFast
+	if dctx.SearchMode == searchModeDeep {
+		mode = query.DeletionSearchDeep
+	}
+	targets, err := resolver.GetDeletionTargetsBySearch(ctx, parsed, filter, mode)
+	if err != nil {
+		return nil, fmt.Errorf("error loading messages: %w", err)
+	}
+	return targets, nil
+}
+
+func deletionSearchModeName(mode searchModeKind) string {
+	switch mode {
+	case searchModeDeep:
+		return string(query.DeletionSearchDeep)
+	case searchModeSemantic:
+		return "semantic"
+	default:
+		return string(query.DeletionSearchFast)
+	}
+}
+
 // buildFilterForAggregate constructs a MessageFilter for a single aggregate key.
 func (c *ActionController) buildFilterForAggregate(key string, dctx DeletionContext) query.MessageFilter {
-	// Start with drill-down filter as base (preserves parent context)
-	// Use Clone() to deep-copy the filter, preventing shared map mutation.
 	var filter query.MessageFilter
-	if dctx.DrillFilter != nil {
+	if dctx.AllMatches || dctx.SearchQuery != "" {
+		// Search-aware aggregate staging starts with the same complete scope
+		// used to render the aggregate, then adds the selected row below.
+		filter = dctx.MatchFilter.Clone()
+	} else if dctx.DrillFilter != nil {
+		// Selected aggregate staging preserves its parent drill-down context.
 		filter = dctx.DrillFilter.Clone()
 	}
+	filter.WithAttachmentsOnly = filter.WithAttachmentsOnly || dctx.MatchFilter.WithAttachmentsOnly
+	filter.HideDeletedFromSource = filter.HideDeletedFromSource || dctx.MatchFilter.HideDeletedFromSource
 	if dctx.AccountFilter != nil {
 		filter.SourceID = dctx.AccountFilter
 	}
@@ -204,19 +389,41 @@ func (c *ActionController) buildFilterForAggregate(key string, dctx DeletionCont
 	switch dctx.AggregateViewType {
 	case query.ViewSenders:
 		filter.Sender = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewSenders)
+		}
+	case query.ViewSenderNames:
+		filter.SenderName = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewSenderNames)
+		}
 	case query.ViewRecipients:
 		filter.Recipient = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewRecipients)
+		}
+	case query.ViewRecipientNames:
+		filter.RecipientName = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewRecipientNames)
+		}
 	case query.ViewDomains:
 		filter.Domain = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewDomains)
+		}
 	case query.ViewLabels:
 		filter.Label = key
+		if key == "" {
+			filter.SetEmptyTarget(query.ViewLabels)
+		}
 	case query.ViewLists:
 		filter.ListID = key
 	case query.ViewTime:
 		filter.TimeRange.Period = key
 		filter.TimeRange.Granularity = dctx.TimeGranularity
 	default:
-		// SenderNames / RecipientNames / Count are not drill-down targets here.
+		// Count is a sentinel, not a drill-down target.
 	}
 	return filter
 }
@@ -224,7 +431,13 @@ func (c *ActionController) buildFilterForAggregate(key string, dctx DeletionCont
 // buildManifestDescription generates a human-readable description for the manifest.
 func (c *ActionController) buildManifestDescription(ctx DeletionContext) string {
 	var description string
-	if len(ctx.AggregateSelection) == 1 {
+	if ctx.AllMatches && ctx.AggregateMatchKey != nil {
+		description = fmt.Sprintf("%s-%s", ctx.AggregateViewType.String(), *ctx.AggregateMatchKey)
+	} else if ctx.AllMatches && ctx.SearchQuery != "" {
+		description = "search-all-matches"
+	} else if ctx.AllMatches {
+		description = "all-matches"
+	} else if len(ctx.AggregateSelection) == 1 {
 		for key := range ctx.AggregateSelection {
 			description = fmt.Sprintf("%s-%s", ctx.AggregateViewType.String(), key)
 			break
@@ -256,6 +469,11 @@ func (c *ActionController) applyManifestFilters(m *deletion.Manifest, ctx Deleti
 		m.Filters.Account = ctx.Accounts[0].Identifier
 	}
 
+	if ctx.AllMatches {
+		applyMessageFilterToManifest(m, ctx.MatchFilter)
+		return
+	}
+
 	// Set context filters from all selected aggregates
 	if len(ctx.AggregateSelection) > 0 {
 		keys := make([]string, 0, len(ctx.AggregateSelection))
@@ -277,6 +495,36 @@ func (c *ActionController) applyManifestFilters(m *deletion.Manifest, ctx Deleti
 		default:
 			// SenderNames / RecipientNames / Time / Count don't map to manifest filters.
 		}
+	}
+}
+
+func applyMessageFilterToManifest(m *deletion.Manifest, filter query.MessageFilter) {
+	if filter.Sender != "" {
+		m.Filters.Senders = []string{filter.Sender}
+	}
+	if filter.Recipient != "" {
+		m.Filters.Recipients = []string{filter.Recipient}
+	}
+	if filter.Domain != "" {
+		m.Filters.SenderDomains = []string{filter.Domain}
+	}
+	if filter.Label != "" {
+		m.Filters.Labels = []string{filter.Label}
+	}
+	if filter.ListID != "" {
+		m.Filters.ListIDs = []string{filter.ListID}
+	}
+	after, before := filter.After, filter.Before
+	if filter.TimeRange.Period != "" {
+		if periodAfter, periodBefore, ok := query.ParseTimePeriodBounds(filter.TimeRange.Period); ok {
+			after, before = &periodAfter, &periodBefore
+		}
+	}
+	if after != nil {
+		m.Filters.After = after.Format(time.RFC3339)
+	}
+	if before != nil {
+		m.Filters.Before = before.Format(time.RFC3339)
 	}
 }
 
@@ -309,7 +557,11 @@ func (c *ActionController) ExportAttachments(detail *query.MessageDetail, select
 	zipFilename := fmt.Sprintf("%s_%d.zip", subject, detail.ID)
 
 	return func() tea.Msg {
-		stats := c.exportSelectedAttachments(zipFilename, attachmentsDir, selectedAttachments)
+		outputDir, err := c.attachmentOutputDirectory()
+		if err != nil {
+			return ExportResultMsg{Title: "Export Failed", Err: err}
+		}
+		stats := c.exportSelectedAttachments(filepath.Join(outputDir, zipFilename), attachmentsDir, selectedAttachments)
 		msg := ExportResultMsg{Title: "Export Complete", Result: export.FormatExportResult(stats)}
 		// Only set Err for true failures: write errors or zero exported files.
 		// Partial success (some files exported, some errors) should show the
@@ -398,27 +650,11 @@ func (c *ActionController) exportOneAttachment(att query.AttachmentInfo) (export
 	if att.URL != "" {
 		return export.ExportedFile{}, errors.New("URL-backed attachments can be opened but not downloaded")
 	}
-	outputDir := c.attachmentOutputDir
-	if outputDir == "" {
-		baseDir := c.dataDir
-		if baseDir == "" {
-			var err error
-			baseDir, err = os.UserCacheDir()
-			if err != nil {
-				return export.ExportedFile{}, fmt.Errorf("get user cache directory: %w", err)
-			}
-			baseDir = filepath.Join(baseDir, "msgvault")
-		}
-		outputDir = filepath.Join(baseDir, "downloads")
-	}
-	absOutputDir, err := filepath.Abs(outputDir)
+	outputDir, err := c.attachmentOutputDirectory()
 	if err != nil {
-		return export.ExportedFile{}, fmt.Errorf("resolve output directory: %w", err)
+		return export.ExportedFile{}, err
 	}
-	if err := fileutil.SecureMkdirAll(absOutputDir, 0o700); err != nil {
-		return export.ExportedFile{}, fmt.Errorf("create output directory: %w", err)
-	}
-	result := export.AttachmentsToDirWithOpener(absOutputDir, []query.AttachmentInfo{att}, c.attachmentOpener())
+	result := export.AttachmentsToDirWithOpener(outputDir, []query.AttachmentInfo{att}, c.attachmentOpener())
 	if len(result.Files) == 1 {
 		exported := result.Files[0]
 		marker := c.markUntrusted
@@ -434,6 +670,30 @@ func (c *ActionController) exportOneAttachment(att query.AttachmentInfo) (export
 		return export.ExportedFile{}, errors.New(result.Errors[0])
 	}
 	return export.ExportedFile{}, errors.New("attachment was not downloaded")
+}
+
+func (c *ActionController) attachmentOutputDirectory() (string, error) {
+	outputDir := c.attachmentOutputDir
+	if outputDir == "" {
+		baseDir := c.dataDir
+		if baseDir == "" {
+			var err error
+			baseDir, err = os.UserCacheDir()
+			if err != nil {
+				return "", fmt.Errorf("get user cache directory: %w", err)
+			}
+			baseDir = filepath.Join(baseDir, "msgvault")
+		}
+		outputDir = filepath.Join(baseDir, "exports")
+	}
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve output directory: %w", err)
+	}
+	if err := fileutil.SecureMkdirAll(absOutputDir, 0o700); err != nil {
+		return "", fmt.Errorf("create output directory: %w", err)
+	}
+	return absOutputDir, nil
 }
 
 func (c *ActionController) attachmentOpener() export.AttachmentOpener {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -131,6 +132,42 @@ func TestStageForDeletion_FromAggregateSelection(t *testing.T) {
 	assert.Equal(deletion.SourceReference{ID: 1, Type: "gmail", Identifier: "test@gmail.com"}, *manifest.Source)
 	assert.Equal([]string{"alice@example.com"}, manifest.Filters.Senders)
 	assert.Equal("tui", manifest.CreatedBy)
+}
+
+func TestStageForDeletion_FromEmptyAggregateSelection(t *testing.T) {
+	tests := []struct {
+		name string
+		view query.ViewType
+	}{
+		{name: "sender", view: query.ViewSenders},
+		{name: "sender name", view: query.ViewSenderNames},
+		{name: "recipient", view: query.ViewRecipients},
+		{name: "recipient name", view: query.ViewRecipientNames},
+		{name: "domain", view: query.ViewDomains},
+		{name: "label", view: query.ViewLabels},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := &querytest.MockEngine{
+				GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+					assert.True(t, filter.MatchesEmpty(tt.view))
+					return []query.DeletionTarget{{
+						MessageID: 1, SourceID: 1, SourceType: "gmail",
+						SourceIdentifier: "test@example.com", SourceMessageID: "gid-empty",
+					}}, nil
+				},
+			}
+			env := NewControllerTestEnv(t, engine)
+
+			manifest := env.StageForDeletion(stageArgs{
+				aggregates: map[string]bool{"": true},
+				view:       tt.view,
+			})
+
+			assert.Equal(t, []string{"gid-empty"}, manifest.GmailIDs)
+		})
+	}
 }
 
 func TestStageForDeletionRejectsMultipleSources(t *testing.T) {
@@ -272,6 +309,44 @@ func TestStageForDeletion_ListSelectionUsesExactListID(t *testing.T) {
 	assert.Equal([]string{matchingGmailID}, manifest.GmailIDs)
 	assert.NotContains(manifest.GmailIDs, nonMatchingGmailID)
 	assert.Equal([]string{"<announce.example.test>"}, manifest.Filters.ListIDs)
+}
+
+func TestStageAllMatchesListScopeRecordsExactProvenance(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	matchingID := tdb.AddMessage(dbtest.MessageOpts{Subject: "matching list"})
+	nonMatchingID := tdb.AddMessage(dbtest.MessageOpts{Subject: "other list"})
+	listID := "<announce.example.test>"
+	_, err := tdb.DB.Exec(`UPDATE messages SET list_id = ? WHERE id = ?`, listID, matchingID)
+	requirements.NoError(err)
+	_, err = tdb.DB.Exec(`UPDATE messages SET list_id = ? WHERE id = ?`, "<digest.example.test>", nonMatchingID)
+	requirements.NoError(err)
+
+	var matchingGmailID, nonMatchingGmailID string
+	err = tdb.DB.QueryRow(`SELECT source_message_id FROM messages WHERE id = ?`, matchingID).Scan(&matchingGmailID)
+	requirements.NoError(err)
+	err = tdb.DB.QueryRow(`SELECT source_message_id FROM messages WHERE id = ?`, nonMatchingID).Scan(&nonMatchingGmailID)
+	requirements.NoError(err)
+
+	controller := NewActionController(query.NewSQLiteEngine(tdb.DB), t.TempDir(), nil)
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AllMatches:  true,
+		MatchFilter: query.MessageFilter{ListID: listID},
+	})
+	requirements.NoError(err)
+	assertions.Equal([]string{matchingGmailID}, manifest.GmailIDs)
+	assertions.NotContains(manifest.GmailIDs, nonMatchingGmailID)
+	assertions.Equal([]string{listID}, manifest.Filters.ListIDs)
+
+	var provenance struct {
+		MatchFilter struct {
+			ListID string `json:"list_id"`
+		} `json:"match_filter"`
+	}
+	requirements.NoError(json.Unmarshal(manifest.RawFilter, &provenance))
+	assertions.Equal(listID, provenance.MatchFilter.ListID)
 }
 
 // TestStageForDeletion_MultipleListSelectionsAreExactAndStable verifies that
@@ -429,6 +504,96 @@ func TestStageForDeletion_EmailScopeExcludesMixedMessageTypes(t *testing.T) {
 	)
 }
 
+func TestStageAllMatchesKeepsAttachmentOnlyScope(t *testing.T) {
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	controller := NewActionController(query.NewSQLiteEngine(tdb.DB), t.TempDir(), nil)
+
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AllMatches:  true,
+		MatchFilter: query.MessageFilter{WithAttachmentsOnly: true},
+	})
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"msg2", "msg4"}, manifest.GmailIDs)
+}
+
+func TestStageSelectedAggregateKeepsAttachmentOnlyScope(t *testing.T) {
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	controller := NewActionController(query.NewSQLiteEngine(tdb.DB), t.TempDir(), nil)
+
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AggregateSelection: map[string]bool{"alice@example.com": true},
+		AggregateViewType:  query.ViewSenders,
+		MatchFilter:        query.MessageFilter{WithAttachmentsOnly: true},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"msg2"}, manifest.GmailIDs)
+}
+
+func TestStageAggregateSearchUsesDisplayedAggregateScope(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	_, err := tdb.DB.Exec(`UPDATE message_bodies SET body_text = 'aggregatebodyneedle' WHERE message_id = 1`)
+	requirements.NoError(err)
+	tdb.EnableFTS()
+	engine := query.NewSQLiteEngine(tdb.DB)
+
+	rows, err := engine.SubAggregate(t.Context(), query.MessageFilter{MessageType: emailMessageType}, query.ViewSenders,
+		query.AggregateOptions{SearchQuery: "aggregatebodyneedle"})
+	requirements.NoError(err)
+	requirements.Len(rows, 1, "aggregate row must be visible before staging")
+	assertions.Equal("alice@example.com", rows[0].Key)
+
+	key := rows[0].Key
+	controller := NewActionController(engine, t.TempDir(), nil)
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AllMatches:        true,
+		AggregateViewType: query.ViewSenders,
+		AggregateMatchKey: &key,
+		SearchQuery:       "aggregatebodyneedle",
+		SearchMode:        searchModeFast,
+		MatchFilter:       query.MessageFilter{Sender: key, MessageType: emailMessageType},
+	})
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg1"}, manifest.GmailIDs)
+	var provenance allMatchesManifestProvenance
+	requirements.NoError(json.Unmarshal(manifest.RawFilter, &provenance))
+	assertions.Equal("aggregate", provenance.SearchMode)
+}
+
+func TestStageAggregateSelectionUsesDisplayedSearchScope(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	_, err := tdb.DB.Exec(`UPDATE message_bodies SET body_text = 'aggregatebodyneedle' WHERE message_id = 1`)
+	requirements.NoError(err)
+	tdb.EnableFTS()
+	engine := query.NewSQLiteEngine(tdb.DB)
+
+	rows, err := engine.SubAggregate(t.Context(), query.MessageFilter{MessageType: emailMessageType}, query.ViewSenders,
+		query.AggregateOptions{SearchQuery: "aggregatebodyneedle"})
+	requirements.NoError(err)
+	requirements.Len(rows, 1, "aggregate row must be visible before staging")
+	assertions.Equal("alice@example.com", rows[0].Key)
+
+	controller := NewActionController(engine, t.TempDir(), nil)
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AggregateSelection: map[string]bool{rows[0].Key: true},
+		AggregateViewType:  query.ViewSenders,
+		SearchQuery:        "aggregatebodyneedle",
+		SearchMode:         searchModeFast,
+		MatchFilter:        query.MessageFilter{MessageType: emailMessageType},
+	})
+	requirements.NoError(err)
+	assertions.Equal([]string{"msg1"}, manifest.GmailIDs)
+}
+
 func TestSaveManifest_UsesInjectedSaver(t *testing.T) {
 	dir := t.TempDir()
 	saver := &captureManifestSaver{}
@@ -521,10 +686,8 @@ func TestExportAttachments_PartialSuccess(t *testing.T) {
 	// Partial success: one valid file exports, one missing file fails.
 	// Err should be nil because stats.Count > 0 (some files succeeded).
 	env := newTestEnv(t)
-
-	// Clean up the zip file that gets created in current directory.
-	// TODO: ExportAttachments should write to a configurable output directory.
-	t.Cleanup(func() { _ = os.Remove("Test_1.zip") })
+	outputDir := filepath.Join(env.Dir, "exports")
+	env.Ctrl.attachmentOutputDir = outputDir
 
 	// Create a valid attachment file (must be valid 64-char hex SHA-256 hash)
 	validHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
@@ -556,6 +719,7 @@ func TestExportAttachments_PartialSuccess(t *testing.T) {
 
 	// Result should contain both success info and error details
 	assert.NotEmpty(result.Result)
+	assert.FileExists(filepath.Join(outputDir, "Test_1.zip"))
 }
 
 func TestExportAttachments_FullSuccess(t *testing.T) {
@@ -563,10 +727,8 @@ func TestExportAttachments_FullSuccess(t *testing.T) {
 	assert := assert.New(t)
 	// Full success: all attachments export without errors.
 	env := newTestEnv(t)
-
-	// Clean up the zip file that gets created in current directory.
-	// TODO: ExportAttachments should write to a configurable output directory.
-	t.Cleanup(func() { _ = os.Remove("Test_1.zip") })
+	outputDir := filepath.Join(env.Dir, "exports")
+	env.Ctrl.attachmentOutputDir = outputDir
 
 	// Create a valid attachment file (must be valid 64-char hex SHA-256 hash)
 	validHash := "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
@@ -593,6 +755,7 @@ func TestExportAttachments_FullSuccess(t *testing.T) {
 
 	require.NoError(result.Err, "expected Err to be nil for full success")
 	assert.NotEmpty(result.Result)
+	assert.FileExists(filepath.Join(outputDir, "Test_1.zip"))
 }
 
 func TestExportAttachments_UsesInjectedAttachmentReader(t *testing.T) {
@@ -600,10 +763,10 @@ func TestExportAttachments_UsesInjectedAttachmentReader(t *testing.T) {
 	assert := assert.New(t)
 	const contentHash = "abc123def456abc123def456abc123def456abc123def456abc123def456abc1"
 	outputDir := t.TempDir()
-	t.Chdir(outputDir)
 
 	ctrl := NewActionControllerWithOptions(&querytest.MockEngine{}, ActionControllerOptions{
-		DataDir: t.TempDir(),
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
 		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
 			contentHash: []byte("daemon bytes"),
 		}},
@@ -688,7 +851,7 @@ func TestDownloadAttachmentDefaultsToPrivateDataDirectory(t *testing.T) {
 	result, ok := msg.(ExportResultMsg)
 	require.True(ok, "expected ExportResultMsg, got %T", msg)
 	require.NoError(result.Err)
-	downloadPath := filepath.Join(dataDir, "downloads", ".zshenv")
+	downloadPath := filepath.Join(dataDir, "exports", ".zshenv")
 	assert.Contains(result.Result, downloadPath)
 	assert.FileExists(downloadPath)
 	if runtime.GOOS != "windows" {

--- a/internal/tui/email_scope_test.go
+++ b/internal/tui/email_scope_test.go
@@ -100,22 +100,21 @@ func TestEmailModeScopesMessageQueries(t *testing.T) {
 	})
 
 	t.Run("deep search", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		var captured *search.Query
+		var captured query.MessageFilter
 		engine := newMockEngine(MockConfig{})
-		engine.SearchFunc = func(_ context.Context, q *search.Query, _, _ int) ([]query.MessageSummary, error) {
-			captured = q
+		engine.SearchDeepFunc = func(
+			_ context.Context, _ *search.Query, filter query.MessageFilter, _, _ int,
+		) ([]query.MessageSummary, error) {
+			captured = filter
 			return nil, nil
 		}
 		model := New(engine, Options{DataDir: t.TempDir(), Version: "test"})
 		model.searchMode = searchModeDeep
 
 		msg, ok := model.loadSearch("shared term")().(searchResultsMsg)
-		require.True(ok)
-		require.NoError(msg.err)
-		require.NotNil(captured)
-		assert.Equal([]string{emailMessageType}, captured.MessageTypes)
+		require.True(t, ok)
+		require.NoError(t, msg.err)
+		assert.Equal(t, emailMessageType, captured.MessageType)
 	})
 
 	t.Run("thread", func(t *testing.T) {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1,17 +1,22 @@
 package tui
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
 )
 
 // Key names matched against tea.KeyPressMsg.String() in the key-handling switches.
 const (
 	keyNameEnter     = "enter"
 	keyNameEsc       = "esc"
+	keyNameCtrlC     = "ctrl+c"
+	keyNameUp        = "up"
 	keyNameDown      = "down"
 	keyNameCtrlN     = "ctrl+n"
 	keyNameCtrlP     = "ctrl+p"
@@ -19,7 +24,6 @@ const (
 	keyNameBackspace = "backspace"
 	keyNameCtrlU     = "ctrl+u"
 	keyNameCtrlD     = "ctrl+d"
-	keyNameCtrlC     = "ctrl+c"
 	keyNameRight     = "right"
 	keyNamePageUp    = "pgup"
 	keyNamePageDown  = "pgdown"
@@ -48,6 +52,12 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.quitting = true
 		return m, tea.Quit
 
+	case keyNameUp:
+		return m.navigateInlineSearchHistory(-1)
+
+	case keyNameDown:
+		return m.navigateInlineSearchHistory(1)
+
 	case keyNameTab:
 		// Toggle search mode — only meaningful at message list level
 		// where Fast (Parquet metadata) and Deep (FTS5 body) differ.
@@ -60,10 +70,17 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		m.searchInput.Placeholder = m.searchPlaceholder()
 		m.inlineSearchDebounce++
 		if query := m.searchInput.Value(); query != "" {
+			if err := m.searchInputValidationError(query); err != nil {
+				m.invalidateInlineSearchRequests()
+				m.inlineSearchLoading = false
+				m.inlineSearchError = err.Error()
+				return m, nil
+			}
+			m.inlineSearchError = ""
 			m.searchQuery = query
 			m.inlineSearchLoading = true
 			spinCmd := m.startSpinner()
-			m.searchRequestID++
+			m.invalidateInlineSearchRequests()
 			m.prepareSearchReplacement()
 			return m, tea.Batch(spinCmd, m.loadSearch(query))
 		}
@@ -71,34 +88,80 @@ func (m Model) handleInlineSearchKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 
 	default:
 		// Pass key to text input
+		previousQuery := m.searchInput.Value()
 		var cmd tea.Cmd
 		m.searchInput, cmd = m.searchInput.Update(msg)
-
-		// Trigger debounced search (Fast: 100ms, Deep: 500ms)
-		query := m.searchInput.Value()
-		m.inlineSearchDebounce++
-		debounceID := m.inlineSearchDebounce
-
-		delay := inlineSearchDebounceDelay
-		if m.searchMode != searchModeFast {
-			delay = deepSearchDebounceDelay
+		if m.searchHistoryIndex >= 0 && m.searchInput.Value() != previousQuery {
+			m.resetInlineSearchHistoryNavigation()
 		}
-
-		// Show loading spinner immediately while waiting for debounce
-		var spinCmd tea.Cmd
-		if query != "" {
-			m.inlineSearchLoading = true
-			spinCmd = m.startSpinner()
-		} else {
-			m.inlineSearchLoading = false
-		}
-
-		debounceCmd := tea.Tick(delay, func(t time.Time) tea.Msg {
-			return searchDebounceMsg{query: query, debounceID: debounceID}
-		})
-
-		return m, tea.Batch(cmd, spinCmd, debounceCmd)
+		return m.scheduleInlineSearch(cmd)
 	}
+}
+
+func (m Model) navigateInlineSearchHistory(direction int) (tea.Model, tea.Cmd) {
+	if len(m.searchHistory) == 0 {
+		return m, nil
+	}
+
+	if m.searchHistoryIndex < 0 {
+		if direction > 0 {
+			return m, nil
+		}
+		m.searchHistoryDraft = m.searchInput.Value()
+		m.searchHistoryIndex = len(m.searchHistory)
+	}
+
+	if direction < 0 && m.searchHistoryIndex > 0 {
+		m.searchHistoryIndex--
+		m.searchInput.SetValue(m.searchHistory[m.searchHistoryIndex])
+	} else if direction > 0 {
+		if m.searchHistoryIndex < len(m.searchHistory)-1 {
+			m.searchHistoryIndex++
+			m.searchInput.SetValue(m.searchHistory[m.searchHistoryIndex])
+		} else {
+			m.searchInput.SetValue(m.searchHistoryDraft)
+			m.resetInlineSearchHistoryNavigation()
+		}
+	}
+
+	return m.scheduleInlineSearch(nil)
+}
+
+func (m Model) scheduleInlineSearch(inputCmd tea.Cmd) (tea.Model, tea.Cmd) {
+	query := m.searchInput.Value()
+	if query != m.searchQuery {
+		m.invalidateInlineSearchRequests()
+	}
+	m.inlineSearchError = ""
+	m.inlineSearchDebounce++
+	debounceID := m.inlineSearchDebounce
+
+	delay := inlineSearchDebounceDelay
+	if m.searchMode != searchModeFast {
+		delay = deepSearchDebounceDelay
+	}
+
+	var spinCmd tea.Cmd
+	if query != "" {
+		m.inlineSearchLoading = true
+		spinCmd = m.startSpinner()
+	} else {
+		m.inlineSearchLoading = false
+	}
+
+	debounceCmd := tea.Tick(delay, func(time.Time) tea.Msg {
+		return searchDebounceMsg{query: query, debounceID: debounceID}
+	})
+	return m, tea.Batch(inputCmd, spinCmd, debounceCmd)
+}
+
+func (m *Model) invalidateInlineSearchRequests() {
+	if m.level == levelMessageList {
+		m.searchRequestID++
+		m.loadRequestID++
+		return
+	}
+	m.aggregateRequestID++
 }
 
 func (m Model) currentSearchFilter() query.MessageFilter {
@@ -115,7 +178,7 @@ func (m Model) semanticSearchAvailable() bool {
 }
 
 func (m Model) deepSearchAvailable() bool {
-	return m.currentSearchFilter().ListID == ""
+	return true
 }
 
 func (m *Model) syncSearchScope() {
@@ -394,12 +457,26 @@ func (m Model) handleAggregateKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.loadRequestID++
 		return m, m.loadMessages()
 
-	case "d", "D": // Stage for deletion (selection or current row)
+	case "d": // Stage selected aggregates, or the current row.
 		if !m.hasSelection() && len(m.rows) > 0 && m.cursor < len(m.rows) {
 			// No selection - select current row first
 			m.selection.aggregateKeys[m.rows[m.cursor].Key] = true
 		}
 		return m.stageForDeletion()
+
+	case "D": // Stage every message in the current aggregate row.
+		if m.loading || m.inlineSearchLoading {
+			return m, nil
+		}
+		if len(m.rows) == 0 || m.cursor >= len(m.rows) {
+			return m, nil
+		}
+		dctx := m.deletionContext(true)
+		dctx.AggregateViewType = m.viewType
+		key := m.rows[m.cursor].Key
+		dctx.AggregateMatchKey = &key
+		dctx.MatchFilter = m.actions.buildFilterForAggregate(key, dctx)
+		return m.stageAllMatchesForDeletionContext(dctx)
 
 	// Drill down - go to message list for selected aggregate
 	case keyNameEnter:
@@ -526,7 +603,8 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	if (key == keyNamePageDown || key == keyNameCtrlD) &&
 		m.searchQuery != "" && m.searchMode == searchModeDeep &&
-		m.searchTotalCount == -1 && !m.searchLoadingMore && !m.loading &&
+		(m.searchTotalCount < 0 || int64(len(m.messages)) < m.searchTotalCount) &&
+		!m.searchLoadingMore && !m.loading &&
 		m.cursor >= len(m.messages)-1 && len(m.messages) > 0 {
 		m.searchLoadingMore = true
 		m.searchRequestID++
@@ -581,12 +659,15 @@ func (m Model) handleMessageListKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "x": // Clear selection
 		m.clearAllSelections()
 
-	case "d", "D": // Stage for deletion (selection or current row)
+	case "d": // Stage selected messages, or the current row.
 		if !m.hasSelection() && len(m.messages) > 0 && m.cursor < len(m.messages) {
 			// No selection - select current row first
 			m.selection.messageIDs[m.messages[m.cursor].ID] = true
 		}
 		return m.stageForDeletion()
+
+	case "D": // Stage every message matching the current filter/search.
+		return m.stageAllMatchesForDeletion()
 
 	// Attachment filter
 	case "f":
@@ -1550,6 +1631,23 @@ func (m *Model) openFilterModal() {
 func (m *Model) exitInlineSearchMode() {
 	m.inlineSearchActive = false
 	m.inlineSearchLoading = false
+	m.inlineSearchError = ""
+	m.resetInlineSearchHistoryNavigation()
+}
+
+func (m *Model) resetInlineSearchHistoryNavigation() {
+	m.searchHistoryIndex = -1
+	m.searchHistoryDraft = ""
+}
+
+func (m *Model) recordInlineSearch(queryStr string) {
+	if queryStr == "" || len(m.searchHistory) > 0 && m.searchHistory[len(m.searchHistory)-1] == queryStr {
+		return
+	}
+	m.searchHistory = append(m.searchHistory, queryStr)
+	if len(m.searchHistory) > inlineSearchHistoryLimit {
+		m.searchHistory = append([]string(nil), m.searchHistory[len(m.searchHistory)-inlineSearchHistoryLimit:]...)
+	}
 }
 
 // clearSearchState clears search query and invalidates pending requests.
@@ -1583,8 +1681,16 @@ func (m Model) reloadCurrentView() (tea.Model, tea.Cmd) {
 
 // commitInlineSearch finalizes the search and exits inline mode.
 func (m Model) commitInlineSearch() (tea.Model, tea.Cmd) {
-	m.exitInlineSearchMode()
 	queryStr := m.searchInput.Value()
+	if err := m.searchInputValidationError(queryStr); err != nil {
+		m.inlineSearchLoading = false
+		m.inlineSearchError = err.Error()
+		return m, nil
+	}
+	aggregateReloadNeeded := (m.level == levelAggregates || m.level == levelDrillDown) &&
+		(queryStr != m.searchQuery || m.inlineSearchLoading)
+	m.recordInlineSearch(queryStr)
+	m.exitInlineSearchMode()
 
 	if queryStr == "" {
 		// Empty search clears filter - restore from snapshot if available
@@ -1607,8 +1713,31 @@ func (m Model) commitInlineSearch() (tea.Model, tea.Cmd) {
 		m.prepareSearchReplacement()
 		return m, tea.Batch(spinCmd, m.loadSearch(queryStr))
 	}
-	// In aggregate views, results already showing from debounced search
+	if aggregateReloadNeeded {
+		m.aggregateRequestID++
+		m.inlineSearchLoading = true
+		spinCmd := m.startSpinner()
+		return m, tea.Batch(spinCmd, m.loadData())
+	}
+	// Aggregate rows already match the committed debounced search.
 	return m, nil
+}
+
+func (m Model) searchInputValidationError(queryStr string) error {
+	if queryStr == "" {
+		return nil
+	}
+	parsed := search.Parse(queryStr)
+	if m.searchMode == searchModeSemantic {
+		if parsed.Err() == nil && len(parsed.TextTerms) == 0 {
+			return errors.New("semantic search requires free text")
+		}
+		return nil
+	}
+	if err := parsed.Err(); err != nil {
+		return fmt.Errorf("invalid search query: %w", err)
+	}
+	return nil
 }
 
 // cancelInlineSearch cancels the search and restores previous state.
@@ -1696,6 +1825,7 @@ func (m *Model) activateInlineSearch(placeholder string) tea.Cmd {
 		m.searchInput.Placeholder = placeholder
 	}
 	m.searchInput.SetValue("") // Clear previous search
+	m.resetInlineSearchHistoryNavigation()
 	m.searchInput.Focus()
 	return textinput.Blink
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -43,8 +43,9 @@ const defaultThreadMessageLimit = 1000
 
 // Options configuration for TUI.
 type Options struct {
-	DataDir string
-	Version string
+	DataDir   string
+	ExportDir string
+	Version   string
 
 	// AggregateLimit overrides the maximum number of aggregate rows to load.
 	// Zero uses the default (50,000).
@@ -224,16 +225,19 @@ type Model struct {
 	height int
 
 	// Loading state
-	loading       bool
-	err           error
-	spinnerFrame  int  // Current frame index into spinnerFrames
-	spinnerActive bool // True when spinner tick is running
+	loading         bool
+	deletionLoading bool // True while resolving every message matching the current filter
+	deletionCancel  context.CancelFunc
+	err             error
+	spinnerFrame    int  // Current frame index into spinnerFrames
+	spinnerActive   bool // True when spinner tick is running
 
 	// Request tracking to ignore stale async results
 	aggregateRequestID     uint64 // Current request ID for aggregate data
 	loadRequestID          uint64 // Current request ID for message list
 	detailRequestID        uint64 // Current request ID for message detail
 	searchRequestID        uint64 // Current request ID for search results
+	deletionRequestID      uint64 // Current request ID for bulk deletion target resolution
 	presentationGeneration uint64 // Mode activation owning shared presentation
 	textRequestID          uint64 // Latest Text navigation/data request
 
@@ -252,6 +256,10 @@ type Model struct {
 	inlineSearchActive   bool   // True when inline search bar is active
 	inlineSearchDebounce uint64 // Increment to cancel pending debounce timers
 	inlineSearchLoading  bool   // True when a debounced search query is in-flight
+	inlineSearchError    string // Non-modal validation feedback for incomplete/invalid input
+	searchHistory        []string
+	searchHistoryIndex   int
+	searchHistoryDraft   string
 
 	// Pre-search snapshot: cached message list state before search began,
 	// so Esc can restore instantly without re-querying.
@@ -327,9 +335,10 @@ func New(engine query.Engine, opts Options) Model {
 		settingsBackend: opts.SettingsBackend,
 		settings:        newSettingsState(),
 		actions: NewActionControllerWithOptions(engine, ActionControllerOptions{
-			DataDir:          opts.DataDir,
-			ManifestSaver:    opts.ManifestSaver,
-			AttachmentReader: opts.AttachmentReader,
+			DataDir:             opts.DataDir,
+			AttachmentOutputDir: opts.ExportDir,
+			ManifestSaver:       opts.ManifestSaver,
+			AttachmentReader:    opts.AttachmentReader,
 		}),
 		semanticSearch:     opts.SemanticSearch,
 		version:            opts.Version,
@@ -497,10 +506,12 @@ func (m Model) loadData() tea.Cmd {
 					filteredStats = &query.TotalStats{}
 				} else {
 					statsOpts := query.StatsOptions{
+						Filter:                &aggregateFilter,
 						SourceID:              m.accountFilter,
 						WithAttachmentsOnly:   m.filters.attachmentsOnly,
 						HideDeletedFromSource: m.filters.hideDeletedFromSource,
 						SearchQuery:           scopedQuery,
+						SearchScope:           true,
 						GroupBy:               m.viewType,
 					}
 					filteredStats, _ = m.engine.GetTotalStats(ctx, statsOpts)
@@ -588,6 +599,14 @@ type searchResultsMsg struct {
 	presentationGeneration uint64
 }
 
+// deletionPreparedMsg is sent when asynchronous bulk deletion target
+// resolution has built a manifest or failed.
+type deletionPreparedMsg struct {
+	manifest  *deletion.Manifest
+	err       error
+	requestID uint64
+}
+
 // threadMessagesLoadedMsg is sent when thread messages are loaded.
 type threadMessagesLoadedMsg struct {
 	messages               []query.MessageSummary
@@ -616,6 +635,9 @@ type exportResultMsg = ExportResultMsg
 
 // inlineSearchDebounceDelay is the delay before executing inline search (fast mode).
 const inlineSearchDebounceDelay = 100 * time.Millisecond
+
+// inlineSearchHistoryLimit bounds session-only search history.
+const inlineSearchHistoryLimit = 100
 
 // deepSearchDebounceDelay is the delay before executing inline search (deep FTS mode).
 const deepSearchDebounceDelay = 500 * time.Millisecond
@@ -697,7 +719,6 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 					"duration_ms", time.Since(start).Milliseconds(),
 				)
 			}()
-
 			switch m.searchMode {
 			case searchModeFast:
 				// Fast search: single-scan with temp table materialization
@@ -711,47 +732,15 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 				}
 				err = fastErr
 			case searchModeDeep:
-				// A list drill is exact equality, while the list: search operator
-				// is intentionally a substring filter. Route this unsupported deep
-				// scope through Fast rather than widening its result set.
-				if searchFilter.ListID != "" {
-					result, fastErr := m.engine.SearchFastWithStats(ctx, q, queryStr, searchFilter, m.viewType, searchPageSize, offset)
-					if fastErr == nil {
-						results = result.Messages
-						totalCount = result.TotalCount
-						if !appendResults {
-							stats = result.Stats
-						}
-					}
-					err = fastErr
-					break
-				}
-				// Deep search: FTS5 body search
-				// Merge context filter into query to honor drill-down context
-				mergedQuery := query.MergeFilterIntoQuery(q, searchFilter)
-				results, err = m.engine.Search(ctx, mergedQuery, searchPageSize, offset)
-				// For deep search, estimate total from result count (no separate count query)
-				if err == nil && offset == 0 {
-					totalCount = int64(len(results))
-					if len(results) == searchPageSize {
-						totalCount = -1 // Indicate more results available
-					}
-				}
-
-				// Fetch aggregate stats (size, attachments) for the search results
-				// on the initial page load so the header metrics are accurate.
-				if err == nil && !appendResults {
-					statsOpts, noMatches := deepSearchStatsOptions(mergedQuery, m.viewType)
-					if noMatches {
-						stats = &query.TotalStats{}
-					} else {
-						var statsErr error
-						stats, statsErr = m.engine.GetTotalStats(ctx, statsOpts)
-						if statsErr != nil {
-							slog.Warn("tui deep search stats failed",
-								"query_len", len(queryStr),
-								"error", statsErr.Error(),
-							)
+				// Deep search returns results and header metrics from one complete
+				// view filter so names, conversations, and empty buckets stay scoped.
+				result, deepErr := m.engine.SearchDeepWithStats(ctx, q, searchFilter, searchPageSize, offset)
+				if deepErr == nil {
+					results = result.Messages
+					totalCount = result.TotalCount
+					if !appendResults {
+						stats = result.Stats
+						if stats == nil {
 							fallbackCount := totalCount
 							if fallbackCount < 0 {
 								fallbackCount = int64(len(results))
@@ -760,6 +749,7 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 						}
 					}
 				}
+				err = deepErr
 			case searchModeSemantic:
 				if m.semanticSearch == nil {
 					err = errors.New("semantic search is not enabled")
@@ -806,35 +796,6 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 			}
 		},
 	)
-}
-
-// deepSearchStatsOptions derives stats from the already-merged query used for
-// deep results. Search.Query cannot represent SenderName, RecipientName,
-// ConversationID, or empty aggregate buckets; MergeFilterIntoQuery deliberately
-// leaves those unsupported contexts out of both paths. A non-nil empty account
-// scope is the shared match-nothing signal for conflicting message types or an
-// explicitly empty collection.
-func deepSearchStatsOptions(merged *search.Query, groupBy query.ViewType) (query.StatsOptions, bool) {
-	opts := query.StatsOptions{
-		SearchQuery: search.Format(merged),
-		SearchScope: true,
-		GroupBy:     groupBy,
-	}
-	if merged == nil {
-		return opts, false
-	}
-	if merged.AccountIDs != nil && len(merged.AccountIDs) == 0 {
-		return opts, true
-	}
-	if len(merged.AccountIDs) == 1 {
-		sourceID := merged.AccountIDs[0]
-		opts.SourceID = &sourceID
-	} else if len(merged.AccountIDs) > 1 {
-		opts.SourceIDs = append([]int64(nil), merged.AccountIDs...)
-	}
-	opts.WithAttachmentsOnly = merged.HasAttachment != nil && *merged.HasAttachment
-	opts.HideDeletedFromSource = merged.HideDeleted
-	return opts, false
 }
 
 // buildMessageFilter constructs a MessageFilter from the current model state.
@@ -1160,6 +1121,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleThreadMessagesLoaded(msg)
 	case searchResultsMsg:
 		return m.handleSearchResults(msg)
+	case deletionPreparedMsg:
+		return m.handleDeletionPrepared(msg)
 	case flashClearMsg:
 		return m.handleFlashClear()
 	case searchDebounceMsg:
@@ -1658,6 +1621,14 @@ func (m Model) handleSearchDebounce(msg searchDebounceMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
+	if err := m.searchInputValidationError(msg.query); err != nil {
+		m.invalidateInlineSearchRequests()
+		m.inlineSearchLoading = false
+		m.inlineSearchError = err.Error()
+		return m, nil
+	}
+
+	m.inlineSearchError = ""
 	m.searchQuery = msg.query
 	if m.searchQuery == "" {
 		m.contextStats = nil
@@ -1668,8 +1639,7 @@ func (m Model) handleSearchDebounce(msg searchDebounceMsg) (tea.Model, tea.Cmd) 
 	if m.level == levelMessageList {
 		// Message list: use search engine for live results
 		m.syncSearchScope()
-		m.searchRequestID++
-		m.loadRequestID++ // Invalidate any in-flight loadMessages to prevent overwriting search results
+		m.invalidateInlineSearchRequests()
 		if msg.query == "" {
 			// Empty query: reload unfiltered messages
 			return m, tea.Batch(spinCmd, m.loadMessages())
@@ -1685,7 +1655,7 @@ func (m Model) handleSearchDebounce(msg searchDebounceMsg) (tea.Model, tea.Cmd) 
 // handleSpinnerTick processes spinner animation ticks.
 func (m Model) handleSpinnerTick() (tea.Model, tea.Cmd) {
 	// Only advance if still loading (any loading state)
-	if m.loading || m.inlineSearchLoading || m.searchLoadingMore {
+	if m.isLoading() {
 		m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
 		return m, spinnerTick()
 	}
@@ -1715,6 +1685,21 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Handle modal first (error modals must dismiss even during search)
 	if m.modal != modalNone {
 		return m.handleModalKeys(msg)
+	}
+
+	// Resolving every deletion match is view-independent. Keep the current
+	// scope stable until it finishes, while still allowing cancellation and
+	// the normal quit flow from aggregate and message-list views alike.
+	if m.deletionLoading {
+		switch msg.String() {
+		case keyNameEsc:
+			m.cancelDeletionResolution()
+			return m.showFlash("Deletion match resolution canceled")
+		case "q", keyNameCtrlC:
+			m.cancelDeletionResolution()
+		default:
+			return m, nil
+		}
 	}
 
 	// Handle inline search (takes priority over view)
@@ -1850,12 +1835,50 @@ func (m *Model) updateDetailLineCount() {
 
 // stageForDeletion prepares messages for deletion via the ActionController.
 func (m Model) stageForDeletion() (tea.Model, tea.Cmd) {
+	return m.stageForDeletionContext(false)
+}
+
+func (m Model) stageAllMatchesForDeletion() (tea.Model, tea.Cmd) {
+	return m.stageAllMatchesForDeletionContext(m.deletionContext(true))
+}
+
+func (m Model) stageAllMatchesForDeletionContext(ctx DeletionContext) (tea.Model, tea.Cmd) {
+	if m.deletionLoading {
+		return m, nil
+	}
+
+	m.deletionRequestID++
+	requestID := m.deletionRequestID
+	m.deletionLoading = true
+	resolveContext, cancel := context.WithCancel(context.Background())
+	m.deletionCancel = cancel
+	spinCmd := m.startSpinner()
+	resolveCmd := safeCmdWithPanic(
+		func() tea.Msg {
+			manifest, err := m.actions.StageForDeletionContext(resolveContext, ctx)
+			return deletionPreparedMsg{manifest: manifest, err: err, requestID: requestID}
+		},
+		func(r any) tea.Msg {
+			return deletionPreparedMsg{
+				err: fmt.Errorf("bulk deletion target resolution panic: %v", r), requestID: requestID,
+			}
+		},
+	)
+	return m, tea.Batch(spinCmd, resolveCmd)
+}
+
+func (m Model) stageForDeletionContext(allMatches bool) (tea.Model, tea.Cmd) {
+	manifest, err := m.actions.StageForDeletion(m.deletionContext(allMatches))
+	return m.applyPreparedDeletion(manifest, err)
+}
+
+func (m Model) deletionContext(allMatches bool) DeletionContext {
 	var drillFilter *query.MessageFilter
 	if m.hasDrillFilter() {
 		f := m.drillFilter
 		drillFilter = &f
 	}
-	manifest, err := m.actions.StageForDeletion(DeletionContext{
+	dctx := DeletionContext{
 		AggregateSelection: m.selection.aggregateKeys,
 		MessageSelection:   m.selection.messageIDs,
 		AggregateViewType:  m.selection.aggregateViewType,
@@ -1864,7 +1887,45 @@ func (m Model) stageForDeletion() (tea.Model, tea.Cmd) {
 		TimeGranularity:    m.timeGranularity,
 		Messages:           m.messages,
 		DrillFilter:        drillFilter,
-	})
+		AllMatches:         allMatches,
+		SearchQuery:        m.searchQuery,
+		SearchMode:         m.searchMode,
+		MatchFilter:        m.currentSearchFilter(),
+	}
+	if allMatches {
+		// Space selections are a different command scope. Keep them out of both
+		// resolution and the manifest audit record for uppercase D.
+		dctx.AggregateSelection = nil
+		dctx.MessageSelection = nil
+	}
+	return dctx
+}
+
+func (m Model) handleDeletionPrepared(msg deletionPreparedMsg) (tea.Model, tea.Cmd) {
+	if msg.requestID != m.deletionRequestID {
+		return m, nil
+	}
+	m.finishDeletionResolution()
+	return m.applyPreparedDeletion(msg.manifest, msg.err)
+}
+
+func (m *Model) finishDeletionResolution() {
+	if m.deletionCancel != nil {
+		m.deletionCancel()
+		m.deletionCancel = nil
+	}
+	m.deletionLoading = false
+}
+
+func (m *Model) cancelDeletionResolution() {
+	if !m.deletionLoading {
+		return
+	}
+	m.deletionRequestID++
+	m.finishDeletionResolution()
+}
+
+func (m Model) applyPreparedDeletion(manifest *deletion.Manifest, err error) (tea.Model, tea.Cmd) {
 	if err != nil {
 		m.modal = modalDeleteResult
 		m.modalResult = err.Error()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +39,81 @@ func TestModelUpdateAnalyticsNotice(t *testing.T) {
 	assert.Empty(t, asModel(t, updated).analyticsNotice)
 }
 
+func TestDebouncedMalformedSearchStaysInlineAndDoesNotReplaceActiveQuery(t *testing.T) {
+	assertions := assert.New(t)
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model.inlineSearchActive = true
+	model.searchMode = searchModeFast
+	model.searchQuery = "working query"
+	model.searchRequestID = 4
+	model.loadRequestID = 6
+	model.inlineSearchDebounce = 7
+	model.searchInput.SetValue("before:not-a-date")
+	model.searchInput.Focus()
+
+	updated, cmd := model.handleSearchDebounce(searchDebounceMsg{query: model.searchInput.Value(), debounceID: 7})
+	model = asModel(t, updated)
+
+	assertions.Nil(cmd)
+	assertions.Equal(modalNone, model.modal)
+	assertions.True(model.inlineSearchActive)
+	assertions.Equal("working query", model.searchQuery)
+	assertions.Contains(model.inlineSearchError, "invalid value")
+	assertions.Contains(model.View().Content, "invalid value")
+	assertions.Equal(uint64(5), model.searchRequestID)
+	assertions.Equal(uint64(7), model.loadRequestID)
+
+	updated, _ = model.handleSearchResults(searchResultsMsg{
+		messages:  []query.MessageSummary{{ID: 99, Subject: "stale"}},
+		requestID: 4,
+	})
+	model = asModel(t, updated)
+	assertions.Empty(model.messages, "results started before validation feedback must be ignored")
+	assertions.Contains(model.inlineSearchError, "invalid value")
+
+	model, _ = applyInlineSearchKey(t, model, key('x'))
+	assertions.Contains(model.searchInput.Value(), "x", "validation feedback must not swallow the next typed character")
+}
+
+func TestChangedInlineSearchInputImmediatelyInvalidatesInFlightResults(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model.inlineSearchActive = true
+	model.searchQuery = "old query"
+	model.searchInput.SetValue("old query")
+	model.searchInput.Focus()
+	model.searchRequestID = 8
+	model.loadRequestID = 10
+
+	model, _ = applyInlineSearchKey(t, model, key('!'))
+	assert.Equal(t, uint64(9), model.searchRequestID)
+	assert.Equal(t, uint64(11), model.loadRequestID)
+
+	updated, _ := model.handleSearchResults(searchResultsMsg{
+		messages:  []query.MessageSummary{{ID: 99, Subject: "stale"}},
+		requestID: 8,
+	})
+	model = asModel(t, updated)
+	assert.Empty(t, model.messages)
+}
+
+func TestDebouncedSemanticOperatorOnlySearchStaysInline(t *testing.T) {
+	assertions := assert.New(t)
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model.inlineSearchActive = true
+	model.searchMode = searchModeSemantic
+	model.searchQuery = "working query"
+	model.inlineSearchDebounce = 8
+	model.searchInput.SetValue("message_type:email")
+
+	updated, cmd := model.handleSearchDebounce(searchDebounceMsg{query: model.searchInput.Value(), debounceID: 8})
+	model = asModel(t, updated)
+
+	assertions.Nil(cmd)
+	assertions.Equal(modalNone, model.modal)
+	assertions.Equal("working query", model.searchQuery)
+	assertions.Contains(model.inlineSearchError, "semantic search requires free text")
+}
+
 // =============================================================================
 // New (Constructor) Tests
 // =============================================================================
@@ -72,73 +146,17 @@ func TestNew_OverridesLimits(t *testing.T) {
 	assert.Equal(t, 50, model.threadMessageLimit)
 }
 
-func TestDeepSearchStatsOptions_EnableSearchScope(t *testing.T) {
-	t.Run("deep search stats use merged representable scope", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		engine := newMockEngine(MockConfig{})
-		tracker := &statsTracker{result: &query.TotalStats{}}
-		tracker.install(engine)
-		model := New(engine, Options{DataDir: "/tmp/test", Version: "test"})
-		model.searchMode = searchModeDeep
-		after := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
-		before := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
-		model.searchFilter = query.MessageFilter{
-			Sender:                "alice@example.com",
-			Recipient:             "bob@example.com",
-			Domain:                "example.com",
-			Label:                 "Project Review",
-			MessageType:           "meeting_transcript",
-			SourceIDs:             []int64{7, 8},
-			After:                 &after,
-			Before:                &before,
-			WithAttachmentsOnly:   true,
-			HideDeletedFromSource: true,
-		}
-
-		cmd := model.loadSearch("cross-type stats needle")
-		require.NotNil(cmd, "loadSearch command")
-		msg := cmd()
-		require.IsType(searchResultsMsg{}, msg)
-		require.Equal(1, tracker.callCount, "deep search stats call count")
-		assert.True(tracker.lastOpts.SearchScope, "deep search stats use search scope")
-		assert.Nil(tracker.lastOpts.SourceID, "multi-source scope does not collapse to one source")
-		assert.Equal([]int64{7, 8}, tracker.lastOpts.SourceIDs, "merged source scope")
-		assert.True(tracker.lastOpts.WithAttachmentsOnly, "merged attachment scope")
-		assert.True(tracker.lastOpts.HideDeletedFromSource, "merged deletion scope")
-
-		formatted := search.Parse(tracker.lastOpts.SearchQuery)
-		assert.Equal([]string{"cross-type", "stats", "needle"}, formatted.TextTerms)
-		assert.ElementsMatch([]string{"alice@example.com", "@example.com"}, formatted.FromAddrs)
-		assert.Equal([]string{"bob@example.com"}, formatted.ToAddrs)
-		assert.Equal([]string{"Project Review"}, formatted.Labels)
-		assert.Equal([]string{emailMessageType}, formatted.MessageTypes)
-		require.NotNil(formatted.AfterDate, "merged after date")
-		require.NotNil(formatted.BeforeDate, "merged before date")
-		assert.Equal(after, *formatted.AfterDate)
-		assert.Equal(before, *formatted.BeforeDate)
+func TestNew_ConfiguresAttachmentExportDirectory(t *testing.T) {
+	engine := newMockEngine(MockConfig{})
+	model := New(engine, Options{
+		DataDir:   "/tmp/test",
+		ExportDir: "/tmp/configured-exports",
 	})
 
-	t.Run("conflicting message types short-circuit stats", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		engine := newMockEngine(MockConfig{})
-		tracker := &statsTracker{result: &query.TotalStats{MessageCount: 99}}
-		tracker.install(engine)
-		model := New(engine, Options{DataDir: "/tmp/test", Version: "test"})
-		model.searchMode = searchModeDeep
-		model.searchFilter = query.MessageFilter{}
+	assert.Equal(t, "/tmp/configured-exports", model.actions.attachmentOutputDir)
+}
 
-		cmd := model.loadSearch("message_type:sms conflictneedle")
-		require.NotNil(cmd, "loadSearch command")
-		msg := cmd()
-		result, ok := msg.(searchResultsMsg)
-		require.True(ok, "expected searchResultsMsg, got %T", msg)
-		assert.Zero(tracker.callCount, "conflicting scope skips stats query")
-		require.NotNil(result.stats, "conflicting scope zero stats")
-		assert.Zero(result.stats.MessageCount, "conflicting scope stats count")
-	})
-
+func TestStatsOptions_SearchScopeBoundaries(t *testing.T) {
 	t.Run("aggregate analytics stats", func(t *testing.T) {
 		require := require.New(t)
 		engine := newMockEngine(MockConfig{})
@@ -152,7 +170,7 @@ func TestDeepSearchStatsOptions_EnableSearchScope(t *testing.T) {
 		msg := cmd()
 		require.IsType(dataLoadedMsg{}, msg)
 		require.Equal(1, tracker.callCount, "aggregate analytics stats call count")
-		assert.False(t, tracker.lastOpts.SearchScope, "aggregate analytics retain default scope")
+		assert.True(t, tracker.lastOpts.SearchScope, "aggregate search stats use the body-aware scope")
 	})
 
 	t.Run("ordinary total stats", func(t *testing.T) {
@@ -171,69 +189,65 @@ func TestDeepSearchStatsOptions_EnableSearchScope(t *testing.T) {
 	})
 }
 
-func TestDeepSearchStatsFailureClearsStaleContextStats(t *testing.T) {
-	tests := []struct {
-		name         string
-		messages     []query.MessageSummary
-		wantTotal    int64
-		wantMsgCount int64
-	}{
-		{
-			name:         "short page keeps known result count",
-			messages:     []query.MessageSummary{{ID: 42, Subject: "matching result"}},
-			wantTotal:    1,
-			wantMsgCount: 1,
-		},
-		{
-			name:         "full page keeps loaded count when total is unknown",
-			messages:     makeMessages(searchPageSize),
-			wantTotal:    -1,
-			wantMsgCount: searchPageSize,
-		},
+func TestLoadSearchDeepPreservesCompleteViewFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	engine := newMockEngine(MockConfig{})
+	var gotFilter query.MessageFilter
+	engine.SearchDeepWithStatsFunc = func(
+		_ context.Context, _ *search.Query, filter query.MessageFilter, _, _ int,
+	) (*query.SearchFastResult, error) {
+		gotFilter = filter
+		return &query.SearchFastResult{
+			TotalCount: 2,
+			Stats:      &query.TotalStats{MessageCount: 2, TotalSize: 300},
+		}, nil
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			engine := newMockEngine(MockConfig{Messages: tc.messages})
-			engine.GetTotalStatsFunc = func(context.Context, query.StatsOptions) (*query.TotalStats, error) {
-				return nil, errors.New("stats unavailable")
-			}
-			model := New(engine, Options{DataDir: "/tmp/test", Version: "test"})
-			model.searchMode = searchModeDeep
-			model.contextStats = &query.TotalStats{
-				MessageCount:    99,
-				TotalSize:       12345,
-				AttachmentCount: 7,
-				LabelCount:      3,
-				AccountCount:    2,
-			}
-
-			cmd := model.loadSearch("matching")
-			require.NotNil(cmd, "loadSearch command")
-			msg, ok := cmd().(searchResultsMsg)
-			require.True(ok, "expected searchResultsMsg")
-			require.NoError(msg.err, "successful results survive stats failure")
-			assert.Equal(tc.wantTotal, msg.totalCount)
-			require.NotNil(msg.stats, "stats failure produces explicit fallback stats")
-			assert.Equal(tc.wantMsgCount, msg.stats.MessageCount)
-			assert.Zero(msg.stats.TotalSize)
-			assert.Zero(msg.stats.AttachmentCount)
-			assert.Zero(msg.stats.LabelCount)
-			assert.Zero(msg.stats.AccountCount)
-
-			model.searchRequestID = msg.requestID
-			updated, _ := model.Update(msg)
-			got := asModel(t, updated)
-			require.NotNil(got.contextStats)
-			assert.Equal(tc.wantMsgCount, got.contextStats.MessageCount)
-			assert.Zero(got.contextStats.TotalSize)
-			assert.Zero(got.contextStats.AttachmentCount)
-			assert.Zero(got.contextStats.LabelCount)
-			assert.Zero(got.contextStats.AccountCount)
-			assert.Len(got.messages, len(tc.messages), "successful search results are preserved")
-		})
+	model := New(engine, Options{DataDir: "/tmp/test", Version: "test"})
+	model.searchMode = searchModeDeep
+	model.searchFilter = query.MessageFilter{
+		SenderName:        "Alice",
+		RecipientName:     "Bob",
+		Domain:            "example.com",
+		Label:             "Work",
+		EmptyValueTargets: map[query.ViewType]bool{query.ViewLabels: true},
 	}
+
+	msg, ok := model.loadSearch("needle")().(searchResultsMsg)
+	requirements.True(ok)
+	assertions.Equal("Alice", gotFilter.SenderName)
+	assertions.Equal("Bob", gotFilter.RecipientName)
+	assertions.Equal("example.com", gotFilter.Domain)
+	assertions.Equal("Work", gotFilter.Label)
+	assertions.True(gotFilter.MatchesEmpty(query.ViewLabels))
+	assertions.Equal(emailMessageType, gotFilter.MessageType)
+	requirements.NotNil(msg.stats)
+	assertions.Equal(int64(2), msg.totalCount)
+	assertions.Equal(int64(2), msg.stats.MessageCount)
+	assertions.Equal(int64(300), msg.stats.TotalSize)
+}
+
+func TestLoadSearchDeepClearsStaleStatsWhenBackendOmitsStats(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	engine := newMockEngine(MockConfig{})
+	engine.SearchDeepWithStatsFunc = func(
+		context.Context, *search.Query, query.MessageFilter, int, int,
+	) (*query.SearchFastResult, error) {
+		return &query.SearchFastResult{
+			Messages:   []query.MessageSummary{{ID: 42}},
+			TotalCount: 1,
+		}, nil
+	}
+	model := New(engine, Options{DataDir: "/tmp/test", Version: "test"})
+	model.searchMode = searchModeDeep
+	model.contextStats = &query.TotalStats{MessageCount: 99, TotalSize: 12345}
+
+	msg, ok := model.loadSearch("matching")().(searchResultsMsg)
+	requirements.True(ok)
+	requirements.NotNil(msg.stats)
+	assertions.Equal(int64(1), msg.stats.MessageCount)
+	assertions.Zero(msg.stats.TotalSize)
 }
 
 // =============================================================================

--- a/internal/tui/nav_view_test.go
+++ b/internal/tui/nav_view_test.go
@@ -998,8 +998,17 @@ func TestLoadDataSetsGroupByInStatsOpts(t *testing.T) {
 	tracker.install(engine)
 
 	model := New(engine, Options{DataDir: "/tmp/test", Version: "test123"})
+	conversationID := int64(42)
 	model.viewType = query.ViewRecipients
 	model.searchQuery = "bob"
+	model.drillFilter = query.MessageFilter{
+		SenderName:        "Alice",
+		RecipientName:     "Bob",
+		Domain:            "example.com",
+		Label:             "Work",
+		ConversationID:    &conversationID,
+		EmptyValueTargets: map[query.ViewType]bool{query.ViewLists: true},
+	}
 	model.level = levelAggregates
 	model.width = 100
 	model.height = 20
@@ -1012,6 +1021,9 @@ func TestLoadDataSetsGroupByInStatsOpts(t *testing.T) {
 	// The command should have called GetTotalStats with GroupBy=ViewRecipients
 	require.NotZero(tracker.callCount, "expected GetTotalStats to be called during loadData with search active")
 	assert.Equal(query.ViewRecipients, tracker.lastOpts.GroupBy)
+	require.NotNil(tracker.lastOpts.Filter)
+	wantFilter := emailScopedMessageFilter(model.drillFilter)
+	assert.Equal(wantFilter, *tracker.lastOpts.Filter)
 	scopedSearch := search.Parse(tracker.lastOpts.SearchQuery)
 	assert.Equal([]string{"bob"}, scopedSearch.TextTerms)
 	assert.Equal([]string{emailMessageType}, scopedSearch.MessageTypes)

--- a/internal/tui/people_content_test.go
+++ b/internal/tui/people_content_test.go
@@ -459,8 +459,10 @@ func TestPeopleFilesPageDeduplicatesAndUsesAttachmentExportPath(t *testing.T) {
 		},
 	}
 	model := peopleContentModel(backend, &contact)
+	outputDir := t.TempDir()
 	model.actions = NewActionControllerWithOptions(model.engine, ActionControllerOptions{
-		DataDir: t.TempDir(),
+		DataDir:             t.TempDir(),
+		AttachmentOutputDir: outputDir,
 		AttachmentReader: mapAttachmentReader{data: map[string][]byte{
 			contentHash: []byte("attachment bytes"),
 		}},
@@ -503,8 +505,6 @@ func TestPeopleFilesPageDeduplicatesAndUsesAttachmentExportPath(t *testing.T) {
 	model = asModel(t, updatedModel)
 	require.NotNil(exportCmd)
 
-	outputDir := t.TempDir()
-	t.Chdir(outputDir)
 	exportMessage, ok := exportCmd().(peopleFileExportedMsg)
 	require.True(ok)
 	require.NoError(exportMessage.result.Err)

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -3,9 +3,11 @@ package tui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/query"
@@ -16,6 +18,114 @@ type recordingSemanticSearcher struct {
 	request  query.SemanticMessageSearchRequest
 	response *query.SemanticMessageSearchResult
 	err      error
+}
+
+func commitInlineSearchForHistory(t *testing.T, model Model, value string) Model {
+	t.Helper()
+	model.activateInlineSearch("search")
+	model.searchInput.SetValue(value)
+	updated, _ := applyInlineSearchKey(t, model, keyEnter())
+	return updated
+}
+
+func TestInlineSearchHistoryRecallsQueriesAndRestoresDraft(t *testing.T) {
+	assert := assert.New(t)
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model = commitInlineSearchForHistory(t, model, "first query")
+	model = commitInlineSearchForHistory(t, model, "second query")
+	model.activateInlineSearch("search")
+	model.searchInput.SetValue("unfinished draft")
+
+	model, cmd := applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal("second query", model.searchInput.Value())
+	assert.NotNil(cmd, "recall should use the existing debounced search path")
+
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal("first query", model.searchInput.Value())
+
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal("second query", model.searchInput.Value())
+
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal("unfinished draft", model.searchInput.Value())
+}
+
+func TestInlineSearchHistorySuppressesEmptyAndConsecutiveDuplicateQueries(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model = commitInlineSearchForHistory(t, model, "first query")
+	model = commitInlineSearchForHistory(t, model, "")
+	model = commitInlineSearchForHistory(t, model, "first query")
+	model = commitInlineSearchForHistory(t, model, "second query")
+	model.activateInlineSearch("search")
+
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, "second query", model.searchInput.Value())
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, "first query", model.searchInput.Value())
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, "first query", model.searchInput.Value(), "duplicate query must occupy only one history entry")
+}
+
+func TestInlineSearchHistoryDropsOldestEntryAtCapacity(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	for i := range 101 {
+		model = commitInlineSearchForHistory(t, model, fmt.Sprintf("query-%03d", i))
+	}
+	model.activateInlineSearch("search")
+
+	for range 100 {
+		model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	assert.Equal(t, "query-001", model.searchInput.Value())
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, "query-001", model.searchInput.Value(), "history must retain at most 100 entries")
+}
+
+func TestInlineSearchHistoryEditingRecalledQueryStartsNewDraft(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model = commitInlineSearchForHistory(t, model, "saved query")
+	model.activateInlineSearch("search")
+	model.searchInput.SetValue("original draft")
+
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	require.Equal(t, "saved query", model.searchInput.Value())
+	model, _ = applyInlineSearchKey(t, model, key('!'))
+	require.Equal(t, "saved query!", model.searchInput.Value())
+	model, _ = applyInlineSearchKey(t, model, tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, "saved query!", model.searchInput.Value(), "editing recall must leave history navigation")
+}
+
+func TestInlineSearchHistoryDoesNotReplaceMessageListNavigation(t *testing.T) {
+	model := NewBuilder().WithLevel(levelMessageList).WithMessages(
+		query.MessageSummary{ID: 1},
+		query.MessageSummary{ID: 2},
+	).Build()
+	model.cursor = 1
+
+	model = applyMessageListKey(t, model, tea.KeyPressMsg{Code: tea.KeyUp})
+	assert.Equal(t, 0, model.cursor)
+}
+
+func TestAggregateSearchCommitBeforeDebounceReloadsAndBlocksDeletion(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	model := newTestModelWithRows([]query.AggregateRow{{Key: "stale@example.com", Count: 1}})
+	model.searchQuery = "old query"
+	model.activateInlineSearch("search")
+
+	model, _ = applyInlineSearchKey(t, model, key('n'))
+	pendingRequestID := model.aggregateRequestID
+	model, cmd := applyInlineSearchKey(t, model, keyEnter())
+
+	assert.Equal("n", model.searchQuery)
+	assert.False(model.inlineSearchActive)
+	assert.True(model.inlineSearchLoading)
+	assert.Greater(model.aggregateRequestID, pendingRequestID)
+	require.NotNil(cmd, "committing before debounce must reload aggregate rows")
+
+	model, deletionCmd := applyAggregateKeyWithCmd(t, model, key('D'))
+	assert.False(model.deletionLoading)
+	assert.Nil(deletionCmd, "bulk deletion must wait for rows from the committed query")
 }
 
 func (s *recordingSemanticSearcher) SearchSemanticMessages(
@@ -214,23 +324,22 @@ func TestInlineSearchOmitsSemanticForUnsupportedScopes(t *testing.T) {
 	}
 }
 
-func TestListIDScopeForcesDeepSearchToFast(t *testing.T) {
-	var deepCalls int
-	var fastFilter query.MessageFilter
+func TestListIDScopeUsesDeepSearchWithExactFilter(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var deepFilter query.MessageFilter
+	var fastCalls int
 	engine := newMockEngine(MockConfig{})
-	engine.SearchFunc = func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-		deepCalls++
-		return nil, nil
+	engine.SearchDeepWithStatsFunc = func(
+		_ context.Context, _ *search.Query, filter query.MessageFilter, _, _ int,
+	) (*query.SearchFastResult, error) {
+		deepFilter = filter
+		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
 	}
 	engine.SearchFastWithStatsFunc = func(
-		_ context.Context,
-		_ *search.Query,
-		_ string,
-		filter query.MessageFilter,
-		_ query.ViewType,
-		_, _ int,
+		context.Context, *search.Query, string, query.MessageFilter, query.ViewType, int, int,
 	) (*query.SearchFastResult, error) {
-		fastFilter = filter
+		fastCalls++
 		return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
 	}
 
@@ -240,49 +349,12 @@ func TestListIDScopeForcesDeepSearchToFast(t *testing.T) {
 	model.drillFilter = query.MessageFilter{ListID: "<dev_1@example.test>"}
 	model.syncSearchScope()
 
-	{
-		assert := assert.New(t)
-		require := require.New(t)
-		assert.Equal(searchModeFast, model.searchMode)
-		msg, ok := model.loadSearch("find the invoice")().(searchResultsMsg)
-		require.True(ok)
-		require.NoError(msg.err)
-		assert.Zero(deepCalls, "List-Id drills must not use deep substring search")
-		assert.Equal("<dev_1@example.test>", fastFilter.ListID)
-	}
-
-	t.Run("execution fallback when synchronization is bypassed", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		var bypassDeepCalls int
-		var bypassFastFilter query.MessageFilter
-		bypassEngine := newMockEngine(MockConfig{})
-		bypassEngine.SearchFunc = func(context.Context, *search.Query, int, int) ([]query.MessageSummary, error) {
-			bypassDeepCalls++
-			return nil, nil
-		}
-		bypassEngine.SearchFastWithStatsFunc = func(
-			_ context.Context,
-			_ *search.Query,
-			_ string,
-			filter query.MessageFilter,
-			_ query.ViewType,
-			_, _ int,
-		) (*query.SearchFastResult, error) {
-			bypassFastFilter = filter
-			return &query.SearchFastResult{Stats: &query.TotalStats{}}, nil
-		}
-
-		bypassModel := New(bypassEngine, Options{DataDir: t.TempDir(), Version: "test"})
-		bypassModel.searchMode = searchModeDeep
-		bypassModel.searchFilter = query.MessageFilter{ListID: "<dev_1@example.test>"}
-
-		msg, ok := bypassModel.loadSearch("find the invoice")().(searchResultsMsg)
-		require.True(ok)
-		require.NoError(msg.err)
-		assert.Zero(bypassDeepCalls, "runtime List-Id fallback must not use deep search")
-		assert.Equal("<dev_1@example.test>", bypassFastFilter.ListID)
-	})
+	assertions.Equal(searchModeDeep, model.searchMode)
+	msg, ok := model.loadSearch("find the invoice")().(searchResultsMsg)
+	requirements.True(ok)
+	requirements.NoError(msg.err)
+	assertions.Equal("<dev_1@example.test>", deepFilter.ListID)
+	assertions.Zero(fastCalls, "exact List-Id scope stays on deep search")
 }
 
 func TestInheritedSemanticSearchFallsBackInUnsupportedScope(t *testing.T) {
@@ -359,6 +431,21 @@ func TestSemanticSearchPreservesSourceAndAttachmentScope(t *testing.T) {
 	assert.Equal(100, searcher.request.Limit)
 	require.Len(result.messages, 1)
 	assert.True(result.messages[0].HasAttachments)
+}
+
+func TestSemanticSearchPassesOperatorShapedNaturalLanguageThroughRaw(t *testing.T) {
+	searcher := &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
+	model := NewBuilder().WithLevel(levelMessageList).Build()
+	model.semanticSearch = searcher
+	model.searchMode = searchModeSemantic
+	model.searchRequestID = 1
+	const naturalLanguage = "before:not-a-date explain message_type:sms invoices"
+
+	msg := model.loadSearch(naturalLanguage)()
+	result, ok := msg.(searchResultsMsg)
+	require.True(t, ok, "expected searchResultsMsg, got %T", msg)
+	require.NoError(t, result.err)
+	assert.Equal(t, naturalLanguage, searcher.request.Query)
 }
 
 func TestSemanticSearchLabelsItsActiveOnlyPopulation(t *testing.T) {
@@ -545,6 +632,53 @@ func TestSearchPaginationUpdatesContextStats(t *testing.T) {
 
 	assert.Len(t, m.messages, 100, "after append")
 	assertContextStats(t, m, 100, -1, -1)
+}
+
+func TestDeepSearchPaginationLoadsKnownRemainingPage(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	firstPage := makeMessages(searchPageSize)
+	secondPage := makeMessages(25)
+	for i := range secondPage {
+		secondPage[i].ID += searchPageSize
+	}
+	engine := newMockEngine(MockConfig{})
+	engine.SearchDeepWithStatsFunc = func(
+		_ context.Context, _ *search.Query, _ query.MessageFilter, limit, offset int,
+	) (*query.SearchFastResult, error) {
+		assertions.Equal(searchPageSize, limit)
+		assertions.Equal(searchPageSize, offset)
+		return &query.SearchFastResult{Messages: secondPage, TotalCount: 125}, nil
+	}
+	model := New(engine, Options{DataDir: t.TempDir()})
+	model.level = levelMessageList
+	model.messages = firstPage
+	model.searchQuery = "invoice"
+	model.searchMode = searchModeDeep
+	model.searchOffset = searchPageSize
+	model.searchTotalCount = 125
+	model.cursor = len(firstPage) - 1
+	model.loading = false
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, tea.KeyPressMsg{Code: tea.KeyPgDown})
+	requirements.NotNil(cmd)
+	assertions.True(model.searchLoadingMore)
+	var result searchResultsMsg
+	found := false
+	for _, msg := range runBatchCommand(t, cmd) {
+		if searchResult, ok := msg.(searchResultsMsg); ok {
+			result = searchResult
+			found = true
+		}
+	}
+	requirements.True(found, "load-more command must return search results")
+	updated, _ := model.Update(result)
+	model = asModel(t, updated)
+
+	assertions.Len(model.messages, 125)
+	assertions.Equal(125, model.searchOffset)
+	assertions.Equal(int64(125), model.searchTotalCount)
+	assertions.False(model.searchLoadingMore)
 }
 
 // TestFastSearchPaginationTriggersOnNavigation verifies that cursor movement

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -10,6 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/query/querytest"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/testutil/dbtest"
 )
 
 func TestSelectionToggle(t *testing.T) {
@@ -121,10 +125,422 @@ func TestStageForDeletionWithAggregateSelection(t *testing.T) {
 		Build()
 
 	model = selectRow(t, model)
-	model, _ = sendKey(t, model, key('D'))
+	var cmd tea.Cmd
+	model, cmd = applyAggregateKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
 
 	assertModal(t, model, modalDeleteConfirm)
 	assertPendingManifestGmailIDs(t, model, 2)
+}
+
+func deletionScopeMessages(count int) []query.MessageSummary {
+	messages := make([]query.MessageSummary, count)
+	for i := range count {
+		messages[i] = query.MessageSummary{
+			ID: int64(i + 1), SourceID: 1, SourceMessageID: fmt.Sprintf("message-%03d", i+1),
+		}
+	}
+	return messages
+}
+
+func deletionScopeTargets(messages []query.MessageSummary) []query.DeletionTarget {
+	targets := make([]query.DeletionTarget, len(messages))
+	for i, msg := range messages {
+		targets[i] = query.DeletionTarget{
+			MessageID: msg.ID, SourceID: 1, SourceType: "gmail",
+			SourceIdentifier: "user@example.com", SourceMessageID: msg.SourceMessageID,
+		}
+	}
+	return targets
+}
+
+type engineWithoutDeletionSearchResolver struct {
+	query.Engine
+}
+
+func deletionScopeModel(t *testing.T, engine *querytest.MockEngine, messages []query.MessageSummary) Model {
+	t.Helper()
+	model := NewBuilder().
+		WithLevel(levelMessageList).
+		WithMessages(messages...).
+		WithAccounts(query.AccountInfo{ID: 1, SourceType: "gmail", Identifier: "user@example.com"}).
+		Build()
+	model.engine = engine
+	model.actions = NewActionController(engine, t.TempDir(), nil)
+	return model
+}
+
+func finishDeletionResolution(t *testing.T, model Model, cmd tea.Cmd) Model {
+	t.Helper()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, batchedCmd := range batch {
+			if batchedMsg := batchedCmd(); batchedMsg != nil {
+				if _, ok := batchedMsg.(deletionPreparedMsg); ok {
+					msg = batchedMsg
+					break
+				}
+			}
+		}
+	}
+	_, ok := msg.(deletionPreparedMsg)
+	require.True(t, ok, "expected deletion resolution message")
+	updated, _ := model.Update(msg)
+	return asModel(t, updated)
+}
+
+func TestDeletionKeyScope(t *testing.T) {
+	allTargets := []query.DeletionTarget{
+		{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "message-001"},
+		{MessageID: 2, SourceID: 1, SourceType: "gmail", SourceIdentifier: "user@example.com", SourceMessageID: "message-002"},
+	}
+	engine := &querytest.MockEngine{
+		ListResults:     deletionScopeMessages(2),
+		DeletionTargets: allTargets,
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			assert.Equal(t, emailMessageType, filter.MessageType)
+			return allTargets, nil
+		},
+	}
+
+	t.Run("lowercase stages current message", func(t *testing.T) {
+		model := deletionScopeModel(t, engine, deletionScopeMessages(1))
+		model = applyMessageListKey(t, model, key('d'))
+		assertPendingManifestGmailIDs(t, model, 1)
+	})
+
+	t.Run("uppercase stages every filter match", func(t *testing.T) {
+		model := deletionScopeModel(t, engine, deletionScopeMessages(1))
+		model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+		assert.True(t, model.deletionLoading)
+		assertModal(t, model, modalNone)
+		assert.Contains(t, model.View().Content, "Resolving all deletion matches")
+		model = finishDeletionResolution(t, model, cmd)
+		assert.False(t, model.deletionLoading)
+		assertPendingManifestGmailIDs(t, model, 2)
+	})
+}
+
+func TestUppercaseDResolvesEveryFilteredMessageInOneBackendCall(t *testing.T) {
+	allMessages := deletionScopeMessages(searchPageSize + 1)
+	var calls int
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			calls++
+			assert.Equal(t, query.Pagination{}, filter.Pagination)
+			assert.True(t, filter.WithAttachmentsOnly)
+			assert.True(t, filter.MatchesEmpty(query.ViewSenders))
+			return deletionScopeTargets(allMessages), nil
+		},
+	}
+	model := deletionScopeModel(t, engine, allMessages[:1])
+	model.filters.attachmentsOnly = true
+	model.drillFilter.SetEmptyTarget(query.ViewSenders)
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertPendingManifestGmailIDs(t, model, len(allMessages))
+	assert.Equal(t, 1, calls)
+}
+
+func TestUppercaseDSearchStagesOnlySourceDeletableMessages(t *testing.T) {
+	messages := []query.MessageSummary{
+		{ID: 1, SourceID: 1, SourceMessageID: "gmail-message"},
+		{ID: 2, SourceID: 2, SourceMessageID: "mbox-message"},
+	}
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsBySearchFunc: func(_ context.Context, parsed *search.Query, filter query.MessageFilter, mode query.DeletionSearchMode) ([]query.DeletionTarget, error) {
+			assert.Equal(t, []string{"invoice"}, parsed.TextTerms)
+			assert.Equal(t, emailMessageType, filter.MessageType)
+			assert.Equal(t, query.DeletionSearchFast, mode)
+			return []query.DeletionTarget{{
+				MessageID: 1, SourceID: 1, SourceType: "gmail",
+				SourceIdentifier: "user@example.com", SourceMessageID: "gmail-message",
+			}}, nil
+		},
+	}
+	model := deletionScopeModel(t, engine, messages)
+	model.accounts = []query.AccountInfo{
+		{ID: 1, SourceType: "gmail", Identifier: "user@example.com"},
+		{ID: 2, SourceType: "mbox", Identifier: "archive.mbox"},
+	}
+	model.searchQuery = "invoice"
+	model.searchMode = searchModeFast
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertPendingManifestGmailIDs(t, model, 1)
+	assert.Equal(t, []string{"gmail-message"}, model.pendingManifest.GmailIDs)
+}
+
+func TestUppercaseDStagesEveryFastSearchMatch(t *testing.T) {
+	allMessages := deletionScopeMessages(searchPageSize + 1)
+	var calls int
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsBySearchFunc: func(_ context.Context, parsed *search.Query, filter query.MessageFilter, mode query.DeletionSearchMode) ([]query.DeletionTarget, error) {
+			calls++
+			assert.Equal(t, []string{"invoice"}, parsed.TextTerms)
+			assert.Equal(t, emailMessageType, filter.MessageType)
+			assert.Equal(t, query.Pagination{}, filter.Pagination)
+			assert.Equal(t, query.DeletionSearchFast, mode)
+			return deletionScopeTargets(allMessages), nil
+		},
+	}
+	model := deletionScopeModel(t, engine, allMessages[:1])
+	model.searchQuery = "invoice"
+	model.searchMode = searchModeFast
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	assert.Equal(t, 0, calls, "search must not run on the update loop")
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertPendingManifestGmailIDs(t, model, len(allMessages))
+	assert.Equal(t, 1, calls)
+}
+
+func TestUppercaseDStagesEveryDeepSearchMatchWithinFilter(t *testing.T) {
+	allMessages := deletionScopeMessages(searchPageSize + 1)
+	var calls int
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsBySearchFunc: func(_ context.Context, parsed *search.Query, filter query.MessageFilter, mode query.DeletionSearchMode) ([]query.DeletionTarget, error) {
+			calls++
+			assert.Equal(t, []string{"invoice"}, parsed.TextTerms)
+			assert.Equal(t, "alice@example.com", filter.Sender)
+			assert.True(t, filter.MatchesEmpty(query.ViewSenderNames))
+			assert.Equal(t, query.DeletionSearchDeep, mode)
+			return deletionScopeTargets(allMessages), nil
+		},
+	}
+	model := deletionScopeModel(t, engine, allMessages[:1])
+	model.searchQuery = "invoice"
+	model.searchMode = searchModeDeep
+	model.drillFilter.Sender = "alice@example.com"
+	model.drillFilter.SetEmptyTarget(query.ViewSenderNames)
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	assert.Equal(t, 0, calls, "search must not run on the update loop")
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertPendingManifestGmailIDs(t, model, len(allMessages))
+	assert.Equal(t, 1, calls)
+}
+
+func TestUppercaseDSearchRequiresStableResolver(t *testing.T) {
+	messages := deletionScopeMessages(1)
+	baseEngine := &querytest.MockEngine{}
+	engine := engineWithoutDeletionSearchResolver{Engine: baseEngine}
+	model := deletionScopeModel(t, baseEngine, messages)
+	model.engine = engine
+	model.actions = NewActionController(engine, t.TempDir(), nil)
+	model.searchQuery = "invoice"
+	model.searchMode = searchModeFast
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertModal(t, model, modalDeleteResult)
+	assert.Contains(t, model.modalResult, "cannot resolve every search match safely")
+}
+
+func TestUppercaseDRejectsSemanticSearch(t *testing.T) {
+	engine := &querytest.MockEngine{}
+	model := deletionScopeModel(t, engine, deletionScopeMessages(1))
+	model.searchQuery = "find the invoice"
+	model.searchMode = searchModeSemantic
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertModal(t, model, modalDeleteResult)
+	assert.Contains(t, model.modalResult, "semantic")
+}
+
+func TestUppercaseDRejectsMalformedSearchQuery(t *testing.T) {
+	engine := &querytest.MockEngine{
+		SearchFastFunc: func(_ context.Context, _ *search.Query, _ query.MessageFilter, _, _ int) ([]query.MessageSummary, error) {
+			require.FailNow(t, "malformed bulk-deletion query reached the search engine")
+			return nil, nil
+		},
+	}
+	model := deletionScopeModel(t, engine, deletionScopeMessages(1))
+	model.searchQuery = "before:not-a-date"
+	model.searchMode = searchModeFast
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertModal(t, model, modalDeleteResult)
+	assert.Contains(t, model.modalResult, "invalid value")
+}
+
+func TestUppercaseDReportsNoMatchingDeletableMessages(t *testing.T) {
+	model := deletionScopeModel(t, &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(context.Context, query.MessageFilter) ([]query.DeletionTarget, error) {
+			return nil, nil
+		},
+	}, deletionScopeMessages(1))
+
+	model, cmd := applyMessageListKeyWithCmd(t, model, key('D'))
+	model = finishDeletionResolution(t, model, cmd)
+
+	assertModal(t, model, modalDeleteResult)
+	assert.Contains(t, model.modalResult, "no deletable messages match the current filter or search")
+}
+
+func TestAllMatchesManifestRecordsMatchScopeInsteadOfStaleSelection(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	controller := NewActionController(&querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			assertions.Equal("current@example.com", filter.Sender)
+			return deletionScopeTargets(deletionScopeMessages(2)), nil
+		},
+	}, t.TempDir(), nil)
+
+	manifest, err := controller.StageForDeletion(DeletionContext{
+		AllMatches:         true,
+		AggregateSelection: map[string]bool{"stale@example.com": true},
+		MessageSelection:   map[int64]bool{99: true},
+		AggregateViewType:  query.ViewSenders,
+		Accounts:           []query.AccountInfo{{ID: 1, SourceType: "gmail", Identifier: "user@example.com"}},
+		MatchFilter:        query.MessageFilter{Sender: "current@example.com"},
+	})
+	requirements.NoError(err)
+	assertions.Equal("all-matches", manifest.Description)
+	assertions.Equal([]string{"current@example.com"}, manifest.Filters.Senders)
+	assertions.NotContains(manifest.Filters.Senders, "stale@example.com")
+
+	var provenance struct {
+		Scope       string `json:"scope"`
+		MatchFilter struct {
+			Sender string `json:"sender"`
+		} `json:"match_filter"`
+	}
+	requirements.NoError(json.Unmarshal(manifest.RawFilter, &provenance))
+	assertions.Equal("all_matches", provenance.Scope)
+	assertions.Equal("current@example.com", provenance.MatchFilter.Sender)
+}
+
+func TestAllMatchesCanonicalEmptySearchUsesFilterScope(t *testing.T) {
+	tests := []struct {
+		name        string
+		searchQuery string
+	}{
+		{name: "empty subject", searchQuery: "subject:"},
+		{name: "whitespace", searchQuery: "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			var filterCalls, searchCalls int
+			engine := &querytest.MockEngine{
+				GetDeletionTargetsByFilterFunc: func(context.Context, query.MessageFilter) ([]query.DeletionTarget, error) {
+					filterCalls++
+					return deletionScopeTargets(deletionScopeMessages(1)), nil
+				},
+				GetDeletionTargetsBySearchFunc: func(context.Context, *search.Query, query.MessageFilter, query.DeletionSearchMode) ([]query.DeletionTarget, error) {
+					searchCalls++
+					return deletionScopeTargets(deletionScopeMessages(1)), nil
+				},
+			}
+			controller := NewActionController(engine, t.TempDir(), nil)
+
+			manifest, err := controller.StageForDeletion(DeletionContext{
+				AllMatches: true, SearchQuery: tt.searchQuery, SearchMode: searchModeFast,
+			})
+
+			requirements.NoError(err)
+			assertions.Equal(1, filterCalls)
+			assertions.Zero(searchCalls)
+			assertions.Equal("all-matches", manifest.Description)
+			var provenance allMatchesManifestProvenance
+			requirements.NoError(json.Unmarshal(manifest.RawFilter, &provenance))
+			assertions.Empty(provenance.SearchQuery)
+			assertions.Empty(provenance.SearchMode)
+		})
+	}
+}
+
+func TestBulkDeletionResolutionBlocksMessageListActions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	model := deletionScopeModel(t, &querytest.MockEngine{}, deletionScopeMessages(1))
+	model, resolveCmd := sendKey(t, model, key('D'))
+	require.NotNil(resolveCmd)
+	require.True(model.deletionLoading)
+
+	for _, blockedKey := range []tea.KeyPressMsg{key('d'), key('f'), key('?')} {
+		updated, cmd := sendKey(t, model, blockedKey)
+		assert.True(updated.deletionLoading)
+		assertModal(t, updated, modalNone)
+		assert.Nil(updated.pendingManifest)
+		assert.Nil(cmd)
+	}
+
+	canceled := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	model.deletionCancel = func() {
+		cancel()
+		close(canceled)
+	}
+	updated, cmd := sendKey(t, model, keyEsc())
+	assert.False(updated.deletionLoading)
+	assert.NotNil(cmd)
+	select {
+	case <-canceled:
+	default:
+		require.FailNow("Esc did not cancel deletion resolution")
+	}
+	require.ErrorIs(ctx.Err(), context.Canceled)
+
+	model.deletionLoading = true
+	model.deletionCancel = cancel
+	updated, cmd = sendKey(t, model, key('q'))
+	assertModal(t, updated, modalQuitConfirm)
+	assert.False(updated.deletionLoading)
+	assert.Nil(cmd)
+}
+
+func TestBulkDeletionResolutionBlocksAndCancelsAggregateActions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	model := deletionScopeModel(t, &querytest.MockEngine{}, deletionScopeMessages(1))
+	model.level = levelAggregates
+	model.viewType = query.ViewSenders
+	model.rows = []query.AggregateRow{
+		makeRow("alice@example.com", 1),
+		makeRow("bob@example.com", 1),
+	}
+
+	model, resolveCmd := sendKey(t, model, key('D'))
+	require.NotNil(resolveCmd)
+	require.True(model.deletionLoading)
+
+	updated, cmd := sendKey(t, model, key('j'))
+	assert.Zero(updated.cursor)
+	assert.True(updated.deletionLoading)
+	assert.Nil(cmd)
+
+	canceled := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	model.deletionCancel = func() {
+		cancel()
+		close(canceled)
+	}
+	updated, cmd = sendKey(t, model, keyEsc())
+	assert.False(updated.deletionLoading)
+	assert.NotNil(cmd)
+	select {
+	case <-canceled:
+	default:
+		require.FailNow("Esc did not cancel aggregate deletion resolution")
+	}
+	require.ErrorIs(ctx.Err(), context.Canceled)
 }
 
 func TestStageForDeletion(t *testing.T) {
@@ -322,6 +738,75 @@ func TestDKeyWithExistingSelection(t *testing.T) {
 	assertSelected(t, m, "alice@example.com")
 	assertNotSelected(t, m, "bob@example.com")
 	assertModal(t, m, modalDeleteConfirm)
+}
+
+func TestUppercaseDStagesCurrentAggregateRowDespiteExistingSelection(t *testing.T) {
+	var gotSender string
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			gotSender = filter.Sender
+			return deletionScopeTargets(deletionScopeMessages(1)), nil
+		},
+	}
+	model := NewBuilder().
+		WithRows(makeRow("alice@example.com", 10), makeRow("bob@example.com", 5)).
+		WithViewType(query.ViewSenders).
+		WithAccounts(query.AccountInfo{ID: 1, SourceType: "gmail", Identifier: "test@gmail.com"}).
+		WithSelectedAggregates("alice@example.com").
+		Build()
+	model.engine = engine
+	model.actions = NewActionController(engine, t.TempDir(), nil)
+	model.cursor = 1
+
+	updated, cmd := applyAggregateKeyWithCmd(t, model, key('D'))
+	updated = finishDeletionResolution(t, updated, cmd)
+
+	assert.Equal(t, "bob@example.com", gotSender)
+	assert.Equal(t, "Senders-bob@example.com", updated.pendingManifest.Description)
+	assert.Equal(t, []string{"bob@example.com"}, updated.pendingManifest.Filters.Senders)
+}
+
+func TestUppercaseDWaitsForAggregateReloadAfterViewChange(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	model := NewBuilder().
+		WithRows(makeRow("alice@example.com", 1)).
+		WithViewType(query.ViewSenders).
+		Build()
+
+	model, loadCmd := applyAggregateKeyWithCmd(t, model, key('g'))
+	requirements.NotNil(loadCmd)
+	requirements.True(model.loading)
+
+	model, deletionCmd := applyAggregateKeyWithCmd(t, model, key('D'))
+	assertions.Nil(deletionCmd)
+	assertions.False(model.deletionLoading)
+	assertions.Nil(model.pendingManifest)
+	assertModal(t, model, modalNone)
+}
+
+func TestUppercaseDAggregateStagesOnlyDisplayedSearchAndAttachmentMatches(t *testing.T) {
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	engine := query.NewSQLiteEngine(tdb.DB)
+	model := NewBuilder().
+		WithRows(makeRow("alice@example.com", 1)).
+		WithViewType(query.ViewSenders).
+		WithAccounts(query.AccountInfo{ID: 1, SourceType: "gmail", Identifier: "test@gmail.com"}).
+		Build()
+	model.engine = engine
+	model.actions = NewActionController(engine, t.TempDir(), nil)
+	model.searchQuery = "Hello"
+	model.searchMode = searchModeFast
+	model.filters.attachmentsOnly = true
+
+	model, cmd := applyAggregateKeyWithCmd(t, model, key('D'))
+	if cmd != nil {
+		model = finishDeletionResolution(t, model, cmd)
+	}
+
+	require.NotNil(t, model.pendingManifest)
+	assert.Equal(t, []string{"msg2"}, model.pendingManifest.GmailIDs)
 }
 
 func TestMessageListDKeyAutoSelectsCurrentMessage(t *testing.T) {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -463,15 +463,17 @@ func (m Model) aggregateTableView() string {
 
 	// Info line - show inline search bar when active, search filter when searching, otherwise blank
 	var infoContent string
-	isLoading := m.loading || m.inlineSearchLoading || m.searchLoadingMore
 	if m.inlineSearchActive {
 		infoContent = "/" + m.searchInput.View()
+		if m.inlineSearchError != "" {
+			infoContent += "  " + m.inlineSearchError
+		}
 	} else if m.searchQuery != "" {
 		infoContent = fmt.Sprintf(" Search: %q", m.searchQuery)
 	} else if m.loading && m.analyticsNotice != "" {
 		infoContent = " " + m.analyticsNotice
 	}
-	sb.WriteString(m.renderInfoLine(infoContent, isLoading))
+	sb.WriteString(m.renderInfoLine(infoContent, m.isLoading()))
 
 	// Overlay modal if active
 	if m.modal != modalNone {
@@ -647,7 +649,6 @@ func (m Model) messageListView() string {
 
 	// Info line - show inline search bar when active, search info when searching, otherwise blank
 	var infoContent string
-	isLoading := m.loading || m.inlineSearchLoading || m.searchLoadingMore
 	if m.inlineSearchActive {
 		modeTag := "[Fast]"
 		switch m.searchMode {
@@ -658,6 +659,11 @@ func (m Model) messageListView() string {
 			modeTag = "[Semantic: active messages only]"
 		}
 		infoContent = modeTag + "/" + m.searchInput.View()
+		if m.inlineSearchError != "" {
+			infoContent += "  " + m.inlineSearchError
+		}
+	} else if m.deletionLoading {
+		infoContent = " Resolving all deletion matches…"
 	} else if m.searchQuery != "" {
 		infoContent = fmt.Sprintf(" Search: %q", m.searchQuery)
 		if m.searchTotalCount > 0 {
@@ -675,7 +681,7 @@ func (m Model) messageListView() string {
 			infoContent += " [Semantic: active messages only]"
 		}
 	}
-	sb.WriteString(m.renderInfoLine(infoContent, isLoading))
+	sb.WriteString(m.renderInfoLine(infoContent, m.isLoading()))
 
 	// Overlay modal if active
 	if m.modal != modalNone {
@@ -683,6 +689,10 @@ func (m Model) messageListView() string {
 	}
 
 	return sb.String()
+}
+
+func (m Model) isLoading() bool {
+	return m.loading || m.inlineSearchLoading || m.searchLoadingMore || m.deletionLoading
 }
 
 // buildDetailLines constructs the lines for message detail view.
@@ -1215,7 +1225,8 @@ var rawHelpLines = []string{
 	"  Space       Toggle selection",
 	"  S           Select all visible",
 	"  x           Clear selection",
-	"  d/D         Stage for deletion",
+	"  d           Stage selected/current for deletion",
+	"  D           Stage all current row/filter matches",
 	"  a           View all messages",
 	"",
 	"Other",

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -590,6 +590,18 @@ type GetGmailIDsByFilterQuery struct {
 
 	// Direction Sort direction: asc or desc
 	Direction *string `json:"direction,omitempty"`
+
+	// Q Structured search query
+	Q *string `json:"q,omitempty"`
+
+	// SearchMode Search mode: fast, deep, or aggregate; required with q
+	SearchMode *string `json:"search_mode,omitempty"`
+
+	// ViewType Aggregate view type; required for aggregate search
+	ViewType *string `json:"view_type,omitempty"`
+
+	// AggregateKey Displayed aggregate row key; required for aggregate search
+	AggregateKey *string `json:"aggregate_key,omitempty"`
 }
 
 type GetMessageInlinePartQuery struct {
@@ -1000,37 +1012,37 @@ type DeepSearchQuery struct {
 	// Scope Exact search scope: body; omit for composite full-text search
 	Scope *string `json:"scope,omitempty"`
 
-	// Sender Sender email/address filter
+	// Sender Sender email/address filter; not supported when scope=body
 	Sender *string `json:"sender,omitempty"`
 
-	// SenderName Sender display-name filter; not supported by deep search
+	// SenderName Sender display-name filter; not supported when scope=body
 	SenderName *string `json:"sender_name,omitempty"`
 
-	// Recipient Recipient email/address filter
+	// Recipient Recipient email/address filter; not supported when scope=body
 	Recipient *string `json:"recipient,omitempty"`
 
-	// RecipientName Recipient display-name filter; not supported by deep search
+	// RecipientName Recipient display-name filter; not supported when scope=body
 	RecipientName *string `json:"recipient_name,omitempty"`
 
-	// Domain Domain filter
+	// Domain Domain filter; not supported when scope=body
 	Domain *string `json:"domain,omitempty"`
 
-	// Label Label filter
+	// Label Label filter; not supported when scope=body
 	Label *string `json:"label,omitempty"`
 
-	// ListID Exact case-insensitive RFC 2919 List-Id filter; not supported by deep search
+	// ListID Exact case-insensitive RFC 2919 List-Id filter; not supported when scope=body
 	ListID *string `json:"list_id,omitempty"`
 
-	// MessageType Message type filter; not supported by deep search
+	// MessageType Message type filter; not supported when scope=body
 	MessageType *string `json:"message_type,omitempty"`
 
-	// TimePeriod Named time period; not supported by deep search
+	// TimePeriod Named time period; not supported when scope=body
 	TimePeriod *string `json:"time_period,omitempty"`
 
 	// TimeGranularity Time bucket granularity
 	TimeGranularity *string `json:"time_granularity,omitempty"`
 
-	// ConversationID Conversation ID; not supported by deep search
+	// ConversationID Conversation ID; not supported when scope=body
 	ConversationID *int64 `json:"conversation_id,omitempty"`
 
 	// SourceID Source ID
@@ -1048,7 +1060,7 @@ type DeepSearchQuery struct {
 	// Before Upper date/time bound (RFC3339 or YYYY-MM-DD)
 	Before *string `json:"before,omitempty"`
 
-	// EmptyTargets Comma-separated aggregate view names to match empty values; not supported by deep search
+	// EmptyTargets Comma-separated aggregate view names to match empty values; not supported when scope=body
 	EmptyTargets *string `json:"empty_targets,omitempty"`
 
 	// Offset Zero-based row offset
@@ -1196,17 +1208,8 @@ type ListSourceStatusQuery struct {
 }
 
 type GetTotalStatsQuery struct {
-	// SourceID Source ID
-	SourceID *int64 `json:"source_id,omitempty"`
-
 	// SourceIds Source IDs; repeat the parameter for multiple sources
 	SourceIds []int64 `json:"source_ids,omitempty"`
-
-	// AttachmentsOnly Only include messages with attachments
-	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
-
-	// HideDeleted Exclude deleted messages
-	HideDeleted *bool `json:"hide_deleted,omitempty"`
 
 	// SearchQuery Search query
 	SearchQuery *string `json:"search_query,omitempty"`
@@ -1216,6 +1219,57 @@ type GetTotalStatsQuery struct {
 
 	// GroupBy Aggregate view type for grouping
 	GroupBy *string `json:"group_by,omitempty"`
+
+	// Sender Sender email/address filter
+	Sender *string `json:"sender,omitempty"`
+
+	// SenderName Sender display-name filter
+	SenderName *string `json:"sender_name,omitempty"`
+
+	// Recipient Recipient email/address filter
+	Recipient *string `json:"recipient,omitempty"`
+
+	// RecipientName Recipient display-name filter
+	RecipientName *string `json:"recipient_name,omitempty"`
+
+	// Domain Domain filter
+	Domain *string `json:"domain,omitempty"`
+
+	// Label Label filter
+	Label *string `json:"label,omitempty"`
+
+	// ListID Exact case-insensitive RFC 2919 List-Id filter
+	ListID *string `json:"list_id,omitempty"`
+
+	// MessageType Message type filter
+	MessageType *string `json:"message_type,omitempty"`
+
+	// TimePeriod Named time period
+	TimePeriod *string `json:"time_period,omitempty"`
+
+	// TimeGranularity Time bucket granularity
+	TimeGranularity *string `json:"time_granularity,omitempty"`
+
+	// ConversationID Conversation ID
+	ConversationID *int64 `json:"conversation_id,omitempty"`
+
+	// SourceID Source ID
+	SourceID *int64 `json:"source_id,omitempty"`
+
+	// AttachmentsOnly Only include messages with attachments
+	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
+
+	// HideDeleted Exclude deleted messages
+	HideDeleted *bool `json:"hide_deleted,omitempty"`
+
+	// After Lower date/time bound (RFC3339 or YYYY-MM-DD)
+	After *string `json:"after,omitempty"`
+
+	// Before Upper date/time bound (RFC3339 or YYYY-MM-DD)
+	Before *string `json:"before,omitempty"`
+
+	// EmptyTargets Comma-separated aggregate view names to match empty values
+	EmptyTargets *string `json:"empty_targets,omitempty"`
 }
 
 type TriggerSyncQuery struct {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -2216,6 +2216,8 @@ type DeepSearchResponse struct {
 	Offset       int64               `json:"offset"`
 	Query        string              `json:"query" validate:"required"`
 	Scope        *string             `json:"scope,omitempty"`
+	Stats        *TotalStatsResponse `json:"stats,omitempty"`
+	TotalCount   int64               `json:"total_count"`
 }
 
 func (d DeepSearchResponse) Validate() error {
@@ -2236,6 +2238,13 @@ func (d DeepSearchResponse) Validate() error {
 	}
 	if err := typesValidator.Var(d.Query, "required"); err != nil {
 		errors = errors.Append("Query", err)
+	}
+	if d.Stats != nil {
+		if v, ok := any(d.Stats).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Stats", err)
+			}
+		}
 	}
 	if len(errors) == 0 {
 		return nil
@@ -4094,8 +4103,10 @@ func (g GenerationSummary) Validate() error {
 }
 
 type GmailIDsResponse struct {
-	GmailIds []string         `json:"gmail_ids" validate:"required"`
-	Targets  []DeletionTarget `json:"targets,omitempty"`
+	GmailIds    []string         `json:"gmail_ids" validate:"required"`
+	SearchMode  *string          `json:"search_mode,omitempty"`
+	SearchQuery *string          `json:"search_query,omitempty"`
+	Targets     []DeletionTarget `json:"targets,omitempty"`
 }
 
 func (g GmailIDsResponse) Validate() error {
@@ -4676,7 +4687,7 @@ type Manifest struct {
 	Filters     Filters          `json:"filters"`
 	GmailIds    []string         `json:"gmail_ids" validate:"required"`
 	ID          string           `json:"id" validate:"required"`
-	RawFilter   *struct{}        `json:"raw_filter,omitempty"`
+	RawFilter   *json.RawMessage `json:"raw_filter,omitempty"`
 	Source      *SourceReference `json:"source,omitempty"`
 	Status      string           `json:"status" validate:"required"`
 	Summary     *Summary         `json:"summary,omitempty"`
@@ -4711,6 +4722,13 @@ func (m Manifest) Validate() error {
 	}
 	if err := typesValidator.Var(m.ID, "required"); err != nil {
 		errors = errors.Append("ID", err)
+	}
+	if m.RawFilter != nil {
+		if v, ok := any(m.RawFilter).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("RawFilter", err)
+			}
+		}
 	}
 	if m.Source != nil {
 		if v, ok := any(m.Source).(runtime.Validator); ok {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -2476,10 +2476,16 @@ components:
           type: string
         scope:
           type: string
+        stats:
+          $ref: "#/components/schemas/TotalStatsResponse"
+        total_count:
+          format: int64
+          type: integer
       required:
         - query
         - messages
         - count
+        - total_count
         - has_more
         - offset
         - limit
@@ -4523,6 +4529,10 @@ components:
           items:
             type: string
           type: array
+        search_mode:
+          type: string
+        search_query:
+          type: string
         targets:
           items:
             $ref: "#/components/schemas/DeletionTarget"
@@ -5102,7 +5112,10 @@ components:
           type: array
         id:
           type: string
-        raw_filter: {}
+        raw_filter:
+          x-go-type: json.RawMessage
+          x-go-type-import:
+            path: encoding/json
         source:
           $ref: "#/components/schemas/SourceReference"
         status:
@@ -17209,6 +17222,26 @@ paths:
           name: direction
           schema:
             type: string
+        - description: Structured search query
+          in: query
+          name: q
+          schema:
+            type: string
+        - description: "Search mode: fast, deep, or aggregate; required with q"
+          in: query
+          name: search_mode
+          schema:
+            type: string
+        - description: Aggregate view type; required for aggregate search
+          in: query
+          name: view_type
+          schema:
+            type: string
+        - description: Displayed aggregate row key; required for aggregate search
+          in: query
+          name: aggregate_key
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -22576,47 +22609,47 @@ paths:
           name: scope
           schema:
             type: string
-        - description: Sender email/address filter
+        - description: Sender email/address filter; not supported when scope=body
           in: query
           name: sender
           schema:
             type: string
-        - description: Sender display-name filter; not supported by deep search
+        - description: Sender display-name filter; not supported when scope=body
           in: query
           name: sender_name
           schema:
             type: string
-        - description: Recipient email/address filter
+        - description: Recipient email/address filter; not supported when scope=body
           in: query
           name: recipient
           schema:
             type: string
-        - description: Recipient display-name filter; not supported by deep search
+        - description: Recipient display-name filter; not supported when scope=body
           in: query
           name: recipient_name
           schema:
             type: string
-        - description: Domain filter
+        - description: Domain filter; not supported when scope=body
           in: query
           name: domain
           schema:
             type: string
-        - description: Label filter
+        - description: Label filter; not supported when scope=body
           in: query
           name: label
           schema:
             type: string
-        - description: Exact case-insensitive RFC 2919 List-Id filter; not supported by deep search
+        - description: Exact case-insensitive RFC 2919 List-Id filter; not supported when scope=body
           in: query
           name: list_id
           schema:
             type: string
-        - description: Message type filter; not supported by deep search
+        - description: Message type filter; not supported when scope=body
           in: query
           name: message_type
           schema:
             type: string
-        - description: Named time period; not supported by deep search
+        - description: Named time period; not supported when scope=body
           in: query
           name: time_period
           schema:
@@ -22626,7 +22659,7 @@ paths:
           name: time_granularity
           schema:
             type: string
-        - description: Conversation ID; not supported by deep search
+        - description: Conversation ID; not supported when scope=body
           in: query
           name: conversation_id
           schema:
@@ -22658,7 +22691,7 @@ paths:
           name: before
           schema:
             type: string
-        - description: Comma-separated aggregate view names to match empty values; not supported by deep search
+        - description: Comma-separated aggregate view names to match empty values; not supported when scope=body
           in: query
           name: empty_targets
           schema:
@@ -23367,12 +23400,6 @@ paths:
     get:
       operationId: getTotalStats
       parameters:
-        - description: Source ID
-          in: query
-          name: source_id
-          schema:
-            format: int64
-            type: integer
         - description: Source IDs; repeat the parameter for multiple sources
           in: query
           name: source_ids
@@ -23381,16 +23408,6 @@ paths:
               format: int64
               type: integer
             type: array
-        - description: Only include messages with attachments
-          in: query
-          name: attachments_only
-          schema:
-            type: boolean
-        - description: Exclude deleted messages
-          in: query
-          name: hide_deleted
-          schema:
-            type: boolean
         - description: Search query
           in: query
           name: search_query
@@ -23404,6 +23421,93 @@ paths:
         - description: Aggregate view type for grouping
           in: query
           name: group_by
+          schema:
+            type: string
+        - description: Sender email/address filter
+          in: query
+          name: sender
+          schema:
+            type: string
+        - description: Sender display-name filter
+          in: query
+          name: sender_name
+          schema:
+            type: string
+        - description: Recipient email/address filter
+          in: query
+          name: recipient
+          schema:
+            type: string
+        - description: Recipient display-name filter
+          in: query
+          name: recipient_name
+          schema:
+            type: string
+        - description: Domain filter
+          in: query
+          name: domain
+          schema:
+            type: string
+        - description: Label filter
+          in: query
+          name: label
+          schema:
+            type: string
+        - description: Exact case-insensitive RFC 2919 List-Id filter
+          in: query
+          name: list_id
+          schema:
+            type: string
+        - description: Message type filter
+          in: query
+          name: message_type
+          schema:
+            type: string
+        - description: Named time period
+          in: query
+          name: time_period
+          schema:
+            type: string
+        - description: Time bucket granularity
+          in: query
+          name: time_granularity
+          schema:
+            type: string
+        - description: Conversation ID
+          in: query
+          name: conversation_id
+          schema:
+            format: int64
+            type: integer
+        - description: Source ID
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
+        - description: Only include messages with attachments
+          in: query
+          name: attachments_only
+          schema:
+            type: boolean
+        - description: Exclude deleted messages
+          in: query
+          name: hide_deleted
+          schema:
+            type: boolean
+        - description: Lower date/time bound (RFC3339 or YYYY-MM-DD)
+          in: query
+          name: after
+          schema:
+            type: string
+        - description: Upper date/time bound (RFC3339 or YYYY-MM-DD)
+          in: query
+          name: before
+          schema:
+            type: string
+        - description: Comma-separated aggregate view names to match empty values
+          in: query
+          name: empty_targets
           schema:
             type: string
       responses:

--- a/web/src/lib/api/generated/models/deepSearchParams.ts
+++ b/web/src/lib/api/generated/models/deepSearchParams.ts
@@ -12,39 +12,39 @@ export type DeepSearchParams = {
    */
   scope?: string;
   /**
-   * Sender email/address filter
+   * Sender email/address filter; not supported when scope=body
    */
   sender?: string;
   /**
-   * Sender display-name filter; not supported by deep search
+   * Sender display-name filter; not supported when scope=body
    */
   sender_name?: string;
   /**
-   * Recipient email/address filter
+   * Recipient email/address filter; not supported when scope=body
    */
   recipient?: string;
   /**
-   * Recipient display-name filter; not supported by deep search
+   * Recipient display-name filter; not supported when scope=body
    */
   recipient_name?: string;
   /**
-   * Domain filter
+   * Domain filter; not supported when scope=body
    */
   domain?: string;
   /**
-   * Label filter
+   * Label filter; not supported when scope=body
    */
   label?: string;
   /**
-   * Exact case-insensitive RFC 2919 List-Id filter; not supported by deep search
+   * Exact case-insensitive RFC 2919 List-Id filter; not supported when scope=body
    */
   list_id?: string;
   /**
-   * Message type filter; not supported by deep search
+   * Message type filter; not supported when scope=body
    */
   message_type?: string;
   /**
-   * Named time period; not supported by deep search
+   * Named time period; not supported when scope=body
    */
   time_period?: string;
   /**
@@ -52,7 +52,7 @@ export type DeepSearchParams = {
    */
   time_granularity?: string;
   /**
-   * Conversation ID; not supported by deep search
+   * Conversation ID; not supported when scope=body
    */
   conversation_id?: number;
   /**
@@ -76,7 +76,7 @@ export type DeepSearchParams = {
    */
   before?: string;
   /**
-   * Comma-separated aggregate view names to match empty values; not supported by deep search
+   * Comma-separated aggregate view names to match empty values; not supported when scope=body
    */
   empty_targets?: string;
   /**

--- a/web/src/lib/api/generated/models/deepSearchResponse.ts
+++ b/web/src/lib/api/generated/models/deepSearchResponse.ts
@@ -3,6 +3,7 @@
  */
 import type { BodySearchContext } from "./bodySearchContext";
 import type { MessageSummary } from "./messageSummary";
+import type { TotalStatsResponse } from "./totalStatsResponse";
 
 export interface DeepSearchResponse {
   body_contexts?: BodySearchContext[];
@@ -13,5 +14,7 @@ export interface DeepSearchResponse {
   offset: number;
   query: string;
   scope?: string;
+  stats?: TotalStatsResponse;
+  total_count: number;
   [key: string]: unknown;
 }

--- a/web/src/lib/api/generated/models/getGmailIDsByFilterParams.ts
+++ b/web/src/lib/api/generated/models/getGmailIDsByFilterParams.ts
@@ -87,4 +87,20 @@ export type GetGmailIDsByFilterParams = {
    * Sort direction: asc or desc
    */
   direction?: string;
+  /**
+   * Structured search query
+   */
+  q?: string;
+  /**
+   * Search mode: fast, deep, or aggregate; required with q
+   */
+  search_mode?: string;
+  /**
+   * Aggregate view type; required for aggregate search
+   */
+  view_type?: string;
+  /**
+   * Displayed aggregate row key; required for aggregate search
+   */
+  aggregate_key?: string;
 };

--- a/web/src/lib/api/generated/models/getTotalStatsParams.ts
+++ b/web/src/lib/api/generated/models/getTotalStatsParams.ts
@@ -4,21 +4,9 @@
 
 export type GetTotalStatsParams = {
   /**
-   * Source ID
-   */
-  source_id?: number;
-  /**
    * Source IDs; repeat the parameter for multiple sources
    */
   source_ids?: number[];
-  /**
-   * Only include messages with attachments
-   */
-  attachments_only?: boolean;
-  /**
-   * Exclude deleted messages
-   */
-  hide_deleted?: boolean;
   /**
    * Search query
    */
@@ -31,4 +19,72 @@ export type GetTotalStatsParams = {
    * Aggregate view type for grouping
    */
   group_by?: string;
+  /**
+   * Sender email/address filter
+   */
+  sender?: string;
+  /**
+   * Sender display-name filter
+   */
+  sender_name?: string;
+  /**
+   * Recipient email/address filter
+   */
+  recipient?: string;
+  /**
+   * Recipient display-name filter
+   */
+  recipient_name?: string;
+  /**
+   * Domain filter
+   */
+  domain?: string;
+  /**
+   * Label filter
+   */
+  label?: string;
+  /**
+   * Exact case-insensitive RFC 2919 List-Id filter
+   */
+  list_id?: string;
+  /**
+   * Message type filter
+   */
+  message_type?: string;
+  /**
+   * Named time period
+   */
+  time_period?: string;
+  /**
+   * Time bucket granularity
+   */
+  time_granularity?: string;
+  /**
+   * Conversation ID
+   */
+  conversation_id?: number;
+  /**
+   * Source ID
+   */
+  source_id?: number;
+  /**
+   * Only include messages with attachments
+   */
+  attachments_only?: boolean;
+  /**
+   * Exclude deleted messages
+   */
+  hide_deleted?: boolean;
+  /**
+   * Lower date/time bound (RFC3339 or YYYY-MM-DD)
+   */
+  after?: string;
+  /**
+   * Upper date/time bound (RFC3339 or YYYY-MM-DD)
+   */
+  before?: string;
+  /**
+   * Comma-separated aggregate view names to match empty values
+   */
+  empty_targets?: string;
 };

--- a/web/src/lib/api/generated/models/gmailIDsResponse.ts
+++ b/web/src/lib/api/generated/models/gmailIDsResponse.ts
@@ -5,6 +5,8 @@ import type { DeletionTarget } from "./deletionTarget";
 
 export interface GmailIDsResponse {
   gmail_ids: string[];
+  search_mode?: string;
+  search_query?: string;
   targets?: DeletionTarget[];
   [key: string]: unknown;
 }


### PR DESCRIPTION
## What changed

- Added session-only inline search history in the TUI, including draft restore and a 100-query cap.
- Split deletion staging so `d` uses the selection/current row and `D` resolves every message-list filter or search match in the background before confirmation.
- Added `[data].export_dir` and routed TUI attachment ZIPs, downloads, and opened files through it.
- Corrected `export-eml` usage and default-filename guidance.
- Documented how incremental Gmail sync and expired-history recovery reconcile messages deleted at the source.

## Why

Search-heavy cleanup should not require retyping queries or selecting one loaded page at a time. Attachment exports should also have one predictable destination, while the CLI and sync docs should describe the behavior users actually get.

The all-match deletion path keeps source boundaries intact, rejects bounded semantic results, paginates fast and deep searches, stays responsive during resolution, and always presents the final count before a batch is staged.

Closes #40
Closes #41
Closes #44
Closes #72
Closes #88

## Usage

- In inline search, press Up or Down to recall earlier queries and return to the draft you were typing.
- In a message list, press `d` for the current selection or `D` for every filter/search match.
- Set `export_dir` under `[data]` to choose where TUI attachment exports land. Relative paths resolve from the config directory; the default is `<data_dir>/exports`.
- Run `msgvault export-eml <message-id> [source-message-id]`, optionally with `-o -` for stdout.
