### PR TITLE
feat(slack): import Slackdump exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,8 @@ internal/web/dist/**/*.svg text eol=lf
 # vCard conformance fixtures intentionally retain wire-format CRLF bytes.
 internal/vcard/testdata/*.vcf -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
 internal/vcard/registry/data/*.csv -text whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol
+
+# Slackdump attachments are arbitrary archived bytes. Never rewrite fixture
+# line endings on Windows checkouts.
+internal/slack/testdata/slackdump/standard/general/attachments/** -text
+internal/slack/testdata/slackdump/standard/__uploads/** -text

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ make lint                     # Run linter
 ./msgvault add-slack                         # Register a workspace (prompts for xoxp token)
 ./msgvault sync-slack                        # Sync channels, group DMs, DMs
 ./msgvault sync-slack --full                 # Repair: re-fetch + upsert in place
+./msgvault import-slackdump --me you@example.com /path/to/export.zip  # Offline Slackdump import
 
 # Daemon mode (NAS/server deployment)
 ./msgvault serve                                      # Start HTTP API + scheduled syncs

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Archive a lifetime of email, messages, meetings. Analytics and search in millise
 Your messages are yours. Decades of correspondence, attachments, and history shouldn't be locked behind a web interface or an API. By default, msgvault downloads a complete local copy and then everything runs offline. Search, analytics, and the MCP server all work against your msgvault archive with no mailbox network access required. If you configure a remote deployment, the archive lives on your own server rather than a hosted msgvault service.
 
 Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, CardDAV,
-Granola, Circleback, Beeper Desktop, and IMAP sync, plus offline imports from MBOX
-exports, Apple Mail (`.emlx`) directories, PST archives, and common chat/text
-export formats.
+Granola, Circleback, Beeper Desktop, and IMAP sync, plus offline imports from
+Slackdump, MBOX exports, Apple Mail (`.emlx`) directories, PST archives, and
+common chat/text export formats.
 
 ## Features
 
@@ -37,6 +37,7 @@ export formats.
 - **Microsoft Teams sync**: archive delegated Graph chats, channels, replies, and inline media with `message_type = teams`
 - **Discord sync**: archive guild channels, threads, forum posts, and attachments through a read-only bot with `message_type = discord`
 - **Slack sync**: archive joined channels, group DMs, direct messages, threads, reactions, and files with `message_type = slack`
+- **Slackdump import**: archive a Slackdump directory or ZIP without a Slack token or network access
 - **Meeting notes**: sync Granola and Circleback notes and transcripts, then browse them in the TUI
 - **Beeper Desktop sync**: archive chats and media from every network connected to Beeper, including iMessage, through its local API
 - **IMAP sync**: archive mail from any standard IMAP server
@@ -124,6 +125,7 @@ available with `msgvault tui`.
 | `sync-teams EMAIL` | Sync Microsoft Teams chats and channels |
 | `add-discord` / `sync-discord` | Register a read-only bot and sync Discord guild channels and threads |
 | `add-slack` / `sync-slack` | Register and archive a Slack workspace, including threads and media |
+| `import-slackdump` | Import a Slackdump directory or ZIP, including threads, reactions, and exported files |
 | `add-carddav` / `sync-carddav` | Discover and sync a CardDAV account; passwords are read from stdin, never argv |
 | `carddav` | Manage address-book roles and resolve retained conflicts |
 | `export-messages` | Stream a bounded, provider-neutral archive window as versioned JSONL |

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -332,6 +332,7 @@ func attachmentProducingCommand(args []string) bool {
 		importMboxCommand,
 		"import-messenger",
 		"import-pst",
+		"import-slackdump",
 		"import-synctech-sms",
 		"import-whatsapp",
 		"sync-beeper",

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -514,6 +514,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 		importMboxCommand,
 		"import-messenger",
 		"import-pst",
+		"import-slackdump",
 		"import-synctech-sms",
 		"import-whatsapp",
 		"sync-beeper",

--- a/cmd/msgvault/cmd/constants.go
+++ b/cmd/msgvault/cmd/constants.go
@@ -10,6 +10,7 @@ const (
 	sourceTypeCalendar   = "gcal"
 	sourceTypeBeeper     = "beeper"
 	sourceTypeSlack      = "slack"
+	sourceTypeSlackdump  = "slackdump"
 	sourceTypeGranola    = "granola"
 	sourceTypeCircleback = "circleback"
 )

--- a/cmd/msgvault/cmd/daemon_cli_http.go
+++ b/cmd/msgvault/cmd/daemon_cli_http.go
@@ -113,7 +113,7 @@ var errCLISubprocessProxied = errors.New("cli subprocess failed")
 func daemonCLIRunCwd(info HTTPStoreInfo, requiresLocalFiles bool) (string, error) {
 	if info.Kind != HTTPStoreLocalDaemon {
 		if requiresLocalFiles {
-			return "", errors.New("this command uses a local capability manifest and cannot run through a configured remote daemon; run it on the daemon host with --local")
+			return "", errors.New("this command uses local files and cannot run through a configured remote daemon; run it on the daemon host with --local")
 		}
 		return "", nil
 	}

--- a/cmd/msgvault/cmd/import_slackdump.go
+++ b/cmd/msgvault/cmd/import_slackdump.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/slack"
+	"go.kenn.io/msgvault/internal/store"
 )
 
 type slackdumpCLIOptions struct {
@@ -81,24 +83,21 @@ func runImportSlackdump(cmd *cobra.Command, sourcePath string, opts slackdumpCLI
 		},
 		Progress: func(line string) { writeSlackProgress(cmd.OutOrStdout(), line) },
 	})
+	postImportErr := runSlackdumpPostImportMigrations(
+		cmd.OutOrStdout(), st, summary, opts.NoDefaultIdentity,
+	)
 	if importErr != nil {
 		if ctx.Err() != nil {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nImport interrupted. Re-run the command to import the export again.")
 		}
-		return errors.Join(fmt.Errorf("import Slackdump: %w", importErr), rebuildCacheAfterWrite(dbPath))
-	}
-	if !opts.NoDefaultIdentity {
-		source, sourceErr := st.GetSourceByID(summary.SourceID)
-		if sourceErr != nil {
-			return errors.Join(fmt.Errorf("read Slackdump source: %w", sourceErr), rebuildCacheAfterWrite(dbPath))
-		}
-		confirmDefaultIdentity(
-			cmd.OutOrStdout(), st, source.ID,
-			source.Identifier, source.Identifier, "account-identifier",
+		return errors.Join(
+			fmt.Errorf("import Slackdump: %w", importErr),
+			postImportErr,
+			rebuildCacheAfterWrite(dbPath),
 		)
 	}
-	if err := runPostSourceCreateMigrations(st); err != nil {
-		return errors.Join(fmt.Errorf("post-source-create migrations: %w", err), rebuildCacheAfterWrite(dbPath))
+	if postImportErr != nil {
+		return errors.Join(postImportErr, rebuildCacheAfterWrite(dbPath))
 	}
 
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nImport complete!")
@@ -112,6 +111,34 @@ func runImportSlackdump(cmd *cobra.Command, sourcePath string, opts slackdumpCLI
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Errors:        %d\n", summary.Errors)
 	}
 	return rebuildCacheAfterWrite(dbPath)
+}
+
+func runSlackdumpPostImportMigrations(
+	out io.Writer,
+	st *store.Store,
+	summary *slack.SlackdumpImportSummary,
+	noDefaultIdentity bool,
+) error {
+	if summary == nil || summary.SourceID == 0 {
+		return nil
+	}
+	var identityErr error
+	if !noDefaultIdentity {
+		source, err := st.GetSourceByID(summary.SourceID)
+		if err != nil {
+			identityErr = fmt.Errorf("read Slackdump source: %w", err)
+		} else {
+			confirmDefaultIdentity(
+				out, st, source.ID,
+				source.Identifier, source.Identifier, "account-identifier",
+			)
+		}
+	}
+	migrationErr := runPostSourceCreateMigrations(st)
+	if migrationErr != nil {
+		migrationErr = fmt.Errorf("post-source-create migrations: %w", migrationErr)
+	}
+	return errors.Join(identityErr, migrationErr)
 }
 
 func resolveSlackdumpMediaPolicy(teamID string, overrideMB int64) attachmentpolicy.Policy {

--- a/cmd/msgvault/cmd/import_slackdump.go
+++ b/cmd/msgvault/cmd/import_slackdump.go
@@ -13,9 +13,10 @@ import (
 )
 
 type slackdumpCLIOptions struct {
-	Me         string
-	Limit      int
-	MaxMediaMB int64
+	Me                string
+	Limit             int
+	MaxMediaMB        int64
+	NoDefaultIdentity bool
 }
 
 func newImportSlackdumpCmd() *cobra.Command {
@@ -46,6 +47,7 @@ func newImportSlackdumpCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.Me, "me", "", "your Slack user ID or profile email (required)")
 	cmd.Flags().IntVar(&opts.Limit, "limit", 0, "maximum messages per conversation (0 = unlimited)")
 	cmd.Flags().Int64Var(&opts.MaxMediaMB, "max-media-mb", 0, "maximum exported file size in MiB (0 = configured/default limit)")
+	cmd.Flags().BoolVar(&opts.NoDefaultIdentity, "no-default-identity", false, noDefaultIdentityHelp)
 	_ = cmd.MarkFlagRequired("me")
 	return cmd
 }
@@ -84,6 +86,16 @@ func runImportSlackdump(cmd *cobra.Command, sourcePath string, opts slackdumpCLI
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nImport interrupted. Re-run the command to import the export again.")
 		}
 		return errors.Join(fmt.Errorf("import Slackdump: %w", importErr), rebuildCacheAfterWrite(dbPath))
+	}
+	if !opts.NoDefaultIdentity {
+		source, sourceErr := st.GetSourceByID(summary.SourceID)
+		if sourceErr != nil {
+			return errors.Join(fmt.Errorf("read Slackdump source: %w", sourceErr), rebuildCacheAfterWrite(dbPath))
+		}
+		confirmDefaultIdentity(
+			cmd.OutOrStdout(), st, source.ID,
+			source.Identifier, source.Identifier, "account-identifier",
+		)
 	}
 	if err := runPostSourceCreateMigrations(st); err != nil {
 		return errors.Join(fmt.Errorf("post-source-create migrations: %w", err), rebuildCacheAfterWrite(dbPath))

--- a/cmd/msgvault/cmd/import_slackdump.go
+++ b/cmd/msgvault/cmd/import_slackdump.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/slack"
+)
+
+type slackdumpCLIOptions struct {
+	Me         string
+	Limit      int
+	MaxMediaMB int64
+}
+
+func newImportSlackdumpCmd() *cobra.Command {
+	var opts slackdumpCLIOptions
+	cmd := &cobra.Command{
+		Use:   "import-slackdump <export-dir-or-zip>",
+		Short: "Import a Slackdump export",
+		Args:  cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if opts.Limit < 0 {
+				return usageErr(cmd, errors.New("--limit must be non-negative"))
+			}
+			if opts.MaxMediaMB < 0 {
+				return usageErr(cmd, errors.New("--max-media-mb must be non-negative"))
+			}
+			if opts.MaxMediaMB > math.MaxInt64>>20 {
+				return usageErr(cmd, errors.New("--max-media-mb is too large"))
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobraWithLocalFiles(cmd, args, nil)
+			}
+			return runImportSlackdump(cmd, args[0], opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Me, "me", "", "your Slack user ID or profile email (required)")
+	cmd.Flags().IntVar(&opts.Limit, "limit", 0, "maximum messages per conversation (0 = unlimited)")
+	cmd.Flags().Int64Var(&opts.MaxMediaMB, "max-media-mb", 0, "maximum exported file size in MiB (0 = configured/default limit)")
+	_ = cmd.MarkFlagRequired("me")
+	return cmd
+}
+
+func runImportSlackdump(cmd *cobra.Command, sourcePath string, opts slackdumpCLIOptions) error {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("source path not found: %w", err)
+	}
+	if !info.IsDir() && !info.Mode().IsRegular() {
+		return fmt.Errorf("source path is neither a directory nor a ZIP file: %s", sourcePath)
+	}
+
+	dbPath := cfg.DatabaseDSN()
+	st, cleanup, err := openWritableStoreAndInitForIngest()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	ctx, stop := withInterruptCancel(cmd, "\nInterrupted. Stopping Slackdump import...")
+	defer stop()
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Importing Slackdump export from %s\n", sourcePath)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Me: %s\n\n", opts.Me)
+	summary, importErr := slack.ImportSlackdump(ctx, st, sourcePath, slack.SlackdumpImportOptions{
+		Me:             opts.Me,
+		Limit:          opts.Limit,
+		AttachmentsDir: cfg.AttachmentsDir(),
+		MediaPolicyForTeam: func(teamID string) attachmentpolicy.Policy {
+			return resolveSlackdumpMediaPolicy(teamID, opts.MaxMediaMB)
+		},
+		Progress: func(line string) { writeSlackProgress(cmd.OutOrStdout(), line) },
+	})
+	if importErr != nil {
+		if ctx.Err() != nil {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nImport interrupted. Re-run the command to import the export again.")
+		}
+		return errors.Join(fmt.Errorf("import Slackdump: %w", importErr), rebuildCacheAfterWrite(dbPath))
+	}
+	if err := runPostSourceCreateMigrations(st); err != nil {
+		return errors.Join(fmt.Errorf("post-source-create migrations: %w", err), rebuildCacheAfterWrite(dbPath))
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nImport complete!")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Duration:      %s\n", summary.Duration.Round(time.Millisecond))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Conversations: %d\n", summary.ConversationsProcessed)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Messages:      %d processed, %d added, %d updated\n",
+		summary.MessagesProcessed, summary.MessagesAdded, summary.MessagesUpdated)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Attachments:   %d stored, %d missing, %d skipped\n",
+		summary.AttachmentsDownloaded, summary.AttachmentsMissing, summary.AttachmentsSkipped)
+	if summary.Errors > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Errors:        %d\n", summary.Errors)
+	}
+	return rebuildCacheAfterWrite(dbPath)
+}
+
+func resolveSlackdumpMediaPolicy(teamID string, overrideMB int64) attachmentpolicy.Policy {
+	policy := cfg.Slack.MediaPolicy(teamID)
+	if overrideMB > 0 {
+		policy.MaxBytes = overrideMB << 20
+	}
+	return policy
+}
+
+func init() {
+	rootCmd.AddCommand(newImportSlackdumpCmd())
+}

--- a/cmd/msgvault/cmd/import_slackdump_e2e_test.go
+++ b/cmd/msgvault/cmd/import_slackdump_e2e_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"io"
 	"os"
 	"path/filepath"
@@ -48,6 +49,21 @@ func TestImportSlackdumpEndToEnd(t *testing.T) {
 	require.NoError(err)
 	require.Len(sources, 1)
 	assert.Equal("slackdump", sources[0].SourceType)
+	identities, err := st.ListAccountIdentities(sources[0].ID)
+	require.NoError(err)
+	require.Len(identities, 1)
+	assert.Equal("T_TEST:UALICE", identities[0].Address)
+	assert.Equal("account-identifier", identities[0].SourceSignal)
+	assert.Contains(stdout.String(), "Confirmed identity T_TEST:UALICE")
+	duckdb, err := sql.Open("duckdb", "")
+	require.NoError(err)
+	t.Cleanup(func() { _ = duckdb.Close() })
+	var ownerRows int
+	require.NoError(duckdb.QueryRow(
+		`SELECT COUNT(*) FROM read_parquet(?) WHERE source_id = ?`,
+		filepath.Join(home, "analytics", "owner_participants", "*.parquet"), sources[0].ID,
+	).Scan(&ownerRows))
+	assert.Equal(1, ownerRows)
 
 	results, total, err := st.SearchMessages("first day", 0, 10)
 	require.NoError(err)
@@ -70,6 +86,39 @@ func TestImportSlackdumpEndToEnd(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(home, "attachments", filepath.FromSlash(storagePath)))
 	require.NoError(err)
 	assert.Equal([]byte("standard attachment bytes\n"), content)
+}
+
+func TestImportSlackdumpNoDefaultIdentity(t *testing.T) {
+	require := require.New(t)
+
+	markDaemonCLISubprocessForTest(t)
+	t.Cleanup(saveMessengerState(t))
+	resetImportSlackdumpFlagsAfterTest(t)
+
+	home := t.TempDir()
+	fixture, err := filepath.Abs("../../../internal/slack/testdata/slackdump/standard")
+	require.NoError(err)
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"--home", home,
+		"import-slackdump",
+		"--me", "UALICE",
+		"--no-default-identity",
+		fixture,
+	})
+	require.NoError(rootCmd.ExecuteContext(context.Background()))
+
+	st, err := store.Open(filepath.Join(home, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	sources, err := st.GetSourcesByIdentifier("T_TEST:UALICE")
+	require.NoError(err)
+	require.Len(sources, 1)
+	identities, err := st.ListAccountIdentities(sources[0].ID)
+	require.NoError(err)
+	assert.Empty(t, identities)
 }
 
 func resetImportSlackdumpFlagsAfterTest(t *testing.T) {

--- a/cmd/msgvault/cmd/import_slackdump_e2e_test.go
+++ b/cmd/msgvault/cmd/import_slackdump_e2e_test.go
@@ -121,6 +121,51 @@ func TestImportSlackdumpNoDefaultIdentity(t *testing.T) {
 	assert.Empty(t, identities)
 }
 
+func TestImportSlackdumpPartialFailureConfirmsIdentity(t *testing.T) {
+	require := require.New(t)
+
+	markDaemonCLISubprocessForTest(t)
+	t.Cleanup(saveMessengerState(t))
+	resetImportSlackdumpFlagsAfterTest(t)
+
+	home := t.TempDir()
+	fixture, err := filepath.Abs("../../../internal/slack/testdata/slackdump/standard")
+	require.NoError(err)
+	exportRoot := filepath.Join(t.TempDir(), "export")
+	require.NoError(os.CopyFS(exportRoot, os.DirFS(fixture)))
+	require.NoError(os.WriteFile(
+		filepath.Join(exportRoot, "general", "2024-01-02.json"),
+		[]byte(`[{"type":"message"`),
+		0o600,
+	))
+
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"--home", home,
+		"import-slackdump",
+		"--me", "UALICE",
+		exportRoot,
+	})
+	err = rootCmd.ExecuteContext(context.Background())
+	require.Error(err)
+	require.ErrorContains(err, "2024-01-02.json")
+
+	st, err := store.Open(filepath.Join(home, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	var messages int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages`).Scan(&messages))
+	assert.Positive(t, messages)
+	sources, err := st.GetSourcesByIdentifier("T_TEST:UALICE")
+	require.NoError(err)
+	require.Len(sources, 1)
+	identities, err := st.ListAccountIdentities(sources[0].ID)
+	require.NoError(err)
+	require.Len(identities, 1)
+	assert.Equal(t, "T_TEST:UALICE", identities[0].Address)
+}
+
 func resetImportSlackdumpFlagsAfterTest(t *testing.T) {
 	t.Helper()
 	command, _, err := rootCmd.Find([]string{"import-slackdump"})

--- a/cmd/msgvault/cmd/import_slackdump_e2e_test.go
+++ b/cmd/msgvault/cmd/import_slackdump_e2e_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestImportSlackdumpEndToEnd(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	markDaemonCLISubprocessForTest(t)
+	t.Cleanup(saveMessengerState(t))
+	resetImportSlackdumpFlagsAfterTest(t)
+
+	home := t.TempDir()
+	fixture, err := filepath.Abs("../../../internal/slack/testdata/slackdump/standard")
+	require.NoError(err)
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs([]string{
+		"--home", home,
+		"import-slackdump",
+		"--me", "alice@example.com",
+		fixture,
+	})
+	require.NoError(rootCmd.ExecuteContext(context.Background()))
+	assert.Contains(stdout.String(), "Import complete!")
+	assert.Contains(stdout.String(), "Messages:      6 processed, 6 added, 0 updated")
+	assert.Contains(stdout.String(), "Attachments:   2 stored, 1 missing, 0 skipped")
+
+	st, err := store.Open(filepath.Join(home, "msgvault.db"))
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+
+	sources, err := st.GetSourcesByIdentifier("T_TEST:UALICE")
+	require.NoError(err)
+	require.Len(sources, 1)
+	assert.Equal("slackdump", sources[0].SourceType)
+
+	results, total, err := st.SearchMessages("first day", 0, 10)
+	require.NoError(err)
+	assert.EqualValues(1, total)
+	require.Len(results, 1)
+	assert.Equal("C001:1704067200.000001", results[0].SourceMessageID)
+
+	var linked int
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_message_id = 'C001:1704153600.000002'
+		  AND parent.source_message_id = 'C001:1704067200.000001'`).Scan(&linked))
+	assert.Equal(1, linked)
+
+	var storagePath string
+	require.NoError(st.DB().QueryRow(`
+		SELECT storage_path FROM attachments
+		WHERE source_attachment_id = 'slack:F_STD' AND attachment_state = 'stored'`).Scan(&storagePath))
+	content, err := os.ReadFile(filepath.Join(home, "attachments", filepath.FromSlash(storagePath)))
+	require.NoError(err)
+	assert.Equal([]byte("standard attachment bytes\n"), content)
+}
+
+func resetImportSlackdumpFlagsAfterTest(t *testing.T) {
+	t.Helper()
+	command, _, err := rootCmd.Find([]string{"import-slackdump"})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		command.Flags().VisitAll(func(flag *pflag.Flag) {
+			require.NoError(t, flag.Value.Set(flag.DefValue))
+			flag.Changed = false
+		})
+	})
+}

--- a/cmd/msgvault/cmd/import_slackdump_test.go
+++ b/cmd/msgvault/cmd/import_slackdump_test.go
@@ -41,6 +41,7 @@ func TestImportSlackdumpCommandForwardsFlagsAndPath(t *testing.T) {
 		"--me", "alice@example.com",
 		"--limit", "25",
 		"--max-media-mb", "7",
+		"--no-default-identity",
 		"relative/export.zip",
 	}))
 
@@ -51,6 +52,7 @@ func TestImportSlackdumpCommandForwardsFlagsAndPath(t *testing.T) {
 		"--limit=25",
 		"--max-media-mb=7",
 		"--me=alice@example.com",
+		"--no-default-identity",
 		"relative/export.zip",
 	}, args)
 }

--- a/cmd/msgvault/cmd/import_slackdump_test.go
+++ b/cmd/msgvault/cmd/import_slackdump_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+func TestImportSlackdumpCommandRequiresIdentity(t *testing.T) {
+	command := newImportSlackdumpCmd()
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"export.zip"})
+
+	err := command.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, `required flag(s) "me" not set`)
+}
+
+func TestImportSlackdumpCommandRejectsNegativeLimitBeforeRouting(t *testing.T) {
+	command := newImportSlackdumpCmd()
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"--me", "UALICE", "--limit", "-1", "export.zip"})
+
+	err := command.ExecuteContext(context.Background())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "--limit must be non-negative")
+}
+
+func TestImportSlackdumpCommandForwardsFlagsAndPath(t *testing.T) {
+	command := newImportSlackdumpCmd()
+	require.NoError(t, command.ParseFlags([]string{
+		"--me", "alice@example.com",
+		"--limit", "25",
+		"--max-media-mb", "7",
+		"relative/export.zip",
+	}))
+
+	args, err := daemonCLIArgsFromCobra(command, command.Flags().Args())
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"import-slackdump",
+		"--limit=25",
+		"--max-media-mb=7",
+		"--me=alice@example.com",
+		"relative/export.zip",
+	}, args)
+}
+
+func TestRunImportSlackdumpRejectsMissingSourcePath(t *testing.T) {
+	command := &cobra.Command{Use: "import-slackdump"}
+	command.SetContext(context.Background())
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+
+	err := runImportSlackdump(command, filepath.Join(t.TempDir(), "missing.zip"), slackdumpCLIOptions{Me: "UALICE"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "source path not found")
+}
+
+func TestResolveSlackdumpMediaPolicyPreservesWorkspaceRulesAndOverridesOnlySize(t *testing.T) {
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = config.NewDefaultConfig()
+	disabled := false
+	cfg.Slack = config.SlackConfig{
+		Media:                &disabled,
+		MediaScope:           "direct",
+		MediaMaxParticipants: 4,
+		MaxMediaMB:           11,
+		AccountsConfig: map[string]config.MediaAccountConfig{
+			"T001": {MaxMediaMB: 7},
+		},
+	}
+
+	want := attachmentpolicy.Policy{
+		Scope:           attachmentpolicy.ScopeDirect,
+		MaxParticipants: 4,
+		MaxBytes:        7 << 20,
+		DisabledReason:  attachmentpolicy.SkipPolicyScope,
+	}
+	assert.Equal(t, want, resolveSlackdumpMediaPolicy("T001", 0))
+	want.MaxBytes = 3 << 20
+	assert.Equal(t, want, resolveSlackdumpMediaPolicy("T001", 3))
+}

--- a/cmd/msgvault/cmd/purge_excluded_media.go
+++ b/cmd/msgvault/cmd/purge_excluded_media.go
@@ -191,7 +191,7 @@ func mediaPolicyForSource(cfg *config.Config, sourceType, identifier string) (at
 	switch sourceType {
 	case sourceTypeBeeper:
 		return cfg.Beeper.MediaPolicy(identifier), true
-	case sourceTypeSlack:
+	case sourceTypeSlack, sourceTypeSlackdump:
 		teamID, _, ok := splitSlackIdentifier(identifier)
 		if !ok {
 			return attachmentpolicy.Policy{}, false

--- a/cmd/msgvault/cmd/purge_excluded_media_test.go
+++ b/cmd/msgvault/cmd/purge_excluded_media_test.go
@@ -137,6 +137,19 @@ func TestPurgeExcludedMediaDryRunAndApplyPreservesSharedBlob(t *testing.T) {
 	assert.NoFileExists(f.fullPath)
 }
 
+func TestMediaPolicyForSlackdumpUsesSlackWorkspaceConfig(t *testing.T) {
+	current := &config.Config{Slack: config.SlackConfig{
+		MaxMediaMB: 7,
+		AccountsConfig: map[string]config.MediaAccountConfig{
+			"T_TEST": {MaxMediaMB: 11},
+		},
+	}}
+
+	policy, ok := mediaPolicyForSource(current, "slackdump", "T_TEST:UALICE")
+	require.True(t, ok)
+	assert.Equal(t, int64(11)<<20, policy.MaxBytes)
+}
+
 func TestPurgeExcludedMediaPreservesBlobReferencedByThumbnail(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,9 @@ All notable changes to msgvault, grouped by release.
   clients safely forward consent through local and remote daemon execution;
   daemon-host config and environment are not treated as client consent.
 
+- Import Slackdump directories and ZIPs without a Slack token, preserving
+  conversations, threads, reactions, identities, raw JSON, and exported files.
+
 - Exact source selection is available through `--source-id` on `sync`,
   `sync-full`, `update-account`, `remove-account`, and `delete-staged`.
   Account arguments continue to accept identifiers and display names, while

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -559,6 +559,28 @@ After adding, sync with `msgvault sync-slack`.
 
 ---
 
+## import-slackdump
+
+Import a Slackdump directory or ZIP without contacting Slack. `--me` resolves
+your account from `users.json` by exact Slack user ID or unique profile email.
+The import preserves conversations, threads, reactions, raw JSON, identities,
+and exported files. The path must be local to the daemon host; exports are not
+uploaded through a configured remote. See
+[Slack](/usage/slack/#import-a-slackdump-export).
+
+```bash
+msgvault import-slackdump --me you@example.com /path/to/export
+msgvault import-slackdump --me U0123456789 --limit 100 /path/to/export.zip
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--me` | required | Slack user ID or unique profile email in the export |
+| `--limit` | `0` | Max messages imported per conversation (0 = no limit) |
+| `--max-media-mb` | configured/default limit | Max exported file size in MiB (0 = configured/default limit) |
+
+---
+
 ## sync-slack
 
 Sync Slack conversations — channels you are a member of, group DMs, and 1:1

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -578,6 +578,7 @@ msgvault import-slackdump --me U0123456789 --limit 100 /path/to/export.zip
 | `--me` | required | Slack user ID or unique profile email in the export |
 | `--limit` | `0` | Max messages imported per conversation (0 = no limit) |
 | `--max-media-mb` | configured/default limit | Max exported file size in MiB (0 = configured/default limit) |
+| `--no-default-identity` | `false` | Do not auto-confirm the workspace user ID as the source's "me" identity |
 
 ---
 

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -1,6 +1,7 @@
 ---
+last_edited: 2026-08-30
 title: Slack
-description: Archive your Slack workspaces — channels, group DMs, and DMs — via the Web API.
+description: Archive Slack workspaces through the Web API or a Slackdump export.
 ---
 
 msgvault archives your own view of a Slack workspace: every public and
@@ -11,6 +12,41 @@ search.
 
 Slack sync is strictly read-only: msgvault only calls read methods of the Web
 API and never posts, edits, or marks anything in Slack.
+
+## Import a Slackdump export
+
+Use `import-slackdump` when you already have an export created by
+[Slackdump](https://github.com/rusq/slackdump). The import runs entirely from
+the local directory or ZIP and does not need a Slack token:
+
+```bash
+msgvault import-slackdump --me you@example.com /path/to/slackdump-export
+msgvault import-slackdump --me U0123456789 /path/to/slackdump-export.zip
+```
+
+`--me` accepts your exact Slack user ID or a unique profile email from the
+export. The importer preserves channels, private channels, group DMs, DMs,
+threads, reactions, mentions, raw Slack JSON, and exported files. Standard
+Slackdump attachment directories and Mattermost-style `__uploads` directories
+are both supported.
+
+Each imported account is stored as a `slackdump` source identified by
+`<team-id>:<user-id>`. Messages still use `message_type = slack`, so live Slack
+syncs and offline imports share the same search and analytics behavior while
+remaining separately filterable sources.
+
+| Flag | Description |
+|---|---|
+| `--me ID_OR_EMAIL` | Your Slack user ID or unique profile email in the export (required) |
+| `--limit N` | Import at most N messages per conversation (0 = unlimited) |
+| `--max-media-mb N` | Skip exported files larger than N MiB (0 = configured/default limit) |
+
+Re-running the same export updates existing messages and reuses stored file
+content instead of creating duplicates. If a file is referenced but absent
+from the export, msgvault keeps a metadata-only attachment record and reports
+it as missing in the command summary. With a configured remote, run the import
+on the daemon host with `--local`; msgvault does not upload the export from a
+client machine.
 
 ## Prerequisites
 

--- a/docs/usage/slack.md
+++ b/docs/usage/slack.md
@@ -40,6 +40,7 @@ remaining separately filterable sources.
 | `--me ID_OR_EMAIL` | Your Slack user ID or unique profile email in the export (required) |
 | `--limit N` | Import at most N messages per conversation (0 = unlimited) |
 | `--max-media-mb N` | Skip exported files larger than N MiB (0 = configured/default limit) |
+| `--no-default-identity` | Do not auto-confirm the workspace user ID as the source's "me" identity |
 
 Re-running the same export updates existing messages and reuses stored file
 content instead of creating duplicates. If a file is referenced but absent

--- a/internal/api/cli_allowlist_slack_test.go
+++ b/internal/api/cli_allowlist_slack_test.go
@@ -15,6 +15,7 @@ func TestCLIRunCommandAllowedSlackCommands(t *testing.T) {
 		{"sync-slack"},
 		{"sync-slack", "T0123456789", "--full"},
 		{"backfill-slack-media"},
+		{"import-slackdump", "--me=U0123456789", "/tmp/slackdump.zip"},
 	} {
 		t.Run(args[0], func(t *testing.T) {
 			assert.True(t, cliRunCommandAllowed(args), "%v must be runnable via the daemon CLI", args)

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1559,6 +1559,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"import-mbox",
 		"import-messenger",
 		"import-pst",
+		"import-slackdump",
 		"import-synctech-sms",
 		"import-whatsapp",
 		"list-deletions",

--- a/internal/export/store_attachment.go
+++ b/internal/export/store_attachment.go
@@ -57,10 +57,21 @@ func prepareStorageDir(attachmentsDir string) (string, error) {
 // content-addressed storage (hash[:2]/hash). It validates existing files when
 // de-duping. If attachmentsDir is a symlink, it is resolved before writing.
 //
-// Returns the storage path relative to attachmentsDir (e.g. "ab/<hash>"), or
-// empty string if nothing was stored.
+// Empty content is skipped. Returns the storage path relative to attachmentsDir
+// (e.g. "ab/<hash>"), or empty string if nothing was stored.
 func StoreAttachmentFile(attachmentsDir string, att *mime.Attachment) (string, error) {
-	if attachmentsDir == "" || len(att.Content) == 0 {
+	return storeAttachmentFile(attachmentsDir, att, false)
+}
+
+// StoreAttachmentFileIncludingEmpty stores loaded attachment content even
+// when it is a present zero-length slice. A nil Content slice still means the
+// bytes were not loaded and is skipped.
+func StoreAttachmentFileIncludingEmpty(attachmentsDir string, att *mime.Attachment) (string, error) {
+	return storeAttachmentFile(attachmentsDir, att, true)
+}
+
+func storeAttachmentFile(attachmentsDir string, att *mime.Attachment, includeEmpty bool) (string, error) {
+	if attachmentsDir == "" || att.Content == nil || (!includeEmpty && len(att.Content) == 0) {
 		return "", nil
 	}
 

--- a/internal/export/store_attachment_test.go
+++ b/internal/export/store_attachment_test.go
@@ -171,6 +171,27 @@ func TestStoreAttachmentFileDurableStoresEmptyContent(t *testing.T) {
 	assert.Empty(skipped, "ordinary ingest must keep its empty-content skip semantics")
 }
 
+func TestStoreAttachmentFileIncludingEmptyStoresPresentEmptyContent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	const emptySHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	att := &mime.Attachment{Content: []byte{}}
+
+	storagePath, err := StoreAttachmentFileIncludingEmpty(dir, att)
+	require.NoError(err)
+	assert.Equal(path.Join(emptySHA256[:2], emptySHA256), storagePath)
+	assert.Equal(emptySHA256, att.ContentHash)
+	info, err := os.Lstat(filepath.Join(dir, filepath.FromSlash(storagePath)))
+	require.NoError(err)
+	assert.True(info.Mode().IsRegular())
+	assert.Zero(info.Size())
+
+	skipped, err := StoreAttachmentFile(t.TempDir(), &mime.Attachment{Content: []byte{}})
+	require.NoError(err)
+	assert.Empty(skipped, "ordinary ingest must keep its empty-content skip semantics")
+}
+
 func TestStoreAttachmentFileDurableSurfacesParentSyncFailure(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()

--- a/internal/slack/export_importer.go
+++ b/internal/slack/export_importer.go
@@ -1,0 +1,494 @@
+package slack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	attachmentexport "go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+const sourceTypeSlackdump = "slackdump"
+
+var errSlackdumpMessageLimitReached = errors.New("slackdump message limit reached")
+
+// SlackdumpImportOptions configures one offline Slackdump import.
+type SlackdumpImportOptions struct {
+	// Me is the importing Slack user's ID or profile email.
+	Me string
+	// Limit caps messages processed per conversation (zero means unlimited).
+	Limit int
+	// AttachmentsDir is populated by the attachment import path.
+	AttachmentsDir string
+	// MaxMediaBytes caps one exported attachment (zero uses the default).
+	MaxMediaBytes int64
+	// MediaPolicy is the resolved attachment retention policy. A
+	// MediaPolicyForTeam result replaces it after the export identity is known.
+	MediaPolicy attachmentpolicy.Policy
+	// MediaPolicyForTeam resolves workspace-specific retention settings after
+	// the export identity is known.
+	MediaPolicyForTeam func(string) attachmentpolicy.Policy
+	// Progress receives one status line after each conversation.
+	Progress func(string)
+}
+
+// SlackdumpImportSummary uses the live Slack counters and adds the number of
+// exported file records whose bytes were absent from the snapshot.
+type SlackdumpImportSummary struct {
+	ImportSummary
+
+	AttachmentsMissing int
+}
+
+// ImportSlackdump imports a Slackdump standard export without contacting
+// Slack. Directory and ZIP inputs share the same reader and persistence path.
+func ImportSlackdump(
+	ctx context.Context,
+	st *store.Store,
+	inputPath string,
+	opts SlackdumpImportOptions,
+) (summary *SlackdumpImportSummary, err error) {
+	started := time.Now()
+	if st == nil {
+		return nil, errors.New("slackdump import requires a store")
+	}
+	if opts.Limit < 0 {
+		return nil, errors.New("slackdump import limit must be non-negative")
+	}
+
+	export, err := openSlackdumpExport(inputPath)
+	if err != nil {
+		return nil, err
+	}
+	exportClosed := false
+	defer func() {
+		if exportClosed {
+			return
+		}
+		if closeErr := export.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close Slackdump export %s: %w", inputPath, closeErr)
+		}
+	}()
+
+	users, err := export.users()
+	if err != nil {
+		return nil, err
+	}
+	me, err := resolveSlackdumpIdentity(users, opts.Me)
+	if err != nil {
+		return nil, err
+	}
+	if me.TeamID == "" {
+		return nil, fmt.Errorf("slackdump user %s has no team ID", me.ID)
+	}
+	if opts.MediaPolicyForTeam != nil {
+		opts.MediaPolicy = opts.MediaPolicyForTeam(me.TeamID)
+	}
+	if opts.MaxMediaBytes > 0 {
+		opts.MediaPolicy.MaxBytes = opts.MaxMediaBytes
+	}
+	if err = opts.MediaPolicy.Validate(); err != nil {
+		return nil, fmt.Errorf("slackdump media policy: %w", err)
+	}
+	conversations, err := export.conversations(me.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	source, err := st.GetOrCreateSource(sourceTypeSlackdump, me.TeamID+":"+me.ID)
+	if err != nil {
+		return nil, err
+	}
+	summary = &SlackdumpImportSummary{}
+	summary.SourceID = source.ID
+	defer func() {
+		summary.Duration = time.Since(started)
+	}()
+
+	syncID, err := st.StartSync(source.ID, sourceTypeSlackdump)
+	if err != nil {
+		return summary, err
+	}
+	scopedStore := st.ScopedToSync(source.ID, syncID)
+	importer := &Importer{
+		store: scopedStore,
+		res:   newParticipantResolver(scopedStore, me.TeamID),
+		now:   time.Now,
+	}
+	importer.res.loadUserSnapshot(users)
+	importer.opts = ImportOptions{
+		TeamID:         me.TeamID,
+		UserID:         me.ID,
+		Limit:          opts.Limit,
+		NoMedia:        true,
+		MaxMediaBytes:  opts.MaxMediaBytes,
+		AttachmentsDir: opts.AttachmentsDir,
+		Progress:       opts.Progress,
+	}
+	importer.sourceID = source.ID
+	defer func() {
+		if err != nil {
+			_ = scopedStore.FailSyncWithCheckpoint(syncID, err.Error(), slackdumpCheckpoint(summary))
+		}
+	}()
+
+	for index := range conversations {
+		if err = ctx.Err(); err != nil {
+			return summary, err
+		}
+		conversation := &conversations[index]
+		var conversationID int64
+		conversationID, err = scopedStore.EnsureConversationWithType(
+			source.ID,
+			conversation.ID,
+			conversationType(conversation),
+			conversationTitle(conversation, importer.res.displayName),
+		)
+		if err != nil {
+			return summary, err
+		}
+
+		var toRecipients []messageRecipient
+		var participantCount int
+		toRecipients, participantCount, err = ensureSlackdumpMembership(
+			scopedStore, importer.res, conversationID, conversation, me.ID, opts.MediaPolicy,
+		)
+		if err != nil {
+			return summary, err
+		}
+
+		before := summary.MessagesProcessed
+		cc := &convScope{
+			channelID:              conversation.ID,
+			convID:                 conversationID,
+			sourceID:               source.ID,
+			syncID:                 syncID,
+			opts:                   importer.opts,
+			toRecipients:           toRecipients,
+			filesHandledExternally: true,
+		}
+		cc.opts.MediaConversation = attachmentpolicy.Conversation{
+			Type:             conversationType(conversation),
+			ParticipantCount: participantCount,
+		}
+		err = export.walkMessages(*conversation, func(message *Message) error {
+			if err = ctx.Err(); err != nil {
+				return err
+			}
+			if err = importer.processMessage(ctx, cc, message, &summary.ImportSummary); err != nil {
+				return fmt.Errorf("import Slackdump conversation %s: %w", conversation.ID, err)
+			}
+			if message.Type == "message" && message.TS != "" {
+				var messageIDs map[string]int64
+				messageIDs, err = scopedStore.MessageExistsBatch(source.ID, []string{
+					sourceMessageID(conversation.ID, message.TS),
+				})
+				if err != nil {
+					return fmt.Errorf("find imported Slackdump message: %w", err)
+				}
+				messageID := messageIDs[sourceMessageID(conversation.ID, message.TS)]
+				if messageID == 0 {
+					return fmt.Errorf("imported Slackdump message %s was not persisted", sourceMessageID(conversation.ID, message.TS))
+				}
+				if err = persistSlackdumpAttachments(
+					scopedStore,
+					export,
+					*conversation,
+					messageID,
+					message,
+					cc.opts.MediaConversation,
+					opts,
+					summary,
+				); err != nil {
+					return fmt.Errorf("persist Slackdump attachments for %s: %w", sourceMessageID(conversation.ID, message.TS), err)
+				}
+			}
+			if opts.Limit > 0 && summary.MessagesProcessed-before >= opts.Limit {
+				return errSlackdumpMessageLimitReached
+			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, errSlackdumpMessageLimitReached) {
+			return summary, err
+		}
+		summary.ConversationsProcessed++
+		if opts.Progress != nil {
+			opts.Progress(fmt.Sprintf(
+				"conversation %d/%d (%s): %d messages",
+				index+1,
+				len(conversations),
+				conversationTitle(conversation, importer.res.displayName),
+				summary.MessagesProcessed-before,
+			))
+		}
+	}
+
+	if err = scopedStore.RecomputeConversationStats(source.ID); err != nil {
+		return summary, err
+	}
+	if err = scopedStore.UpdateSyncCheckpoint(syncID, slackdumpCheckpoint(summary)); err != nil {
+		return summary, err
+	}
+	if err = export.Close(); err != nil {
+		return summary, fmt.Errorf("close Slackdump export %s: %w", inputPath, err)
+	}
+	exportClosed = true
+	if err = scopedStore.CompleteSync(syncID, ""); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+func resolveSlackdumpIdentity(users []User, identity string) (User, error) {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return User{}, errors.New("slackdump importing identity is required")
+	}
+	var matches []User
+	for _, user := range users {
+		if user.ID == identity {
+			matches = append(matches, user)
+		}
+	}
+	if len(matches) == 0 {
+		for _, user := range users {
+			if user.Profile.Email != "" && strings.EqualFold(user.Profile.Email, identity) {
+				matches = append(matches, user)
+			}
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return User{}, fmt.Errorf("slackdump identity %q not found in users.json", identity)
+	case 1:
+		return matches[0], nil
+	default:
+		return User{}, fmt.Errorf("slackdump identity %q matches multiple users in users.json", identity)
+	}
+}
+
+func ensureSlackdumpMembership(
+	st *store.Store,
+	resolver *participantResolver,
+	conversationID int64,
+	conversation *Conversation,
+	meUserID string,
+	mediaPolicy attachmentpolicy.Policy,
+) ([]messageRecipient, int, error) {
+	userIDs := conversation.Members
+	if conversation.IsIM {
+		userIDs = []string{conversation.User, meUserID}
+	} else if len(userIDs) == 0 {
+		if conversation.NumMembers > 0 {
+			if err := st.SetConversationMemberCount(conversationID, conversation.NumMembers); err != nil {
+				return nil, 0, err
+			}
+			return nil, conversation.NumMembers, nil
+		}
+		if err := st.MarkConversationMemberCountUnknown(conversationID); err != nil {
+			return nil, 0, err
+		}
+		return nil, unknownMembershipCount(mediaPolicy), nil
+	}
+	seen := make(map[string]struct{}, len(userIDs))
+	participants := make([]store.ConversationParticipantRef, 0, len(userIDs))
+	toRecipients := make([]messageRecipient, 0, len(userIDs))
+	for _, userID := range userIDs {
+		if userID == "" {
+			continue
+		}
+		if _, duplicate := seen[userID]; duplicate {
+			continue
+		}
+		seen[userID] = struct{}{}
+		participantID, err := resolver.resolveID(userID)
+		if err != nil {
+			return nil, 0, err
+		}
+		if participantID == 0 {
+			continue
+		}
+		participants = append(participants, store.ConversationParticipantRef{
+			ParticipantID: participantID,
+			Role:          "member",
+		})
+		if conversation.IsIM || conversation.IsMpim {
+			toRecipients = append(toRecipients, messageRecipient{
+				id:   participantID,
+				name: resolver.displayName(userID),
+			})
+		}
+	}
+	if err := st.ReplaceConversationParticipants(conversationID, participants); err != nil {
+		return nil, 0, err
+	}
+	participantCount := max(len(participants), conversation.NumMembers)
+	if err := st.SetConversationMemberCount(conversationID, participantCount); err != nil {
+		return nil, 0, err
+	}
+	return toRecipients, participantCount, nil
+}
+
+func slackdumpCheckpoint(summary *SlackdumpImportSummary) *store.Checkpoint {
+	return &store.Checkpoint{
+		MessagesProcessed: int64(summary.MessagesProcessed),
+		MessagesAdded:     int64(summary.MessagesAdded),
+		MessagesUpdated:   int64(summary.MessagesUpdated),
+		ErrorsCount:       int64(summary.Errors),
+	}
+}
+
+func persistSlackdumpAttachments(
+	st *store.Store,
+	dump *slackdumpExport,
+	conversation Conversation,
+	messageID int64,
+	message *Message,
+	mediaConversation attachmentpolicy.Conversation,
+	opts SlackdumpImportOptions,
+	summary *SlackdumpImportSummary,
+) error {
+	existing, err := st.MessageSlackAttachments(messageID)
+	if err != nil {
+		return fmt.Errorf("read existing attachments: %w", err)
+	}
+	maxBytes := opts.MediaPolicy.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = opts.MaxMediaBytes
+	}
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	policy := opts.MediaPolicy
+	policy.MaxBytes = maxBytes
+	refs := make([]store.AttachmentRef, 0, len(message.Files))
+	seen := make(map[string]struct{}, len(message.Files))
+	for index := range message.Files {
+		file := &message.Files[index]
+		if file.ID == "" || file.Mode == "tombstone" {
+			continue
+		}
+		sourceAttachmentID := slackAttachmentID(file.ID)
+		seen[sourceAttachmentID] = struct{}{}
+		if previous, ok := existing[sourceAttachmentID]; ok && previous.ContentHash != "" {
+			previous.Role = store.AttachmentRoleStandalone
+			previous.RoleSource = store.AttachmentRoleSourceProviderExplicit
+			refs = append(refs, previous)
+			continue
+		}
+
+		metadata := slackdumpMetadataAttachment(file, "slackdump:missing:"+file.ID)
+		if reason := policy.Evaluate(mediaConversation, file.Size); reason != "" {
+			metadata = slackdumpMetadataAttachment(file, "slackdump:skipped:"+file.ID)
+			metadata.MediaType = ""
+			metadata.State = attachmentpolicy.StateSkipped
+			metadata.SkipReason = reason
+			refs = append(refs, metadata)
+			summary.AttachmentsSkipped++
+			continue
+		}
+		content, found, readErr := dump.attachmentWithLimit(conversation, *file, maxBytes)
+		if errors.Is(readErr, ErrAssetTooLarge) {
+			metadata = slackdumpMetadataAttachment(file, "slackdump:skipped:"+file.ID)
+			metadata.MediaType = ""
+			metadata.State = attachmentpolicy.StateSkipped
+			metadata.SkipReason = attachmentpolicy.SkipSizeCap
+			refs = append(refs, metadata)
+			summary.AttachmentsSkipped++
+			continue
+		}
+		if readErr != nil {
+			return readErr
+		}
+		if !found {
+			refs = append(refs, metadata)
+			summary.AttachmentsMissing++
+			continue
+		}
+		if opts.AttachmentsDir == "" {
+			metadata = slackdumpMetadataAttachment(file, "slackdump:available:"+file.ID)
+			refs = append(refs, metadata)
+			continue
+		}
+
+		attachment := &mime.Attachment{
+			Filename:    file.Name,
+			ContentType: file.Mimetype,
+			Content:     content,
+		}
+		storagePath, err := attachmentexport.StoreAttachmentFileIncludingEmpty(opts.AttachmentsDir, attachment)
+		if err != nil {
+			return err
+		}
+		if storagePath == "" {
+			refs = append(refs, metadata)
+			summary.AttachmentsMissing++
+			continue
+		}
+		refs = append(refs, store.AttachmentRef{
+			Filename:           file.Name,
+			MimeType:           file.Mimetype,
+			StoragePath:        storagePath,
+			ContentHash:        attachment.ContentHash,
+			Size:               len(content),
+			SourceAttachmentID: sourceAttachmentID,
+			MediaType:          mediaTypeOf(file),
+			Role:               store.AttachmentRoleStandalone,
+			RoleSource:         store.AttachmentRoleSourceProviderExplicit,
+			State:              attachmentpolicy.StateStored,
+		})
+		summary.AttachmentsDownloaded++
+	}
+
+	var omitted []string
+	for sourceAttachmentID := range existing {
+		if _, present := seen[sourceAttachmentID]; !present {
+			omitted = append(omitted, sourceAttachmentID)
+		}
+	}
+	sort.Strings(omitted)
+	for _, sourceAttachmentID := range omitted {
+		refs = append(refs, existing[sourceAttachmentID])
+	}
+	if err := st.ReplaceMessageSlackAttachments(messageID, refs); err != nil {
+		return fmt.Errorf("replace attachment rows: %w", err)
+	}
+	if err := st.RecomputeMessageAttachmentStats(messageID); err != nil {
+		return fmt.Errorf("recompute attachment stats: %w", err)
+	}
+	return nil
+}
+
+func slackdumpMetadataAttachment(file *File, fallbackPath string) store.AttachmentRef {
+	storagePath := slackdumpMetadataURL(file)
+	if storagePath == "" {
+		storagePath = fallbackPath
+	}
+	return store.AttachmentRef{
+		Filename:           file.Name,
+		MimeType:           file.Mimetype,
+		StoragePath:        storagePath,
+		Size:               int(file.Size),
+		SourceAttachmentID: slackAttachmentID(file.ID),
+		MediaType:          "link",
+		Role:               store.AttachmentRoleStandalone,
+		RoleSource:         store.AttachmentRoleSourceProviderExplicit,
+	}
+}
+
+func slackdumpMetadataURL(file *File) string {
+	for _, candidate := range []string{file.Permalink, file.URLPrivate, file.URLPrivateDownload} {
+		candidate = strings.TrimSpace(candidate)
+		lower := strings.ToLower(candidate)
+		if strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "http://") {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/slack/export_importer.go
+++ b/internal/slack/export_importer.go
@@ -358,6 +358,9 @@ func persistSlackdumpAttachments(
 	if err != nil {
 		return fmt.Errorf("read existing attachments: %w", err)
 	}
+	if len(message.Files) == 0 && len(existing) == 0 {
+		return nil
+	}
 	maxBytes := opts.MediaPolicy.MaxBytes
 	if maxBytes <= 0 {
 		maxBytes = opts.MaxMediaBytes

--- a/internal/slack/export_importer_test.go
+++ b/internal/slack/export_importer_test.go
@@ -1,0 +1,515 @@
+package slack
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestImportSlackdumpPersistsSlackSemantics(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	st := testutil.NewTestStore(t)
+
+	summary, err := ImportSlackdump(context.Background(), st, slackdumpFixture, SlackdumpImportOptions{
+		Me: "alice@example.com",
+	})
+	require.NoError(err)
+	assert.Equal(5, summary.ConversationsProcessed)
+	assert.Equal(6, summary.MessagesProcessed)
+	assert.Equal(6, summary.MessagesAdded)
+	assert.Zero(summary.MessagesUpdated)
+
+	source, err := st.GetSourceByID(summary.SourceID)
+	require.NoError(err)
+	assert.Equal(sourceTypeSlackdump, source.SourceType)
+	assert.Equal("T_TEST:UALICE", source.Identifier)
+	var syncStatus string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT status FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1`),
+		summary.SourceID).Scan(&syncStatus))
+	assert.Equal("completed", syncStatus)
+
+	assertSlackdumpConversation(t, st, "C001", "#general", "channel")
+	assertSlackdumpConversation(t, st, "D001", "Bob Test", "direct_chat")
+	assertSlackdumpConversation(t, st, "G002", "mpdm-alice--bob-1", "group_chat")
+
+	var members int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		WHERE c.source_conversation_id = ?`), "C001").Scan(&members))
+	assert.Equal(2, members)
+
+	rootSourceID := "C001:1704067200.000001"
+	replySourceID := "C001:1704153600.000002"
+	root, err := st.InspectMessage(rootSourceID)
+	require.NoError(err)
+	assert.Equal("first day @Bob Test", root.BodyText)
+	assert.Equal(1, root.RecipientCounts["from"])
+	assert.Equal(1, root.RecipientCounts["mention"])
+	assert.True(root.RawDataExists)
+
+	var rootID int64
+	var isFromMe bool
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id, is_from_me FROM messages WHERE source_id = ? AND source_message_id = ?`),
+		summary.SourceID, rootSourceID).Scan(&rootID, &isFromMe))
+	assert.True(isFromMe)
+	raw, err := st.GetMessageRaw(rootID)
+	require.NoError(err)
+	assert.JSONEq(
+		`{"type":"message","ts":"1704067200.000001","thread_ts":"1704067200.000001","reply_count":1,"user":"UALICE","text":"first day <@UBOB>","files":[{"id":"F_STD","name":"what do these colored bars mean?.txt","mimetype":"text/plain","size":26}],"future_field":{"kept":true}}`,
+		string(raw),
+	)
+
+	var linked int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM messages child
+		JOIN messages parent ON parent.id = child.reply_to_message_id
+		WHERE child.source_id = ? AND child.source_message_id = ?
+		  AND parent.source_message_id = ?`),
+		summary.SourceID, replySourceID, rootSourceID).Scan(&linked))
+	assert.Equal(1, linked)
+
+	var reactions int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM reactions r
+		JOIN messages m ON m.id = r.message_id
+		WHERE m.source_id = ? AND m.source_message_id = ? AND r.reaction_value = 'eyes'`),
+		summary.SourceID, replySourceID).Scan(&reactions))
+	assert.Equal(2, reactions)
+
+	results, total, err := st.SearchMessages("first day", 0, 10)
+	require.NoError(err)
+	assert.EqualValues(1, total)
+	require.Len(results, 1)
+	assert.Equal(rootSourceID, results[0].SourceMessageID)
+}
+
+func TestImportSlackdumpRequiresUniqueExportIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		me      string
+		users   string
+		wantErr string
+	}{
+		{name: "missing", wantErr: "identity is required"},
+		{name: "unknown", me: "nobody@example.com", wantErr: "not found"},
+		{
+			name: "ambiguous email",
+			me:   "shared@example.com",
+			users: `[
+				{"id":"U_ONE","team_id":"T_TEST","profile":{"email":"shared@example.com"}},
+				{"id":"U_TWO","team_id":"T_TEST","profile":{"email":"SHARED@example.com"}}
+			]`,
+			wantErr: "matches multiple users",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := copySlackdumpFixture(t)
+			if tt.users != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(root, "users.json"), []byte(tt.users), 0o644))
+			}
+
+			_, err := ImportSlackdump(context.Background(), testutil.NewTestStore(t), root, SlackdumpImportOptions{Me: tt.me})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestImportSlackdumpRecordsFailedSync(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "general", "2024-01-02.json"),
+		[]byte(`[{"type":"message"`),
+		0o644,
+	))
+	st := testutil.NewTestStore(t)
+
+	_, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{Me: "UALICE"})
+	require.Error(err)
+	require.ErrorContains(err, filepath.ToSlash(filepath.Join("general", "2024-01-02.json")))
+
+	var status, failure string
+	require.NoError(st.DB().QueryRow(`
+		SELECT sr.status, sr.error_message
+		FROM sync_runs sr
+		JOIN sources s ON s.id = sr.source_id
+		WHERE s.source_type = 'slackdump' AND s.identifier = 'T_TEST:UALICE'
+		ORDER BY sr.id DESC LIMIT 1`).Scan(&status, &failure))
+	assert.Equal("failed", status)
+	assert.Contains(failure, "2024-01-02.json")
+}
+
+func TestImportSlackdumpLimitDoesNotReadPastCap(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "general", "2024-01-02.json"),
+		[]byte(`[{"type":"message"`),
+		0o644,
+	))
+	st := testutil.NewTestStore(t)
+
+	summary, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{
+		Me:    "UALICE",
+		Limit: 1,
+	})
+	require.NoError(err)
+	assert.Equal(5, summary.MessagesProcessed)
+
+	rootMessage, err := st.InspectMessage("C001:1704067200.000001")
+	require.NoError(err)
+	assert.Equal("first day @Bob Test", rootMessage.BodyText)
+	_, err = st.InspectMessage("C001:1704153600.000002")
+	require.Error(err)
+}
+
+func TestImportSlackdumpMarksMissingConversationRosterUnknown(t *testing.T) {
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "mpims.json"),
+		[]byte(`[{"id":"G002","name":"mpdm-alice--bob-1","is_group":true,"is_mpim":true,"is_private":true,"is_member":true}]`),
+		0o644,
+	))
+	st := testutil.NewTestStore(t)
+
+	_, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{Me: "UALICE"})
+	require.NoError(err)
+
+	var metadata string
+	require.NoError(st.DB().QueryRow(`
+		SELECT COALESCE(CAST(metadata AS TEXT), '') FROM conversations
+		WHERE source_conversation_id = 'G002'`).Scan(&metadata))
+	assert.JSONEq(t, `{"member_count_unknown":true}`, metadata)
+}
+
+func TestImportSlackdumpUnknownRosterFailsParticipantPolicyClosed(t *testing.T) {
+	tests := []struct {
+		name    string
+		catalog string
+	}{
+		{
+			name:    "missing members field",
+			catalog: `[{"id":"C001","name":"general","is_channel":true,"is_member":true}]`,
+		},
+		{
+			name:    "empty members list",
+			catalog: `[{"id":"C001","name":"general","is_channel":true,"is_member":true,"members":[]}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			root := copySlackdumpFixture(t)
+			require.NoError(os.WriteFile(filepath.Join(root, "channels.json"), []byte(tt.catalog), 0o644))
+			st := testutil.NewTestStore(t)
+
+			summary, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{
+				Me:             "UALICE",
+				AttachmentsDir: t.TempDir(),
+				MediaPolicy: attachmentpolicy.Policy{
+					Scope: attachmentpolicy.ScopeAll, MaxParticipants: 1, MaxBytes: 100 << 20,
+				},
+			})
+			require.NoError(err)
+			assert.Positive(summary.AttachmentsSkipped)
+
+			var state, reason string
+			require.NoError(st.DB().QueryRow(`
+				SELECT attachment_state, attachment_skip_reason FROM attachments
+				WHERE source_attachment_id = 'slack:F_STD'`).Scan(&state, &reason))
+			assert.Equal(string(attachmentpolicy.StateSkipped), state)
+			assert.Equal(string(attachmentpolicy.SkipParticipantThreshold), reason)
+		})
+	}
+}
+
+func TestImportSlackdumpUsesCatalogMemberCountWithoutRoster(t *testing.T) {
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "channels.json"),
+		[]byte(`[{"id":"C001","name":"general","is_channel":true,"num_members":7}]`),
+		0o644,
+	))
+	st := testutil.NewTestStore(t)
+
+	_, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{Me: "UALICE"})
+	require.NoError(err)
+
+	var metadata string
+	require.NoError(st.DB().QueryRow(`
+		SELECT COALESCE(CAST(metadata AS TEXT), '') FROM conversations
+		WHERE source_conversation_id = 'C001'`).Scan(&metadata))
+	assert.JSONEq(t, `{"member_count":7}`, metadata)
+}
+
+func TestImportSlackdumpStoresDirectoryAndZIPAttachments(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(t *testing.T) string
+	}{
+		{name: "directory", path: func(t *testing.T) string {
+			t.Helper()
+			return slackdumpFixture
+		}},
+		{name: "ZIP", path: func(t *testing.T) string {
+			t.Helper()
+			return zipSlackdumpFixtureReverseOrder(t, slackdumpFixture)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			st := testutil.NewTestStore(t)
+			attachmentsDir := t.TempDir()
+
+			summary, err := ImportSlackdump(context.Background(), st, tt.path(t), SlackdumpImportOptions{
+				Me:             "UALICE",
+				AttachmentsDir: attachmentsDir,
+			})
+			require.NoError(err)
+			assert.Equal(2, summary.AttachmentsDownloaded)
+			assert.Equal(1, summary.AttachmentsMissing)
+			assert.Zero(summary.AttachmentsPending, "offline files must not leave live API retry debt")
+
+			assertSlackdumpStoredAttachment(t, st, attachmentsDir, "slack:F_STD", "standard attachment bytes\n")
+			assertSlackdumpStoredAttachment(t, st, attachmentsDir, "slack:F_MM", "mattermost attachment bytes\n")
+
+			var contentHash, mediaType, state string
+			require.NoError(st.DB().QueryRow(`
+				SELECT COALESCE(content_hash, ''), COALESCE(media_type, ''), COALESCE(attachment_state, '')
+				FROM attachments WHERE source_attachment_id = 'slack:F_MISSING'`).
+				Scan(&contentHash, &mediaType, &state))
+			assert.Empty(contentHash)
+			assert.Equal("link", mediaType)
+			assert.Empty(state)
+		})
+	}
+}
+
+func TestImportSlackdumpStoresPresentEmptyAttachment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	messagePath := filepath.Join(root, "general", "2024-01-01.json")
+	content, err := os.ReadFile(messagePath)
+	require.NoError(err)
+	content = []byte(strings.Replace(
+		string(content),
+		`"size":26}`,
+		`"size":26},{"id":"F_EMPTY","name":"empty.txt","mimetype":"text/plain","size":0}`,
+		1,
+	))
+	require.NoError(os.WriteFile(messagePath, content, 0o644))
+	require.NoError(os.WriteFile(
+		filepath.Join(root, "general", "attachments", "F_EMPTY-empty.txt"),
+		[]byte{},
+		0o600,
+	))
+	attachmentsDir := t.TempDir()
+	st := testutil.NewTestStore(t)
+
+	summary, err := ImportSlackdump(context.Background(), st, root, SlackdumpImportOptions{
+		Me:             "UALICE",
+		AttachmentsDir: attachmentsDir,
+	})
+	require.NoError(err)
+	assert.Equal(3, summary.AttachmentsDownloaded)
+	assert.Equal(1, summary.AttachmentsMissing)
+
+	const emptySHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	var storagePath, contentHash, state string
+	var size int
+	require.NoError(st.DB().QueryRow(`
+		SELECT storage_path, content_hash, attachment_state, size
+		FROM attachments WHERE source_attachment_id = 'slack:F_EMPTY'`).
+		Scan(&storagePath, &contentHash, &state, &size))
+	assert.Equal(filepath.ToSlash(filepath.Join(emptySHA256[:2], emptySHA256)), storagePath)
+	assert.Equal(emptySHA256, contentHash)
+	assert.Equal("stored", state)
+	assert.Zero(size)
+
+	info, err := os.Stat(filepath.Join(attachmentsDir, filepath.FromSlash(storagePath)))
+	require.NoError(err)
+	assert.Zero(info.Size())
+}
+
+func TestImportSlackdumpAppliesMediaPolicyForExportTeam(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	var resolvedTeamID string
+
+	summary, err := ImportSlackdump(context.Background(), st, slackdumpFixture, SlackdumpImportOptions{
+		Me:             "UALICE",
+		AttachmentsDir: t.TempDir(),
+		MediaPolicyForTeam: func(teamID string) attachmentpolicy.Policy {
+			resolvedTeamID = teamID
+			return attachmentpolicy.Policy{
+				Scope:    attachmentpolicy.ScopeNone,
+				MaxBytes: 100 << 20,
+			}
+		},
+	})
+	require.NoError(err)
+	assert.Equal("T_TEST", resolvedTeamID)
+	assert.Equal(3, summary.AttachmentsSkipped)
+	assert.Zero(summary.AttachmentsMissing, "policy must be evaluated before reading export bytes")
+	var skipped int
+	require.NoError(st.DB().QueryRow(`
+		SELECT COUNT(*) FROM attachments
+		WHERE attachment_state = 'skipped' AND attachment_skip_reason = 'policy_scope'`).Scan(&skipped))
+	assert.Equal(3, skipped)
+	var storagePath string
+	require.NoError(st.DB().QueryRow(`
+		SELECT storage_path FROM attachments WHERE source_attachment_id = 'slack:F_MM'`).Scan(&storagePath))
+	assert.Equal("https://files.slack.com/files-pri/T_TEST-F_MM/quarterly-report", storagePath)
+}
+
+func TestSlackdumpMetadataAttachmentUsesCapturedHTTPURLFallbacks(t *testing.T) {
+	tests := []struct {
+		name string
+		file File
+		want string
+	}{
+		{
+			name: "permalink",
+			file: File{Permalink: "https://example.com/permalink", URLPrivate: "https://example.com/private"},
+			want: "https://example.com/permalink",
+		},
+		{
+			name: "private URL",
+			file: File{URLPrivate: "https://files.slack.com/private"},
+			want: "https://files.slack.com/private",
+		},
+		{
+			name: "private download URL",
+			file: File{URLPrivateDownload: "http://files.slack.com/download"},
+			want: "http://files.slack.com/download",
+		},
+		{
+			name: "non HTTP URL",
+			file: File{Permalink: "javascript:alert(1)", URLPrivate: "file:///tmp/private"},
+			want: "slackdump:missing:F_TEST",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref := slackdumpMetadataAttachment(&tt.file, "slackdump:missing:F_TEST")
+			assert.Equal(t, tt.want, ref.StoragePath)
+		})
+	}
+}
+
+func TestImportSlackdumpRerunUpdatesWithoutDuplicates(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	st := testutil.NewTestStore(t)
+	attachmentsDir := t.TempDir()
+	opts := SlackdumpImportOptions{Me: "UALICE", AttachmentsDir: attachmentsDir}
+
+	first, err := ImportSlackdump(context.Background(), st, root, opts)
+	require.NoError(err)
+	require.Equal(6, first.MessagesAdded)
+
+	messagePath := filepath.Join(root, "general", "2024-01-02.json")
+	content, err := os.ReadFile(messagePath)
+	require.NoError(err)
+	content = []byte(strings.ReplaceAll(string(content), "second day reply", "updated second day reply"))
+	require.NoError(os.WriteFile(messagePath, content, 0o644))
+	firstDayPath := filepath.Join(root, "general", "2024-01-01.json")
+	firstDay, err := os.ReadFile(firstDayPath)
+	require.NoError(err)
+	firstDay = []byte(strings.Replace(
+		string(firstDay),
+		`,"files":[{"id":"F_STD","name":"what do these colored bars mean?.txt","mimetype":"text/plain","size":26}]`,
+		"",
+		1,
+	))
+	require.NoError(os.WriteFile(firstDayPath, firstDay, 0o644))
+
+	second, err := ImportSlackdump(context.Background(), st, root, opts)
+	require.NoError(err)
+	assert.Zero(second.MessagesAdded)
+	assert.Equal(6, second.MessagesUpdated)
+	assert.Zero(second.AttachmentsDownloaded, "stored content must be reused on rerun")
+
+	var messages, reactions, attachments int
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE message_type = 'slack'`).Scan(&messages))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM reactions`).Scan(&reactions))
+	require.NoError(st.DB().QueryRow(`SELECT COUNT(*) FROM attachments`).Scan(&attachments))
+	assert.Equal(6, messages)
+	assert.Equal(2, reactions)
+	assert.Equal(3, attachments)
+	var hasAttachments bool
+	var attachmentCount int
+	require.NoError(st.DB().QueryRow(`
+		SELECT has_attachments, attachment_count FROM messages
+		WHERE source_message_id = 'C001:1704067200.000001'`).
+		Scan(&hasAttachments, &attachmentCount))
+	assert.True(hasAttachments, "retained attachment rows must remain visible after a file is omitted")
+	assert.Equal(1, attachmentCount)
+	body, err := st.InspectBodyText("C001:1704153600.000002")
+	require.NoError(err)
+	assert.Equal("updated second day reply", body)
+}
+
+func assertSlackdumpStoredAttachment(
+	t *testing.T,
+	st *store.Store,
+	attachmentsDir string,
+	sourceAttachmentID string,
+	want string,
+) {
+	t.Helper()
+
+	var storagePath, contentHash, state string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT storage_path, content_hash, attachment_state
+		FROM attachments WHERE source_attachment_id = ?`), sourceAttachmentID).
+		Scan(&storagePath, &contentHash, &state))
+	assert.NotEmpty(t, contentHash)
+	assert.Equal(t, "stored", state)
+	content, err := os.ReadFile(filepath.Join(attachmentsDir, filepath.FromSlash(storagePath)))
+	require.NoError(t, err)
+	assert.Equal(t, []byte(want), content)
+}
+
+func assertSlackdumpConversation(t *testing.T, st *store.Store, sourceConversationID, wantTitle, wantType string) {
+	t.Helper()
+
+	var title, conversationType string
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT title, conversation_type FROM conversations
+		WHERE source_conversation_id = ?`), sourceConversationID).Scan(&title, &conversationType))
+	assert.Equal(t, wantTitle, title)
+	assert.Equal(t, wantType, conversationType)
+}

--- a/internal/slack/export_reader.go
+++ b/internal/slack/export_reader.go
@@ -1,0 +1,353 @@
+package slack
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+)
+
+var slackdumpDailyFileRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}\.json$`)
+
+// slackdumpExport provides the parts of a Slackdump standard export needed by
+// the importer. Both directories and ZIP archives expose the same fs.FS view.
+type slackdumpExport struct {
+	fsys                fs.FS
+	name                string
+	standardAttachments map[string]string
+	close               func() error
+}
+
+func openSlackdumpExport(name string) (*slackdumpExport, error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return nil, fmt.Errorf("open Slackdump export %s: %w", name, err)
+	}
+
+	if info.IsDir() {
+		root, err := os.OpenRoot(name)
+		if err != nil {
+			return nil, fmt.Errorf("open Slackdump export %s: %w", name, err)
+		}
+		return newSlackdumpExport(root.FS(), name, root.Close)
+	}
+
+	zr, err := zip.OpenReader(name)
+	if err != nil {
+		return nil, fmt.Errorf("open Slackdump export %s: %w", name, err)
+	}
+	root, err := slackdumpArchiveRoot(zr)
+	if err != nil {
+		_ = zr.Close()
+		return nil, fmt.Errorf("open Slackdump export %s: %w", name, err)
+	}
+	return newSlackdumpExport(root, name, zr.Close)
+}
+
+func newSlackdumpExport(fsys fs.FS, name string, closeFn func() error) (*slackdumpExport, error) {
+	attachments, err := slackdumpStandardAttachmentIndex(fsys)
+	if err != nil {
+		_ = closeFn()
+		return nil, fmt.Errorf("open Slackdump export %s: index attachments: %w", name, err)
+	}
+	return &slackdumpExport{
+		fsys: fsys, name: name, standardAttachments: attachments, close: closeFn,
+	}, nil
+}
+
+// slackdumpStandardAttachmentIndex mirrors Slackdump's workspace-wide file-ID
+// lookup. A file can be shared into more than one conversation while its bytes
+// appear under only one conversation's attachments directory.
+func slackdumpStandardAttachmentIndex(fsys fs.FS) (map[string]string, error) {
+	index := make(map[string]string)
+	err := fs.WalkDir(fsys, ".", func(filename string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !slackdumpPathContainsDirectory(filename, "attachments") {
+			return nil
+		}
+		fileID, _, found := strings.Cut(path.Base(filename), "-")
+		if !found || !slackdumpValidPathSegment(fileID) {
+			return nil
+		}
+		index[fileID] = filename
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk Slackdump export for attachments: %w", err)
+	}
+	return index, nil
+}
+
+func slackdumpPathContainsDirectory(filename, directory string) bool {
+	parts := strings.Split(filename, "/")
+	return slices.Contains(parts[:len(parts)-1], directory)
+}
+
+func slackdumpValidPathSegment(value string) bool {
+	return value != "" && value != "." && fs.ValidPath(value) && !strings.Contains(value, "/")
+}
+
+// slackdumpArchiveRoot accepts both Slackdump ZIPs whose indexes are at the
+// archive root and ZIPs wrapped in a single top-level directory.
+func slackdumpArchiveRoot(zr *zip.ReadCloser) (fs.FS, error) {
+	if _, err := fs.Stat(zr, "users.json"); err == nil {
+		return zr, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("stat Slackdump archive users.json: %w", err)
+	}
+
+	entries, err := fs.ReadDir(zr, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read Slackdump archive root: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate, err := fs.Sub(zr, entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("open Slackdump archive directory %s: %w", entry.Name(), err)
+		}
+		if _, err := fs.Stat(candidate, "users.json"); err == nil {
+			return candidate, nil
+		}
+	}
+	return zr, nil
+}
+
+func (e *slackdumpExport) Close() error {
+	if e == nil || e.close == nil {
+		return nil
+	}
+	return e.close()
+}
+
+func (e *slackdumpExport) users() ([]User, error) {
+	var users []User
+	_, err := e.readJSON("users.json", &users, true)
+	return users, err
+}
+
+func (e *slackdumpExport) conversations(meUserID string) ([]Conversation, error) {
+	var conversations []Conversation
+	for _, catalog := range []string{"channels.json", "groups.json", "mpims.json"} {
+		var entries []Conversation
+		if _, err := e.readJSON(catalog, &entries, false); err != nil {
+			return nil, err
+		}
+		conversations = append(conversations, entries...)
+	}
+
+	var dms []struct {
+		ID      string   `json:"id"`
+		User    string   `json:"user"`
+		Members []string `json:"members"`
+	}
+	if found, err := e.readJSON("dms.json", &dms, false); err != nil {
+		return nil, err
+	} else if found {
+		for _, dm := range dms {
+			peer := dm.User
+			if peer == "" {
+				peer = slackdumpDMPeer(dm.Members, meUserID)
+			}
+			conversations = append(conversations, Conversation{
+				ID:   dm.ID,
+				IsIM: true,
+				User: peer,
+			})
+		}
+	}
+
+	sort.Slice(conversations, func(i, j int) bool {
+		return conversations[i].ID < conversations[j].ID
+	})
+	return conversations, nil
+}
+
+func slackdumpDMPeer(members []string, meUserID string) string {
+	for _, member := range members {
+		if member != "" && member != meUserID {
+			return member
+		}
+	}
+	for _, member := range members {
+		if member != "" {
+			return member
+		}
+	}
+	return ""
+}
+
+func (e *slackdumpExport) messages(conversation Conversation) ([]Message, error) {
+	var messages []Message
+	err := e.walkMessages(conversation, func(message *Message) error {
+		messages = append(messages, *message)
+		return nil
+	})
+	return messages, err
+}
+
+func (e *slackdumpExport) walkMessages(conversation Conversation, visit func(*Message) error) error {
+	directory := conversation.Name
+	if conversation.IsIM {
+		directory = conversation.ID
+	}
+	if directory == "" || !fs.ValidPath(directory) {
+		return fmt.Errorf("read Slackdump export %s: invalid conversation directory %q", e.name, directory)
+	}
+
+	entries, err := fs.ReadDir(e.fsys, directory)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return e.pathError(directory, err)
+	}
+	// Slackdump export (both Standard and Mattermost layouts) flattens roots
+	// and replies into date files. Timestamp-named per-thread files belong to
+	// Slackdump's separate dump format and are intentionally ignored here.
+	var dailyFiles []string
+	for _, entry := range entries {
+		if !entry.IsDir() && slackdumpDailyFileRE.MatchString(entry.Name()) {
+			dailyFiles = append(dailyFiles, entry.Name())
+		}
+	}
+	sort.Strings(dailyFiles)
+
+	for _, filename := range dailyFiles {
+		var daily []Message
+		if _, err := e.readJSON(path.Join(directory, filename), &daily, true); err != nil {
+			return err
+		}
+		sort.SliceStable(daily, func(i, j int) bool {
+			return tsLess(daily[i].TS, daily[j].TS)
+		})
+		for index := range daily {
+			if err := visit(&daily[index]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *slackdumpExport) attachment(conversation Conversation, file File) ([]byte, bool, error) {
+	return e.attachmentWithLimit(conversation, file, defaultMaxMediaBytes)
+}
+
+func (e *slackdumpExport) attachmentWithLimit(
+	conversation Conversation,
+	file File,
+	maxBytes int64,
+) ([]byte, bool, error) {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxMediaBytes
+	}
+	if !slackdumpValidPathSegment(file.ID) {
+		return nil, false, fmt.Errorf("read Slackdump export %s: invalid attachment ID %q", e.name, file.ID)
+	}
+	directory := conversation.Name
+	if conversation.IsIM {
+		directory = conversation.ID
+	}
+	sanitized := slackdumpSanitizeFilename(file.Name)
+	candidates := []string{
+		path.Join(directory, "attachments", file.ID+"-"+sanitized),
+	}
+	if indexed := e.standardAttachments[file.ID]; indexed != "" && indexed != candidates[0] {
+		candidates = append(candidates, indexed)
+	}
+	candidates = append(candidates, path.Join("__uploads", file.ID, sanitized))
+
+	for _, filename := range candidates {
+		if !fs.ValidPath(filename) {
+			continue
+		}
+		content, found, err := e.readAttachmentFile(filename, maxBytes)
+		if err == nil && found {
+			return content, true, nil
+		}
+		if err != nil {
+			return nil, false, err
+		}
+	}
+	return nil, false, nil
+}
+
+func (e *slackdumpExport) readAttachmentFile(filename string, maxBytes int64) ([]byte, bool, error) {
+	file, err := e.fsys.Open(filename)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, e.pathError(filename, err)
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false, e.pathError(filename, err)
+	}
+	if info.Size() > maxBytes {
+		return nil, false, e.pathError(filename, fmt.Errorf("%d bytes exceeds %d-byte limit: %w", info.Size(), maxBytes, ErrAssetTooLarge))
+	}
+	content, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil {
+		return nil, false, e.pathError(filename, err)
+	}
+	if int64(len(content)) > maxBytes {
+		return nil, false, e.pathError(filename, ErrAssetTooLarge)
+	}
+	return content, true, nil
+}
+
+func (e *slackdumpExport) readJSON(filename string, destination any, required bool) (bool, error) {
+	content, err := fs.ReadFile(e.fsys, filename)
+	if err != nil {
+		if !required && errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, e.pathError(filename, err)
+	}
+	if err := json.Unmarshal(content, destination); err != nil {
+		return true, e.pathError(filename, err)
+	}
+	return true, nil
+}
+
+func (e *slackdumpExport) pathError(filename string, err error) error {
+	return fmt.Errorf("slackdump export %s/%s: %w", e.name, filename, err)
+}
+
+var slackdumpUnsafeFilenameRE = regexp.MustCompile(`[<>:"/\\|?*]`)
+
+var slackdumpReservedFilenames = map[string]struct{}{
+	"CON": {}, "PRN": {}, "AUX": {}, "NUL": {},
+	"COM1": {}, "COM2": {}, "COM3": {}, "COM4": {}, "COM5": {}, "COM6": {}, "COM7": {}, "COM8": {}, "COM9": {},
+	"LPT1": {}, "LPT2": {}, "LPT3": {}, "LPT4": {}, "LPT5": {}, "LPT6": {}, "LPT7": {}, "LPT8": {}, "LPT9": {},
+}
+
+// slackdumpSanitizeFilename mirrors Slackdump's portable filename mapping.
+func slackdumpSanitizeFilename(name string) string {
+	safe := slackdumpUnsafeFilenameRE.ReplaceAllString(name, "_")
+	safe = strings.TrimRight(safe, " .")
+	base, _, _ := strings.Cut(safe, ".")
+	if _, reserved := slackdumpReservedFilenames[strings.ToUpper(base)]; reserved {
+		safe = "_" + safe
+	}
+	if safe == "" {
+		return "unnamed_file"
+	}
+	return safe
+}

--- a/internal/slack/export_reader_test.go
+++ b/internal/slack/export_reader_test.go
@@ -1,0 +1,535 @@
+package slack
+
+import (
+	"archive/zip"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const slackdumpFixture = "testdata/slackdump/standard"
+
+type slackdumpSnapshot struct {
+	Users         []User
+	Conversations []Conversation
+	Messages      map[string][]Message
+	Attachments   map[string][]byte
+}
+
+func TestSlackdumpExportDirectoryAndZIPParity(t *testing.T) {
+	dirSnapshot := readSlackdumpSnapshot(t, slackdumpFixture)
+	zipSnapshot := readSlackdumpSnapshot(t, zipSlackdumpFixtureReverseOrder(t, slackdumpFixture))
+
+	assert.Equal(t, dirSnapshot, zipSnapshot)
+}
+
+func TestSlackdumpExportReadsUsers(t *testing.T) {
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	users, err := export.users()
+	require.NoError(t, err)
+	assert.Equal(t, []User{
+		{ID: "UALICE", TeamID: "T_TEST", Name: "alice", Profile: UserProfile{Email: "alice@example.com", DisplayName: "Alice Test"}},
+		{ID: "UBOB", TeamID: "T_TEST", Name: "bob", Profile: UserProfile{Email: "bob@example.com", DisplayName: "Bob Test"}},
+	}, users)
+}
+
+func TestSlackdumpExportMergesConversationCatalogAndNormalizesDMs(t *testing.T) {
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	conversations, err := export.conversations("UALICE")
+	require.NoError(t, err)
+	assert.Equal(t, []Conversation{
+		{ID: "C001", Name: "general", IsChannel: true, IsMember: true, Members: []string{"UALICE", "UBOB"}},
+		{ID: "D001", IsIM: true, User: "UBOB"},
+		{ID: "D002", IsIM: true, User: "UALICE"},
+		{ID: "G001", Name: "private-team", IsGroup: true, IsPrivate: true, IsMember: true, Members: []string{"UALICE", "UBOB"}},
+		{ID: "G002", Name: "mpdm-alice--bob-1", IsGroup: true, IsMpim: true, IsPrivate: true, IsMember: true, Members: []string{"UALICE", "UBOB"}},
+	}, conversations)
+}
+
+func TestSlackdumpExportOrdersDailyMessagesAndPreservesRawJSON(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	defer func() {
+		assert.NoError(export.Close())
+	}()
+
+	messages, err := export.messages(Conversation{ID: "C001", Name: "general", IsChannel: true})
+	require.NoError(err, "non-date JSON siblings must be ignored")
+	require.Len(messages, 2)
+	assert.Equal([]string{"1704067200.000001", "1704153600.000002"}, []string{messages[0].TS, messages[1].TS})
+	assert.JSONEq(
+		`{"type":"message","ts":"1704067200.000001","thread_ts":"1704067200.000001","reply_count":1,"user":"UALICE","text":"first day <@UBOB>","files":[{"id":"F_STD","name":"what do these colored bars mean?.txt","mimetype":"text/plain","size":26}],"future_field":{"kept":true}}`,
+		string(messages[0].Raw),
+	)
+}
+
+func TestSlackdumpExportMapsConversationDirectories(t *testing.T) {
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	tests := []struct {
+		name         string
+		conversation Conversation
+		wantTS       string
+		wantText     string
+	}{
+		{
+			name:         "public channel name",
+			conversation: Conversation{ID: "C001", Name: "general", IsChannel: true},
+			wantTS:       "1704067200.000001",
+			wantText:     "first day <@UBOB>",
+		},
+		{
+			name:         "private group name",
+			conversation: Conversation{ID: "G001", Name: "private-team", IsGroup: true},
+			wantTS:       "1704240000.000003",
+			wantText:     "private group",
+		},
+		{
+			name:         "MPIM name",
+			conversation: Conversation{ID: "G002", Name: "mpdm-alice--bob-1", IsMpim: true},
+			wantTS:       "1704326400.000004",
+			wantText:     "group direct message",
+		},
+		{
+			name:         "DM channel ID",
+			conversation: Conversation{ID: "D001", IsIM: true, User: "UBOB"},
+			wantTS:       "1704412800.000005",
+			wantText:     "direct message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			messages, err := export.messages(tt.conversation)
+			require.NoError(err)
+			require.NotEmpty(messages)
+			assert.Equal(tt.wantTS, messages[0].TS)
+			assert.Equal(tt.wantText, messages[0].Text)
+		})
+	}
+}
+
+func TestSlackdumpExportTreatsMissingConversationDirectoryAsEmpty(t *testing.T) {
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	messages, err := export.messages(Conversation{ID: "C_EMPTY", Name: "empty-channel", IsChannel: true})
+	require.NoError(t, err)
+	assert.Empty(t, messages)
+}
+
+func TestSlackdumpExportReadsAttachmentsAcrossLayouts(t *testing.T) {
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	tests := []struct {
+		name         string
+		conversation Conversation
+		file         File
+		want         string
+	}{
+		{
+			name:         "standard portable filename",
+			conversation: Conversation{ID: "C001", Name: "general", IsChannel: true},
+			file:         File{ID: "F_STD", Name: "what do these colored bars mean?.txt"},
+			want:         "standard attachment bytes\n",
+		},
+		{
+			name:         "Mattermost portable filename",
+			conversation: Conversation{ID: "G001", Name: "private-team", IsGroup: true},
+			file:         File{ID: "F_MM", Name: "quarterly report?.txt"},
+			want:         "mattermost attachment bytes\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content, found, err := export.attachment(tt.conversation, tt.file)
+			require.NoError(t, err)
+			assert.True(t, found)
+			assert.Equal(t, []byte(tt.want), content)
+		})
+	}
+}
+
+func TestSlackdumpExportResolvesStandardAttachmentByWorkspaceFileID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	filename := "F_STD-what do these colored bars mean_.txt"
+	source := filepath.Join(root, "general", "attachments", filename)
+	destinationDir := filepath.Join(root, "private-team", "attachments")
+	require.NoError(os.MkdirAll(destinationDir, 0o700))
+	require.NoError(os.Rename(source, filepath.Join(destinationDir, filename)))
+
+	export, err := openSlackdumpExport(root)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(export.Close()) })
+
+	content, found, err := export.attachment(
+		Conversation{ID: "C001", Name: "general", IsChannel: true},
+		File{ID: "F_STD", Name: "what do these colored bars mean?.txt"},
+	)
+	require.NoError(err)
+	assert.True(found)
+	assert.Equal([]byte("standard attachment bytes\n"), content)
+}
+
+func TestSlackdumpExportReportsMissingAttachment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	defer func() {
+		assert.NoError(export.Close())
+	}()
+
+	content, found, err := export.attachment(
+		Conversation{ID: "C001", Name: "general", IsChannel: true},
+		File{ID: "F_MISSING", Name: "missing.txt"},
+	)
+	require.NoError(err)
+	assert.False(found)
+	assert.Nil(content)
+}
+
+func TestSlackdumpExportBoundsAttachmentReads(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	defer func() {
+		assert.NoError(export.Close())
+	}()
+
+	content, found, err := export.attachmentWithLimit(
+		Conversation{ID: "C001", Name: "general", IsChannel: true},
+		File{ID: "F_STD", Name: "what do these colored bars mean?.txt"},
+		4,
+	)
+	require.ErrorIs(err, ErrAssetTooLarge)
+	assert.False(found)
+	assert.Nil(content)
+}
+
+func TestSlackdumpExportDoesNotResolveAttachmentNamesOutsideTheirLayout(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	defer func() {
+		assert.NoError(export.Close())
+	}()
+
+	content, found, err := export.attachment(
+		Conversation{ID: "C001", Name: "general", IsChannel: true},
+		File{ID: "F_TRAVERSAL", Name: "../../users.json"},
+	)
+	require.NoError(err)
+	assert.False(found)
+	assert.Nil(content)
+}
+
+func TestSlackdumpExportRejectsAttachmentIDTraversal(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(export.Close()) })
+
+	content, found, err := export.attachment(
+		Conversation{ID: "C001", Name: "general", IsChannel: true},
+		File{ID: "..", Name: "users.json"},
+	)
+	require.Error(err)
+	require.ErrorContains(err, "invalid attachment ID")
+	assert.False(found)
+	assert.Nil(content)
+}
+
+func TestSlackdumpExportDoesNotFollowAttachmentSymlinkOutsideDirectory(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	root := copySlackdumpFixture(t)
+	external := filepath.Join(t.TempDir(), "external.txt")
+	require.NoError(os.WriteFile(external, []byte("must not be imported"), 0o600))
+	attachmentPath := filepath.Join(
+		root,
+		"general",
+		"attachments",
+		"F_STD-what do these colored bars mean_.txt",
+	)
+	require.NoError(os.Remove(attachmentPath))
+	if err := os.Symlink(external, attachmentPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	export, err := openSlackdumpExport(root)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(export.Close()) })
+
+	content, found, err := export.attachment(Conversation{ID: "C001", Name: "general"}, File{
+		ID: "F_STD", Name: "what do these colored bars mean?.txt",
+	})
+	require.Error(err)
+	assert.False(found)
+	assert.NotEqual([]byte("must not be imported"), content)
+}
+
+func TestSlackdumpSanitizeFilenameMatchesPortableSlackdumpNames(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: `all<>:"/\|?*characters.txt`, want: "all_________characters.txt"},
+		{name: "CON.txt", want: "_CON.txt"},
+		{name: "trailing. ", want: "trailing"},
+		{name: "", want: "unnamed_file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, slackdumpSanitizeFilename(tt.name))
+		})
+	}
+}
+
+func TestSlackdumpExportReportsMalformedInputPath(t *testing.T) {
+	t.Run("malformed required index", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		root := copySlackdumpFixture(t)
+		require.NoError(os.WriteFile(filepath.Join(root, "users.json"), []byte(`{"id":`), 0o644))
+
+		export, err := openSlackdumpExport(root)
+		require.NoError(err)
+		defer func() {
+			assert.NoError(export.Close())
+		}()
+
+		_, err = export.users()
+		require.Error(err)
+		require.ErrorContains(err, root)
+		assert.ErrorContains(err, "users.json")
+	})
+
+	t.Run("missing required index", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		root := copySlackdumpFixture(t)
+		require.NoError(os.Remove(filepath.Join(root, "users.json")))
+
+		export, err := openSlackdumpExport(root)
+		require.NoError(err)
+		defer func() {
+			assert.NoError(export.Close())
+		}()
+
+		_, err = export.users()
+		require.Error(err)
+		require.ErrorIs(err, fs.ErrNotExist)
+		require.ErrorContains(err, root)
+		assert.ErrorContains(err, "users.json")
+	})
+
+	t.Run("daily messages", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+
+		root := copySlackdumpFixture(t)
+		messagePath := filepath.Join("general", "2024-01-02.json")
+		require.NoError(os.WriteFile(filepath.Join(root, messagePath), []byte(`[{"type":"message"`), 0o644))
+
+		export, err := openSlackdumpExport(root)
+		require.NoError(err)
+		defer func() {
+			assert.NoError(export.Close())
+		}()
+
+		_, err = export.messages(Conversation{ID: "C001", Name: "general", IsChannel: true})
+		require.Error(err)
+		require.ErrorContains(err, root)
+		assert.ErrorContains(err, filepath.ToSlash(messagePath))
+	})
+}
+
+func TestSlackdumpExportAcceptsMissingOptionalCatalogs(t *testing.T) {
+	tests := []struct {
+		missing string
+		wantIDs []string
+	}{
+		{missing: "channels.json", wantIDs: []string{"D001", "D002", "G001", "G002"}},
+		{missing: "groups.json", wantIDs: []string{"C001", "D001", "D002", "G002"}},
+		{missing: "mpims.json", wantIDs: []string{"C001", "D001", "D002", "G001"}},
+		{missing: "dms.json", wantIDs: []string{"C001", "G001", "G002"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.missing, func(t *testing.T) {
+			require := require.New(t)
+
+			root := copySlackdumpFixture(t)
+			require.NoError(os.Remove(filepath.Join(root, tt.missing)))
+
+			export, err := openSlackdumpExport(root)
+			require.NoError(err)
+			defer func() {
+				assert.NoError(t, export.Close())
+			}()
+
+			conversations, err := export.conversations("UALICE")
+			require.NoError(err)
+			gotIDs := make([]string, len(conversations))
+			for i := range conversations {
+				gotIDs[i] = conversations[i].ID
+			}
+			assert.Equal(t, tt.wantIDs, gotIDs)
+		})
+	}
+}
+
+func TestSlackdumpExportIgnoresUnknownMalformedRootSibling(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	export, err := openSlackdumpExport(slackdumpFixture)
+	require.NoError(err)
+	defer func() {
+		assert.NoError(export.Close())
+	}()
+
+	users, err := export.users()
+	require.NoError(err)
+	assert.Len(users, 2)
+	conversations, err := export.conversations("UALICE")
+	require.NoError(err)
+	assert.Len(conversations, 5)
+}
+
+func readSlackdumpSnapshot(t *testing.T, path string) slackdumpSnapshot {
+	t.Helper()
+
+	export, err := openSlackdumpExport(path)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, export.Close())
+	}()
+
+	users, err := export.users()
+	require.NoError(t, err)
+	conversations, err := export.conversations("UALICE")
+	require.NoError(t, err)
+	messages := make(map[string][]Message, len(conversations))
+	for _, conversation := range conversations {
+		messages[conversation.ID], err = export.messages(conversation)
+		require.NoError(t, err)
+	}
+	attachments := make(map[string][]byte, 2)
+	for _, item := range []struct {
+		conversation Conversation
+		file         File
+	}{
+		{
+			conversation: Conversation{ID: "C001", Name: "general", IsChannel: true},
+			file:         File{ID: "F_STD", Name: "what do these colored bars mean?.txt"},
+		},
+		{
+			conversation: Conversation{ID: "G001", Name: "private-team", IsGroup: true},
+			file:         File{ID: "F_MM", Name: "quarterly report?.txt"},
+		},
+	} {
+		var found bool
+		attachments[item.file.ID], found, err = export.attachment(item.conversation, item.file)
+		require.NoError(t, err)
+		require.True(t, found)
+	}
+
+	return slackdumpSnapshot{
+		Users:         users,
+		Conversations: conversations,
+		Messages:      messages,
+		Attachments:   attachments,
+	}
+}
+
+func zipSlackdumpFixtureReverseOrder(t *testing.T, root string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "export.zip")
+	file, err := os.Create(path)
+	require.NoError(t, err)
+
+	var paths []string
+	err = fs.WalkDir(os.DirFS(root), ".", func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	require.NoError(t, err)
+	// Slackdump readers must order daily files themselves rather than inherit
+	// archive insertion order. In particular, 2024-01-02 is packed before
+	// 2024-01-01 here.
+	sort.Sort(sort.Reverse(sort.StringSlice(paths)))
+
+	zw := zip.NewWriter(file)
+	for _, path := range paths {
+		content, err := fs.ReadFile(os.DirFS(root), path)
+		require.NoError(t, err)
+
+		destination, err := zw.Create(filepath.ToSlash(path))
+		require.NoError(t, err)
+		_, err = destination.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	require.NoError(t, file.Close())
+	return path
+}
+
+func copySlackdumpFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.CopyFS(root, os.DirFS(slackdumpFixture)))
+	return root
+}

--- a/internal/slack/importer.go
+++ b/internal/slack/importer.go
@@ -41,7 +41,10 @@ type convScope struct {
 	cs              *ConvState
 	toRecipients    []messageRecipient
 	membershipReady bool
-	budgetUsed      int
+	// filesHandledExternally lets the offline Slackdump importer preserve the
+	// shared message mapping while replacing file rows from exported bytes.
+	filesHandledExternally bool
+	budgetUsed             int
 }
 
 type messageRecipient struct {
@@ -1108,8 +1111,10 @@ func (imp *Importer) processMessage(ctx context.Context, cc *convScope, m *Messa
 		}
 	}
 
-	if err := imp.persistFiles(ctx, cc.syncID, messageID, m, cc.opts, sum); err != nil {
-		return err
+	if !cc.filesHandledExternally {
+		if err := imp.persistFiles(ctx, cc.syncID, messageID, m, cc.opts, sum); err != nil {
+			return err
+		}
 	}
 
 	if err := imp.persistRecipients(messageID, m, senderPID, cc.toRecipients); err != nil {

--- a/internal/slack/participants.go
+++ b/internal/slack/participants.go
@@ -55,6 +55,13 @@ func (r *participantResolver) loadUsers(ctx context.Context, c *Client) error {
 	})
 }
 
+// loadUserSnapshot seeds identity resolution from an offline Slack export.
+func (r *participantResolver) loadUserSnapshot(users []User) {
+	for _, user := range users {
+		r.users[user.ID] = user
+	}
+}
+
 // tzLocation returns the cached user's timezone as a *time.Location: the
 // IANA zone when its name loads (search date modifiers follow the zone's
 // historical DST rules — probed live), falling back to a fixed zone at the

--- a/internal/slack/testdata/slackdump/standard/D001/2024-01-05.json
+++ b/internal/slack/testdata/slackdump/standard/D001/2024-01-05.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704412800.000005","user":"UBOB","text":"direct message","files":[{"id":"F_MISSING","name":"gone.pdf","mimetype":"application/pdf","size":123,"permalink":"https://example.invalid/gone.pdf"}]}
+]

--- a/internal/slack/testdata/slackdump/standard/D002/2024-01-06.json
+++ b/internal/slack/testdata/slackdump/standard/D002/2024-01-06.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704499200.000006","user":"UALICE","text":"self direct message"}
+]

--- a/internal/slack/testdata/slackdump/standard/__uploads/F_MM/quarterly report_.txt
+++ b/internal/slack/testdata/slackdump/standard/__uploads/F_MM/quarterly report_.txt
@@ -1,0 +1,1 @@
+mattermost attachment bytes

--- a/internal/slack/testdata/slackdump/standard/channels.json
+++ b/internal/slack/testdata/slackdump/standard/channels.json
@@ -1,0 +1,3 @@
+[
+  {"id":"C001","name":"general","is_channel":true,"is_member":true,"members":["UALICE","UBOB"]}
+]

--- a/internal/slack/testdata/slackdump/standard/dms.json
+++ b/internal/slack/testdata/slackdump/standard/dms.json
@@ -1,0 +1,4 @@
+[
+  {"id":"D001","user":"UBOB","members":["UALICE","UNOTPEER"]},
+  {"id":"D002","user":"UALICE","members":["UALICE","UALICE"]}
+]

--- a/internal/slack/testdata/slackdump/standard/general/2024-01-01.json
+++ b/internal/slack/testdata/slackdump/standard/general/2024-01-01.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704067200.000001","thread_ts":"1704067200.000001","reply_count":1,"user":"UALICE","text":"first day <@UBOB>","files":[{"id":"F_STD","name":"what do these colored bars mean?.txt","mimetype":"text/plain","size":26}],"future_field":{"kept":true}}
+]

--- a/internal/slack/testdata/slackdump/standard/general/2024-01-02.json
+++ b/internal/slack/testdata/slackdump/standard/general/2024-01-02.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704153600.000002","thread_ts":"1704067200.000001","user":"UBOB","text":"second day reply","reactions":[{"name":"eyes","users":["UALICE","UBOB"],"count":2}]}
+]

--- a/internal/slack/testdata/slackdump/standard/general/attachments/F_STD-what do these colored bars mean_.txt
+++ b/internal/slack/testdata/slackdump/standard/general/attachments/F_STD-what do these colored bars mean_.txt
@@ -1,0 +1,1 @@
+standard attachment bytes

--- a/internal/slack/testdata/slackdump/standard/general/preferences.json
+++ b/internal/slack/testdata/slackdump/standard/general/preferences.json
@@ -1,0 +1,1 @@
+{"this":"non-date JSON sibling must be ignored"

--- a/internal/slack/testdata/slackdump/standard/groups.json
+++ b/internal/slack/testdata/slackdump/standard/groups.json
@@ -1,0 +1,3 @@
+[
+  {"id":"G001","name":"private-team","is_group":true,"is_private":true,"is_member":true,"members":["UALICE","UBOB"]}
+]

--- a/internal/slack/testdata/slackdump/standard/mpdm-alice--bob-1/2024-01-04.json
+++ b/internal/slack/testdata/slackdump/standard/mpdm-alice--bob-1/2024-01-04.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704326400.000004","user":"UALICE","text":"group direct message"}
+]

--- a/internal/slack/testdata/slackdump/standard/mpims.json
+++ b/internal/slack/testdata/slackdump/standard/mpims.json
@@ -1,0 +1,3 @@
+[
+  {"id":"G002","name":"mpdm-alice--bob-1","is_group":true,"is_mpim":true,"is_private":true,"is_member":true,"members":["UALICE","UBOB"]}
+]

--- a/internal/slack/testdata/slackdump/standard/private-team/2024-01-03.json
+++ b/internal/slack/testdata/slackdump/standard/private-team/2024-01-03.json
@@ -1,0 +1,3 @@
+[
+  {"type":"message","ts":"1704240000.000003","user":"UBOB","text":"private group","files":[{"id":"F_MM","name":"quarterly report?.txt","mimetype":"text/plain","size":28,"url_private":"https://files.slack.com/files-pri/T_TEST-F_MM/quarterly-report"}]}
+]

--- a/internal/slack/testdata/slackdump/standard/unknown.json
+++ b/internal/slack/testdata/slackdump/standard/unknown.json
@@ -1,0 +1,1 @@
+{"unknown":"malformed root siblings must be ignored"

--- a/internal/slack/testdata/slackdump/standard/users.json
+++ b/internal/slack/testdata/slackdump/standard/users.json
@@ -1,0 +1,4 @@
+[
+  {"id":"UALICE","team_id":"T_TEST","name":"alice","profile":{"email":"alice@example.com","display_name":"Alice Test"}},
+  {"id":"UBOB","team_id":"T_TEST","name":"bob","profile":{"email":"bob@example.com","display_name":"Bob Test"}}
+]

--- a/internal/slack/types.go
+++ b/internal/slack/types.go
@@ -32,17 +32,18 @@ type AuthTestResult struct {
 // Conversation is one channel/group DM/DM from conversations.list or
 // users.conversations.
 type Conversation struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	IsChannel  bool   `json:"is_channel"`
-	IsGroup    bool   `json:"is_group"`
-	IsIM       bool   `json:"is_im"`
-	IsMpim     bool   `json:"is_mpim"`
-	IsPrivate  bool   `json:"is_private"`
-	IsArchived bool   `json:"is_archived"`
-	IsMember   bool   `json:"is_member"`
-	User       string `json:"user"` // IM peer user ID (im only)
-	NumMembers int    `json:"num_members"`
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	IsChannel  bool     `json:"is_channel"`
+	IsGroup    bool     `json:"is_group"`
+	IsIM       bool     `json:"is_im"`
+	IsMpim     bool     `json:"is_mpim"`
+	IsPrivate  bool     `json:"is_private"`
+	IsArchived bool     `json:"is_archived"`
+	IsMember   bool     `json:"is_member"`
+	User       string   `json:"user"` // IM peer user ID (im only)
+	NumMembers int      `json:"num_members"`
+	Members    []string `json:"members"`
 }
 
 // User is one workspace member from users.list.

--- a/internal/store/attachment_policy.go
+++ b/internal/store/attachment_policy.go
@@ -54,7 +54,7 @@ func (s *Store) ListAttachmentPolicyCandidates(ctx context.Context) ([]Attachmen
 		JOIN messages m ON m.id = a.message_id
 		JOIN conversations c ON c.id = m.conversation_id
 		JOIN sources src ON src.id = m.source_id
-		WHERE src.source_type IN ('beeper', 'slack', 'discord', 'teams')
+		WHERE src.source_type IN ('beeper', 'slack', 'slackdump', 'discord', 'teams')
 		  AND COALESCE(a.attachment_state, '') IN (?, '')
 		  AND (
 		    COALESCE(a.source_attachment_id, '') <> ''

--- a/internal/store/attachment_policy_test.go
+++ b/internal/store/attachment_policy_test.go
@@ -202,13 +202,15 @@ func TestExcludeAttachmentOccurrencesRemovesOnlySelectedBlobReference(t *testing
 	assert.True(referenced)
 }
 
-func TestAttachmentPolicyCandidatesIncludeLegacyAliasesAndTeamsInlineRows(t *testing.T) {
+func TestAttachmentPolicyCandidatesIncludeLegacyAliasesSlackdumpAndTeamsInlineRows(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	st := testutil.NewTestStore(t)
 	_, slackMessageID := newPolicyMessage(t, st, "slack", "T01:U01", "channel", "legacy-alias", 5)
+	_, slackdumpMessageID := newPolicyMessage(t, st, "slackdump", "T02:U02", "channel", "exported-file", 3)
 	_, teamsMessageID := newPolicyMessage(t, st, "teams", "user@example.com", "direct_chat", "legacy-inline", 2)
 	aliasHash := strings.Repeat("ab", 32)
+	slackdumpHash := strings.Repeat("bc", 32)
 	inlineHash := strings.Repeat("cd", 32)
 
 	var aliasID int64
@@ -217,6 +219,18 @@ func TestAttachmentPolicyCandidatesIncludeLegacyAliasesAndTeamsInlineRows(t *tes
 		VALUES (?, ?, NULL, ?)
 		RETURNING id
 	`), slackMessageID, aliasHash[:2]+"/"+aliasHash, "slack:legacy-alias").Scan(&aliasID)
+	require.NoError(err)
+	var slackdumpID int64
+	err = st.DB().QueryRow(st.Rebind(`
+		INSERT INTO attachments (message_id, storage_path, content_hash, source_attachment_id, attachment_state)
+		VALUES (?, ?, ?, ?, 'stored')
+		RETURNING id
+	`), slackdumpMessageID, slackdumpHash[:2]+"/"+slackdumpHash, slackdumpHash, "slack:F_EXPORT").Scan(&slackdumpID)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE conversations SET participant_count = 99
+		WHERE id = (SELECT conversation_id FROM messages WHERE id = ?)
+	`), slackdumpMessageID)
 	require.NoError(err)
 	var inlineID int64
 	err = st.DB().QueryRow(st.Rebind(`
@@ -228,13 +242,16 @@ func TestAttachmentPolicyCandidatesIncludeLegacyAliasesAndTeamsInlineRows(t *tes
 
 	candidates, err := st.ListAttachmentPolicyCandidates(context.Background())
 	require.NoError(err)
-	require.Len(candidates, 2)
+	require.Len(candidates, 3)
 	byID := make(map[int64]store.AttachmentPolicyCandidate, len(candidates))
 	for _, candidate := range candidates {
 		byID[candidate.AttachmentID] = candidate
 	}
 	assert.Equal(aliasHash, byID[aliasID].ContentHash)
 	assert.Equal("slack:legacy-alias", byID[aliasID].SourceAttachmentID)
+	assert.Equal(slackdumpHash, byID[slackdumpID].ContentHash)
+	assert.Equal("slack:F_EXPORT", byID[slackdumpID].SourceAttachmentID)
+	assert.Equal(3, byID[slackdumpID].ParticipantCount, "Slackdump roster snapshot is authoritative")
 	assert.Equal(inlineHash, byID[inlineID].ContentHash)
 	assert.Equal(fmt.Sprintf("teams:inline:legacy:%d", inlineID), byID[inlineID].SourceAttachmentID)
 

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -324,10 +324,11 @@ func (s *Store) MessageConversation(messageID int64) (MessageConversationRef, er
 // Provider identities used to select membership semantics. Callers pass
 // either a source type or the provider's attachment-ID prefix.
 const (
-	sourceTypeDiscord = "discord"
-	sourceTypeTeams   = "teams"
-	sourceTypeSlack   = "slack"
-	sourceTypeBeeper  = "beeper"
+	sourceTypeDiscord   = "discord"
+	sourceTypeTeams     = "teams"
+	sourceTypeSlack     = "slack"
+	sourceTypeSlackdump = "slackdump"
+	sourceTypeBeeper    = "beeper"
 )
 
 // membershipRecord is the provider-maintained membership a conversation's
@@ -378,7 +379,7 @@ func attachmentPolicyParticipantCount(sourceType string, observed int, metadata 
 	switch strings.TrimSuffix(sourceType, ":") {
 	case sourceTypeDiscord:
 		return max(record.memberCount, observed)
-	case sourceTypeTeams, sourceTypeSlack, sourceTypeBeeper:
+	case sourceTypeTeams, sourceTypeSlack, sourceTypeSlackdump, sourceTypeBeeper:
 		return record.memberCount
 	default:
 		return observed

--- a/internal/store/person_sweep_evidence.go
+++ b/internal/store/person_sweep_evidence.go
@@ -1035,7 +1035,7 @@ func personSweepAuthorship(
 func personSweepSourceAuthenticatesSender(sourceType string) bool {
 	switch strings.ToLower(strings.TrimSpace(sourceType)) {
 	case "apple_messages", "beeper", "discord", "facebook_messenger", "google_messages",
-		"imessage", "slack", "synctech-sms", "synctech_sms", "teams", "whatsapp":
+		"imessage", "slack", "slackdump", "synctech-sms", "synctech_sms", "teams", "whatsapp":
 		return true
 	default:
 		return false

--- a/internal/store/person_sweep_evidence_test.go
+++ b/internal/store/person_sweep_evidence_test.go
@@ -333,15 +333,19 @@ func TestSearchPersonSweepMessagesPreservesNewestFirstCandidateRanking(t *testin
 }
 
 func TestPersonSweepAuthenticatedChatSenderCanBeDirectSelf(t *testing.T) {
-	f := newPersonSweepJournalFixture(t, true, false)
-	_, err := f.store.DB().ExecContext(t.Context(), f.store.Rebind(
-		`UPDATE sources SET source_type = 'slack' WHERE id = ?`), f.sourceID)
-	require.NoError(t, err)
-	id := f.insertMessage(t, "authored chat", "chat", f.aliceID, time.Now().UTC())
-	addSweepBody(t, f, id, "I work in product.")
-	item := sweepItem(t, loadSweepWindow(t, f, peoplesweep.SourceConversationText, 0).Seeds, id)
-	require.NotNil(t, item.SubjectPersonID)
-	assert.Equal(t, personfacts.DirectSelf, item.Directness)
+	for _, sourceType := range []string{"slack", "slackdump"} {
+		t.Run(sourceType, func(t *testing.T) {
+			f := newPersonSweepJournalFixture(t, true, false)
+			_, err := f.store.DB().ExecContext(t.Context(), f.store.Rebind(
+				`UPDATE sources SET source_type = ? WHERE id = ?`), sourceType, f.sourceID)
+			require.NoError(t, err)
+			id := f.insertMessage(t, "authored chat", "chat", f.aliceID, time.Now().UTC())
+			addSweepBody(t, f, id, "I work in product.")
+			item := sweepItem(t, loadSweepWindow(t, f, peoplesweep.SourceConversationText, 0).Seeds, id)
+			require.NotNil(t, item.SubjectPersonID)
+			assert.Equal(t, personfacts.DirectSelf, item.Directness)
+		})
+	}
 }
 
 func TestPersonSweepEvidenceStatusChangesCoalesceToTerminalEffect(t *testing.T) {


### PR DESCRIPTION
## What changed

- Added token-free imports for Slackdump Standard and Mattermost export directories or ZIP files.
- Preserved Slack identities, threads, reactions, raw message JSON, participants, and exported attachments under a distinct `slackdump` source.
- Wired the command through daemon routing and attachment maintenance, with idempotent reruns and bounded file handling.

## Why

Slackdump can archive a workspace without an admin export or live Slack token, but msgvault could not ingest those archives. This keeps offline history import separate from live Slack sync while reusing the same Slack message semantics.

## Usage

`msgvault import-slackdump --me alice@example.com /path/to/slackdump.zip`

Closes #414