### PR TITLE
fix(sync): repair mismatched Gmail message snapshots

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -879,6 +879,31 @@ components:
       required:
         - type
       type: object
+    CLIRepairMessageEvent:
+      additionalProperties: true
+      properties:
+        data:
+          type: string
+        error:
+          type: string
+        type:
+          type: string
+      required:
+        - type
+      type: object
+    CLIRepairMessageRequest:
+      additionalProperties: false
+      properties:
+        audit:
+          type: boolean
+        json:
+          type: boolean
+        reference:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      type: object
     CLIRunEvent:
       additionalProperties: true
       properties:
@@ -11263,7 +11288,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.14.0
+  version: 2.15.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -13816,6 +13841,33 @@ paths:
       security:
         - apiKey: []
       summary: Repair CLI archive encoding
+      tags:
+        - API
+  /api/v1/cli/repair-message:
+    post:
+      operationId: repairMessageCLI
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CLIRepairMessageRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/CLIRepairMessageEvent"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Repair or audit Gmail message snapshots
       tags:
         - API
   /api/v1/cli/run:

--- a/cmd/msgvault/cmd/repair_message.go
+++ b/cmd/msgvault/cmd/repair_message.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/store"
+	syncer "go.kenn.io/msgvault/internal/sync"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+type repairMessageCommandDeps struct {
+	isDaemonSubprocess func() bool
+	openHTTPStore      func(context.Context) (*daemonclient.Client, HTTPStoreInfo, error)
+	preflightReauth    func(context.Context, *daemonclient.Client, HTTPStoreInfo, int64) error
+	openWritableStore  func() (*store.Store, func(), error)
+	openReadOnlyStore  func() (*store.Store, func(), error)
+	newGmailClient     func(context.Context, *store.Source) (gmail.API, error)
+	refreshCache       func() error
+	attachmentsDir     string
+}
+
+func defaultRepairMessageCommandDeps() repairMessageCommandDeps {
+	return repairMessageCommandDeps{
+		isDaemonSubprocess: isDaemonCLISubprocess,
+		openHTTPStore:      OpenHTTPStore,
+		preflightReauth: func(
+			ctx context.Context, client *daemonclient.Client, info HTTPStoreInfo, sourceID int64,
+		) error {
+			return preflightReauth(ctx, buildSyncPreflight(client, info), "", sourceID)
+		},
+		openWritableStore: openWritableStoreAndInit,
+		openReadOnlyStore: func() (*store.Store, func(), error) {
+			st, err := store.OpenReadOnly(cfg.DatabaseDSN())
+			if err != nil {
+				return nil, nil, fmt.Errorf("open database read-only: %w", err)
+			}
+			return st, func() { _ = st.Close() }, nil
+		},
+		newGmailClient: func(ctx context.Context, source *store.Source) (gmail.API, error) {
+			return buildAPIClient(ctx, source, oauthManagerCache(), nil)
+		},
+		refreshCache: func() error {
+			return rebuildCacheAfterWrite(cfg.DatabaseDSN())
+		},
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(newRepairMessageCmd(defaultRepairMessageCommandDeps()))
+}
+
+func newRepairMessageCmd(deps repairMessageCommandDeps) *cobra.Command {
+	var (
+		audit    bool
+		jsonOut  bool
+		sourceID int64
+	)
+	command := &cobra.Command{
+		Use:   "repair-message <internal-id-or-gmail-id>",
+		Short: "Repair one Gmail message snapshot or audit stored Gmail MIME",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if audit {
+				if len(args) != 0 {
+					return usageErr(cmd, errors.New("--audit does not accept a message reference"))
+				}
+			} else if len(args) != 1 {
+				return usageErr(cmd, errors.New("repair-message requires exactly one message reference unless --audit is set"))
+			}
+			if cmd.Flags().Changed("source-id") && sourceID <= 0 {
+				return usageErr(cmd, errors.New("--source-id must be a positive integer"))
+			}
+			if jsonOut && !audit {
+				return usageErr(cmd, errors.New("--json requires --audit"))
+			}
+			if deps.isDaemonSubprocess != nil && !deps.isDaemonSubprocess() {
+				return runRepairMessageHTTP(cmd, deps, args, sourceID, audit, jsonOut)
+			}
+			if audit {
+				return runRepairMessageAudit(cmd, deps, sourceID, jsonOut)
+			}
+			return runRepairMessageLocal(cmd, deps, args[0], sourceID)
+		},
+	}
+	command.Flags().BoolVar(&audit, "audit", false, "audit stored Gmail MIME without changing the archive")
+	command.Flags().Int64Var(&sourceID, "source-id", 0, "scope the operation to one positive source ID")
+	command.Flags().BoolVar(&jsonOut, "json", false, "emit newline-delimited JSON audit results")
+	return command
+}
+
+func runRepairMessageHTTP(
+	cmd *cobra.Command,
+	deps repairMessageCommandDeps,
+	args []string,
+	sourceID int64,
+	audit bool,
+	jsonOut bool,
+) error {
+	if deps.openHTTPStore == nil {
+		return errors.New("repair message HTTP store is unavailable")
+	}
+	client, info, err := deps.openHTTPStore(cmd.Context())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	req := generated.CLIRepairMessageRequest{}
+	if audit {
+		req.Audit = new(true)
+	} else {
+		reference := args[0]
+		req.Reference = &reference
+	}
+	if sourceID > 0 {
+		req.SourceID = &sourceID
+	}
+	if jsonOut {
+		req.JSON = new(true)
+	}
+
+	var preflight func(context.Context) error
+	if !audit && info.Kind == HTTPStoreLocalDaemon {
+		resolvedSourceID := sourceID
+		if resolvedSourceID == 0 {
+			if deps.openReadOnlyStore == nil {
+				return errors.New("repair message read-only store is unavailable")
+			}
+			st, cleanup, err := deps.openReadOnlyStore()
+			if err != nil {
+				return err
+			}
+			source, resolveErr := resolveRepairMessageSource(cmd.Context(), st, args[0], 0)
+			cleanup()
+			if resolveErr != nil {
+				return resolveErr
+			}
+			resolvedSourceID = source.ID
+			req.SourceID = &resolvedSourceID
+		}
+		if deps.preflightReauth != nil {
+			preflight = func(ctx context.Context) error {
+				return deps.preflightReauth(ctx, client, info, resolvedSourceID)
+			}
+		}
+	}
+
+	output := func(stream, data string) error {
+		switch stream {
+		case cliStreamStdout:
+			if _, err := fmt.Fprint(cmd.OutOrStdout(), data); err != nil {
+				return fmt.Errorf("write repair-message stdout: %w", err)
+			}
+		case cliStreamStderr:
+			if _, err := fmt.Fprint(cmd.ErrOrStderr(), data); err != nil {
+				return fmt.Errorf("write repair-message stderr: %w", err)
+			}
+		}
+		return nil
+	}
+	if preflight != nil {
+		return client.RunCLIRepairMessageWithPreflight(cmd.Context(), req, preflight, output)
+	}
+	return client.RunCLIRepairMessage(cmd.Context(), req, output)
+}
+
+func runRepairMessageLocal(
+	cmd *cobra.Command, deps repairMessageCommandDeps, reference string, sourceID int64,
+) error {
+	if deps.openWritableStore == nil {
+		return errors.New("repair message writable store is unavailable")
+	}
+	st, cleanup, err := deps.openWritableStore()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cleanup != nil {
+			cleanup()
+		}
+	}()
+
+	source, err := resolveRepairMessageSource(cmd.Context(), st, reference, sourceID)
+	if err != nil {
+		return err
+	}
+	if deps.newGmailClient == nil {
+		return errors.New("repair message Gmail client is unavailable")
+	}
+	client, err := deps.newGmailClient(cmd.Context(), source)
+	if err != nil {
+		return fmt.Errorf("open Gmail client for source %d: %w", source.ID, err)
+	}
+	if closer, ok := client.(io.Closer); ok {
+		defer func() { _ = closer.Close() }()
+	}
+	attachmentsDir := deps.attachmentsDir
+	if attachmentsDir == "" && cfg != nil {
+		attachmentsDir = cfg.AttachmentsDir()
+	}
+	service := syncer.New(client, st, &syncer.Options{AttachmentsDir: attachmentsDir}).WithLogger(logger)
+	result, err := service.RepairMessage(cmd.Context(), syncer.RepairRequest{
+		Reference: reference,
+		SourceID:  sourceID,
+	})
+	if err != nil {
+		return err
+	}
+	cleanup()
+	cleanup = nil
+	if deps.refreshCache != nil {
+		if err := deps.refreshCache(); err != nil {
+			return err
+		}
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Repaired message %d (source %d, Gmail %s): %s\n",
+		result.InternalID, result.SourceID, result.SourceMessageID, result.Subject)
+	if err != nil {
+		return fmt.Errorf("write repair-message result: %w", err)
+	}
+	return nil
+}
+
+func resolveRepairMessageSource(
+	ctx context.Context, st *store.Store, reference string, sourceID int64,
+) (*store.Source, error) {
+	targets, err := st.FindRepairMessageTargetsContext(ctx, strings.TrimSpace(reference), sourceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("repair message %q not found", reference)
+	}
+	if len(targets) != 1 {
+		return nil, fmt.Errorf("repair message reference %q is ambiguous across %d archive rows", reference, len(targets))
+	}
+	if targets[0].SourceType != sourceTypeGmail {
+		return nil, fmt.Errorf("repair message source %d is %s, not gmail", targets[0].SourceID, targets[0].SourceType)
+	}
+	return st.GetSourceByIDContext(ctx, targets[0].SourceID)
+}
+
+func runRepairMessageAudit(
+	cmd *cobra.Command, deps repairMessageCommandDeps, sourceID int64, jsonOut bool,
+) error {
+	if deps.openReadOnlyStore == nil {
+		return errors.New("repair message read-only store is unavailable")
+	}
+	st, cleanup, err := deps.openReadOnlyStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	service := syncer.New(nil, st, &syncer.Options{})
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetEscapeHTML(false)
+	return service.AuditGmailMessages(cmd.Context(), sourceID, func(result syncer.RepairAuditResult) error {
+		if jsonOut {
+			return encoder.Encode(result)
+		}
+		return writeRepairAuditHuman(cmd.OutOrStdout(), result)
+	})
+}
+
+func writeRepairAuditHuman(w io.Writer, result syncer.RepairAuditResult) error {
+	fields := make([]string, 0, len(result.Fields))
+	for name := range result.Fields {
+		fields = append(fields, name)
+	}
+	sort.Strings(fields)
+	parts := make([]string, 0, len(fields)+1)
+	for _, name := range fields {
+		parts = append(parts, name+"="+string(result.Fields[name]))
+	}
+	if result.Error != "" {
+		parts = append(parts, "error="+strconv.Quote(result.Error))
+	}
+	_, err := fmt.Fprintf(w, "%s message %d (source %d, Gmail %s): %s\n",
+		result.Status, result.InternalID, result.SourceID, result.SourceMessageID, strings.Join(parts, ", "))
+	if err != nil {
+		return fmt.Errorf("write repair-message audit result: %w", err)
+	}
+	return nil
+}

--- a/cmd/msgvault/cmd/repair_message_test.go
+++ b/cmd/msgvault/cmd/repair_message_test.go
@@ -62,6 +62,27 @@ func TestRepairMessageCommandValidatesModeAndSourceScope(t *testing.T) {
 	}
 }
 
+func TestRepairMessageCommandTreatsHyphenReferenceAfterTerminatorAsRepair(t *testing.T) {
+	storeErr := errors.New("writable store opened for repair")
+	auditOpened := false
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		isDaemonSubprocess: func() bool { return true },
+		openWritableStore: func() (*store.Store, func(), error) {
+			return nil, func() {}, storeErr
+		},
+		openReadOnlyStore: func() (*store.Store, func(), error) {
+			auditOpened = true
+			return nil, func() {}, errors.New("must not audit")
+		},
+	})
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--", "--audit"})
+
+	require.ErrorIs(t, command.Execute(), storeErr)
+	assert.False(t, auditOpened, "a reference spelled like a flag must not select audit mode")
+}
+
 func TestRepairMessageCommandRunsProductionRepairAndPrintsStableResult(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/cmd/msgvault/cmd/repair_message_test.go
+++ b/cmd/msgvault/cmd/repair_message_test.go
@@ -1,0 +1,582 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/store"
+	syncer "go.kenn.io/msgvault/internal/sync"
+	testemail "go.kenn.io/msgvault/internal/testutil/email"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+func TestRepairMessageCommandValidatesModeAndSourceScope(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing repair reference", want: "requires exactly one message reference unless --audit is set"},
+		{name: "multiple repair references", args: []string{"one", "two"}, want: "requires exactly one message reference unless --audit is set"},
+		{name: "audit rejects reference", args: []string{"--audit", "one"}, want: "--audit does not accept a message reference"},
+		{name: "zero source", args: []string{"one", "--source-id", "0"}, want: "--source-id must be a positive integer"},
+		{name: "negative source", args: []string{"--audit", "--source-id", "-1"}, want: "--source-id must be a positive integer"},
+		{name: "repair rejects json", args: []string{"one", "--json"}, want: "--json requires --audit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			opened := false
+			command := newRepairMessageCmd(repairMessageCommandDeps{
+				openWritableStore: func() (*store.Store, func(), error) {
+					opened = true
+					return nil, func() {}, errors.New("must not open store")
+				},
+				openReadOnlyStore: func() (*store.Store, func(), error) {
+					opened = true
+					return nil, func() {}, errors.New("must not open store")
+				},
+			})
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs(test.args)
+
+			err := command.Execute()
+			require.ErrorContains(t, err, test.want)
+			assert.False(t, opened)
+			assert.False(t, command.SilenceUsage, "invocation errors keep usage visible")
+		})
+	}
+}
+
+func TestRepairMessageCommandRunsProductionRepairAndPrintsStableResult(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("gmail-42")
+	var lifecycle []string
+	mock := gmail.NewMockAPI()
+	mock.Profile = &gmail.Profile{EmailAddress: fixture.Source.Identifier}
+	mock.AddMessage("gmail-42", testemail.NewMessage().
+		From("alice@example.com").To("bob@example.com").
+		Subject("Repaired subject").Body("Repaired body").Bytes(), []string{"INBOX"})
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		isDaemonSubprocess: func() bool { return true },
+		openWritableStore: func() (*store.Store, func(), error) {
+			return fixture.Store, func() { lifecycle = append(lifecycle, "store closed") }, nil
+		},
+		newGmailClient: func(context.Context, *store.Source) (gmail.API, error) {
+			return mock, nil
+		},
+		refreshCache: func() error {
+			lifecycle = append(lifecycle, "cache refreshed")
+			return nil
+		},
+		attachmentsDir: filepath.Join(t.TempDir(), "attachments"),
+	})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"gmail-42", "--source-id", "1"})
+
+	require.NoError(command.Execute())
+	assert.Equal(
+		"Repaired message "+jsonNumber(messageID)+" (source 1, Gmail gmail-42): Repaired subject\n",
+		output.String())
+	assert.Equal([]string{"gmail-42"}, mock.GetMessageCalls)
+	assert.Equal([]string{"store closed", "cache refreshed"}, lifecycle)
+	var subject string
+	require.NoError(fixture.Store.DB().QueryRow(
+		fixture.Store.Rebind(`SELECT subject FROM messages WHERE id = ?`), messageID,
+	).Scan(&subject))
+	assert.Equal("Repaired subject", subject)
+}
+
+func TestRepairMessageCommandPropagatesCacheRefreshFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := storetest.New(t)
+	fixture.CreateMessage("gmail-42")
+	mock := gmail.NewMockAPI()
+	mock.Profile = &gmail.Profile{EmailAddress: fixture.Source.Identifier}
+	mock.AddMessage("gmail-42", testemail.NewMessage().
+		From("alice@example.com").To("bob@example.com").
+		Subject("Repaired subject").Body("Repaired body").Bytes(), []string{"INBOX"})
+	storeClosed := false
+	cacheErr := errors.New("synthetic cache refresh failure")
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		isDaemonSubprocess: func() bool { return true },
+		openWritableStore: func() (*store.Store, func(), error) {
+			return fixture.Store, func() { storeClosed = true }, nil
+		},
+		newGmailClient: func(context.Context, *store.Source) (gmail.API, error) {
+			return mock, nil
+		},
+		refreshCache: func() error {
+			assert.True(storeClosed, "writable store must close before cache refresh")
+			return cacheErr
+		},
+	})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"gmail-42", "--source-id", "1"})
+
+	require.ErrorIs(command.Execute(), cacheErr)
+	assert.True(storeClosed)
+	assert.NotContains(output.String(), "Repaired message", "do not report complete success before cache refresh")
+}
+
+func TestRepairMessageCommandUsesDedicatedRemoteEndpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantBody   generated.CLIRepairMessageRequest
+		stdoutLine string
+		stderrLine string
+	}{
+		{
+			name: "repair",
+			args: []string{"gmail-42", "--source-id", "7"},
+			wantBody: generated.CLIRepairMessageRequest{
+				Reference: new("gmail-42"),
+				SourceID:  new(int64(7)),
+			},
+			stdoutLine: "repaired remote message\n",
+			stderrLine: "repair warning\n",
+		},
+		{
+			name: "audit JSON",
+			args: []string{"--audit", "--source-id", "7", "--json"},
+			wantBody: generated.CLIRepairMessageRequest{
+				Audit:    new(true),
+				JSON:     new(true),
+				SourceID: new(int64(7)),
+			},
+			stdoutLine: `{"internal_id":42,"status":"mismatch"}` + "\n",
+			stderrLine: "audit warning\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			var paths []string
+			var preflightCalls atomic.Int32
+			var readOnlyCalls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				paths = append(paths, r.URL.Path)
+				switch r.URL.Path {
+				case "/api/v1/health":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.15.0"}`))
+				case "/api/v1/cli/repair-message":
+					assert.Equal(http.MethodPost, r.Method)
+					assert.Empty(r.URL.RawQuery)
+					var got generated.CLIRepairMessageRequest
+					if !assert.NoError(json.NewDecoder(r.Body).Decode(&got)) {
+						return
+					}
+					assert.Equal(test.wantBody, got)
+					w.Header().Set("Content-Type", "application/x-ndjson")
+					_, _ = w.Write([]byte(`{"type":"stdout","data":` + string(marshalRepairCommandJSON(t, test.stdoutLine)) + `}` + "\n"))
+					_, _ = w.Write([]byte(`{"type":"stderr","data":` + string(marshalRepairCommandJSON(t, test.stderrLine)) + `}` + "\n"))
+					_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+				default:
+					http.Error(w, "unexpected endpoint", http.StatusNotFound)
+				}
+			}))
+			t.Cleanup(server.Close)
+			configureRemoteSyncTest(t, server.URL)
+			deps := defaultRepairMessageCommandDeps()
+			deps.preflightReauth = func(context.Context, *daemonclient.Client, HTTPStoreInfo, int64) error {
+				preflightCalls.Add(1)
+				return errors.New("configured remote must not run local OAuth preflight")
+			}
+			deps.openReadOnlyStore = func() (*store.Store, func(), error) {
+				readOnlyCalls.Add(1)
+				return nil, func() {}, errors.New("configured remote must not require the local archive")
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			command := newRepairMessageCmd(deps)
+			command.SetOut(&stdout)
+			command.SetErr(&stderr)
+			command.SetArgs(test.args)
+
+			require.NoError(command.Execute())
+			assert.Equal([]string{"/api/v1/health", "/api/v1/cli/repair-message"}, paths)
+			assert.Equal(test.stdoutLine, stdout.String())
+			assert.Equal(test.stderrLine, stderr.String())
+			assert.Zero(preflightCalls.Load())
+			assert.Zero(readOnlyCalls.Load())
+		})
+	}
+}
+
+func TestRepairMessageCommandPreflightsOAuthForSelectedLocalSource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var sequence atomic.Int32
+	var capabilityStep atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			capabilityStep.Store(sequence.Add(1))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.15.0"}`))
+			return
+		}
+		http.Error(w, "repair must not start", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	client, err := daemonclient.New(daemonclient.Config{
+		URL: server.URL, AllowInsecure: true, HTTPClient: server.Client(),
+	})
+	require.NoError(err)
+
+	var selectedSourceID int64
+	var preflightStep atomic.Int32
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		isDaemonSubprocess: func() bool { return false },
+		openHTTPStore: func(context.Context) (*daemonclient.Client, HTTPStoreInfo, error) {
+			return client, HTTPStoreInfo{Kind: HTTPStoreLocalDaemon}, nil
+		},
+		preflightReauth: func(_ context.Context, _ *daemonclient.Client, _ HTTPStoreInfo, sourceID int64) error {
+			preflightStep.Store(sequence.Add(1))
+			selectedSourceID = sourceID
+			return errors.New("reauth failed")
+		},
+	})
+	command.SilenceUsage = true
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"gmail-42", "--source-id", "42"})
+
+	err = command.Execute()
+	require.EqualError(err, "reauth failed")
+	assert.Equal(int64(42), selectedSourceID)
+	assert.Equal(int32(1), capabilityStep.Load())
+	assert.Equal(int32(2), preflightStep.Load())
+	assert.True(command.SilenceUsage, "runtime preflight errors hide usage")
+}
+
+func TestRepairMessageCommandIncompatibleLocalDaemonFailsBeforeOAuthOrMutation(t *testing.T) {
+	tests := []struct {
+		name          string
+		healthPayload string
+	}{
+		{name: "missing version", healthPayload: `{"status":"ok"}`},
+		{name: "malformed version", healthPayload: `{"status":"ok","api_schema_version":"2.13"}`},
+		{name: "older version", healthPayload: `{"status":"ok","api_schema_version":"2.13.0"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			var nonHealthRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/health" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(test.healthPayload))
+					return
+				}
+				nonHealthRequests.Add(1)
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+			}))
+			t.Cleanup(server.Close)
+			client, err := daemonclient.New(daemonclient.Config{
+				URL: server.URL, AllowInsecure: true, HTTPClient: server.Client(),
+			})
+			require.NoError(err)
+
+			var preflightCalls atomic.Int32
+			command := newRepairMessageCmd(repairMessageCommandDeps{
+				isDaemonSubprocess: func() bool { return false },
+				openHTTPStore: func(context.Context) (*daemonclient.Client, HTTPStoreInfo, error) {
+					return client, HTTPStoreInfo{Kind: HTTPStoreLocalDaemon}, nil
+				},
+				preflightReauth: func(context.Context, *daemonclient.Client, HTTPStoreInfo, int64) error {
+					preflightCalls.Add(1)
+					return nil
+				},
+			})
+			command.SilenceUsage = true
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs([]string{"gmail-42", "--source-id", "42"})
+
+			err = command.Execute()
+			require.ErrorContains(err, "requires daemon API schema 2.15.0")
+			assert.Zero(preflightCalls.Load())
+			assert.Zero(nonHealthRequests.Load())
+			assert.True(command.SilenceUsage, "runtime compatibility errors hide usage")
+		})
+	}
+}
+
+func TestRepairMessageCommandResolvesOmittedLocalSourceBeforeScopedOAuthPreflight(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := storetest.New(t)
+	targetSource, err := fixture.Store.GetOrCreateSource("gmail", "target@example.com")
+	require.NoError(err)
+	targetConversation, err := fixture.Store.EnsureConversation(targetSource.ID, "target-thread", "")
+	require.NoError(err)
+	_, err = fixture.Store.UpsertMessage(&store.Message{
+		ConversationID:  targetConversation,
+		SourceID:        targetSource.ID,
+		SourceMessageID: "gmail-target",
+		MessageType:     "email",
+	})
+	require.NoError(err)
+
+	var sequence atomic.Int32
+	var capabilityStep atomic.Int32
+	var repairStep atomic.Int32
+	requestBody := make(chan generated.CLIRepairMessageRequest, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			capabilityStep.Store(sequence.Add(1))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.15.0"}`))
+		case "/api/v1/cli/repair-message":
+			repairStep.Store(sequence.Add(1))
+			var body generated.CLIRepairMessageRequest
+			if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				return
+			}
+			requestBody <- body
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+		default:
+			http.Error(w, "unexpected endpoint", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client, err := daemonclient.New(daemonclient.Config{
+		URL: server.URL, AllowInsecure: true, HTTPClient: server.Client(),
+	})
+	require.NoError(err)
+
+	var selectedSourceID atomic.Int64
+	var preflightStep atomic.Int32
+	readOnlyOpened := false
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		isDaemonSubprocess: func() bool { return false },
+		openHTTPStore: func(context.Context) (*daemonclient.Client, HTTPStoreInfo, error) {
+			return client, HTTPStoreInfo{Kind: HTTPStoreLocalDaemon}, nil
+		},
+		openReadOnlyStore: func() (*store.Store, func(), error) {
+			readOnlyOpened = true
+			return fixture.Store, func() {}, nil
+		},
+		preflightReauth: func(_ context.Context, _ *daemonclient.Client, _ HTTPStoreInfo, sourceID int64) error {
+			selectedSourceID.Store(sourceID)
+			preflightStep.Store(sequence.Add(1))
+			return nil
+		},
+	})
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"gmail-target"})
+
+	require.NoError(command.Execute())
+	assert.True(readOnlyOpened)
+	assert.Equal(targetSource.ID, selectedSourceID.Load())
+	assert.Equal(int32(1), capabilityStep.Load())
+	assert.Equal(int32(2), preflightStep.Load())
+	assert.Equal(int32(3), repairStep.Load())
+	body := <-requestBody
+	require.NotNil(body.SourceID)
+	assert.Equal(targetSource.ID, *body.SourceID)
+}
+
+func TestRepairMessageCommandLocalResolutionFailsBeforeOAuthOrRepair(t *testing.T) {
+	requirements := require.New(t)
+	fixture := storetest.New(t)
+	otherSource, err := fixture.Store.GetOrCreateSource("gmail", "other@example.com")
+	requirements.NoError(err)
+	otherConversation, err := fixture.Store.EnsureConversation(otherSource.ID, "other-thread", "")
+	requirements.NoError(err)
+	_, err = fixture.Store.UpsertMessage(&store.Message{
+		ConversationID: otherConversation, SourceID: otherSource.ID,
+		SourceMessageID: "shared", MessageType: "email",
+	})
+	requirements.NoError(err)
+	fixture.CreateMessage("shared")
+	imap, err := fixture.Store.GetOrCreateSource("imap", "imap@example.com")
+	requirements.NoError(err)
+	imapConversation, err := fixture.Store.EnsureConversation(imap.ID, "imap-thread", "")
+	requirements.NoError(err)
+	_, err = fixture.Store.UpsertMessage(&store.Message{
+		ConversationID: imapConversation, SourceID: imap.ID,
+		SourceMessageID: "imap-message", MessageType: "email",
+	})
+	requirements.NoError(err)
+
+	for _, test := range []struct {
+		name      string
+		reference string
+		want      string
+	}{
+		{name: "ambiguous", reference: "shared", want: "ambiguous"},
+		{name: "non Gmail", reference: "imap-message", want: "not gmail"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			var repairRequests atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/health" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"status":"ok","api_schema_version":"2.15.0"}`))
+					return
+				}
+				repairRequests.Add(1)
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+			}))
+			t.Cleanup(server.Close)
+			client, clientErr := daemonclient.New(daemonclient.Config{
+				URL: server.URL, AllowInsecure: true, HTTPClient: server.Client(),
+			})
+			require.NoError(clientErr)
+
+			var preflightCalls atomic.Int32
+			command := newRepairMessageCmd(repairMessageCommandDeps{
+				isDaemonSubprocess: func() bool { return false },
+				openHTTPStore: func(context.Context) (*daemonclient.Client, HTTPStoreInfo, error) {
+					return client, HTTPStoreInfo{Kind: HTTPStoreLocalDaemon}, nil
+				},
+				openReadOnlyStore: func() (*store.Store, func(), error) {
+					return fixture.Store, func() {}, nil
+				},
+				preflightReauth: func(context.Context, *daemonclient.Client, HTTPStoreInfo, int64) error {
+					preflightCalls.Add(1)
+					return errors.New("OAuth preflight must not run")
+				},
+			})
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs([]string{test.reference})
+
+			require.ErrorContains(command.Execute(), test.want)
+			assert.Zero(preflightCalls.Load())
+			assert.Zero(repairRequests.Load())
+		})
+	}
+}
+
+func TestRepairMessageCommandAuditUsesReadOnlyStoreAndExactJSON(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := storetest.New(t)
+	messageID := fixture.CreateMessage("gmail-audit")
+	_, err := fixture.Store.DB().Exec(
+		fixture.Store.Rebind(`UPDATE messages SET subject = 'stored subject' WHERE id = ?`), messageID)
+	require.NoError(err)
+	require.NoError(fixture.Store.UpsertMessageRaw(messageID,
+		testemail.NewMessage().Subject("raw subject").Body("body").Bytes()))
+	readOnlyOpened := false
+	command := newRepairMessageCmd(repairMessageCommandDeps{
+		openWritableStore: func() (*store.Store, func(), error) {
+			return nil, func() {}, errors.New("audit must not open writable store")
+		},
+		openReadOnlyStore: func() (*store.Store, func(), error) {
+			readOnlyOpened = true
+			return fixture.Store, func() {}, nil
+		},
+	})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	command.SetArgs([]string{"--audit", "--source-id", "1", "--json"})
+
+	require.NoError(command.Execute())
+	assert.True(readOnlyOpened)
+	var result syncer.RepairAuditResult
+	require.NoError(json.Unmarshal(bytes.TrimSpace(output.Bytes()), &result))
+	assert.Equal(messageID, result.InternalID)
+	assert.Equal(syncer.AuditMismatch, result.Status)
+	assert.Equal(syncer.AuditMismatch, result.Fields[syncer.AuditFieldSubject])
+	assert.Equal(
+		`{"internal_id":`+jsonNumber(messageID)+`,"source_id":1,"source_message_id":"gmail-audit","status":"mismatch","fields":{"attachment_hashes":"match","attachment_part_keys":"match","bcc":"match","body_html":"inconclusive","body_text":"inconclusive","cc":"match","from":"mismatch","raw_mime":"match","rfc822_message_id":"inconclusive","subject":"mismatch","to":"mismatch"}}`+"\n",
+		output.String())
+}
+
+func TestRepairMessageCommandSurfacesAmbiguousAndNonGmailTargetsBeforeProviderAccess(t *testing.T) {
+	requirements := require.New(t)
+	fixture := storetest.New(t)
+	otherSource, err := fixture.Store.GetOrCreateSource("gmail", "other@example.com")
+	requirements.NoError(err)
+	otherConversation, err := fixture.Store.EnsureConversation(otherSource.ID, "other-thread", "")
+	requirements.NoError(err)
+	_, err = fixture.Store.UpsertMessage(&store.Message{
+		ConversationID: otherConversation, SourceID: otherSource.ID,
+		SourceMessageID: "shared", MessageType: "email",
+	})
+	requirements.NoError(err)
+	fixture.CreateMessage("shared")
+	imap, err := fixture.Store.GetOrCreateSource("imap", "imap@example.com")
+	requirements.NoError(err)
+	imapConversation, err := fixture.Store.EnsureConversation(imap.ID, "imap-thread", "")
+	requirements.NoError(err)
+	_, err = fixture.Store.UpsertMessage(&store.Message{
+		ConversationID: imapConversation, SourceID: imap.ID,
+		SourceMessageID: "imap-message", MessageType: "email", Subject: sql.NullString{String: "imap", Valid: true},
+	})
+	requirements.NoError(err)
+	clientCalls := 0
+	deps := repairMessageCommandDeps{
+		openWritableStore: func() (*store.Store, func(), error) { return fixture.Store, func() {}, nil },
+		newGmailClient: func(context.Context, *store.Source) (gmail.API, error) {
+			clientCalls++
+			return gmail.NewMockAPI(), nil
+		},
+	}
+	for _, test := range []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{name: "ambiguous", arg: "shared", want: "ambiguous"},
+		{name: "non gmail", arg: "imap-message", want: "not gmail"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			command := newRepairMessageCmd(deps)
+			command.SetOut(&bytes.Buffer{})
+			command.SetErr(&bytes.Buffer{})
+			command.SetArgs([]string{test.arg})
+			require.ErrorContains(command.Execute(), test.want)
+		})
+	}
+	assert.Zero(t, clientCalls)
+}
+
+func jsonNumber(value int64) string {
+	return strconv.FormatInt(value, 10)
+}
+
+func marshalRepairCommandJSON(t *testing.T, value string) []byte {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return encoded
+}

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1155,6 +1155,7 @@ var _ api.CLICacheBuilder = (*storeAPIAdapter)(nil)
 var _ api.CLISyncRunner = (*storeAPIAdapter)(nil)
 var _ api.CLIVerifyRunner = (*storeAPIAdapter)(nil)
 var _ api.CLIRepairEncodingRunner = (*storeAPIAdapter)(nil)
+var _ api.CLIRepairMessageRunner = (*storeAPIAdapter)(nil)
 var _ api.CLIRunner = (*storeAPIAdapter)(nil)
 var _ api.CLIAddCalendarPlanner = (*storeAPIAdapter)(nil)
 var _ api.CLIDeleteStagedPlanner = (*storeAPIAdapter)(nil)
@@ -1577,6 +1578,58 @@ func (a *storeAPIAdapter) RunCLIRepairEncoding(
 		}
 		return emit(api.CLIRepairEncodingEvent{Type: stream, Data: data})
 	})
+}
+
+func (a *storeAPIAdapter) RunCLIRepairMessage(
+	ctx context.Context,
+	req api.CLIRepairMessageRequest,
+	emit func(api.CLIRepairMessageEvent) error,
+) error {
+	return a.runCLIRepairMessageWithRunner(ctx, req, emit, runDaemonCLISubprocessStream)
+}
+
+func (a *storeAPIAdapter) runCLIRepairMessageWithRunner(
+	ctx context.Context,
+	req api.CLIRepairMessageRequest,
+	emit func(api.CLIRepairMessageEvent) error,
+	run cliSyncSubprocessRunner,
+) error {
+	emitSubprocess := func(stream, data string) error {
+		if emit == nil {
+			return nil
+		}
+		return emit(api.CLIRepairMessageEvent{Type: stream, Data: data})
+	}
+	runRepair := func(ctx context.Context) error {
+		return run(ctx, cliRepairMessageSubprocessArgs(req), emitSubprocess)
+	}
+	if req.Audit {
+		return runRepair(ctx)
+	}
+	emitWarning := func(message string) error {
+		if emit == nil {
+			return nil
+		}
+		return emit(api.CLIRepairMessageEvent{Type: "stderr", Data: message})
+	}
+	return runAfterSuccessfulAttachmentIngest(ctx, a.attachmentMaintenance, runRepair, emitWarning)
+}
+
+func cliRepairMessageSubprocessArgs(req api.CLIRepairMessageRequest) []string {
+	args := []string{"repair-message", "--local"}
+	if req.Audit {
+		args = append(args, "--audit")
+	}
+	if req.SourceID > 0 {
+		args = append(args, "--source-id", strconv.FormatInt(req.SourceID, 10))
+	}
+	if req.JSON {
+		args = append(args, "--json")
+	}
+	if req.Reference != "" {
+		args = append(args, req.Reference)
+	}
+	return args
 }
 
 func (a *storeAPIAdapter) RunCLICommand(

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1627,7 +1627,9 @@ func cliRepairMessageSubprocessArgs(req api.CLIRepairMessageRequest) []string {
 		args = append(args, "--json")
 	}
 	if req.Reference != "" {
-		args = append(args, req.Reference)
+		// The reference is user data. Terminate flag parsing so a value such
+		// as "--audit" reaches the subprocess as a positional argument.
+		args = append(args, "--", req.Reference)
 	}
 	return args
 }

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -1646,6 +1646,55 @@ func TestStoreAPIAdapterRunCLICommandPacksOnlyAllowlistedSuccess(t *testing.T) {
 	}
 }
 
+func TestStoreAPIAdapterRunCLIRepairMessageUsesDedicatedLocalArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		req  api.CLIRepairMessageRequest
+		want []string
+	}{
+		{
+			name: "repair",
+			req:  api.CLIRepairMessageRequest{Reference: "gmail-42", SourceID: 7},
+			want: []string{"repair-message", "--local", "--source-id", "7", "gmail-42"},
+		},
+		{
+			name: "whole archive audit json",
+			req:  api.CLIRepairMessageRequest{Audit: true, JSON: true},
+			want: []string{"repair-message", "--local", "--audit", "--json"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotArgs []string
+			var events []api.CLIRepairMessageEvent
+			adapter := &storeAPIAdapter{}
+			err := adapter.runCLIRepairMessageWithRunner(t.Context(), test.req, func(event api.CLIRepairMessageEvent) error {
+				events = append(events, event)
+				return nil
+			}, func(_ context.Context, args []string, emit func(string, string) error) error {
+				gotArgs = append([]string(nil), args...)
+				return emit("stdout", "line\n")
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, test.want, gotArgs)
+			assert.Equal(t, []api.CLIRepairMessageEvent{{Type: "stdout", Data: "line\n"}}, events)
+		})
+	}
+}
+
+func TestStoreAPIAdapterRunCLIRepairMessagePropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	adapter := &storeAPIAdapter{}
+	err := adapter.runCLIRepairMessageWithRunner(ctx, api.CLIRepairMessageRequest{Audit: true}, nil,
+		func(ctx context.Context, _ []string, _ func(string, string) error) error {
+			cancel()
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestStoreAPIAdapterAppendsServerOwnedGrantDecision(t *testing.T) {
 	adapter := &storeAPIAdapter{}
 	req := api.CLIRunRequest{

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -1655,7 +1655,12 @@ func TestStoreAPIAdapterRunCLIRepairMessageUsesDedicatedLocalArgv(t *testing.T) 
 		{
 			name: "repair",
 			req:  api.CLIRepairMessageRequest{Reference: "gmail-42", SourceID: 7},
-			want: []string{"repair-message", "--local", "--source-id", "7", "gmail-42"},
+			want: []string{"repair-message", "--local", "--source-id", "7", "--", "gmail-42"},
+		},
+		{
+			name: "hyphen-prefixed reference stays positional",
+			req:  api.CLIRepairMessageRequest{Reference: "--audit"},
+			want: []string{"repair-message", "--local", "--", "--audit"},
 		},
 		{
 			name: "whole archive audit json",

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -304,6 +304,10 @@ type CLIVerifyRunner interface {
 	RunCLIVerify(ctx context.Context, req CLIVerifyRequest, emit func(CLIVerifyEvent) error) error
 }
 
+type CLIRepairMessageRunner interface {
+	RunCLIRepairMessage(ctx context.Context, req CLIRepairMessageRequest, emit func(CLIRepairMessageEvent) error) error
+}
+
 type CLIRunner interface {
 	RunCLICommand(ctx context.Context, req CLIRunRequest, emit func(CLIRunEvent) error) error
 }
@@ -489,6 +493,19 @@ type CLIVerifyEvent struct {
 }
 
 type CLIRepairEncodingEvent struct {
+	Type  string `json:"type"`
+	Data  string `json:"data,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+type CLIRepairMessageRequest struct {
+	Reference string `json:"reference,omitempty"`
+	SourceID  int64  `json:"source_id,omitempty"`
+	Audit     bool   `json:"audit,omitempty"`
+	JSON      bool   `json:"json,omitempty"`
+}
+
+type CLIRepairMessageEvent struct {
 	Type  string `json:"type"`
 	Data  string `json:"data,omitempty"`
 	Error string `json:"error,omitempty"`
@@ -1212,6 +1229,53 @@ func (s *Server) handleCLIRepairEncoding(w http.ResponseWriter, r *http.Request)
 	}
 	if err := writeEvent(CLIRepairEncodingEvent{Type: cliStreamEventTypeComplete}); err != nil {
 		s.logger.Error("failed to stream CLI repair-encoding completion event", "error", err)
+	}
+}
+
+func (s *Server) handleCLIRepairMessage(w http.ResponseWriter, r *http.Request) {
+	runner, ok := s.store.(CLIRepairMessageRunner)
+	if !ok {
+		writeAPIHTTPError(w, cliStoreUnavailableError())
+		return
+	}
+	var req CLIRepairMessageRequest
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "invalid JSON request body")
+		return
+	}
+	if !requireSingleJSONValue(w, dec, "invalid_request") {
+		return
+	}
+	req.Reference = strings.TrimSpace(req.Reference)
+	if req.Audit {
+		if req.Reference != "" {
+			writeError(w, http.StatusBadRequest, "invalid_request", "audit does not accept a reference")
+			return
+		}
+	} else if req.Reference == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "reference is required unless audit is true")
+		return
+	}
+	if req.SourceID < 0 {
+		writeError(w, http.StatusBadRequest, "invalid_request", "source_id must be positive")
+		return
+	}
+	if req.JSON && !req.Audit {
+		writeError(w, http.StatusBadRequest, "invalid_request", "json requires audit")
+		return
+	}
+
+	writeEvent := newCLINDJSONEventWriter[CLIRepairMessageEvent](w)
+	if err := runner.RunCLIRepairMessage(r.Context(), req, writeEvent); err != nil {
+		s.logger.Error("failed to run CLI repair-message", "audit", req.Audit, "source_id", req.SourceID, "error", err)
+		if writeErr := writeEvent(CLIRepairMessageEvent{Type: cliStreamEventTypeError, Error: err.Error()}); writeErr != nil {
+			s.logger.Error("failed to stream CLI repair-message error event", "error", writeErr)
+		}
+		return
+	}
+	if err := writeEvent(CLIRepairMessageEvent{Type: cliStreamEventTypeComplete}); err != nil {
+		s.logger.Error("failed to stream CLI repair-message completion event", "error", err)
 	}
 }
 

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -247,7 +247,10 @@ import (
 // values in the message change feed. Remote clients must require this version
 // before sending list_id because older compatible daemons ignore unknown query
 // parameters and could widen a scoped request.
-const APISchemaVersion = "2.14.0"
+// 2.15.0 adds POST /api/v1/cli/repair-message with a dedicated request and
+// streaming event contract for Gmail snapshot repair and audit operations.
+// Additive (minor bump): existing CLI routes and clients remain unchanged.
+const APISchemaVersion = "2.15.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -34,8 +34,8 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 	assert.NotEmpty(t, doc.Paths, "paths")
 }
 
-func TestOpenAPISchemaVersionListIDFilteringIs2140(t *testing.T) {
-	assert.Equal(t, "2.14.0", APISchemaVersion)
+func TestOpenAPISchemaVersionRepairMessageIs2150(t *testing.T) {
+	assert.Equal(t, "2.15.0", APISchemaVersion)
 }
 
 func TestCLISearchOpenAPIDocumentsDeletionScope(t *testing.T) {
@@ -145,7 +145,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.14.0", APISchemaVersion)
+	assert.Equal("2.15.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -167,11 +167,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.14.0", APISchemaVersion)
+	assert.Equal(t, "2.15.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.14.0", APISchemaVersion)
+	assert.Equal(t, "2.15.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -195,7 +195,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.14.0", APISchemaVersion,
+	assert.Equal(t, "2.15.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -519,7 +519,7 @@ func TestOpenAPISearchDocumentsConversationID(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.14.0", APISchemaVersion,
+	assert.Equal("2.15.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -633,7 +633,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.14.0", APISchemaVersion,
+	assertions.Equal("2.15.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -653,7 +653,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.14.0", APISchemaVersion,
+	assert.Equal("2.15.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -681,7 +681,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.14.0", APISchemaVersion,
+	assertions.Equal("2.15.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -728,9 +728,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// 2.5.0. Person search in 2.6.0, structured filters in 2.7.0, CardDAV routes
 	// in 2.8.0, person merge/split operations in 2.9.0, and relationship
 	// calendars in 2.10.0, person fact diagnostics in 2.11.0, lexical deletion
-	// scope in 2.12.0, deduplicate planning in 2.13.0, and List-ID filtering in
-	// 2.14.0 did not touch it.
-	assert.Equal("2.14.0", APISchemaVersion, "meeting import is an additive schema release")
+	// scope in 2.12.0, deduplicate planning in 2.13.0, List-ID filtering in
+	// 2.14.0, and Gmail repair in 2.15.0 did not touch it.
+	assert.Equal("2.15.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/operation_gate.go
+++ b/internal/api/operation_gate.go
@@ -448,6 +448,16 @@ func operationGateRequest(r *http.Request) (bool, string, error) {
 	if readOnlyPostRouteRequest(r) {
 		return false, "", nil
 	}
+	if r.URL.Path == "/api/v1/cli/repair-message" {
+		label, skip, err := cliRepairMessageGateDecision(r)
+		if err != nil {
+			return false, "", err
+		}
+		if skip {
+			return false, "", nil
+		}
+		return true, label, nil
+	}
 	if r.URL.Path == "/api/v1/cli/run" {
 		label, skip, err := cliRunGateDecision(r)
 		if err != nil {
@@ -459,6 +469,31 @@ func operationGateRequest(r *http.Request) (bool, string, error) {
 		return true, label, nil
 	}
 	return true, operationGateLabelFromPath(r.URL.Path), nil
+}
+
+// cliRepairMessageGateDecision bypasses the mutation gate only for a request
+// body that the handler will accept as read-only audit mode. The body is
+// restored before returning so the Huma handler sees the exact same bytes.
+// Malformed and invalid bodies stay gated and are rejected by the handler.
+func cliRepairMessageGateDecision(r *http.Request) (label string, skip bool, err error) {
+	if r == nil || r.Body == nil {
+		return "msgvault repair-message", false, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, cliRunGateInspectionMaxBytes+1))
+	if err != nil {
+		return "", false, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	if len(body) > cliRunGateInspectionMaxBytes {
+		return "", false, errCLIRunGateInspectionBodyTooLarge
+	}
+
+	var req CLIRepairMessageRequest
+	if json.Unmarshal(body, &req) == nil &&
+		req.Audit && strings.TrimSpace(req.Reference) == "" && req.SourceID >= 0 {
+		return "", true, nil
+	}
+	return "msgvault repair-message", false, nil
 }
 
 // cliRunReadOnlyCommands are proxied CLI commands that only read. Keys are

--- a/internal/api/relationship_calendar_test.go
+++ b/internal/api/relationship_calendar_test.go
@@ -177,7 +177,7 @@ func TestRelationshipCalendarRequestRejectsTrailingJSON(t *testing.T) {
 func TestRelationshipCalendarOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.Equal("2.14.0", APISchemaVersion)
+	assert.Equal("2.15.0", APISchemaVersion)
 	document := OpenAPIDocument()
 	path := document.Paths["/api/v1/relationships/{id}/calendar"]
 	require.NotNil(path)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -291,6 +291,7 @@ func (s *Server) registerHumaRoutes(api huma.API, apiV1 huma.API) {
 	registerAPIV1RawHumaNDJSONRoute[CLICacheBuildEvent](apiV1, "buildCLICache", http.MethodPost, "/cli/build-cache", "Build the CLI analytics cache", s.handleCLIBuildCache)
 	registerAPIV1RawHumaNDJSONRoute[CLISyncEvent](apiV1, "syncCLI", http.MethodPost, "/cli/sync", "Run CLI incremental sync", s.handleCLISync)
 	registerAPIV1RawHumaNDJSONRoute[CLISyncEvent](apiV1, "syncFullCLI", http.MethodPost, "/cli/sync-full", "Run CLI full sync", s.handleCLISyncFull)
+	registerAPIV1RawHumaNDJSONRouteWithRequest[CLIRepairMessageRequest, CLIRepairMessageEvent](apiV1, "repairMessageCLI", http.MethodPost, "/cli/repair-message", "Repair or audit Gmail message snapshots", s.handleCLIRepairMessage)
 	registerAPIV1RawHumaNDJSONRoute[CLIVerifyEvent](apiV1, "verifyCLI", http.MethodPost, "/cli/verify", "Verify the CLI archive against Gmail", s.handleCLIVerify)
 	registerAPIV1RawHumaNDJSONRoute[CLIRepairEncodingEvent](apiV1, "repairEncodingCLI", http.MethodPost, "/cli/repair-encoding", "Repair CLI archive encoding", s.handleCLIRepairEncoding)
 	registerAPIV1RawHumaJSONRouteWithRequest[CLIAddCalendarPlanRequest, CLIAddCalendarPlanResponse](apiV1, "planCLIAddCalendar", http.MethodPost, "/cli/add-calendar/plan", "Plan CLI Calendar account setup", s.handleCLIAddCalendarPlan)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1094,6 +1094,7 @@ func isLongDaemonRequest(path string) bool {
 		"/api/v1/cli/identities/discover",
 		"/api/v1/cli/rebuild-fts",
 		"/api/v1/cli/repair-encoding",
+		"/api/v1/cli/repair-message",
 		"/api/v1/cli/run",
 		"/api/v1/cli/search",
 		"/api/v1/cli/sync",

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -350,6 +350,7 @@ type mockStore struct {
 	verifyFunc            func(context.Context, CLIVerifyRequest, func(CLIVerifyEvent) error) error
 	repairFunc            func(context.Context, func(CLIRepairEncodingEvent) error) error
 	runFunc               func(context.Context, CLIRunRequest, func(CLIRunEvent) error) error
+	repairMessageFunc     func(context.Context, CLIRepairMessageRequest, func(CLIRepairMessageEvent) error) error
 	planCalendarFunc      func(context.Context, CLIAddCalendarPlanRequest) (CLIAddCalendarPlanResponse, error)
 	planEmbedsFunc        func(context.Context, CLIEmbeddingsPlanRequest) (CLIEmbeddingsPlanResponse, error)
 	planDeleteFunc        func(context.Context, CLIDeleteStagedPlanRequest) (CLIDeleteStagedPlanResponse, error)
@@ -731,6 +732,17 @@ func (m *mockStore) RunCLICommand(
 ) error {
 	if m.runFunc != nil {
 		return m.runFunc(ctx, req, emit)
+	}
+	return nil
+}
+
+func (m *mockStore) RunCLIRepairMessage(
+	ctx context.Context,
+	req CLIRepairMessageRequest,
+	emit func(CLIRepairMessageEvent) error,
+) error {
+	if m.repairMessageFunc != nil {
+		return m.repairMessageFunc(ctx, req, emit)
 	}
 	return nil
 }
@@ -1444,6 +1456,248 @@ func TestCLIRequestDurationPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCLIRepairMessageRouteParsesDedicatedRequestAndStreamsNDJSON(t *testing.T) {
+	assert := assert.New(t)
+	var got CLIRepairMessageRequest
+	store := &mockStore{repairMessageFunc: func(
+		_ context.Context,
+		req CLIRepairMessageRequest,
+		emit func(CLIRepairMessageEvent) error,
+	) error {
+		got = req
+		return emit(CLIRepairMessageEvent{Type: "stdout", Data: "repaired\n"})
+	}}
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, store, newMockScheduler(), testLogger())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message",
+		strings.NewReader(`{"reference":"gmail-42","source_id":7}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(w, req)
+
+	assert.Equal(http.StatusOK, w.Code)
+	assert.Equal("application/x-ndjson", w.Header().Get("Content-Type"))
+	assert.Equal(CLIRepairMessageRequest{Reference: "gmail-42", SourceID: 7}, got)
+	body, terminated := strings.CutSuffix(w.Body.String(), "\n")
+	if assert.True(terminated, "NDJSON response must end with a newline") {
+		lines := strings.Split(body, "\n")
+		if assert.Len(lines, 2) {
+			assert.JSONEq(`{"type":"stdout","data":"repaired\n"}`, lines[0])
+			assert.JSONEq(`{"type":"complete"}`, lines[1])
+		}
+	}
+}
+
+func TestCLIRepairMessageRouteRejectsInvalidModeBeforeRunning(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "missing reference", body: `{}`, want: "reference is required unless audit is true"},
+		{name: "audit with reference", body: `{"audit":true,"reference":"gmail-42"}`, want: "audit does not accept a reference"},
+		{name: "negative source", body: `{"audit":true,"source_id":-1}`, want: "source_id must be positive"},
+		{name: "repair json", body: `{"reference":"gmail-42","json":true}`, want: "json requires audit"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			called := false
+			store := &mockStore{repairMessageFunc: func(
+				context.Context, CLIRepairMessageRequest, func(CLIRepairMessageEvent) error,
+			) error {
+				called = true
+				return nil
+			}}
+			srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, store, newMockScheduler(), testLogger())
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message", strings.NewReader(test.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			srv.Router().ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), test.want)
+			assert.False(t, called)
+		})
+	}
+}
+
+func TestCLIRepairMessageRoutePropagatesCancellation(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan error, 1)
+	store := &mockStore{repairMessageFunc: func(
+		ctx context.Context, _ CLIRepairMessageRequest, _ func(CLIRepairMessageEvent) error,
+	) error {
+		close(started)
+		<-ctx.Done()
+		stopped <- ctx.Err()
+		return ctx.Err()
+	}}
+	srv := NewServer(&config.Config{Server: config.ServerConfig{APIPort: 8080}}, store, newMockScheduler(), testLogger())
+	ctx, cancel := context.WithCancel(t.Context())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message",
+		strings.NewReader(`{"audit":true}`)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+	done := make(chan struct{})
+	go func() {
+		srv.Router().ServeHTTP(httptest.NewRecorder(), req)
+		close(done)
+	}()
+	<-started
+	cancel()
+
+	assert.ErrorIs(t, <-stopped, context.Canceled)
+	<-done
+}
+
+func TestCLIRepairMessageRepairWaitsForOperationGate(t *testing.T) {
+	gate := NewSerialOperationGate()
+	release, ok := gate.BeginWorkContext(t.Context())
+	require.True(t, ok)
+	called := make(chan struct{})
+	store := &mockStore{repairMessageFunc: func(
+		context.Context, CLIRepairMessageRequest, func(CLIRepairMessageEvent) error,
+	) error {
+		close(called)
+		return nil
+	}}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  store, Scheduler: newMockScheduler(), Logger: testLogger(), OperationGate: gate,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message",
+		strings.NewReader(`{"reference":"gmail-42"}`))
+	req.Header.Set("Content-Type", "application/json")
+	done := make(chan struct{})
+	go func() {
+		srv.Router().ServeHTTP(httptest.NewRecorder(), req)
+		close(done)
+	}()
+
+	select {
+	case <-called:
+		require.FailNow(t, "repair ran while another archive operation held the gate")
+	case <-time.After(30 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		require.FailNow(t, "repair did not run after the operation gate was released")
+	}
+	<-done
+}
+
+func TestCLIRepairMessageValidAuditBypassesOperationGateAndPreservesBody(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	gate := NewSerialOperationGate()
+	release, ok := gate.BeginWorkContext(t.Context())
+	require.True(ok)
+	var releaseOnce sync.Once
+	releaseGate := func() { releaseOnce.Do(release) }
+	defer releaseGate()
+
+	got := make(chan CLIRepairMessageRequest, 1)
+	store := &mockStore{repairMessageFunc: func(
+		_ context.Context, req CLIRepairMessageRequest, _ func(CLIRepairMessageEvent) error,
+	) error {
+		got <- req
+		return nil
+	}}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  store, Scheduler: newMockScheduler(), Logger: testLogger(), OperationGate: gate,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message",
+		strings.NewReader(`{"audit":true,"source_id":7,"json":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		srv.Router().ServeHTTP(w, req)
+		close(done)
+	}()
+
+	select {
+	case request := <-got:
+		assert.Equal(CLIRepairMessageRequest{Audit: true, SourceID: 7, JSON: true}, request)
+	case <-time.After(250 * time.Millisecond):
+		releaseGate()
+		<-done
+		require.FailNow("valid read-only audit waited on the mutation gate")
+	}
+	<-done
+	assert.Equal(http.StatusOK, w.Code)
+}
+
+func TestCLIRepairMessageInvalidAuditBodiesDoNotBypassOperationGate(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "audit with repair reference", body: `{"audit":true,"reference":"gmail-42"}`},
+		{name: "audit with negative source", body: `{"audit":true,"source_id":-1}`},
+		{name: "malformed JSON", body: `{"audit":true`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			gate := &recordingOperationGate{allow: true}
+			called := make(chan struct{}, 1)
+			store := &mockStore{repairMessageFunc: func(
+				context.Context, CLIRepairMessageRequest, func(CLIRepairMessageEvent) error,
+			) error {
+				called <- struct{}{}
+				return nil
+			}}
+			srv := NewServerWithOptions(ServerOptions{
+				Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+				Store:  store, Scheduler: newMockScheduler(), Logger: testLogger(), OperationGate: gate,
+			})
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message", strings.NewReader(test.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.Router().ServeHTTP(w, req)
+
+			assert.Equal(http.StatusBadRequest, w.Code)
+			begin, done := gate.counts()
+			assert.Equal(1, begin, "invalid audit body must remain gated")
+			assert.Equal(1, done, "gate must be released after handler rejection")
+			select {
+			case <-called:
+				require.FailNow(t, "invalid audit body reached the repair runner")
+			default:
+			}
+		})
+	}
+}
+
+func TestCLIRepairMessageWholeArchiveAuditHasNoOrdinaryRequestDeadline(t *testing.T) {
+	deadline := make(chan bool, 1)
+	store := &mockStore{repairMessageFunc: func(
+		ctx context.Context, req CLIRepairMessageRequest, _ func(CLIRepairMessageEvent) error,
+	) error {
+		assert.True(t, req.Audit)
+		assert.Zero(t, req.SourceID)
+		_, ok := ctx.Deadline()
+		deadline <- ok
+		return nil
+	}}
+	srv := NewServerWithOptions(ServerOptions{
+		Config: &config.Config{Server: config.ServerConfig{APIPort: 8080}},
+		Store:  store, Scheduler: newMockScheduler(), Logger: testLogger(), RequestTimeout: time.Millisecond,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/cli/repair-message", strings.NewReader(`{"audit":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Router().ServeHTTP(w, req)
+
+	assert.False(t, <-deadline)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestTimeoutMiddlewareMarkedRequestPreservesCallerCancellation(t *testing.T) {

--- a/internal/daemonclient/cli.go
+++ b/internal/daemonclient/cli.go
@@ -444,6 +444,7 @@ const (
 	sourceIDSyncMinAPISchemaVersion    = "2.4.0"
 	searchDeletionMinAPISchemaVersion  = "2.12.0"
 	deduplicatePlanMinAPISchemaVersion = "2.13.0"
+	repairMessageMinAPISchemaVersion   = "2.15.0"
 )
 
 func (c *Client) requireSourceIDSyncCapability(ctx context.Context) error {
@@ -535,6 +536,52 @@ func (c *Client) RunCLIRepairEncoding(
 	output func(stream, data string) error,
 ) error {
 	return c.runCLIStream(ctx, "/api/v1/cli/repair-encoding", "repair-encoding", nil, output)
+}
+
+// RunCLIRepairMessage repairs one Gmail message snapshot or audits stored
+// Gmail MIME through the dedicated generated endpoint. The explicit schema
+// probe is load-bearing: an older daemon must never receive a request that it
+// could reinterpret as a broader sync operation.
+func (c *Client) RunCLIRepairMessage(
+	ctx context.Context,
+	req generated.CLIRepairMessageRequest,
+	output func(stream, data string) error,
+) error {
+	return c.RunCLIRepairMessageWithPreflight(ctx, req, nil, output)
+}
+
+// RunCLIRepairMessageWithPreflight validates the daemon capability before
+// running the caller's credential preflight, then opens the dedicated repair
+// stream. Keeping that order inside the client prevents credential changes
+// when the selected daemon cannot execute the operation.
+func (c *Client) RunCLIRepairMessageWithPreflight(
+	ctx context.Context,
+	req generated.CLIRepairMessageRequest,
+	preflight func(context.Context) error,
+	output func(stream, data string) error,
+) error {
+	version, err := c.daemonAPISchemaVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("check daemon repair-message capability: %w", err)
+	}
+	if !apiSchemaVersionAtLeast(version, repairMessageMinAPISchemaVersion) {
+		return fmt.Errorf(
+			"repair-message requires daemon API schema %s or newer (daemon reports %q)",
+			repairMessageMinAPISchemaVersion, version,
+		)
+	}
+	if preflight != nil {
+		if err := preflight(ctx); err != nil {
+			return err
+		}
+	}
+	return c.runCLIStream(
+		ctx,
+		"/api/v1/cli/repair-message",
+		"repair-message",
+		&generated.RepairMessageCLIRequestOptions{Body: &req},
+		output,
+	)
 }
 
 func (c *Client) RunCLICommand(

--- a/internal/daemonclient/store_adapter_test.go
+++ b/internal/daemonclient/store_adapter_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1649,6 +1650,183 @@ func TestRunCLIRepairEncodingStreamsOutput(t *testing.T) {
 
 	require.NoError(err, "RunCLIRepairEncoding")
 	assert.Equal([]string{"stdout:Scanning messages\n", "stderr:repair warning\n"}, output, "output")
+}
+
+func TestRunCLIRepairMessageUsesGeneratedRequestAndStreamsOutput(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v1/health":
+			writeJSONResponse(t, w, map[string]any{
+				"status": "ok", "api_schema_version": "2.15.0",
+			})
+		case "/api/v1/cli/repair-message":
+			assertions.Equal(http.MethodPost, r.Method)
+			assertions.Empty(r.URL.RawQuery, "repair request is encoded in the generated JSON body")
+			var body generated.CLIRepairMessageRequest
+			if !assertions.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+				return
+			}
+			if !assertions.NotNil(body.Reference) {
+				return
+			}
+			assertions.Equal("gmail-42", *body.Reference)
+			if !assertions.NotNil(body.SourceID) {
+				return
+			}
+			assertions.Equal(int64(7), *body.SourceID)
+			assertions.Nil(body.Audit)
+			assertions.Nil(body.JSON)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(`{"type":"stdout","data":"repaired\n"}` + "\n"))
+			_, _ = w.Write([]byte(`{"type":"stderr","data":"repair warning\n"}` + "\n"))
+			_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+		default:
+			http.Error(w, "unexpected endpoint", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	s := newTestStore(srv, "secret")
+	reference := "gmail-42"
+	sourceID := int64(7)
+	var output []string
+	err := s.RunCLIRepairMessage(context.Background(), generated.CLIRepairMessageRequest{
+		Reference: &reference,
+		SourceID:  &sourceID,
+	}, func(stream, data string) error {
+		output = append(output, stream+":"+data)
+		return nil
+	})
+
+	requirements.NoError(err)
+	assertions.Equal([]string{"/api/v1/health", "/api/v1/cli/repair-message"}, paths)
+	assertions.Equal([]string{"stdout:repaired\n", "stderr:repair warning\n"}, output)
+}
+
+func TestRunCLIRepairMessageWithPreflightChecksCapabilityBeforePreflightAndRequest(t *testing.T) {
+	assert := assert.New(t)
+	var sequence atomic.Int32
+	var capabilityStep atomic.Int32
+	var repairStep atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			capabilityStep.Store(sequence.Add(1))
+			writeJSONResponse(t, w, map[string]any{
+				"status": "ok", "api_schema_version": "2.15.0",
+			})
+		case "/api/v1/cli/repair-message":
+			repairStep.Store(sequence.Add(1))
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+		default:
+			http.Error(w, "unexpected endpoint", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	s := newTestStore(srv, "secret")
+	reference := "gmail-42"
+	var preflightStep atomic.Int32
+	err := s.RunCLIRepairMessageWithPreflight(
+		context.Background(),
+		generated.CLIRepairMessageRequest{Reference: &reference},
+		func(context.Context) error {
+			preflightStep.Store(sequence.Add(1))
+			return nil
+		},
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(int32(1), capabilityStep.Load())
+	assert.Equal(int32(2), preflightStep.Load())
+	assert.Equal(int32(3), repairStep.Load())
+}
+
+func TestRunCLIRepairMessageFailsClosedWithoutCompatibleSchema(t *testing.T) {
+	tests := []struct {
+		name          string
+		healthPayload string
+		wantVersion   string
+	}{
+		{name: "missing version", healthPayload: `{"status":"ok"}`, wantVersion: `daemon reports ""`},
+		{name: "malformed version", healthPayload: `{"status":"ok","api_schema_version":"2.13"}`, wantVersion: `daemon reports "2.13"`},
+		{name: "older version", healthPayload: `{"status":"ok","api_schema_version":"2.13.0"}`, wantVersion: `daemon reports "2.13.0"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var nonHealthRequests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/v1/health" {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(test.healthPayload))
+					return
+				}
+				nonHealthRequests.Add(1)
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				_, _ = w.Write([]byte(`{"type":"complete"}` + "\n"))
+			}))
+			t.Cleanup(srv.Close)
+
+			s := newTestStore(srv, "")
+			reference := "gmail-42"
+			err := s.RunCLIRepairMessage(context.Background(), generated.CLIRepairMessageRequest{
+				Reference: &reference,
+			}, nil)
+
+			require.ErrorContains(t, err, "requires daemon API schema 2.15.0")
+			require.ErrorContains(t, err, test.wantVersion)
+			assert.Zero(t, nonHealthRequests.Load(), "incompatible daemon must receive neither repair nor sync requests")
+		})
+	}
+}
+
+func TestRunCLIRepairMessagePropagatesCancellation(t *testing.T) {
+	repairStarted := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{
+				"status": "ok", "api_schema_version": "2.15.0",
+			})
+			return
+		}
+		assert.Equal(t, "/api/v1/cli/repair-message", r.URL.Path)
+		close(repairStarted)
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+
+	s := newTestStore(srv, "")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	audit := true
+	go func() {
+		done <- s.RunCLIRepairMessage(ctx, generated.CLIRepairMessageRequest{Audit: &audit}, nil)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-repairStarted:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	cancel()
+
+	require.ErrorIs(t, <-done, context.Canceled)
 }
 
 func TestRebuildCLIFTSUsesGeneratedClientAdapter(t *testing.T) {

--- a/internal/export/store_attachment.go
+++ b/internal/export/store_attachment.go
@@ -142,33 +142,43 @@ func attachmentLooseStore(baseDir string, staging packstore.StagingMode) (*packs
 	return store, nil
 }
 
+// DurableAttachmentReceipt identifies one durable loose publication. Created
+// distinguishes a blob introduced by this call from a verified deduplication.
+type DurableAttachmentReceipt struct {
+	StoragePath string
+	ContentHash string
+	Created     bool
+}
+
 // StoreAttachmentFileDurable stores attachment content, including an empty
 // blob, through the content-addressed atomic write path. Unlike ordinary
 // ingest, this entry point is reserved for maintenance that will discard an
-// existing authoritative copy after the loose file is durable.
-func StoreAttachmentFileDurable(attachmentsDir string, att *mime.Attachment) (string, error) {
+// existing authoritative copy after the loose file is durable. Its receipt is
+// populated even when publication succeeded but a later durability step
+// failed, so callers can roll back a newly created blob.
+func StoreAttachmentFileDurable(attachmentsDir string, att *mime.Attachment) (DurableAttachmentReceipt, error) {
 	if attachmentsDir == "" {
-		return "", nil
+		return DurableAttachmentReceipt{}, nil
 	}
 	var expectedHash packstore.Hash
 	var err error
 	if att.ContentHash != "" {
 		normalized := strings.ToLower(att.ContentHash)
 		if err := ValidateContentHash(normalized); err != nil {
-			return "", fmt.Errorf("invalid attachment content hash %q: %w", normalized, err)
+			return DurableAttachmentReceipt{}, fmt.Errorf("invalid attachment content hash %q: %w", normalized, err)
 		}
 		expectedHash, err = packstore.ParseHash(normalized)
 		if err != nil {
-			return "", fmt.Errorf("parse attachment content hash: %w", err)
+			return DurableAttachmentReceipt{}, fmt.Errorf("parse attachment content hash: %w", err)
 		}
 	}
 	baseDir, err := prepareStorageDir(attachmentsDir)
 	if err != nil {
-		return "", err
+		return DurableAttachmentReceipt{}, err
 	}
 	loose, err := attachmentLooseStore(baseDir, packstore.StagingSameDirectory)
 	if err != nil {
-		return "", err
+		return DurableAttachmentReceipt{}, err
 	}
 	result, writeErr := loose.WriteBytes(context.Background(), att.Content, packstore.WriteOptions{
 		Durability:   packstore.DurablePublication,
@@ -180,11 +190,50 @@ func StoreAttachmentFileDurable(attachmentsDir string, att *mime.Attachment) (st
 	if result.Hash != "" && (expectedHash == "" || result.Hash == expectedHash) {
 		att.ContentHash = result.Hash.String()
 	}
-	if writeErr != nil {
-		return "", fmt.Errorf("store durable loose attachment: %w", writeErr)
+	receipt := DurableAttachmentReceipt{Created: result.Created}
+	if result.Hash != "" {
+		receipt.ContentHash = result.Hash.String()
+		receipt.StoragePath = path.Join(receipt.ContentHash[:2], receipt.ContentHash)
 	}
-	contentHash := result.Hash.String()
-	return path.Join(contentHash[:2], contentHash), nil
+	if writeErr != nil {
+		return receipt, fmt.Errorf("store durable loose attachment: %w", writeErr)
+	}
+	return receipt, nil
+}
+
+// RemoveAttachmentFileDurable removes a blob only when receipt proves the
+// corresponding publication created it. Callers remain responsible for
+// checking that no committed attachment row references StoragePath.
+func RemoveAttachmentFileDurable(attachmentsDir string, receipt DurableAttachmentReceipt) error {
+	if !receipt.Created {
+		return nil
+	}
+	if attachmentsDir == "" {
+		return errors.New("attachments directory is required")
+	}
+	if err := ValidateContentHash(receipt.ContentHash); err != nil {
+		return fmt.Errorf("invalid attachment content hash %q: %w", receipt.ContentHash, err)
+	}
+	expectedPath := path.Join(receipt.ContentHash[:2], receipt.ContentHash)
+	if receipt.StoragePath != expectedPath {
+		return fmt.Errorf("attachment storage path %q does not match content hash", receipt.StoragePath)
+	}
+	hash, err := packstore.ParseHash(receipt.ContentHash)
+	if err != nil {
+		return fmt.Errorf("parse attachment content hash: %w", err)
+	}
+	baseDir, err := prepareStorageDir(attachmentsDir)
+	if err != nil {
+		return err
+	}
+	loose, err := attachmentLooseStore(baseDir, packstore.StagingSameDirectory)
+	if err != nil {
+		return err
+	}
+	if err := loose.Remove(hash, packstore.DurableRemoval); err != nil {
+		return fmt.Errorf("remove durable loose attachment: %w", err)
+	}
+	return nil
 }
 
 // hashSourceFile hashes f without staging any bytes, enforcing maxSize on

--- a/internal/export/store_attachment_test.go
+++ b/internal/export/store_attachment_test.go
@@ -157,9 +157,11 @@ func TestStoreAttachmentFileDurableStoresEmptyContent(t *testing.T) {
 	emptyHash := hex.EncodeToString(emptySum[:])
 	att := &mime.Attachment{ContentHash: emptyHash}
 
-	storagePath, err := StoreAttachmentFileDurable(dir, att)
+	receipt, err := StoreAttachmentFileDurable(dir, att)
 	require.NoError(err)
+	storagePath := receipt.StoragePath
 	assert.Equal(path.Join(emptyHash[:2], emptyHash), storagePath)
+	assert.True(receipt.Created)
 	assert.Equal(emptyHash, att.ContentHash)
 	info, err := os.Lstat(filepath.Join(dir, filepath.FromSlash(storagePath)))
 	require.NoError(err)
@@ -217,9 +219,10 @@ func TestStoreAttachmentFileDurableSurfacesParentSyncFailure(t *testing.T) {
 	require.ErrorIs(err, syncErr)
 
 	pack.SyncDir = originalSyncDir
-	storagePath, err := StoreAttachmentFileDurable(dir, att)
+	receipt, err := StoreAttachmentFileDurable(dir, att)
 	require.NoError(err, "retry must validate and durably reuse loose residue")
-	require.FileExists(filepath.Join(dir, filepath.FromSlash(storagePath)))
+	assert.False(t, receipt.Created)
+	require.FileExists(filepath.Join(dir, filepath.FromSlash(receipt.StoragePath)))
 }
 
 func TestStoreAttachmentFileDurableRejectsCanonicalSymlink(t *testing.T) {

--- a/internal/gmail/client_test.go
+++ b/internal/gmail/client_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -411,6 +412,53 @@ func TestGetMessagesRawBatch_LogLevels(t *testing.T) {
 	assert.Equal("msg_err", batch[2].ID, "batch[2].ID")
 	assert.Nil(batch[2].Message, "batch[2].Message")
 	require.Error(batch[2].Err, "batch[2].Err")
+}
+
+func TestGetMessagesRawBatchWithErrorsRetainsRequestedIdentityDuringParallelFetch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := path.Base(r.URL.Path)
+		if id == "msg-a" {
+			close(firstStarted)
+			<-releaseFirst
+		} else {
+			<-firstStarted
+			close(releaseFirst)
+		}
+		raw := base64.RawURLEncoding.EncodeToString([]byte("body-" + id))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":           id,
+			"threadId":     "thread-" + id,
+			"internalDate": "1704067200000",
+			"raw":          raw,
+		})
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		httpClient:  &http.Client{Transport: &rewriteTransport{base: srv.URL, wrapped: http.DefaultTransport}},
+		userID:      "me",
+		concurrency: 2,
+		logger:      slog.Default(),
+		rateLimiter: NewRateLimiter(1000),
+	}
+
+	results, err := client.GetMessagesRawBatchWithErrors(t.Context(), []string{"msg-a", "msg-b"})
+
+	require.NoError(err)
+	require.Len(results, 2)
+	assert.Equal("msg-a", results[0].ID)
+	require.NotNil(results[0].Message)
+	assert.Equal("msg-a", results[0].Message.ID)
+	assert.Equal([]byte("body-msg-a"), results[0].Message.Raw)
+	assert.Equal("msg-b", results[1].ID)
+	require.NotNil(results[1].Message)
+	assert.Equal("msg-b", results[1].Message.ID)
+	assert.Equal([]byte("body-msg-b"), results[1].Message.Raw)
 }
 
 func TestListCompleteMessageSnapshotIncludesSpamAndTrash(t *testing.T) {

--- a/internal/store/attachment_role_repair.go
+++ b/internal/store/attachment_role_repair.go
@@ -79,7 +79,8 @@ func (s *Store) RepairHistoricalAttachmentRolesBatch(
 			return AttachmentRoleRepairProgress{}, err
 		}
 		decodeLimit := min(int64(attachmentRoleRepairMaxMessageBytes), remainingBytes)
-		raw, bytesRead, decodeErr := decodeMessageRawBounded(compressed, compression, decodeLimit)
+		raw, bytesRead, decodeErr := decodeMessageRawBounded(
+			compressed, compression, decodeLimit, errAttachmentRoleRepairMessageTooLarge)
 		if errors.Is(decodeErr, errAttachmentRoleRepairMessageTooLarge) &&
 			decodeLimit < attachmentRoleRepairMaxMessageBytes {
 			hasMore = true
@@ -278,17 +279,23 @@ func (s *Store) attachmentRoleRepairMessageRaw(
 	return compressed, compression, nil
 }
 
+// decodeMessageRawBounded decompresses at most maxBytes of a stored raw
+// record. Decompression is capped with an io.LimitReader of maxBytes+1, so a
+// stream larger than the cap is detected without materializing it, and the
+// caller-supplied tooLargeErr is returned instead. bytesRead reports how many
+// decompressed bytes were consumed before the cap or stream end.
 func decodeMessageRawBounded(
 	compressed []byte,
 	compression sql.NullString,
 	maxBytes int64,
+	tooLargeErr error,
 ) ([]byte, int64, error) {
 	if maxBytes <= 0 {
-		return nil, 0, errAttachmentRoleRepairMessageTooLarge
+		return nil, 0, tooLargeErr
 	}
 	if !compression.Valid || compression.String != "zlib" {
 		if int64(len(compressed)) > maxBytes {
-			return nil, maxBytes + 1, errAttachmentRoleRepairMessageTooLarge
+			return nil, maxBytes + 1, tooLargeErr
 		}
 		return compressed, int64(len(compressed)), nil
 	}
@@ -300,7 +307,7 @@ func decodeMessageRawBounded(
 	closeErr := reader.Close()
 	bytesRead := int64(len(data))
 	if bytesRead > maxBytes {
-		return nil, bytesRead, errAttachmentRoleRepairMessageTooLarge
+		return nil, bytesRead, tooLargeErr
 	}
 	if readErr != nil {
 		return nil, bytesRead, readErr

--- a/internal/store/attachment_role_repair_internal_test.go
+++ b/internal/store/attachment_role_repair_internal_test.go
@@ -22,6 +22,7 @@ func TestDecodeMessageRawBoundedStopsAtLimit(t *testing.T) {
 
 	raw, bytesRead, err := decodeMessageRawBounded(
 		compressed.Bytes(), sql.NullString{String: "zlib", Valid: true}, 64,
+		errAttachmentRoleRepairMessageTooLarge,
 	)
 	require.ErrorIs(err, errAttachmentRoleRepairMessageTooLarge)
 	assert.Nil(raw)

--- a/internal/store/attachment_roles.go
+++ b/internal/store/attachment_roles.go
@@ -211,7 +211,27 @@ func (s *Store) DeleteUnstoredAttachmentByMetadataContext(
 	})
 }
 
+type attachmentConflictPolicy int
+
+const (
+	updateAttachmentConflicts attachmentConflictPolicy = iota
+	preserveProviderAttachmentConflicts
+)
+
 func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write AttachmentWrite) error {
+	return s.upsertAttachmentRecordWithPolicy(q, messageID, write, updateAttachmentConflicts)
+}
+
+func (s *Store) upsertAttachmentRecordWithPolicy(
+	q querier, messageID int64, write AttachmentWrite, conflictPolicy attachmentConflictPolicy,
+) error {
+	legacyOwnershipPredicate := ""
+	keyedConflictPredicate := ""
+	if conflictPolicy == preserveProviderAttachmentConflicts {
+		legacyOwnershipPredicate = " AND source_attachment_id IS NULL"
+		keyedConflictPredicate = " WHERE attachments.source_attachment_id IS NULL"
+	}
+
 	if write.SourcePartKey != "" && write.ContentHash != "" {
 		// Upgrade the pre-provenance row in place when a resync supplies a
 		// stable source occurrence for the same bytes. This preserves its row
@@ -228,11 +248,12 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 			  AND source_part_key IS NULL
 			  AND content_hash = ?
 			  AND attachment_role = 'unknown'
+			  %s
 			  AND NOT EXISTS (
 				SELECT 1 FROM attachments keyed
 				WHERE keyed.message_id = ? AND keyed.source_part_key = ?
 			  )
-		`, s.dialect.JSONBindExpr()),
+		`, s.dialect.JSONBindExpr(), legacyOwnershipPredicate),
 			write.Filename, write.MIMEType, write.StoragePath, write.ContentHash, write.Size,
 			nullIfEmpty(write.SourceAttachmentID), nullIfEmpty(write.MediaType),
 			nullIfZero(write.Width), nullIfZero(write.Height), nullIfZero(write.DurationMS),
@@ -277,7 +298,7 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 		s.dialect.JSONBindExpr(), s.dialect.Now())
 
 	if write.SourcePartKey != "" {
-		_, err := q.Exec(`
+		result, err := q.Exec(`
 			INSERT INTO attachments `+columns+`
 			`+values+`
 			ON CONFLICT (message_id, source_part_key) WHERE source_part_key IS NOT NULL
@@ -297,12 +318,28 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 				role_source = EXCLUDED.role_source,
 				content_id = EXCLUDED.content_id,
 				attachment_state = EXCLUDED.attachment_state,
-				attachment_skip_reason = EXCLUDED.attachment_skip_reason`, args...)
-		return err
+				attachment_skip_reason = EXCLUDED.attachment_skip_reason`+keyedConflictPredicate, args...)
+		if err != nil {
+			return err
+		}
+		if conflictPolicy != preserveProviderAttachmentConflicts {
+			return nil
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("inspect MIME attachment source-part upsert: %w", err)
+		}
+		if rowsAffected == 0 {
+			return fmt.Errorf(
+				"provider-owned attachment source-part collision: message %d part %q",
+				messageID, write.SourcePartKey,
+			)
+		}
+		return nil
 	}
 
 	if write.ContentHash != "" {
-		_, err := q.Exec(`
+		result, err := q.Exec(`
 			INSERT INTO attachments `+columns+`
 			`+values+`
 			ON CONFLICT (message_id, content_hash)
@@ -310,7 +347,33 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 				  AND content_hash IS NOT NULL
 				  AND content_hash != ''
 			DO NOTHING`, args...)
-		return err
+		if err != nil || conflictPolicy != preserveProviderAttachmentConflicts {
+			return err
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("inspect MIME attachment content-hash upsert: %w", err)
+		}
+		if rowsAffected > 0 {
+			return nil
+		}
+		var providerID int64
+		err = q.QueryRow(`
+			SELECT id FROM attachments
+			WHERE message_id = ? AND content_hash = ?
+			  AND source_part_key IS NULL
+			  AND source_attachment_id IS NOT NULL
+		`, messageID, write.ContentHash).Scan(&providerID)
+		if err == nil {
+			return fmt.Errorf(
+				"provider-owned attachment content-hash collision: message %d hash %q",
+				messageID, write.ContentHash,
+			)
+		}
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("inspect MIME attachment content-hash collision: %w", err)
 	}
 
 	var existingID int64
@@ -331,4 +394,30 @@ func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write Attachm
 	}
 	_, err = q.Exec(`INSERT INTO attachments `+columns+` `+values, args...)
 	return err
+}
+
+func (s *Store) replaceMIMEAttachmentsWith(
+	q querier, messageID int64, replacement *[]AttachmentWrite,
+) error {
+	if replacement == nil {
+		return nil
+	}
+	if _, err := q.Exec(`
+		DELETE FROM attachments
+		WHERE message_id = ? AND source_attachment_id IS NULL
+	`, messageID); err != nil {
+		return err
+	}
+	for _, attachment := range *replacement {
+		attachment = attachment.normalized()
+		if err := attachment.validate(); err != nil {
+			return err
+		}
+		if err := s.upsertAttachmentRecordWithPolicy(
+			q, messageID, attachment, preserveProviderAttachmentConflicts,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/store/changed_messages_commit_bound_test.go
+++ b/internal/store/changed_messages_commit_bound_test.go
@@ -586,10 +586,11 @@ func TestListChangedMessages_DeletionRunTombstonesAllArrive(t *testing.T) {
 
 	stop := make(chan struct{})
 	var workers sync.WaitGroup
-
-	workers.Go(func() {
-		consumer.pollInBackground(st, stop, func(int) time.Duration { return 500 * time.Microsecond })
+	stopWorkers := sync.OnceFunc(func() {
+		close(stop)
+		workers.Wait()
 	})
+	t.Cleanup(stopWorkers)
 
 	// Ordinary sync traffic arriving while the deletion run is open. On
 	// PostgreSQL these commit alongside it; on SQLite they queue behind it.
@@ -614,25 +615,36 @@ func TestListChangedMessages_DeletionRunTombstonesAllArrive(t *testing.T) {
 		}
 	})
 
-	// The deletion list streams in, which is why the transaction outlives the
-	// consumer's poll interval.
+	// The deletion list streams in. Keep its reader open after every doomed ID
+	// has been processed so the transaction is provably still uncommitted when
+	// the consumer reads the bound.
 	reader, writer := io.Pipe()
+	t.Cleanup(func() { _ = writer.Close() })
+	markDone := make(chan error, 1)
 	go func() {
-		for i := range doomedCount {
-			_, _ = fmt.Fprintf(writer, "doomed-%d\n", i)
-			time.Sleep(5 * time.Millisecond)
-		}
-		_ = writer.Close()
+		markDone <- st.MarkMessagesDeletedFromReader(src.ID, reader, 4)
 	}()
-	// Record complete_through on every page read while the deletion transaction
-	// is open. Everything it stamps is uncommitted for the whole of this call.
-	consumer.watchBounds(func() {
-		require.NoError(st.MarkMessagesDeletedFromReader(src.ID, reader, 4),
-			"MarkMessagesDeletedFromReader")
-	})
+	for i := range doomedCount {
+		_, err := fmt.Fprintf(writer, "doomed-%d\n", i)
+		require.NoError(err, "stream a doomed message ID")
+	}
+	// This partial token is read only after Scanner has returned and the store
+	// has flushed the preceding complete token. With no newline or EOF, the
+	// next Scan remains blocked here and keeps the transaction open.
+	_, err = io.WriteString(writer, "hold-open")
+	require.NoError(err, "hold the deletion stream open")
 
-	close(stop)
-	workers.Wait()
+	// Record a bound from a page that completed while the deletion transaction
+	// was still open. Recording until MarkMessagesDeletedFromReader returned
+	// also included polls that acquired SQLite's write lock just after COMMIT,
+	// which made the old test mistake a valid post-commit bound for a violation.
+	consumer.watchBounds(func() {
+		consumer.mustPoll(t, st)
+	})
+	require.NoError(writer.Close(), "finish the deletion stream")
+	require.NoError(<-markDone, "MarkMessagesDeletedFromReader")
+
+	stopWorkers()
 	require.NoError(consumer.failure, "a background worker failed")
 
 	missing := func() []int64 {

--- a/internal/store/gmail_audit_snapshot_test.go
+++ b/internal/store/gmail_audit_snapshot_test.go
@@ -1,0 +1,371 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/sqliteutil"
+)
+
+// gmailAuditSnapshotGateKey arms the driver-boundary gate for exactly one
+// page load. Queries issued with a context carrying the gate pause before the
+// first statement that binds the target message ID executes — the point where
+// the page load is about to touch the second record's rows.
+type gmailAuditSnapshotGateKey struct{}
+
+type gmailAuditSnapshotGate struct {
+	targetID    int64
+	pauseOnce   sync.Once
+	releaseOnce sync.Once
+	paused      chan struct{}
+	release     chan struct{}
+}
+
+func newGmailAuditSnapshotGate(targetID int64) *gmailAuditSnapshotGate {
+	return &gmailAuditSnapshotGate{
+		targetID: targetID,
+		paused:   make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+// hold blocks before the gated statement executes. Only the first matching
+// statement pauses; later ones run through so the page load can finish.
+func (g *gmailAuditSnapshotGate) hold(ctx context.Context) error {
+	var waiting bool
+	g.pauseOnce.Do(func() {
+		waiting = true
+		close(g.paused)
+	})
+	if !waiting {
+		return nil
+	}
+	select {
+	case <-g.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g *gmailAuditSnapshotGate) resume() {
+	g.releaseOnce.Do(func() { close(g.release) })
+}
+
+// gatesTargetQuery reports whether the statement binds the target message ID.
+// A joined page query binds every page ID and a per-record query binds the
+// one record it loads, so both shapes of the evidence load are observable
+// with a single matcher.
+func (g *gmailAuditSnapshotGate) gatesTargetQuery(args []driver.NamedValue) bool {
+	for _, arg := range args {
+		if value, ok := arg.Value.(int64); ok && value == g.targetID {
+			return true
+		}
+	}
+	return false
+}
+
+type gmailAuditSnapshotConnector struct {
+	driver.Connector
+
+	gate *gmailAuditSnapshotGate
+}
+
+func (c *gmailAuditSnapshotConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.Connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &gmailAuditSnapshotConn{Conn: conn, gate: c.gate}, nil
+}
+
+type gmailAuditSnapshotConn struct {
+	driver.Conn
+
+	gate *gmailAuditSnapshotGate
+}
+
+func (c *gmailAuditSnapshotConn) QueryContext(
+	ctx context.Context, query string, args []driver.NamedValue,
+) (driver.Rows, error) {
+	queryer, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	if gate, armed := ctx.Value(gmailAuditSnapshotGateKey{}).(*gmailAuditSnapshotGate); armed &&
+		gate == c.gate && gate.gatesTargetQuery(args) {
+		if err := gate.hold(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return queryer.QueryContext(ctx, query, args)
+}
+
+func (c *gmailAuditSnapshotConn) ExecContext(
+	ctx context.Context, query string, args []driver.NamedValue,
+) (driver.Result, error) {
+	if execer, ok := c.Conn.(driver.ExecerContext); ok {
+		return execer.ExecContext(ctx, query, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (c *gmailAuditSnapshotConn) PrepareContext(
+	ctx context.Context, query string,
+) (driver.Stmt, error) {
+	if preparer, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return preparer.PrepareContext(ctx, query)
+	}
+	return c.Prepare(query)
+}
+
+func (c *gmailAuditSnapshotConn) BeginTx(
+	ctx context.Context, opts driver.TxOptions,
+) (driver.Tx, error) {
+	if beginner, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return beginner.BeginTx(ctx, opts)
+	}
+	return nil, errors.New("wrapped Gmail audit snapshot connection does not implement ConnBeginTx")
+}
+
+func (c *gmailAuditSnapshotConn) Ping(ctx context.Context) error {
+	if pinger, ok := c.Conn.(driver.Pinger); ok {
+		return pinger.Ping(ctx)
+	}
+	return nil
+}
+
+func (c *gmailAuditSnapshotConn) ResetSession(ctx context.Context) error {
+	if resetter, ok := c.Conn.(driver.SessionResetter); ok {
+		return resetter.ResetSession(ctx)
+	}
+	return nil
+}
+
+func (c *gmailAuditSnapshotConn) IsValid() bool {
+	if validator, ok := c.Conn.(driver.Validator); ok {
+		return validator.IsValid()
+	}
+	return true
+}
+
+func (c *gmailAuditSnapshotConn) CheckNamedValue(value *driver.NamedValue) error {
+	if checker, ok := c.Conn.(driver.NamedValueChecker); ok {
+		return checker.CheckNamedValue(value)
+	}
+	return driver.ErrSkip
+}
+
+type gmailAuditSnapshotSQLiteConnector struct {
+	driver driver.Driver
+	dsn    string
+}
+
+func (c *gmailAuditSnapshotSQLiteConnector) Connect(context.Context) (driver.Conn, error) {
+	return c.driver.Open(c.dsn)
+}
+
+func (c *gmailAuditSnapshotSQLiteConnector) Driver() driver.Driver { return c.driver }
+
+func newGmailAuditSnapshotSQLiteStore(
+	t *testing.T, gate *gmailAuditSnapshotGate,
+) *Store {
+	t.Helper()
+	require := require.New(t)
+	sqliteDriver := &sqlite3.SQLiteDriver{ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+		return conn.RegisterFunc(sqliteutil.UnicodeLowerFunction, strings.ToLower, true)
+	}}
+	base := &gmailAuditSnapshotSQLiteConnector{
+		driver: sqliteDriver,
+		dsn:    filepath.Join(t.TempDir(), "gmail-audit-snapshot.db") + testSQLiteParams,
+	}
+	db := sql.OpenDB(&gmailAuditSnapshotConnector{Connector: base, gate: gate})
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(4)
+	dialect := &SQLiteDialect{}
+	st := &Store{db: newLoggedDB(db, dialect.Rebind), dbPath: base.dsn, dialect: dialect}
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchemaContext(t.Context()))
+	return st
+}
+
+func newGmailAuditSnapshotPostgresStore(
+	t *testing.T, dbURL string, gate *gmailAuditSnapshotGate,
+) *Store {
+	t.Helper()
+	require := require.New(t)
+	schemaName := fmt.Sprintf("msgvault_test_gmail_audit_snapshot_%d", time.Now().UnixNano())
+	admin, err := sql.Open("pgx", dbURL)
+	require.NoError(err)
+	t.Cleanup(func() { _ = admin.Close() })
+	_, err = admin.ExecContext(t.Context(), "CREATE SCHEMA "+schemaName)
+	require.NoError(err)
+	t.Cleanup(func() {
+		_, _ = admin.ExecContext(context.Background(), "DROP SCHEMA "+schemaName+" CASCADE")
+	})
+
+	separator := "?"
+	if strings.Contains(dbURL, "?") {
+		separator = "&"
+	}
+	testURL := dbURL + separator + "search_path=" + schemaName
+	config, err := postgresConnConfig(testURL, false)
+	require.NoError(err)
+	db := sql.OpenDB(&gmailAuditSnapshotConnector{
+		Connector: stdlib.GetConnector(*config), gate: gate,
+	})
+	db.SetMaxOpenConns(8)
+	db.SetMaxIdleConns(4)
+	dialect := &PostgreSQLDialect{}
+	require.NoError(dialect.InitConn(db))
+	st := &Store{db: newLoggedDB(db, dialect.Rebind), dbPath: testURL, dialect: dialect}
+	t.Cleanup(func() { _ = st.Close() })
+	require.NoError(st.InitSchemaContext(t.Context()))
+	return st
+}
+
+func seedGmailAuditSnapshotMessage(
+	t *testing.T, st *Store, sourceID int64, sourceMessageID, fromAddress string,
+) int64 {
+	t.Helper()
+	require := require.New(t)
+	conversationID, err := st.EnsureConversation(sourceID, "thread-"+sourceMessageID, sourceMessageID)
+	require.NoError(err)
+	participantID, err := st.EnsureParticipant(fromAddress, "Snapshot Sender", "example.test")
+	require.NoError(err)
+	id, err := st.PersistMessage(&MessagePersistData{
+		Message: &Message{
+			ConversationID:  conversationID,
+			SourceID:        sourceID,
+			SourceMessageID: sourceMessageID,
+			MessageType:     MessageTypeEmail,
+			Subject:         sql.NullString{String: sourceMessageID, Valid: true},
+			SenderID:        sql.NullInt64{Int64: participantID, Valid: true},
+		},
+		RawMIME: []byte("raw-" + sourceMessageID),
+		Recipients: []RecipientSet{{
+			Type: "from", ParticipantIDs: []int64{participantID},
+			EmailAddresses: []string{fromAddress},
+		}},
+	})
+	require.NoError(err)
+	return id
+}
+
+func gmailAuditRecipientAddress(evidence GmailAuditEvidence, recipientType string) string {
+	for _, recipient := range evidence.Recipients {
+		if recipient.Type == recipientType && recipient.EmailAddress.Valid {
+			return recipient.EmailAddress.String
+		}
+	}
+	return ""
+}
+
+// TestGmailAuditEvidencePageReadsOneCoherentSnapshot observes the production
+// page load at the real driver boundary (SQLite here; the same test runs on
+// PostgreSQL when MSGVAULT_TEST_DB points at one). The gate pauses the page
+// load right before the first statement touching the second record's rows;
+// a concurrent repair commit lands in that window. One page must then read
+// every record from the snapshot its first statement established — a
+// committed rewrite must not split the page across two database states.
+func TestGmailAuditEvidencePageReadsOneCoherentSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	gate := newGmailAuditSnapshotGate(0)
+	dbURL := os.Getenv("MSGVAULT_TEST_DB")
+	var st *Store
+	if IsPostgresURL(dbURL) {
+		st = newGmailAuditSnapshotPostgresStore(t, dbURL, gate)
+	} else {
+		st = newGmailAuditSnapshotSQLiteStore(t, gate)
+	}
+	source, err := st.GetOrCreateSource("gmail", "snapshot-audit@example.test")
+	require.NoError(err)
+	firstID := seedGmailAuditSnapshotMessage(t, st, source.ID, "snapshot-a", "first-sender@example.test")
+	secondID := seedGmailAuditSnapshotMessage(t, st, source.ID, "snapshot-b", "second-sender@example.test")
+	require.Less(firstID, secondID)
+	// Arm the pre-created gate only now: the target ID is read by the gated
+	// goroutine, which has not started yet.
+	gate.targetID = secondID
+
+	type pageResult struct {
+		evidence []GmailAuditEvidence
+		pageSize int
+		err      error
+	}
+	done := make(chan pageResult, 1)
+	ctx, cancel := context.WithTimeout(
+		context.WithValue(t.Context(), gmailAuditSnapshotGateKey{}, gate), 15*time.Second,
+	)
+	defer cancel()
+	var delivered []GmailAuditEvidence
+	go func() {
+		pageSize, pageErr := st.StreamGmailAuditEvidencePageContext(
+			ctx, source.ID, 0, 100, func(record GmailAuditEvidence) error {
+				delivered = append(delivered, record)
+				return nil
+			})
+		done <- pageResult{evidence: delivered, pageSize: pageSize, err: pageErr}
+	}()
+
+	select {
+	case <-gate.paused:
+	case <-time.After(10 * time.Second):
+		require.FailNow("page load never reached the second record's rows")
+	}
+	// The page had to touch the second record's rows, so the first record
+	// must already have been delivered to the audit consumer and released —
+	// one page never materializes more than one message's evidence.
+	require.Len(delivered, 1,
+		"each evidence record must be delivered before the next record's rows load")
+	assert.Equal(firstID, delivered[0].ID)
+
+	// The concurrent-repair stand-in: rewrite the second message's envelope
+	// while the page load is between its records, then commit on another
+	// connection.
+	_, err = st.DB().ExecContext( //nolint:gosec // The SQL is static; Rebind only changes placeholders.
+		t.Context(), st.Rebind(`
+		UPDATE message_recipients SET email_address = 'rewritten-sender@example.test'
+		WHERE message_id = ? AND recipient_type = 'from'
+	`), secondID)
+	require.NoError(err)
+	gate.resume()
+
+	var page pageResult
+	select {
+	case page = <-done:
+	case <-time.After(10 * time.Second):
+		require.FailNow("page load did not finish after the concurrent commit")
+	}
+	require.NoError(page.err)
+	require.Equal(2, page.pageSize,
+		"the keyset page size must count selected IDs so pagination stays exact")
+	require.Len(page.evidence, 2)
+	assert.Equal(firstID, page.evidence[0].ID)
+	assert.Equal(secondID, page.evidence[1].ID)
+	assert.Equal("second-sender@example.test", gmailAuditRecipientAddress(page.evidence[1], "from"),
+		"one page must read every record from one snapshot; a concurrently committed rewrite must not split it")
+
+	// The rewrite really committed: a fresh read outside the page observes it,
+	// so the assertion above proves snapshot coherence, not a lost write.
+	var committed string
+	require.NoError(st.DB().QueryRowContext( //nolint:gosec // The SQL is static; Rebind only changes placeholders.
+		t.Context(), st.Rebind(`
+		SELECT email_address FROM message_recipients
+		WHERE message_id = ? AND recipient_type = 'from'
+	`), secondID).Scan(&committed))
+	assert.Equal("rewritten-sender@example.test", committed)
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -74,22 +75,309 @@ type ParticipantPersistData struct {
 // MessagePersistData bundles everything needed to atomically
 // persist a message and its related rows in a single transaction.
 type MessagePersistData struct {
-	Message        *Message
-	Conversation   *ConversationPersistData
-	Metadata       *sql.NullString
-	BodyText       sql.NullString
-	BodyHTML       sql.NullString
-	RawMIME        []byte
-	RawFormat      string
-	Recipients     []RecipientSet
-	LabelIDs       []int64
-	PreserveLabels bool
-	FTS            *FTSDoc
+	Message                   *Message
+	Conversation              *ConversationPersistData
+	Metadata                  *sql.NullString
+	BodyText                  sql.NullString
+	BodyHTML                  sql.NullString
+	RawMIME                   []byte
+	RawFormat                 string
+	Recipients                []RecipientSet
+	LabelIDs                  []int64
+	LabelRefs                 []MessageLabelRef
+	PreserveLabels            bool
+	MIMEAttachmentReplacement *[]AttachmentWrite
+	FTS                       *FTSDoc
+}
+
+// MessageIdentityGuard binds repair persistence to the exact archive row that
+// was resolved before provider fetch and snapshot preparation.
+type MessageIdentityGuard struct {
+	ID              int64
+	SourceID        int64
+	SourceMessageID string
+}
+
+// RepairMessageTarget is one archive identity matched by a repair reference.
+// Callers decide whether multiple rows make the user-supplied reference
+// ambiguous before making any provider request.
+type RepairMessageTarget struct {
+	MessageIdentityGuard
+
+	SourceType       string
+	SourceIdentifier string
+}
+
+// GmailAuditRecipient is immutable envelope evidence for one archived row.
+type GmailAuditRecipient struct {
+	Type         string
+	EmailAddress sql.NullString
+}
+
+// GmailAuditAttachment is MIME-owned attachment evidence. Provider-owned
+// rows are deliberately excluded by StreamGmailAuditEvidencePageContext.
+type GmailAuditAttachment struct {
+	ContentHash   sql.NullString
+	SourcePartKey sql.NullString
+}
+
+// GmailAuditEvidence contains the stored fields independently derivable from
+// raw MIME. SenderID is intentionally absent because participant merges may
+// rewrite it.
+type GmailAuditEvidence struct {
+	ID              int64
+	SourceID        int64
+	SourceMessageID string
+	RFC822MessageID sql.NullString
+	Subject         sql.NullString
+	BodyText        sql.NullString
+	BodyHTML        sql.NullString
+	RawMIME         []byte
+	RawMIMEPresent  bool
+	RawMIMEError    string
+	Recipients      []GmailAuditRecipient
+	Attachments     []GmailAuditAttachment
+}
+
+// FindRepairMessageTargetsContext applies both interpretations of a repair
+// reference: provider message ID always, and internal ID when the reference is
+// a positive decimal integer. sourceID zero means no source scope.
+func (s *Store) FindRepairMessageTargetsContext(
+	ctx context.Context, reference string, sourceID int64,
+) ([]RepairMessageTarget, error) {
+	internalID := int64(-1)
+	if parsed, err := strconv.ParseInt(reference, 10, 64); err == nil && parsed > 0 {
+		internalID = parsed
+	}
+	rows, err := s.db.QueryContext(ctx, s.Rebind(`
+		SELECT m.id, m.source_id, m.source_message_id, src.source_type, src.identifier
+		FROM messages m
+		JOIN sources src ON src.id = m.source_id
+		WHERE (m.source_message_id = ? OR m.id = ?)
+		  AND (? = 0 OR m.source_id = ?)
+		ORDER BY m.id
+	`), reference, internalID, sourceID, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("find repair message targets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var targets []RepairMessageTarget
+	for rows.Next() {
+		var target RepairMessageTarget
+		if err := rows.Scan(
+			&target.ID, &target.SourceID, &target.SourceMessageID,
+			&target.SourceType, &target.SourceIdentifier,
+		); err != nil {
+			return nil, fmt.Errorf("scan repair message target: %w", err)
+		}
+		targets = append(targets, target)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate repair message targets: %w", err)
+	}
+	return targets, nil
+}
+
+// GmailAuditMaxRawMIMEBytes bounds how much stored raw MIME one Gmail audit
+// evidence record may decompress to. A record above the cap is reported as
+// inconclusive (RawMIMEError) instead of being fully materialized: raw
+// storage has no size limit, so unbounded decompression of one record — let
+// alone a whole page of them — could exhaust memory on a corrupt or hostile
+// archive.
+const GmailAuditMaxRawMIMEBytes = 64 << 20
+
+var errGmailAuditRawMIMETooLarge = fmt.Errorf(
+	"stored raw MIME exceeds the %d-byte Gmail audit decompression limit", int64(GmailAuditMaxRawMIMEBytes))
+
+// StreamGmailAuditEvidencePageContext loads one ascending internal-ID keyset
+// page of Gmail audit evidence and streams each record to handle. The keyset
+// page query stays lightweight — it selects only internal IDs — and the ID
+// page plus every per-record load (message row, body, raw MIME, recipients,
+// MIME-owned attachments) run inside one read snapshot spanning the whole
+// page, so a concurrently committed repair can never split one page across
+// two database states. Only one record is materialized at a time: handle
+// receives and may release each record before the next one loads, and raw
+// decompression is bounded by GmailAuditMaxRawMIMEBytes, so peak memory
+// tracks one message rather than the page size. It returns the number of IDs
+// the keyset page selected (not the number of records handle accepted).
+// Every query is read-only; sourceID zero audits all Gmail sources.
+func (s *Store) StreamGmailAuditEvidencePageContext(
+	ctx context.Context, sourceID, afterID int64, limit int,
+	handle func(GmailAuditEvidence) error,
+) (int, error) {
+	if limit <= 0 {
+		return 0, errors.New("gmail audit page limit must be positive")
+	}
+	if handle == nil {
+		return 0, errors.New("gmail audit evidence handler is required")
+	}
+	pageSize := 0
+	err := s.withReadSnapshotContext(ctx, func(tx *loggedTx) error {
+		ids, err := s.gmailAuditPageIDsTx(ctx, tx, sourceID, afterID, limit)
+		if err != nil {
+			return err
+		}
+		for _, id := range ids {
+			evidence, err := s.loadGmailAuditEvidenceTx(ctx, tx, id)
+			if err != nil {
+				return err
+			}
+			if err := handle(evidence); err != nil {
+				return err
+			}
+		}
+		pageSize = len(ids)
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return pageSize, nil
+}
+
+// gmailAuditPageIDsTx selects one ascending internal-ID keyset page of Gmail
+// messages. It reads only the messages.id column so the page query itself
+// never materializes bodies or raw MIME.
+func (s *Store) gmailAuditPageIDsTx(
+	ctx context.Context, tx *loggedTx, sourceID, afterID int64, limit int,
+) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT m.id
+		FROM messages m
+		JOIN sources src ON src.id = m.source_id AND src.source_type = 'gmail'
+		WHERE m.id > ? AND (? = 0 OR m.source_id = ?)
+		ORDER BY m.id
+		LIMIT ?
+	`, afterID, sourceID, sourceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list Gmail audit evidence: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	ids := make([]int64, 0, limit)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan Gmail audit evidence ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate Gmail audit evidence: %w", err)
+	}
+	return ids, nil
+}
+
+// loadGmailAuditEvidenceTx loads one message's full evidence record — message
+// row, body, raw MIME, recipients, and MIME-owned attachments — on the
+// snapshot transaction the page shares.
+func (s *Store) loadGmailAuditEvidenceTx(
+	ctx context.Context, tx *loggedTx, id int64,
+) (GmailAuditEvidence, error) {
+	var item GmailAuditEvidence
+	var rawMessageID sql.NullInt64
+	var compressed []byte
+	var rawFormat sql.NullString
+	var compression sql.NullString
+	err := tx.QueryRowContext(ctx, `
+		SELECT m.id, m.source_id, m.source_message_id, m.rfc822_message_id,
+		       m.subject, mb.body_text, mb.body_html,
+		       mr.message_id, mr.raw_data, mr.raw_format, mr.compression
+		FROM messages m
+		LEFT JOIN message_bodies mb ON mb.message_id = m.id
+		LEFT JOIN message_raw mr ON mr.message_id = m.id
+		WHERE m.id = ?
+	`, id).Scan(
+		&item.ID, &item.SourceID, &item.SourceMessageID,
+		&item.RFC822MessageID, &item.Subject, &item.BodyText, &item.BodyHTML,
+		&rawMessageID, &compressed, &rawFormat, &compression,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return item, fmt.Errorf("gmail audit evidence %d vanished inside the page snapshot", id)
+	}
+	if err != nil {
+		return item, fmt.Errorf("scan Gmail audit evidence: %w", err)
+	}
+	item.RawMIMEPresent = rawMessageID.Valid
+	if item.RawMIMEPresent {
+		if !rawFormat.Valid || rawFormat.String != "mime" {
+			item.RawMIMEError = fmt.Sprintf("stored raw format %q is not MIME", rawFormat.String)
+		} else {
+			raw, _, decodeErr := decodeMessageRawBounded(
+				compressed, compression, GmailAuditMaxRawMIMEBytes, errGmailAuditRawMIMETooLarge)
+			if decodeErr != nil {
+				item.RawMIMEError = fmt.Sprintf("decode stored raw MIME: %v", decodeErr)
+			} else {
+				item.RawMIME = raw
+			}
+		}
+	}
+
+	recipientRows, err := tx.QueryContext(ctx, `
+		SELECT recipient_type, email_address
+		FROM message_recipients
+		WHERE message_id = ?
+		ORDER BY recipient_type, id
+	`, id)
+	if err != nil {
+		return item, fmt.Errorf("list Gmail audit recipients: %w", err)
+	}
+	for recipientRows.Next() {
+		var recipient GmailAuditRecipient
+		if err := recipientRows.Scan(&recipient.Type, &recipient.EmailAddress); err != nil {
+			_ = recipientRows.Close()
+			return item, fmt.Errorf("scan Gmail audit recipient: %w", err)
+		}
+		item.Recipients = append(item.Recipients, recipient)
+	}
+	if err := recipientRows.Err(); err != nil {
+		_ = recipientRows.Close()
+		return item, fmt.Errorf("iterate Gmail audit recipients: %w", err)
+	}
+	if err := recipientRows.Close(); err != nil {
+		return item, fmt.Errorf("close Gmail audit recipients: %w", err)
+	}
+
+	attachmentRows, err := tx.QueryContext(ctx, `
+		SELECT content_hash, source_part_key
+		FROM attachments
+		WHERE message_id = ? AND source_attachment_id IS NULL
+		ORDER BY id
+	`, id)
+	if err != nil {
+		return item, fmt.Errorf("list Gmail audit attachments: %w", err)
+	}
+	for attachmentRows.Next() {
+		var attachment GmailAuditAttachment
+		if err := attachmentRows.Scan(&attachment.ContentHash, &attachment.SourcePartKey); err != nil {
+			_ = attachmentRows.Close()
+			return item, fmt.Errorf("scan Gmail audit attachment: %w", err)
+		}
+		item.Attachments = append(item.Attachments, attachment)
+	}
+	if err := attachmentRows.Err(); err != nil {
+		_ = attachmentRows.Close()
+		return item, fmt.Errorf("iterate Gmail audit attachments: %w", err)
+	}
+	if err := attachmentRows.Close(); err != nil {
+		return item, fmt.Errorf("close Gmail audit attachments: %w", err)
+	}
+	return item, nil
+}
+
+// MessageLabelRef carries provider label identity and its current descriptor
+// so repair can resolve the label catalog in the message transaction.
+type MessageLabelRef struct {
+	SourceLabelID string
+	Info          LabelInfo
 }
 
 // ConversationPersistData optionally makes conversation identity, title, and
 // membership part of PersistMessage's transaction. When absent, PersistMessage
-// uses Message.ConversationID as before.
+// uses Message.ConversationID as before. A nil Participants slice carries no
+// membership snapshot, so existing conversation membership is preserved; a
+// non-nil slice — empty or not — authoritatively replaces the roster.
 type ConversationPersistData struct {
 	SourceConversationID string
 	ConversationType     string
@@ -1459,10 +1747,108 @@ func (s *Store) PersistMessageWithParticipantsContext(
 	return s.persistMessageWithParticipantsContext(ctx, participants, build)
 }
 
+// PersistRepairMessageWithParticipantsContext atomically replaces one
+// provider-authoritative message snapshot after revalidating the exact archive
+// identity. A nil MIMEAttachmentReplacement preserves current attachment rows;
+// a non-nil empty replacement removes every MIME-owned row and keeps rows with
+// provider source_attachment_id provenance.
+func (s *Store) PersistRepairMessageWithParticipantsContext(
+	ctx context.Context,
+	expected MessageIdentityGuard,
+	participants []ParticipantPersistData,
+	build func(participantIDs []int64) *MessagePersistData,
+) (int64, error) {
+	if build == nil {
+		return 0, errors.New("persist repair message requires a participant builder")
+	}
+	beforeParticipants := func(ctx context.Context, tx *loggedTx) error {
+		var actual MessageIdentityGuard
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, source_id, source_message_id
+			FROM messages WHERE id = ?`+s.dialect.SelectForUpdate(), expected.ID,
+		).Scan(&actual.ID, &actual.SourceID, &actual.SourceMessageID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("repair message identity guard mismatch: target id %d not found", expected.ID)
+		}
+		if err != nil {
+			return fmt.Errorf("read repair message identity guard: %w", err)
+		}
+		if actual != expected {
+			return fmt.Errorf(
+				"repair message identity guard mismatch: expected (%d, %d, %q), found (%d, %d, %q)",
+				expected.ID, expected.SourceID, expected.SourceMessageID,
+				actual.ID, actual.SourceID, actual.SourceMessageID,
+			)
+		}
+		return nil
+	}
+	prepare := func(ctx context.Context, tx *loggedTx, data *MessagePersistData) (*MessagePersistData, error) {
+		if data == nil || data.Message == nil {
+			return nil, errors.New("persist repair message requires a message")
+		}
+		if data.Message.SourceID != expected.SourceID ||
+			data.Message.SourceMessageID != expected.SourceMessageID {
+			return nil, fmt.Errorf(
+				"repair message snapshot identity mismatch: expected source (%d, %q), got (%d, %q)",
+				expected.SourceID, expected.SourceMessageID,
+				data.Message.SourceID, data.Message.SourceMessageID,
+			)
+		}
+		labelIDs, err := ensureMessageLabelRefsWith(
+			boundQuerier{ctx: ctx, q: tx}, expected.SourceID, data.LabelRefs,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("resolve repair message labels: %w", err)
+		}
+		prepared := *data
+		prepared.LabelIDs = labelIDs
+		prepared.PreserveLabels = false
+		return &prepared, nil
+	}
+	afterPersist := func(ctx context.Context, tx *loggedTx, data *MessagePersistData, messageID int64) error {
+		if messageID != expected.ID {
+			return fmt.Errorf(
+				"repair message identity guard mismatch: persistence returned id %d, expected %d",
+				messageID, expected.ID,
+			)
+		}
+		q := boundQuerier{ctx: ctx, q: tx}
+		if err := s.replaceMIMEAttachmentsWith(q, messageID, data.MIMEAttachmentReplacement); err != nil {
+			return fmt.Errorf("replace repair message attachments: %w", err)
+		}
+		if err := recomputeMessageAttachmentStatsWith(q, messageID); err != nil {
+			return fmt.Errorf("recompute repair message attachment stats: %w", err)
+		}
+		return nil
+	}
+	messageID, err := s.persistMessageWithParticipantsTransaction(
+		ctx, beforeParticipants, participants, build, prepare, afterPersist,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return messageID, nil
+}
+
 func (s *Store) persistMessageWithParticipantsContext(
 	ctx context.Context,
 	participants []ParticipantPersistData,
 	build func(participantIDs []int64) *MessagePersistData,
+) (int64, error) {
+	return s.persistMessageWithParticipantsTransaction(ctx, nil, participants, build, nil, nil)
+}
+
+type messagePersistBeforeParticipants func(context.Context, *loggedTx) error
+type messagePersistPrepare func(context.Context, *loggedTx, *MessagePersistData) (*MessagePersistData, error)
+type messagePersistAfter func(context.Context, *loggedTx, *MessagePersistData, int64) error
+
+func (s *Store) persistMessageWithParticipantsTransaction(
+	ctx context.Context,
+	beforeParticipants messagePersistBeforeParticipants,
+	participants []ParticipantPersistData,
+	build func(participantIDs []int64) *MessagePersistData,
+	prepare messagePersistPrepare,
+	afterPersist messagePersistAfter,
 ) (int64, error) {
 	var messageID int64
 	err := s.withTxContext(ctx, func(tx *loggedTx) error {
@@ -1475,7 +1861,15 @@ func (s *Store) persistMessageWithParticipantsContext(
 			}
 		}
 		if len(participants) > 1 {
+			// Participant merges take the directory lock before rewriting
+			// message rows. Keep the same order when a repair's preflight
+			// callback locks its target message for identity revalidation.
 			if err := s.lockParticipantDirectoryMutationTxContext(ctx, tx); err != nil {
+				return err
+			}
+		}
+		if beforeParticipants != nil {
+			if err := beforeParticipants(ctx, tx); err != nil {
 				return err
 			}
 		}
@@ -1515,12 +1909,24 @@ func (s *Store) persistMessageWithParticipantsContext(
 		if data == nil || data.Message == nil {
 			return errors.New("persist message requires a message")
 		}
+		if prepare != nil {
+			var err error
+			data, err = prepare(ctx, tx, data)
+			if err != nil {
+				return err
+			}
+		}
 		if err := s.requireSyncSource(data.Message.SourceID); err != nil {
 			return err
 		}
 		id, err := s.persistMessageWith(ctx, tx, data)
 		if err != nil {
 			return err
+		}
+		if afterPersist != nil {
+			if err := afterPersist(ctx, tx, data, id); err != nil {
+				return err
+			}
 		}
 		messageID = id
 		return nil
@@ -1548,10 +1954,12 @@ func (s *Store) persistMessageWith(
 		if err != nil {
 			return 0, fmt.Errorf("ensure conversation: %w", err)
 		}
-		if err := replaceConversationParticipantsTx(
-			ctx, tx, s.dialect, conversationID, data.Conversation.Participants,
-		); err != nil {
-			return 0, fmt.Errorf("replace conversation participants: %w", err)
+		if data.Conversation.Participants != nil {
+			if err := replaceConversationParticipantsTx(
+				ctx, tx, s.dialect, conversationID, data.Conversation.Participants,
+			); err != nil {
+				return 0, fmt.Errorf("replace conversation participants: %w", err)
+			}
 		}
 		messageCopy := *data.Message
 		messageCopy.ConversationID = conversationID
@@ -2093,62 +2501,82 @@ func IsSystemLabel(sourceLabelID string) bool {
 func (s *Store) EnsureLabelsBatch(
 	sourceID int64, labels map[string]LabelInfo,
 ) (map[string]int64, error) {
-	result := make(map[string]int64, len(labels))
+	var result map[string]int64
 	err := s.withTx(func(tx *loggedTx) error {
-		// Phase 1: Move all renamed labels to temporary names so
-		// that cross-renames don't cause one label to incorrectly
-		// merge the other. Temp names embed the row PK (unique by
-		// construction within this source_id) and a SOH (U+0001)
-		// prefix that real Gmail label names cannot contain — Gmail's
-		// UI rejects control characters, so the temp name cannot
-		// collide with any real label name in the same source. The
-		// SQLite-only X'00' hex literal that previously played this
-		// role is not portable: PostgreSQL doesn't parse X'00' and
-		// PG TEXT rejects embedded NUL bytes outright, so we build
-		// the sentinel in Go and bind it as a parameter.
-		for sourceLabelID, info := range labels {
-			var id int64
-			var curName string
-			err := tx.QueryRow(`
-				SELECT id, name FROM labels
-				WHERE source_id = ? AND source_label_id = ?
-			`, sourceID, sourceLabelID).Scan(&id, &curName)
-			if errors.Is(err, sql.ErrNoRows) || curName == info.Name {
-				continue
-			}
-			if err != nil {
-				return fmt.Errorf(
-					"check label %s: %w", sourceLabelID, err,
-				)
-			}
-			tempName := fmt.Sprintf("\x01__msgvault_pending_rename__%d", id)
-			if _, err = tx.Exec(`
-				UPDATE labels SET name = ? WHERE id = ?
-			`, tempName, id); err != nil {
-				return fmt.Errorf(
-					"clear name for label %s: %w", sourceLabelID, err,
-				)
-			}
-		}
-
-		// Phase 2: Apply final names. After phase 1 any remaining
-		// name conflict is from a label NOT in this batch, which
-		// is safe to merge (dead/imported label).
-		for sourceLabelID, info := range labels {
-			id, err := ensureLabelWith(
-				tx, sourceID, sourceLabelID, info.Name, info.Type, &info.SystemRole,
-			)
-			if err != nil {
-				return err
-			}
-			result[sourceLabelID] = id
-		}
-		return nil
+		var err error
+		result, err = ensureLabelsBatchWith(tx, sourceID, labels)
+		return err
 	})
 	if err != nil {
 		return nil, err
 	}
 	return result, nil
+}
+
+func ensureLabelsBatchWith(
+	q querier, sourceID int64, labels map[string]LabelInfo,
+) (map[string]int64, error) {
+	result := make(map[string]int64, len(labels))
+	// Phase 1: Move all renamed labels to temporary names so that cross-renames
+	// do not merge labels that are both present in this snapshot.
+	for sourceLabelID, info := range labels {
+		var id int64
+		var curName string
+		err := q.QueryRow(`
+			SELECT id, name FROM labels
+			WHERE source_id = ? AND source_label_id = ?
+		`, sourceID, sourceLabelID).Scan(&id, &curName)
+		if errors.Is(err, sql.ErrNoRows) || curName == info.Name {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("check label %s: %w", sourceLabelID, err)
+		}
+		tempName := fmt.Sprintf("\x01__msgvault_pending_rename__%d", id)
+		if _, err = q.Exec(`UPDATE labels SET name = ? WHERE id = ?`, tempName, id); err != nil {
+			return nil, fmt.Errorf("clear name for label %s: %w", sourceLabelID, err)
+		}
+	}
+
+	// Phase 2: Apply final descriptors. Any remaining name conflict belongs to
+	// a label outside this snapshot and is safe for ensureLabelWith to merge.
+	for sourceLabelID, info := range labels {
+		id, err := ensureLabelWith(
+			q, sourceID, sourceLabelID, info.Name, info.Type, &info.SystemRole,
+		)
+		if err != nil {
+			return nil, err
+		}
+		result[sourceLabelID] = id
+	}
+	return result, nil
+}
+
+func ensureMessageLabelRefsWith(
+	q querier, sourceID int64, refs []MessageLabelRef,
+) ([]int64, error) {
+	labels := make(map[string]LabelInfo, len(refs))
+	for _, ref := range refs {
+		if ref.SourceLabelID == "" {
+			return nil, errors.New("message label reference requires a source label ID")
+		}
+		labels[ref.SourceLabelID] = ref.Info
+	}
+	resolved, err := ensureLabelsBatchWith(q, sourceID, labels)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(refs))
+	seen := make(map[int64]struct{}, len(refs))
+	for _, ref := range refs {
+		id := resolved[ref.SourceLabelID]
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 // ReplaceMessageLabels replaces all labels for a message atomically.
@@ -4824,18 +5252,22 @@ func (s *Store) RecomputeMessageAttachmentStats(messageID int64) error {
 		if err := s.requireSyncMessageSourceTx(q, messageID); err != nil {
 			return err
 		}
-		_, err := q.Exec(`
-			UPDATE messages
-			SET has_attachments = (SELECT COUNT(*) FROM attachments WHERE message_id = ?) > 0,
-			    attachment_count = (SELECT COUNT(*) FROM attachments WHERE message_id = ?)
-			WHERE id = ?
-		`, messageID, messageID, messageID)
-		return err
+		return recomputeMessageAttachmentStatsWith(q, messageID)
 	}
 	if s.syncGeneration == nil {
 		return write(s.db)
 	}
 	return s.withTx(func(tx *loggedTx) error { return write(tx) })
+}
+
+func recomputeMessageAttachmentStatsWith(q querier, messageID int64) error {
+	_, err := q.Exec(`
+		UPDATE messages
+		SET has_attachments = (SELECT COUNT(*) FROM attachments WHERE message_id = ?) > 0,
+		    attachment_count = (SELECT COUNT(*) FROM attachments WHERE message_id = ?)
+		WHERE id = ?
+	`, messageID, messageID, messageID)
+	return err
 }
 
 type AttachmentRef struct {

--- a/internal/store/messages_test.go
+++ b/internal/store/messages_test.go
@@ -1,10 +1,14 @@
 package store_test
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"io"
+	"slices"
+	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -51,6 +55,1255 @@ func TestUpsertMessagePersistsListID(t *testing.T) {
 	).Scan(&listID), "read persisted list ID")
 	assert.True(listID.Valid, "list ID should be present")
 	assert.Equal("<announce.example.org>", listID.String, "list ID")
+}
+
+type siblingRecipientSnapshot struct {
+	Type          string
+	ParticipantID int64
+	DisplayName   sql.NullString
+	EnvelopeEmail sql.NullString
+	EmailAddress  sql.NullString
+	Participant   sql.NullString
+	Domain        sql.NullString
+}
+
+type siblingActivitySnapshot struct {
+	Revision          int64
+	ProcessedRevision int64
+	QueuedAt          string
+}
+
+type siblingEmbeddingChangeSnapshot struct {
+	Sequence          int64
+	Kind              string
+	MessageID         sql.NullInt64
+	OldMessageType    sql.NullString
+	NewMessageType    sql.NullString
+	OldConversationID sql.NullInt64
+	NewConversationID sql.NullInt64
+	OldSentAt         sql.NullString
+	NewSentAt         sql.NullString
+	ParticipantID     sql.NullInt64
+}
+
+type siblingPersonSweepChangeSnapshot struct {
+	Sequence       int64
+	PersonID       int64
+	SourceLane     string
+	ChangeKind     string
+	EvidenceEffect string
+	SourceID       sql.NullInt64
+	MessageID      sql.NullInt64
+	AttachmentID   sql.NullInt64
+	OccurrenceKey  string
+	RecordedAt     string
+}
+
+type siblingPersonSweepWorkSnapshot struct {
+	PersonID             int64
+	DirtyThroughSequence int64
+	AvailableAt          string
+	AttemptCount         int
+	LastFailureClass     string
+	LeaseOwner           string
+	LeaseUntil           sql.NullString
+	LeaseFence           int64
+	CreatedAt            string
+	UpdatedAt            string
+}
+
+type siblingFTSSnapshot struct {
+	MessageID      int64
+	Subject        string
+	Body           string
+	FromAddr       string
+	ToAddr         string
+	CcAddr         string
+	SearchDocument string
+}
+
+type siblingAttachmentSnapshot struct {
+	Filename           sql.NullString
+	MIMEType           sql.NullString
+	StoragePath        string
+	ContentHash        sql.NullString
+	Size               int64
+	SourceAttachmentID sql.NullString
+	Metadata           sql.NullString
+	Role               string
+	RoleSource         string
+	SourcePartKey      sql.NullString
+	ContentID          sql.NullString
+}
+
+type siblingConversationSnapshot struct {
+	SourceConversationID string
+	ConversationType     string
+	Title                sql.NullString
+	Participants         []string
+}
+
+type siblingMessageSnapshot struct {
+	SourceID         int64
+	SourceMessageID  string
+	ConversationID   int64
+	RFC822MessageID  sql.NullString
+	MessageType      string
+	SentAt           sql.NullTime
+	ReceivedAt       sql.NullTime
+	InternalDate     sql.NullTime
+	SenderID         sql.NullInt64
+	SourceIsFromMe   sql.NullBool
+	IdentityIsFromMe bool
+	IsFromMe         bool
+	Subject          sql.NullString
+	Snippet          sql.NullString
+	SizeEstimate     sql.NullInt64
+	HasAttachments   bool
+	AttachmentCount  int
+	Metadata         sql.NullString
+	IndexingVersion  sql.NullInt64
+	LastModified     sql.NullTime
+	EmbedGen         sql.NullInt64
+	ContentChangedAt sql.NullTime
+	BodyText         sql.NullString
+	BodyHTML         sql.NullString
+	RawMIME          []byte
+	RawFormat        string
+	Recipients       []siblingRecipientSnapshot
+	LabelIDs         []int64
+	MessageLabels    []string
+	Activity         siblingActivitySnapshot
+	EmbeddingChanges []siblingEmbeddingChangeSnapshot
+	PersonChanges    []siblingPersonSweepChangeSnapshot
+	PersonWork       []siblingPersonSweepWorkSnapshot
+	FTS              siblingFTSSnapshot
+	Attachments      []siblingAttachmentSnapshot
+	Conversation     siblingConversationSnapshot
+	ParticipantRows  []string
+	LabelRows        []string
+}
+
+func readSiblingMessageSnapshot(t *testing.T, st *store.Store, messageID int64) siblingMessageSnapshot {
+	t.Helper()
+	var snapshot siblingMessageSnapshot
+	err := st.DB().QueryRowContext(t.Context(), st.Rebind(`
+		SELECT source_id, source_message_id, conversation_id, rfc822_message_id, message_type,
+		       sent_at, received_at, internal_date, sender_id,
+		       source_is_from_me, identity_is_from_me, is_from_me,
+		       subject, snippet, size_estimate, has_attachments, attachment_count, metadata,
+		       indexing_version, last_modified, embed_gen, content_changed_at
+		FROM messages
+		WHERE id = ?
+	`), messageID).Scan(
+		&snapshot.SourceID,
+		&snapshot.SourceMessageID,
+		&snapshot.ConversationID,
+		&snapshot.RFC822MessageID,
+		&snapshot.MessageType,
+		&snapshot.SentAt,
+		&snapshot.ReceivedAt,
+		&snapshot.InternalDate,
+		&snapshot.SenderID,
+		&snapshot.SourceIsFromMe,
+		&snapshot.IdentityIsFromMe,
+		&snapshot.IsFromMe,
+		&snapshot.Subject,
+		&snapshot.Snippet,
+		&snapshot.SizeEstimate,
+		&snapshot.HasAttachments,
+		&snapshot.AttachmentCount,
+		&snapshot.Metadata,
+		&snapshot.IndexingVersion,
+		&snapshot.LastModified,
+		&snapshot.EmbedGen,
+		&snapshot.ContentChangedAt,
+	)
+	require.NoError(t, err, "read sibling message fields")
+
+	err = st.DB().QueryRowContext(t.Context(), st.Rebind(`
+		SELECT body_text, body_html FROM message_bodies WHERE message_id = ?
+	`), messageID).Scan(&snapshot.BodyText, &snapshot.BodyHTML)
+	require.NoError(t, err, "read sibling message body")
+	snapshot.RawMIME, err = st.GetMessageRaw(messageID)
+	require.NoError(t, err, "read sibling raw MIME")
+	err = st.DB().QueryRowContext(t.Context(), st.Rebind(`
+		SELECT raw_format FROM message_raw WHERE message_id = ?
+	`), messageID).Scan(&snapshot.RawFormat)
+	require.NoError(t, err, "read sibling raw format")
+
+	rows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT mr.recipient_type, mr.participant_id, mr.display_name, mr.email_address,
+		       p.email_address, p.display_name, p.domain
+		FROM message_recipients mr
+		JOIN participants p ON p.id = mr.participant_id
+		WHERE mr.message_id = ?
+		ORDER BY mr.recipient_type, mr.id
+	`), messageID)
+	require.NoError(t, err, "read sibling recipients")
+	defer func() { require.NoError(t, rows.Close(), "close sibling recipient rows") }()
+	for rows.Next() {
+		var recipient siblingRecipientSnapshot
+		require.NoError(t, rows.Scan(
+			&recipient.Type,
+			&recipient.ParticipantID,
+			&recipient.DisplayName,
+			&recipient.EnvelopeEmail,
+			&recipient.EmailAddress,
+			&recipient.Participant,
+			&recipient.Domain,
+		), "scan sibling recipient")
+		snapshot.Recipients = append(snapshot.Recipients, recipient)
+	}
+	require.NoError(t, rows.Err(), "iterate sibling recipients")
+
+	labelRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT label_id FROM message_labels WHERE message_id = ? ORDER BY label_id
+	`), messageID)
+	require.NoError(t, err, "read sibling labels")
+	defer func() { require.NoError(t, labelRows.Close(), "close sibling label rows") }()
+	for labelRows.Next() {
+		var labelID int64
+		require.NoError(t, labelRows.Scan(&labelID), "scan sibling label")
+		snapshot.LabelIDs = append(snapshot.LabelIDs, labelID)
+	}
+	require.NoError(t, labelRows.Err(), "iterate sibling labels")
+	messageLabelRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT COALESCE(l.source_label_id, ''), l.name,
+		       COALESCE(l.label_type, ''), COALESCE(l.system_role, '')
+		FROM message_labels ml
+		JOIN labels l ON l.id = ml.label_id
+		WHERE ml.message_id = ?
+		ORDER BY l.source_label_id, l.name, l.id
+	`), messageID)
+	require.NoError(t, err, "read sibling message label descriptors")
+	defer func() { require.NoError(t, messageLabelRows.Close(), "close sibling message label rows") }()
+	for messageLabelRows.Next() {
+		var sourceLabelID, name, labelType, systemRole string
+		require.NoError(t, messageLabelRows.Scan(
+			&sourceLabelID, &name, &labelType, &systemRole,
+		), "scan sibling message label descriptor")
+		snapshot.MessageLabels = append(snapshot.MessageLabels,
+			sourceLabelID+"|"+name+"|"+labelType+"|"+systemRole)
+	}
+	require.NoError(t, messageLabelRows.Err(), "iterate sibling message label descriptors")
+
+	err = st.DB().QueryRowContext(t.Context(), st.Rebind(`
+		SELECT revision, processed_revision, CAST(queued_at AS TEXT)
+		FROM activity_projection_queue WHERE message_id = ?
+	`), messageID).Scan(
+		&snapshot.Activity.Revision,
+		&snapshot.Activity.ProcessedRevision,
+		&snapshot.Activity.QueuedAt,
+	)
+	require.NoError(t, err, "read sibling activity queue")
+
+	embeddingRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT sequence, kind, message_id, old_message_type, new_message_type,
+		       old_conversation_id, new_conversation_id,
+		       CAST(old_sent_at AS TEXT), CAST(new_sent_at AS TEXT), participant_id
+		FROM embedding_changes WHERE message_id = ? ORDER BY sequence
+	`), messageID)
+	require.NoError(t, err, "read sibling embedding changes")
+	defer func() { require.NoError(t, embeddingRows.Close(), "close sibling embedding changes") }()
+	for embeddingRows.Next() {
+		var change siblingEmbeddingChangeSnapshot
+		require.NoError(t, embeddingRows.Scan(
+			&change.Sequence,
+			&change.Kind,
+			&change.MessageID,
+			&change.OldMessageType,
+			&change.NewMessageType,
+			&change.OldConversationID,
+			&change.NewConversationID,
+			&change.OldSentAt,
+			&change.NewSentAt,
+			&change.ParticipantID,
+		), "scan sibling embedding change")
+		snapshot.EmbeddingChanges = append(snapshot.EmbeddingChanges, change)
+	}
+	require.NoError(t, embeddingRows.Err(), "iterate sibling embedding changes")
+
+	personScope := `
+		SELECT pp.person_id
+		FROM person_participants pp
+		JOIN messages m ON m.sender_id = pp.participant_id
+		WHERE m.id = ?
+		UNION
+		SELECT pp.person_id
+		FROM person_participants pp
+		JOIN message_recipients mr ON mr.participant_id = pp.participant_id
+		WHERE mr.message_id = ?`
+	personRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT sequence, person_id, source_lane, change_kind, evidence_effect,
+		       source_id, message_id, attachment_id, occurrence_key, CAST(recorded_at AS TEXT)
+		FROM person_sweep_changes
+		WHERE message_id = ? OR person_id IN (`+personScope+`)
+		ORDER BY sequence
+	`), messageID, messageID, messageID)
+	require.NoError(t, err, "read sibling person sweep changes")
+	defer func() { require.NoError(t, personRows.Close(), "close sibling person sweep changes") }()
+	for personRows.Next() {
+		var change siblingPersonSweepChangeSnapshot
+		require.NoError(t, personRows.Scan(
+			&change.Sequence,
+			&change.PersonID,
+			&change.SourceLane,
+			&change.ChangeKind,
+			&change.EvidenceEffect,
+			&change.SourceID,
+			&change.MessageID,
+			&change.AttachmentID,
+			&change.OccurrenceKey,
+			&change.RecordedAt,
+		), "scan sibling person sweep change")
+		snapshot.PersonChanges = append(snapshot.PersonChanges, change)
+	}
+	require.NoError(t, personRows.Err(), "iterate sibling person sweep changes")
+
+	workRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT person_id, dirty_through_sequence, CAST(available_at AS TEXT), attempt_count,
+		       last_failure_class, lease_owner, CAST(lease_until AS TEXT), lease_fence,
+		       CAST(created_at AS TEXT), CAST(updated_at AS TEXT)
+		FROM person_sweep_work
+		WHERE person_id IN (`+personScope+`)
+		ORDER BY person_id
+	`), messageID, messageID)
+	require.NoError(t, err, "read sibling person sweep work")
+	defer func() { require.NoError(t, workRows.Close(), "close sibling person sweep work") }()
+	for workRows.Next() {
+		var work siblingPersonSweepWorkSnapshot
+		require.NoError(t, workRows.Scan(
+			&work.PersonID,
+			&work.DirtyThroughSequence,
+			&work.AvailableAt,
+			&work.AttemptCount,
+			&work.LastFailureClass,
+			&work.LeaseOwner,
+			&work.LeaseUntil,
+			&work.LeaseFence,
+			&work.CreatedAt,
+			&work.UpdatedAt,
+		), "scan sibling person sweep work")
+		snapshot.PersonWork = append(snapshot.PersonWork, work)
+	}
+	require.NoError(t, workRows.Err(), "iterate sibling person sweep work")
+
+	if st.IsPostgreSQL() {
+		err = st.DB().QueryRowContext(t.Context(), `
+			SELECT id, COALESCE(CAST(search_fts AS TEXT), '') FROM messages WHERE id = $1
+		`, messageID).Scan(&snapshot.FTS.MessageID, &snapshot.FTS.SearchDocument)
+		require.NoError(t, err, "read sibling PostgreSQL FTS document")
+	} else {
+		err = st.DB().QueryRowContext(t.Context(), `
+			SELECT message_id, subject, body, from_addr, to_addr, cc_addr
+			FROM messages_fts WHERE rowid = ?
+		`, messageID).Scan(
+			&snapshot.FTS.MessageID,
+			&snapshot.FTS.Subject,
+			&snapshot.FTS.Body,
+			&snapshot.FTS.FromAddr,
+			&snapshot.FTS.ToAddr,
+			&snapshot.FTS.CcAddr,
+		)
+		require.NoError(t, err, "read sibling SQLite FTS document")
+	}
+
+	attachmentRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT filename, mime_type, storage_path, content_hash, size,
+		       source_attachment_id, attachment_metadata, attachment_role,
+		       role_source, source_part_key, content_id
+		FROM attachments WHERE message_id = ? ORDER BY id
+	`), messageID)
+	require.NoError(t, err, "read sibling attachments")
+	defer func() { require.NoError(t, attachmentRows.Close(), "close sibling attachment rows") }()
+	for attachmentRows.Next() {
+		var attachment siblingAttachmentSnapshot
+		require.NoError(t, attachmentRows.Scan(
+			&attachment.Filename,
+			&attachment.MIMEType,
+			&attachment.StoragePath,
+			&attachment.ContentHash,
+			&attachment.Size,
+			&attachment.SourceAttachmentID,
+			&attachment.Metadata,
+			&attachment.Role,
+			&attachment.RoleSource,
+			&attachment.SourcePartKey,
+			&attachment.ContentID,
+		), "scan sibling attachment")
+		snapshot.Attachments = append(snapshot.Attachments, attachment)
+	}
+	require.NoError(t, attachmentRows.Err(), "iterate sibling attachments")
+
+	err = st.DB().QueryRowContext(t.Context(), st.Rebind(`
+		SELECT source_conversation_id, conversation_type, title
+		FROM conversations WHERE id = ?
+	`), snapshot.ConversationID).Scan(
+		&snapshot.Conversation.SourceConversationID,
+		&snapshot.Conversation.ConversationType,
+		&snapshot.Conversation.Title,
+	)
+	require.NoError(t, err, "read sibling conversation")
+	conversationParticipantRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT CAST(participant_id AS TEXT) || ':' || role
+		FROM conversation_participants WHERE conversation_id = ?
+		ORDER BY participant_id, role
+	`), snapshot.ConversationID)
+	require.NoError(t, err, "read sibling conversation participants")
+	defer func() {
+		require.NoError(t, conversationParticipantRows.Close(), "close sibling conversation participant rows")
+	}()
+	for conversationParticipantRows.Next() {
+		var participant string
+		require.NoError(t, conversationParticipantRows.Scan(&participant), "scan sibling conversation participant")
+		snapshot.Conversation.Participants = append(snapshot.Conversation.Participants, participant)
+	}
+	require.NoError(t, conversationParticipantRows.Err(), "iterate sibling conversation participants")
+
+	participantRows, err := st.DB().QueryContext(t.Context(), `
+		SELECT COALESCE(email_address, ''), COALESCE(display_name, ''), COALESCE(domain, '')
+		FROM participants ORDER BY email_address, display_name, domain, id`)
+	require.NoError(t, err, "read participant directory")
+	defer func() { require.NoError(t, participantRows.Close(), "close participant directory rows") }()
+	for participantRows.Next() {
+		var email, name, domain string
+		require.NoError(t, participantRows.Scan(&email, &name, &domain), "scan participant directory row")
+		snapshot.ParticipantRows = append(snapshot.ParticipantRows, email+"|"+name+"|"+domain)
+	}
+	require.NoError(t, participantRows.Err(), "iterate participant directory")
+
+	labelDirectoryRows, err := st.DB().QueryContext(t.Context(), st.Rebind(`
+		SELECT COALESCE(source_label_id, ''), name, COALESCE(label_type, ''), COALESCE(system_role, '')
+		FROM labels WHERE source_id = ? ORDER BY source_label_id, name, id
+	`), snapshot.SourceID)
+	require.NoError(t, err, "read label directory")
+	defer func() { require.NoError(t, labelDirectoryRows.Close(), "close label directory rows") }()
+	for labelDirectoryRows.Next() {
+		var sourceLabelID, name, labelType, systemRole string
+		require.NoError(t, labelDirectoryRows.Scan(
+			&sourceLabelID, &name, &labelType, &systemRole,
+		), "scan label directory row")
+		snapshot.LabelRows = append(snapshot.LabelRows,
+			sourceLabelID+"|"+name+"|"+labelType+"|"+systemRole)
+	}
+	require.NoError(t, labelDirectoryRows.Err(), "iterate label directory")
+	return snapshot
+}
+
+func TestPersistMessageWithParticipantsKeepsSiblingDependentsIsolatedOnUpsert(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := t.Context()
+	lastModifiedBaseline := time.Date(2000, 1, 2, 3, 4, 5, 0, time.UTC)
+	contentChangedBaseline := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	source, err := st.GetOrCreateSource("gmail", "sibling-isolation@example.test")
+	require.NoError(err, "GetOrCreateSource")
+	conversationA, err := st.EnsureConversation(source.ID, "thread-a", "Thread A")
+	require.NoError(err, "EnsureConversation A")
+	conversationB, err := st.EnsureConversation(source.ID, "thread-b", "Thread B")
+	require.NoError(err, "EnsureConversation B")
+	labelA, err := st.EnsureLabel(source.ID, "LABEL_A", "Label A", "user")
+	require.NoError(err, "EnsureLabel A")
+	labelB1, err := st.EnsureLabel(source.ID, "LABEL_B1", "Label B 1", "user")
+	require.NoError(err, "EnsureLabel B1")
+	labelB2, err := st.EnsureLabel(source.ID, "LABEL_B2", "Label B 2", "user")
+	require.NoError(err, "EnsureLabel B2")
+	bSenderParticipantID, err := st.EnsureParticipant(
+		"sender-b@example.test", "Sender B", "example.test",
+	)
+	require.NoError(err, "EnsureParticipant B sender")
+	bPerson, created, err := st.CreatePersonFromParticipant(bSenderParticipantID)
+	require.NoError(err, "CreatePersonFromParticipant B sender")
+	require.True(created, "B sender person fixture must be newly created")
+	_, err = st.SetPersonTrackingContext(ctx, bPerson.ID, true)
+	require.NoError(err, "track B sender person")
+	require.NoError(st.EnableEmbeddingChangeJournal(ctx), "enable embedding journal")
+
+	messageAID, err := st.PersistMessageWithParticipantsContext(ctx, []store.ParticipantPersistData{
+		{EmailAddress: "sender-a@example.test", DisplayName: "Sender A", Domain: "example.test"},
+		{EmailAddress: "recipient-a@example.test", DisplayName: "Recipient A", Domain: "example.test"},
+	}, func(participantIDs []int64) *store.MessagePersistData {
+		metadata := sql.NullString{String: `{"fixture":"a-v1"}`, Valid: true}
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  conversationA,
+				SourceID:        source.ID,
+				SourceMessageID: "message-a",
+				RFC822MessageID: sql.NullString{String: "<message-a@example.test>", Valid: true},
+				MessageType:     "email",
+				SentAt:          sql.NullTime{Time: time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC), Valid: true},
+				SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+				Subject:         sql.NullString{String: "Message A original", Valid: true},
+				Snippet:         sql.NullString{String: "A original snippet", Valid: true},
+				SizeEstimate:    101,
+			},
+			Metadata: &metadata,
+			BodyText: sql.NullString{String: "Message A original body", Valid: true},
+			BodyHTML: sql.NullString{String: "<p>Message A original body</p>", Valid: true},
+			RawMIME:  []byte("raw-message-a-v1"),
+			Recipients: []store.RecipientSet{
+				{Type: "from", ParticipantIDs: []int64{participantIDs[0]}, DisplayNames: []string{"Sender A"}, EmailAddresses: []string{"sender-a@example.test"}},
+				{Type: "to", ParticipantIDs: []int64{participantIDs[1]}, DisplayNames: []string{"Recipient A"}, EmailAddresses: []string{"recipient-a@example.test"}},
+			},
+			LabelIDs: []int64{labelA},
+			FTS: &store.FTSDoc{
+				Subject: "Message A original",
+				Body:    "amber-original-token",
+			},
+		}
+	})
+	require.NoError(err, "persist message A")
+
+	messageBID, err := st.PersistMessageWithParticipantsContext(ctx, []store.ParticipantPersistData{
+		{EmailAddress: "sender-b@example.test", DisplayName: "Sender B", Domain: "example.test"},
+		{EmailAddress: "recipient-b@example.test", DisplayName: "Recipient B", Domain: "example.test"},
+		{EmailAddress: "copy-b@example.test", DisplayName: "Copy B", Domain: "example.test"},
+		{EmailAddress: "blind-b@example.test", DisplayName: "Blind B", Domain: "example.test"},
+	}, func(participantIDs []int64) *store.MessagePersistData {
+		metadata := sql.NullString{String: `{"fixture":"b"}`, Valid: true}
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  conversationB,
+				SourceID:        source.ID,
+				SourceMessageID: "message-b",
+				RFC822MessageID: sql.NullString{String: "<message-b@example.test>", Valid: true},
+				MessageType:     "email",
+				SentAt:          sql.NullTime{Time: time.Date(2026, 8, 29, 11, 0, 0, 0, time.UTC), Valid: true},
+				ReceivedAt:      sql.NullTime{Time: time.Date(2026, 8, 29, 11, 1, 0, 0, time.UTC), Valid: true},
+				InternalDate:    sql.NullTime{Time: time.Date(2026, 8, 29, 11, 2, 0, 0, time.UTC), Valid: true},
+				SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+				IsFromMe:        true,
+				Subject:         sql.NullString{String: "Message B subject", Valid: true},
+				Snippet:         sql.NullString{String: "Message B snippet", Valid: true},
+				SizeEstimate:    202,
+				HasAttachments:  true,
+				AttachmentCount: 2,
+			},
+			Metadata:  &metadata,
+			BodyText:  sql.NullString{String: "Message B text body", Valid: true},
+			BodyHTML:  sql.NullString{String: "<p>Message B HTML body</p>", Valid: true},
+			RawMIME:   []byte("raw-message-b"),
+			RawFormat: "mime",
+			Recipients: []store.RecipientSet{
+				{Type: "from", ParticipantIDs: []int64{participantIDs[0]}, DisplayNames: []string{"Sender B"}, EmailAddresses: []string{"sender-b@example.test"}},
+				{Type: "to", ParticipantIDs: []int64{participantIDs[1]}, DisplayNames: []string{"Recipient B"}, EmailAddresses: []string{"recipient-b@example.test"}},
+				{Type: "cc", ParticipantIDs: []int64{participantIDs[2]}, DisplayNames: []string{"Copy B"}, EmailAddresses: []string{"copy-b@example.test"}},
+				{Type: "bcc", ParticipantIDs: []int64{participantIDs[3]}, DisplayNames: []string{"Blind B"}, EmailAddresses: []string{"blind-b@example.test"}},
+			},
+			LabelIDs: []int64{labelB1, labelB2},
+			FTS: &store.FTSDoc{
+				Subject:  "Message B subject",
+				Body:     "cobalt-sibling-token",
+				FromAddr: "sender-b@example.test",
+				ToAddrs:  "recipient-b@example.test",
+				CcAddrs:  "copy-b@example.test",
+			},
+		}
+	})
+	require.NoError(err, "persist message B")
+	require.NotEqual(messageAID, messageBID, "fixture requires distinct sibling rows")
+	require.NoError(st.SetEmbedGen(ctx, []int64{messageBID}, 73), "seed B embed generation")
+	baselineResult, err := st.DB().ExecContext(ctx, st.Rebind(`
+		UPDATE messages
+		SET last_modified = ?, content_changed_at = ?
+		WHERE id = ?
+	`), lastModifiedBaseline, contentChangedBaseline, messageBID)
+	require.NoError(err, "seed B historical timestamp baselines")
+	baselineRows, err := baselineResult.RowsAffected()
+	require.NoError(err, "read B historical timestamp baseline row count")
+	require.Equal(int64(1), baselineRows, "seed exactly one B historical timestamp baseline")
+
+	beforeB := readSiblingMessageSnapshot(t, st, messageBID)
+	require.True(beforeB.IndexingVersion.Valid, "B FTS indexing version fixture must be seeded")
+	require.True(beforeB.LastModified.Valid, "B last-modified fixture must be seeded")
+	require.Equal(lastModifiedBaseline, beforeB.LastModified.Time.UTC(),
+		"B last-modified fixture must use its fixed historical baseline")
+	require.True(beforeB.EmbedGen.Valid, "B embed generation fixture must be seeded")
+	require.True(beforeB.ContentChangedAt.Valid, "B content watermark fixture must be seeded")
+	require.Equal(contentChangedBaseline, beforeB.ContentChangedAt.Time.UTC(),
+		"B content watermark fixture must use its fixed historical baseline")
+	require.Positive(beforeB.Activity.Revision, "B activity queue fixture must be seeded")
+	require.NotEmpty(beforeB.EmbeddingChanges, "B embedding journal fixture must be seeded")
+	require.NotEmpty(beforeB.PersonChanges, "B person sweep journal fixture must be seeded")
+	require.NotEmpty(beforeB.PersonWork, "B person sweep work fixture must be seeded")
+	require.Equal(messageBID, beforeB.FTS.MessageID, "B FTS row must belong to B")
+	require.NotEmpty(beforeB.FTS.SearchDocument+beforeB.FTS.Subject,
+		"B full FTS document fixture must be seeded")
+	_, beforeBHits, err := st.SearchMessages("cobalt-sibling-token", 0, 10)
+	require.NoError(err, "search B before A upsert")
+	require.Equal(int64(1), beforeBHits, "B FTS fixture")
+
+	repersistedAID, err := st.PersistMessageWithParticipantsContext(ctx, []store.ParticipantPersistData{
+		{EmailAddress: "sender-a@example.test", DisplayName: "Sender A", Domain: "example.test"},
+		{EmailAddress: "recipient-a@example.test", DisplayName: "Recipient A", Domain: "example.test"},
+	}, func(participantIDs []int64) *store.MessagePersistData {
+		metadata := sql.NullString{String: `{"fixture":"a-v2"}`, Valid: true}
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  conversationA,
+				SourceID:        source.ID,
+				SourceMessageID: "message-a",
+				RFC822MessageID: sql.NullString{String: "<message-a-v2@example.test>", Valid: true},
+				MessageType:     "email",
+				SentAt:          sql.NullTime{Time: time.Date(2026, 8, 30, 12, 0, 0, 0, time.UTC), Valid: true},
+				SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+				Subject:         sql.NullString{String: "Message A updated", Valid: true},
+				Snippet:         sql.NullString{String: "A updated snippet", Valid: true},
+				SizeEstimate:    303,
+			},
+			Metadata: &metadata,
+			BodyText: sql.NullString{String: "Message A updated body", Valid: true},
+			BodyHTML: sql.NullString{String: "<p>Message A updated body</p>", Valid: true},
+			RawMIME:  []byte("raw-message-a-v2"),
+			Recipients: []store.RecipientSet{
+				{Type: "from", ParticipantIDs: []int64{participantIDs[0]}, DisplayNames: []string{"Sender A"}, EmailAddresses: []string{"sender-a@example.test"}},
+				{Type: "to", ParticipantIDs: []int64{participantIDs[1]}, DisplayNames: []string{"Recipient A"}, EmailAddresses: []string{"recipient-a@example.test"}},
+			},
+			LabelIDs: []int64{labelA},
+			FTS: &store.FTSDoc{
+				Subject: "Message A updated",
+				Body:    "amber-updated-token",
+			},
+		}
+	})
+	require.NoError(err, "re-persist message A")
+	assert.Equal(messageAID, repersistedAID, "upsert must return A's existing internal ID")
+
+	afterB := readSiblingMessageSnapshot(t, st, messageBID)
+	assert.Equal(beforeB, afterB, "A upsert must leave all B fields and dependents unchanged")
+	_, afterBHits, err := st.SearchMessages("cobalt-sibling-token", 0, 10)
+	require.NoError(err, "search B after A upsert")
+	assert.Equal(int64(1), afterBHits, "A upsert must leave B's FTS document unchanged")
+
+	updatedA := readSiblingMessageSnapshot(t, st, messageAID)
+	assert.Equal("Message A updated", updatedA.Subject.String, "A subject")
+	assert.Equal("Message A updated body", updatedA.BodyText.String, "A body")
+	assert.Equal([]byte("raw-message-a-v2"), updatedA.RawMIME, "A raw MIME")
+}
+
+type repairStoreFixture struct {
+	Store          *store.Store
+	SourceID       int64
+	ConversationID int64
+	TargetID       int64
+	SiblingID      int64
+	Guard          store.MessageIdentityGuard
+	Baseline       time.Time
+}
+
+func seedRepairStoreFixture(t *testing.T) repairStoreFixture {
+	t.Helper()
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	ctx := t.Context()
+	baseline := time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	source, err := st.GetOrCreateSource("gmail", "repair-fixture@example.test")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(
+		source.ID, "repair-thread", "email_thread", "Original repair thread")
+	require.NoError(err)
+	siblingConversationID, err := st.EnsureConversationWithType(
+		source.ID, "sibling-thread", "email_thread", "Sibling thread")
+	require.NoError(err)
+	oldLabelID, err := st.EnsureLabel(source.ID, "OLD", "Old label", "user")
+	require.NoError(err)
+	require.NoError(st.EnableEmbeddingChangeJournal(ctx))
+
+	targetID, err := st.PersistMessageWithParticipantsContext(ctx, []store.ParticipantPersistData{
+		{EmailAddress: "old-sender@example.test", DisplayName: "Old Sender", Domain: "example.test"},
+		{EmailAddress: "old-recipient@example.test", DisplayName: "Old Recipient", Domain: "example.test"},
+	}, func(participantIDs []int64) *store.MessagePersistData {
+		metadata := sql.NullString{String: `{"version":"old"}`, Valid: true}
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  conversationID,
+				SourceID:        source.ID,
+				SourceMessageID: "repair-target",
+				RFC822MessageID: sql.NullString{String: "<repair-old@example.test>", Valid: true},
+				MessageType:     "email",
+				SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+				Subject:         sql.NullString{String: "Original target", Valid: true},
+				Snippet:         sql.NullString{String: "Original snippet", Valid: true},
+				SizeEstimate:    100,
+			},
+			Metadata: &metadata,
+			BodyText: sql.NullString{String: "original target body", Valid: true},
+			BodyHTML: sql.NullString{String: "<p>original target body</p>", Valid: true},
+			RawMIME:  []byte("original-target-raw"),
+			Recipients: []store.RecipientSet{
+				{Type: "from", ParticipantIDs: participantIDs[:1], DisplayNames: []string{"Old Sender"}, EmailAddresses: []string{"old-sender@example.test"}},
+				{Type: "to", ParticipantIDs: participantIDs[1:], DisplayNames: []string{"Old Recipient"}, EmailAddresses: []string{"old-recipient@example.test"}},
+			},
+			LabelIDs: []int64{oldLabelID},
+			FTS: &store.FTSDoc{
+				Subject:  "Original target",
+				Body:     "original-target-token",
+				FromAddr: "old-sender@example.test",
+				ToAddrs:  "old-recipient@example.test",
+			},
+		}
+	})
+	require.NoError(err)
+
+	siblingID, err := st.PersistMessageWithParticipantsContext(ctx, []store.ParticipantPersistData{
+		{EmailAddress: "sibling-sender@example.test", DisplayName: "Sibling Sender", Domain: "example.test"},
+	}, func(participantIDs []int64) *store.MessagePersistData {
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				ConversationID:  siblingConversationID,
+				SourceID:        source.ID,
+				SourceMessageID: "repair-sibling",
+				MessageType:     "email",
+				SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+				Subject:         sql.NullString{String: "Sibling subject", Valid: true},
+				Snippet:         sql.NullString{String: "Sibling snippet", Valid: true},
+				SizeEstimate:    200,
+			},
+			BodyText: sql.NullString{String: "sibling body", Valid: true},
+			RawMIME:  []byte("sibling-raw"),
+			Recipients: []store.RecipientSet{{
+				Type: "from", ParticipantIDs: participantIDs,
+				DisplayNames:   []string{"Sibling Sender"},
+				EmailAddresses: []string{"sibling-sender@example.test"},
+			}},
+			LabelIDs: []int64{oldLabelID},
+			FTS:      &store.FTSDoc{Subject: "Sibling subject", Body: "sibling-stable-token"},
+		}
+	})
+	require.NoError(err)
+
+	attachments := []store.AttachmentWrite{
+		{
+			Filename: "legacy.bin", MIMEType: "application/octet-stream",
+			StoragePath: "legacy.bin", ContentHash: "legacy-hash", Size: 10,
+			Role: store.AttachmentRoleUnknown, RoleSource: store.AttachmentRoleSourceLegacyAPI,
+		},
+		{
+			Filename: "keyed.txt", MIMEType: "text/plain", StoragePath: "keyed.txt",
+			ContentHash: "keyed-hash", Size: 11, SourcePartKey: "mime:part:1",
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceMIMEDisposition,
+		},
+		{
+			Filename: "repaired-old.txt", MIMEType: "text/plain", StoragePath: "repaired-old.txt",
+			ContentHash: "repair-old-hash", Size: 12, SourcePartKey: "repair:part:2",
+			Role: store.AttachmentRoleInline, RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+		},
+		{
+			Filename: "provider.bin", MIMEType: "application/octet-stream", StoragePath: "provider.bin",
+			ContentHash: "provider-hash", Size: 13, SourceAttachmentID: "provider:attachment:1",
+			SourcePartKey: "provider:part:1", Role: store.AttachmentRoleStandalone,
+			RoleSource: store.AttachmentRoleSourceProviderExplicit,
+		},
+	}
+	for _, attachment := range attachments {
+		require.NoError(st.UpsertAttachmentRecord(ctx, targetID, attachment))
+	}
+	require.NoError(st.RecomputeMessageAttachmentStats(targetID))
+	require.NoError(st.SetEmbedGen(ctx, []int64{targetID}, 71))
+	require.NoError(st.SetEmbedGen(ctx, []int64{siblingID}, 72))
+	_, err = st.DB().ExecContext(ctx, st.Rebind(`
+		UPDATE activity_projection_queue SET processed_revision = revision
+		WHERE message_id IN (?, ?)
+	`), targetID, siblingID)
+	require.NoError(err)
+	_, err = st.DB().ExecContext(ctx, st.Rebind(`
+		UPDATE messages SET last_modified = ?, content_changed_at = ?
+		WHERE id IN (?, ?)
+	`), baseline, baseline, targetID, siblingID)
+	require.NoError(err)
+
+	return repairStoreFixture{
+		Store: st, SourceID: source.ID, ConversationID: conversationID,
+		TargetID: targetID, SiblingID: siblingID,
+		Guard: store.MessageIdentityGuard{
+			ID: targetID, SourceID: source.ID, SourceMessageID: "repair-target",
+		},
+		Baseline: baseline,
+	}
+}
+
+func repairedMessageData(
+	fixture repairStoreFixture,
+	participantIDs []int64,
+	replacement *[]store.AttachmentWrite,
+) *store.MessagePersistData {
+	metadata := sql.NullString{String: `{"version":"repaired"}`, Valid: true}
+	return &store.MessagePersistData{
+		Message: &store.Message{
+			ID:              fixture.SiblingID,
+			ConversationID:  fixture.ConversationID,
+			SourceID:        fixture.SourceID,
+			SourceMessageID: "repair-target",
+			RFC822MessageID: sql.NullString{String: "<repair-new@example.test>", Valid: true},
+			MessageType:     "email",
+			SentAt:          sql.NullTime{Time: time.Date(2026, 8, 30, 12, 30, 0, 0, time.UTC), Valid: true},
+			SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+			Subject:         sql.NullString{String: "Repaired target", Valid: true},
+			Snippet:         sql.NullString{String: "Repaired snippet", Valid: true},
+			SizeEstimate:    321,
+		},
+		Conversation: &store.ConversationPersistData{
+			SourceConversationID: "repair-thread",
+			ConversationType:     "email_thread",
+			Title:                "Repaired repair thread",
+			Participants: []store.ConversationParticipantRef{
+				{ParticipantID: participantIDs[0], Role: "sender"},
+				{ParticipantID: participantIDs[1], Role: "recipient"},
+			},
+		},
+		Metadata:  &metadata,
+		BodyText:  sql.NullString{String: "repaired target body", Valid: true},
+		BodyHTML:  sql.NullString{String: "<p>repaired target body</p>", Valid: true},
+		RawMIME:   []byte("repaired-target-raw"),
+		RawFormat: "mime",
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: participantIDs[:1], DisplayNames: []string{"Repair Sender"}, EmailAddresses: []string{"repair-sender@example.test"}},
+			{Type: "to", ParticipantIDs: participantIDs[1:], DisplayNames: []string{"Repair Recipient"}, EmailAddresses: []string{"repair-recipient@example.test"}},
+		},
+		LabelRefs: []store.MessageLabelRef{
+			{SourceLabelID: "SENT", Info: store.LabelInfo{Name: "Sent", Type: "system", SystemRole: store.LabelSystemRoleSent}},
+			{SourceLabelID: "REPAIRED", Info: store.LabelInfo{Name: "Repaired", Type: "user"}},
+		},
+		MIMEAttachmentReplacement: replacement,
+		FTS: &store.FTSDoc{
+			Subject:  "Repaired target",
+			Body:     "repair-green-token",
+			FromAddr: "repair-sender@example.test",
+			ToAddrs:  "repair-recipient@example.test",
+		},
+	}
+}
+
+func repairParticipants() []store.ParticipantPersistData {
+	return []store.ParticipantPersistData{
+		{EmailAddress: "repair-sender@example.test", DisplayName: "Repair Sender", Domain: "example.test"},
+		{EmailAddress: "repair-recipient@example.test", DisplayName: "Repair Recipient", Domain: "example.test"},
+	}
+}
+
+func attachmentFilenames(snapshot siblingMessageSnapshot) []string {
+	names := make([]string, len(snapshot.Attachments))
+	for i, attachment := range snapshot.Attachments {
+		names[i] = attachment.Filename.String
+	}
+	sort.Strings(names)
+	return names
+}
+
+func attachmentBySourcePartKey(
+	t *testing.T, snapshot siblingMessageSnapshot, sourcePartKey string,
+) siblingAttachmentSnapshot {
+	t.Helper()
+	for _, attachment := range snapshot.Attachments {
+		if attachment.SourcePartKey.String == sourcePartKey {
+			return attachment
+		}
+	}
+	require.FailNow(t, "attachment source-part key not found", sourcePartKey)
+	return siblingAttachmentSnapshot{}
+}
+
+func changedMessageIDs(page store.ChangedMessagePage) []int64 {
+	ids := make([]int64, len(page.Messages))
+	for i, message := range page.Messages {
+		ids[i] = message.ID
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func TestPersistRepairMessageReplacesCompleteSnapshotAtomically(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := seedRepairStoreFixture(t)
+	before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	replacement := []store.AttachmentWrite{{
+		Filename: "repaired.txt", MIMEType: "text/plain", StoragePath: "repaired.txt",
+		ContentHash: "repaired-hash", Size: 42, SourcePartKey: "mime:part:new",
+		ContentID: "repair-content-id", Role: store.AttachmentRoleInline,
+		RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+	}}
+
+	messageID, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+		t.Context(), fixture.Guard, repairParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			return repairedMessageData(fixture, participantIDs, &replacement)
+		},
+	)
+	require.NoError(err)
+	assert.Equal(fixture.TargetID, messageID, "repair must return the guarded internal ID")
+
+	after := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	assert.Equal("repair-target", after.SourceMessageID)
+	assert.Equal("Repaired target", after.Subject.String)
+	assert.Equal("repaired target body", after.BodyText.String)
+	assert.Equal("<p>repaired target body</p>", after.BodyHTML.String)
+	assert.Equal([]byte("repaired-target-raw"), after.RawMIME)
+	assert.Equal("mime", after.RawFormat)
+	assert.JSONEq(`{"version":"repaired"}`, after.Metadata.String)
+	assert.Equal("Repaired repair thread", after.Conversation.Title.String)
+	assert.Len(after.Conversation.Participants, 2)
+	assert.Equal([]string{"provider.bin", "repaired.txt"}, attachmentFilenames(after),
+		"repair must replace every MIME-owned row and preserve provider-owned rows")
+	assert.True(after.HasAttachments)
+	assert.Equal(2, after.AttachmentCount)
+	assert.False(after.EmbedGen.Valid, "content repair must invalidate the embedding generation")
+	assert.True(after.ContentChangedAt.Time.After(fixture.Baseline))
+	assert.Greater(after.Activity.Revision, before.Activity.Revision)
+	assert.Less(after.Activity.ProcessedRevision, after.Activity.Revision,
+		"repair must leave activity/conversation projection work pending")
+	assert.Contains(after.ParticipantRows, "repair-sender@example.test|Repair Sender|example.test")
+	assert.Contains(after.ParticipantRows, "repair-recipient@example.test|Repair Recipient|example.test")
+	assert.Contains(after.LabelRows, "SENT|Sent|system|sent")
+	assert.Contains(after.LabelRows, "REPAIRED|Repaired|user|")
+	assert.Equal([]string{
+		"REPAIRED|Repaired|user|",
+		"SENT|Sent|system|sent",
+	}, after.MessageLabels)
+	assert.Len(after.Recipients, 2)
+	assert.Equal("repair-sender@example.test", after.Recipients[0].EnvelopeEmail.String)
+	assert.Equal("repair-recipient@example.test", after.Recipients[1].EnvelopeEmail.String)
+
+	_, hits, err := fixture.Store.SearchMessages("repair-green-token", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), hits, "repair must replace the FTS document")
+	_, oldHits, err := fixture.Store.SearchMessages("original-target-token", 0, 10)
+	require.NoError(err)
+	assert.Zero(oldHits, "repair must remove the old FTS document")
+	page, err := fixture.Store.ListChangedMessages(
+		t.Context(), store.ChangedMessagesFrom(fixture.Baseline.Add(time.Second)), 20)
+	require.NoError(err)
+	assert.Equal([]int64{fixture.TargetID}, changedMessageIDs(page),
+		"the committed repair must publish the normal change feed update")
+}
+
+func TestPersistRepairMessageAttachmentReplacementModes(t *testing.T) {
+	t.Run("nil preserves every attachment row", func(t *testing.T) {
+		assert := assert.New(t)
+		fixture := seedRepairStoreFixture(t)
+		before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+		messageID, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+			t.Context(), fixture.Guard, repairParticipants(),
+			func(participantIDs []int64) *store.MessagePersistData {
+				return repairedMessageData(fixture, participantIDs, nil)
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(fixture.TargetID, messageID)
+		after := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+		assert.Equal(before.Attachments, after.Attachments)
+		assert.True(after.HasAttachments)
+		assert.Equal(len(before.Attachments), after.AttachmentCount)
+	})
+
+	t.Run("non-nil empty removes only MIME-owned rows", func(t *testing.T) {
+		assert := assert.New(t)
+		fixture := seedRepairStoreFixture(t)
+		empty := []store.AttachmentWrite{}
+		messageID, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+			t.Context(), fixture.Guard, repairParticipants(),
+			func(participantIDs []int64) *store.MessagePersistData {
+				return repairedMessageData(fixture, participantIDs, &empty)
+			},
+		)
+		require.NoError(t, err)
+		assert.Equal(fixture.TargetID, messageID)
+		after := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+		assert.Equal([]string{"provider.bin"}, attachmentFilenames(after))
+		assert.True(after.HasAttachments)
+		assert.Equal(1, after.AttachmentCount)
+		assert.True(after.Attachments[0].SourceAttachmentID.Valid,
+			"the remaining row must be provider-owned")
+	})
+}
+
+func TestPersistRepairMessageRejectsProviderAttachmentSourcePartCollision(t *testing.T) {
+	fixture := seedRepairStoreFixture(t)
+	before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	providerBefore := attachmentBySourcePartKey(t, before, "provider:part:1")
+	require.True(t, providerBefore.SourceAttachmentID.Valid,
+		"collision fixture must be provider-owned")
+	replacement := []store.AttachmentWrite{{
+		Filename: "mime-collision.txt", MIMEType: "text/plain",
+		StoragePath: "mime-collision.txt", ContentHash: "mime-collision-hash",
+		Size: 99, SourcePartKey: "provider:part:1", ContentID: "mime-collision",
+		Role:       store.AttachmentRoleInline,
+		RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+	}}
+
+	_, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+		t.Context(), fixture.Guard, repairParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			return repairedMessageData(fixture, participantIDs, &replacement)
+		},
+	)
+	require.ErrorContains(t, err, "provider-owned attachment source-part collision")
+	after := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	assert.Equal(t, before, after,
+		"a source-part collision must roll back the complete repair transaction")
+}
+
+func TestPersistRepairMessageRejectsUnkeyedProviderAttachmentHashCollision(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := seedRepairStoreFixture(t)
+	require.NoError(fixture.Store.UpsertAttachmentRecord(t.Context(), fixture.TargetID, store.AttachmentWrite{
+		Filename: "provider-unkeyed.bin", MIMEType: "application/octet-stream",
+		StoragePath: "provider-unkeyed.bin", ContentHash: "shared-unkeyed-hash", Size: 14,
+		SourceAttachmentID: "provider:attachment:unkeyed",
+		Role:               store.AttachmentRoleStandalone,
+		RoleSource:         store.AttachmentRoleSourceProviderExplicit,
+	}))
+	require.NoError(fixture.Store.RecomputeMessageAttachmentStats(fixture.TargetID))
+	before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	replacement := []store.AttachmentWrite{{
+		Filename: "mime-unkeyed.bin", MIMEType: "application/octet-stream",
+		StoragePath: "mime-unkeyed.bin", ContentHash: "shared-unkeyed-hash", Size: 14,
+		Role:       store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+	}}
+
+	_, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+		t.Context(), fixture.Guard, repairParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			return repairedMessageData(fixture, participantIDs, &replacement)
+		},
+	)
+	require.ErrorContains(err, "provider-owned attachment content-hash collision")
+	assert.Equal(before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID),
+		"an unkeyed provider hash collision must roll back the complete repair transaction")
+}
+
+func TestUpsertAttachmentRecordStillUpdatesProviderOccurrenceBySourcePartKey(t *testing.T) {
+	assert := assert.New(t)
+	fixture := seedRepairStoreFixture(t)
+	updated := store.AttachmentWrite{
+		Filename: "provider-updated.bin", MIMEType: "application/octet-stream",
+		StoragePath: "provider-updated.bin", ContentHash: "provider-updated-hash",
+		Size: 101, SourceAttachmentID: "provider:attachment:1",
+		SourcePartKey: "provider:part:1", Role: store.AttachmentRolePreview,
+		RoleSource: store.AttachmentRoleSourceProviderExplicit,
+	}
+
+	require.NoError(t, fixture.Store.UpsertAttachmentRecord(
+		t.Context(), fixture.TargetID, updated))
+	after := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	providerAfter := attachmentBySourcePartKey(t, after, "provider:part:1")
+	assert.Equal("provider-updated.bin", providerAfter.Filename.String)
+	assert.Equal("provider-updated-hash", providerAfter.ContentHash.String)
+	assert.Equal(int64(101), providerAfter.Size)
+	assert.Equal("provider:attachment:1", providerAfter.SourceAttachmentID.String)
+	assert.Equal(string(store.AttachmentRolePreview), providerAfter.Role)
+	assert.Equal(string(store.AttachmentRoleSourceProviderExplicit), providerAfter.RoleSource)
+}
+
+func TestPersistRepairMessageRejectsIdentityGuardBeforeBuilder(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*store.MessageIdentityGuard)
+	}{
+		{name: "internal id", mutate: func(guard *store.MessageIdentityGuard) { guard.ID++ }},
+		{name: "source id", mutate: func(guard *store.MessageIdentityGuard) { guard.SourceID++ }},
+		{name: "source message id", mutate: func(guard *store.MessageIdentityGuard) { guard.SourceMessageID += "-wrong" }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			fixture := seedRepairStoreFixture(t)
+			beforeTarget := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+			beforeSibling := readSiblingMessageSnapshot(t, fixture.Store, fixture.SiblingID)
+			guard := fixture.Guard
+			test.mutate(&guard)
+			var built atomic.Bool
+			replacement := []store.AttachmentWrite{}
+			_, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+				t.Context(), guard, repairParticipants(),
+				func(participantIDs []int64) *store.MessagePersistData {
+					built.Store(true)
+					return repairedMessageData(fixture, participantIDs, &replacement)
+				},
+			)
+			require.Error(t, err)
+			assert.Contains(err.Error(), "identity guard")
+			assert.False(built.Load(), "guard mismatch must reject before invoking the builder")
+			assert.Equal(beforeTarget, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+			assert.Equal(beforeSibling, readSiblingMessageSnapshot(t, fixture.Store, fixture.SiblingID))
+		})
+	}
+}
+
+func TestPersistRepairMessageRollsBackEveryMutationOnLateFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := seedRepairStoreFixture(t)
+	beforeTarget := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+	beforeSibling := readSiblingMessageSnapshot(t, fixture.Store, fixture.SiblingID)
+	beforeFeed, err := fixture.Store.ListChangedMessages(
+		t.Context(), store.ChangedMessagesFrom(fixture.Baseline.Add(time.Second)), 20)
+	require.NoError(err)
+	require.Empty(beforeFeed.Messages)
+	replacement := []store.AttachmentWrite{
+		{
+			Filename: "valid-before-failure.txt", StoragePath: "valid-before-failure.txt",
+			ContentHash: "valid-before-failure", Size: 7, SourcePartKey: "mime:valid",
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+		},
+		{
+			Filename: "invalid.txt", StoragePath: "invalid.txt", ContentHash: "invalid",
+			Size: 8, SourcePartKey: "mime:invalid", Role: store.AttachmentRole("invalid-role"),
+			RoleSource: store.AttachmentRoleSourceRawMIMERepair,
+		},
+	}
+
+	_, err = fixture.Store.PersistRepairMessageWithParticipantsContext(
+		t.Context(), fixture.Guard, repairParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			data := repairedMessageData(fixture, participantIDs, &replacement)
+			data.Conversation.SourceConversationID = "created-then-rolled-back"
+			data.LabelRefs = append(data.LabelRefs, store.MessageLabelRef{
+				SourceLabelID: "ROLLBACK", Info: store.LabelInfo{Name: "Rollback label", Type: "user"},
+			})
+			return data
+		},
+	)
+	require.Error(err)
+	assert.Contains(err.Error(), "invalid attachment role")
+	assert.Equal(beforeTarget, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID),
+		"late failure must roll the complete target snapshot back")
+	assert.Equal(beforeSibling, readSiblingMessageSnapshot(t, fixture.Store, fixture.SiblingID),
+		"late failure must leave the complete sibling snapshot unchanged")
+	afterFeed, feedErr := fixture.Store.ListChangedMessages(
+		t.Context(), store.ChangedMessagesFrom(fixture.Baseline.Add(time.Second)), 20)
+	require.NoError(feedErr)
+	assert.Empty(afterFeed.Messages, "rolled-back work must not become visible in the change feed")
+}
+
+func TestPersistRepairMessageSerializesIdentityGuardRevalidation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := seedRepairStoreFixture(t)
+	holder, err := fixture.Store.DB().BeginTx(t.Context(), nil)
+	require.NoError(err)
+	held := true
+	t.Cleanup(func() {
+		if held {
+			_ = holder.Rollback()
+		}
+	})
+	_, err = holder.ExecContext(t.Context(), fixture.Store.Rebind(`
+		UPDATE messages SET source_message_id = ? WHERE id = ?
+	`), "repair-target-raced", fixture.TargetID)
+	require.NoError(err)
+
+	var built atomic.Bool
+	result := make(chan error, 1)
+	go func() {
+		_, persistErr := fixture.Store.PersistRepairMessageWithParticipantsContext(
+			t.Context(), fixture.Guard, repairParticipants(),
+			func(participantIDs []int64) *store.MessagePersistData {
+				built.Store(true)
+				return repairedMessageData(fixture, participantIDs, nil)
+			},
+		)
+		result <- persistErr
+	}()
+
+	if fixture.Store.IsPostgreSQL() {
+		waitForPostgreSQLLockWait(t, fixture.Store,
+			"%SELECT id, source_id, source_message_id%FROM messages%FOR UPDATE%")
+	} else {
+		require.Eventually(func() bool {
+			return fixture.Store.DB().Stats().InUse >= 2 || len(result) > 0
+		}, time.Second, time.Millisecond)
+		select {
+		case earlyErr := <-result:
+			require.NoError(earlyErr, "repair returned before the SQLite writer committed")
+		default:
+		}
+		assert.False(built.Load(), "SQLite writer serialization must precede the guard read")
+	}
+
+	require.NoError(holder.Commit())
+	held = false
+	select {
+	case persistErr := <-result:
+		require.Error(persistErr)
+		assert.Contains(persistErr.Error(), "identity guard")
+	case <-time.After(5 * time.Second):
+		require.FailNow("repair did not finish after releasing identity writer")
+	}
+	assert.False(built.Load(), "guard must be re-read after acquiring serialization")
+}
+
+func TestPersistRepairMessageLocksParticipantDirectoryBeforeIdentityGuard(t *testing.T) {
+	require := require.New(t)
+	fixture := seedRepairStoreFixture(t)
+	if !fixture.Store.IsPostgreSQL() {
+		t.Skip("PostgreSQL advisory and row locks are required")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	blocker, err := fixture.Store.DB().BeginTx(ctx, nil)
+	require.NoError(err)
+	held := true
+	t.Cleanup(func() {
+		if held {
+			_ = blocker.Rollback()
+		}
+	})
+	_, err = blocker.ExecContext(ctx, `
+		SELECT pg_advisory_xact_lock(
+			hashtextextended('participant-directory-mutation', 0)
+		)`)
+	require.NoError(err)
+
+	result := make(chan error, 1)
+	go func() {
+		_, persistErr := fixture.Store.PersistRepairMessageWithParticipantsContext(
+			ctx, fixture.Guard, repairParticipants(),
+			func(participantIDs []int64) *store.MessagePersistData {
+				return repairedMessageData(fixture, participantIDs, nil)
+			},
+		)
+		result <- persistErr
+	}()
+	waitForPostgreSQLLockWait(t, fixture.Store, "%pg_advisory_xact_lock%")
+
+	var messageID int64
+	require.NoError(blocker.QueryRowContext(ctx,
+		`SELECT id FROM messages WHERE id = $1 FOR UPDATE`, fixture.TargetID,
+	).Scan(&messageID), "repair must not lock its message while waiting for the participant directory")
+	require.Equal(fixture.TargetID, messageID)
+	require.NoError(blocker.Commit())
+	held = false
+
+	select {
+	case persistErr := <-result:
+		require.NoError(persistErr)
+	case <-ctx.Done():
+		require.FailNow("repair did not finish after the directory lock was released", ctx.Err())
+	}
+}
+
+func TestPersistRepairMessageHonorsCanceledContext(t *testing.T) {
+	fixture := seedRepairStoreFixture(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var built atomic.Bool
+	_, err := fixture.Store.PersistRepairMessageWithParticipantsContext(
+		ctx, fixture.Guard, repairParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			built.Store(true)
+			return repairedMessageData(fixture, participantIDs, nil)
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, built.Load())
 }
 
 func TestRecomputeConversationStats(t *testing.T) {

--- a/internal/sync/repair.go
+++ b/internal/sync/repair.go
@@ -1,0 +1,274 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// RepairRequest names exactly one archived provider message. SourceID zero
+// leaves the reference unscoped; a positive value disambiguates one source.
+type RepairRequest struct {
+	Reference string
+	SourceID  int64
+}
+
+// RepairResult is the stable identity and repaired subject printed by callers.
+type RepairResult struct {
+	InternalID      int64
+	SourceID        int64
+	SourceMessageID string
+	Subject         string
+}
+
+// RepairMessage fetches and strictly prepares one Gmail snapshot, publishes
+// all MIME attachment bytes durably, then invokes the guarded atomic store
+// replacement. Nothing before the final store call mutates archive rows, and
+// failed repairs remove any unreferenced blobs introduced by the attempt.
+func (s *Syncer) RepairMessage(ctx context.Context, request RepairRequest) (_ *RepairResult, repairErr error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	request.Reference = strings.TrimSpace(request.Reference)
+	if request.Reference == "" {
+		return nil, errors.New("repair message reference is required")
+	}
+	if request.SourceID < 0 {
+		return nil, errors.New("repair message source ID must be positive")
+	}
+	targets, err := s.store.FindRepairMessageTargetsContext(ctx, request.Reference, request.SourceID)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("repair message %q not found", request.Reference)
+	}
+	if len(targets) != 1 {
+		return nil, fmt.Errorf("repair message reference %q is ambiguous across %d archive rows", request.Reference, len(targets))
+	}
+	target := targets[0]
+	if target.SourceType != "gmail" {
+		return nil, fmt.Errorf("repair message source %d is %s, not gmail", target.SourceID, target.SourceType)
+	}
+	profile, err := s.client.GetProfile(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read authenticated Gmail account: %w", err)
+	}
+	if profile == nil {
+		return nil, errors.New("read authenticated Gmail account: provider returned no profile")
+	}
+	authenticated := store.NormalizeIdentifierForCompare(strings.TrimSpace(profile.EmailAddress))
+	archived := store.NormalizeIdentifierForCompare(strings.TrimSpace(target.SourceIdentifier))
+	if authenticated == "" || archived == "" || authenticated != archived {
+		return nil, fmt.Errorf(
+			"authenticated Gmail account %q does not match archive source %q",
+			profile.EmailAddress, target.SourceIdentifier,
+		)
+	}
+
+	raw, err := s.client.GetMessageRaw(ctx, target.SourceMessageID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch Gmail message %q: %w", target.SourceMessageID, err)
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("fetch Gmail message %q: provider returned no message", target.SourceMessageID)
+	}
+	if raw.ID != target.SourceMessageID {
+		return nil, fmt.Errorf("gmail returned message ID %q for requested ID %q", raw.ID, target.SourceMessageID)
+	}
+	labels, err := s.client.ListLabels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read Gmail label catalog: %w", err)
+	}
+	labelRefs, err := repairLabelRefs(raw.LabelIDs, labels)
+	if err != nil {
+		return nil, err
+	}
+	prepared, err := s.prepareMessage(target.SourceID, raw, raw.ThreadID, true)
+	if err != nil {
+		return nil, err
+	}
+	attachmentWrites := make([]store.AttachmentWrite, 0, len(prepared.attachments))
+	createdAttachments := make(map[string]export.DurableAttachmentReceipt)
+	defer func() {
+		if repairErr == nil || len(createdAttachments) == 0 {
+			return
+		}
+		if err := s.cleanupRepairAttachments(context.WithoutCancel(ctx), createdAttachments); err != nil {
+			repairErr = errors.Join(repairErr, fmt.Errorf("clean up repair attachments: %w", err))
+		}
+	}()
+	for i := range prepared.attachments {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		attachment := &prepared.attachments[i]
+		if s.opts.AttachmentsDir == "" {
+			return nil, fmt.Errorf("publish attachment %q: attachments directory is required", attachment.Filename)
+		}
+		receipt, err := export.StoreAttachmentFileDurable(s.opts.AttachmentsDir, attachment)
+		if receipt.Created {
+			createdAttachments[receipt.StoragePath] = receipt
+		}
+		if err != nil {
+			return nil, fmt.Errorf("publish attachment %q: %w", attachment.Filename, err)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		role, roleSource := store.AttachmentRoleFromMIME(
+			attachment.Disposition, attachment.IsInline, attachment.ContentID,
+		)
+		attachmentWrites = append(attachmentWrites, store.AttachmentWrite{
+			Filename: attachment.Filename, MIMEType: attachment.ContentType,
+			StoragePath: receipt.StoragePath, ContentHash: attachment.ContentHash,
+			Size: int64(len(attachment.Content)), Role: role, RoleSource: roleSource,
+			SourcePartKey: attachment.PartKey, ContentID: attachment.ContentID,
+		})
+	}
+
+	participants, participantIndex := repairParticipants(prepared)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	guard := target.MessageIdentityGuard
+	messageID, err := s.store.PersistRepairMessageWithParticipantsContext(
+		ctx, guard, participants, func(participantIDs []int64) *store.MessagePersistData {
+			participantMap := make(map[string]int64, len(participantIndex))
+			for email, index := range participantIndex {
+				participantMap[email] = participantIDs[index]
+			}
+			message := *prepared.message
+			if len(prepared.from) > 0 && prepared.from[0].Email != "" {
+				if senderID, ok := participantMap[prepared.from[0].Email]; ok {
+					message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
+				}
+			}
+			recipients := []store.RecipientSet{
+				buildRecipientSet("from", prepared.from, participantMap),
+				buildRecipientSet("to", prepared.to, participantMap),
+				buildRecipientSet("cc", prepared.cc, participantMap),
+				buildRecipientSet("bcc", prepared.bcc, participantMap),
+			}
+			return &store.MessagePersistData{
+				Message: &message,
+				Conversation: &store.ConversationPersistData{
+					SourceConversationID: prepared.threadID,
+					ConversationType:     prepared.conversationType,
+					Title:                prepared.conversationTitle,
+				},
+				BodyText:                  sql.NullString{String: prepared.bodyText, Valid: prepared.bodyText != ""},
+				BodyHTML:                  sql.NullString{String: prepared.bodyHTML, Valid: prepared.bodyHTML != ""},
+				RawMIME:                   prepared.rawMIME,
+				Recipients:                recipients,
+				LabelRefs:                 labelRefs,
+				MIMEAttachmentReplacement: &attachmentWrites,
+				FTS: &store.FTSDoc{
+					Subject: message.Subject.String, Body: prepared.bodyText,
+					FromAddr: joinEmails(prepared.from), ToAddrs: joinEmails(prepared.to),
+					CcAddrs: joinEmails(prepared.cc),
+				},
+			}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &RepairResult{
+		InternalID: messageID, SourceID: target.SourceID,
+		SourceMessageID: target.SourceMessageID, Subject: prepared.message.Subject.String,
+	}, nil
+}
+
+func (s *Syncer) cleanupRepairAttachments(
+	ctx context.Context,
+	receipts map[string]export.DurableAttachmentReceipt,
+) error {
+	paths := make([]string, 0, len(receipts))
+	for storagePath := range receipts {
+		paths = append(paths, storagePath)
+	}
+	sort.Strings(paths)
+
+	return s.store.WithExclusiveLock(ctx, func() error {
+		var cleanupErr error
+		for _, storagePath := range paths {
+			referenced, err := s.store.IsAttachmentPathReferenced(storagePath)
+			if err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("check attachment %q references: %w", storagePath, err))
+				continue
+			}
+			if referenced {
+				continue
+			}
+			if err := export.RemoveAttachmentFileDurable(s.opts.AttachmentsDir, receipts[storagePath]); err != nil {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("remove attachment %q: %w", storagePath, err))
+			}
+		}
+		return cleanupErr
+	})
+}
+
+func repairParticipants(data *messageData) ([]store.ParticipantPersistData, map[string]int) {
+	byEmail := make(map[string]mime.Address)
+	for _, addresses := range [][]mime.Address{data.from, data.to, data.cc, data.bcc} {
+		for _, address := range addresses {
+			if address.Email != "" {
+				if _, exists := byEmail[address.Email]; !exists {
+					byEmail[address.Email] = address
+				}
+			}
+		}
+	}
+	emails := make([]string, 0, len(byEmail))
+	for email := range byEmail {
+		emails = append(emails, email)
+	}
+	sort.Strings(emails)
+	participants := make([]store.ParticipantPersistData, len(emails))
+	index := make(map[string]int, len(emails))
+	for i, email := range emails {
+		address := byEmail[email]
+		participants[i] = store.ParticipantPersistData{
+			EmailAddress: email, DisplayName: address.Name, Domain: address.Domain,
+		}
+		index[email] = i
+	}
+	return participants, index
+}
+
+func repairLabelRefs(messageLabelIDs []string, labels []*gmail.Label) ([]store.MessageLabelRef, error) {
+	catalog := make(map[string]*gmail.Label, len(labels))
+	for _, label := range labels {
+		if label != nil {
+			catalog[label.ID] = label
+		}
+	}
+	refs := make([]store.MessageLabelRef, 0, len(messageLabelIDs))
+	for _, id := range messageLabelIDs {
+		label, ok := catalog[id]
+		if !ok {
+			return nil, fmt.Errorf("label %q is missing from provider catalog", id)
+		}
+		labelType := label.Type
+		if labelType == "" {
+			labelType = "user"
+			if store.IsSystemLabel(id) {
+				labelType = labelTypeSystem
+			}
+		}
+		refs = append(refs, store.MessageLabelRef{
+			SourceLabelID: id,
+			Info:          store.LabelInfo{Name: label.Name, Type: labelType, SystemRole: label.SystemRole},
+		})
+	}
+	return refs, nil
+}

--- a/internal/sync/repair_audit.go
+++ b/internal/sync/repair_audit.go
@@ -1,0 +1,357 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textutil"
+)
+
+// AuditState is both a field comparison state and the overall result class.
+type AuditState string
+
+const (
+	AuditMatch        AuditState = "match"
+	AuditMismatch     AuditState = "mismatch"
+	AuditInconclusive AuditState = "inconclusive"
+
+	AuditFieldRawMIME            = "raw_mime"
+	AuditFieldRFC822MessageID    = "rfc822_message_id"
+	AuditFieldSubject            = "subject"
+	AuditFieldBodyText           = "body_text"
+	AuditFieldBodyHTML           = "body_html"
+	AuditFieldFrom               = "from"
+	AuditFieldTo                 = "to"
+	AuditFieldCC                 = "cc"
+	AuditFieldBCC                = "bcc"
+	AuditFieldAttachmentHashes   = "attachment_hashes"
+	AuditFieldAttachmentPartKeys = "attachment_part_keys"
+
+	auditPageSize = 100
+)
+
+// RepairAuditResult identifies a corruption candidate or a row whose raw MIME
+// could not be audited. Coherent rows are omitted from the stream.
+type RepairAuditResult struct {
+	InternalID      int64                 `json:"internal_id"`
+	SourceID        int64                 `json:"source_id"`
+	SourceMessageID string                `json:"source_message_id"`
+	Status          AuditState            `json:"status"`
+	Fields          map[string]AuditState `json:"fields"`
+	Error           string                `json:"error,omitempty"`
+}
+
+// AuditGmailMessages strictly parses stored Gmail raw MIME and emits only
+// mismatches plus wholly inconclusive rows. sourceID zero audits every Gmail
+// source. The store reader and this comparison path perform no writes.
+func (s *Syncer) AuditGmailMessages(
+	ctx context.Context, sourceID int64, emit func(RepairAuditResult) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if sourceID < 0 {
+		return errors.New("audit source ID must be positive")
+	}
+	if sourceID > 0 {
+		source, err := s.store.GetSourceByIDContext(ctx, sourceID)
+		if err != nil {
+			return err
+		}
+		if source.SourceType != "gmail" {
+			return fmt.Errorf("audit source %d is %s, not gmail", sourceID, source.SourceType)
+		}
+	}
+	if emit == nil {
+		return errors.New("audit result emitter is required")
+	}
+
+	var afterID int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Each page is one read snapshot; records stream one at a time so a
+		// page never materializes more than one message's evidence.
+		pageSize, err := s.store.StreamGmailAuditEvidencePageContext(
+			ctx, sourceID, afterID, auditPageSize,
+			func(evidence store.GmailAuditEvidence) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				result, include := auditGmailEvidence(evidence)
+				if include {
+					if err := ctx.Err(); err != nil {
+						return err
+					}
+					if err := emit(result); err != nil {
+						return err
+					}
+				}
+				afterID = evidence.ID
+				return ctx.Err()
+			})
+		if err != nil {
+			return err
+		}
+		if pageSize < auditPageSize {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+	}
+}
+
+func auditGmailEvidence(evidence store.GmailAuditEvidence) (RepairAuditResult, bool) {
+	result := RepairAuditResult{
+		InternalID: evidence.ID, SourceID: evidence.SourceID,
+		SourceMessageID: evidence.SourceMessageID,
+		Fields:          make(map[string]AuditState),
+	}
+	if !evidence.RawMIMEPresent {
+		result.Status = AuditInconclusive
+		result.Fields[AuditFieldRawMIME] = AuditInconclusive
+		result.Error = "stored raw MIME is missing"
+		return result, true
+	}
+	if evidence.RawMIMEError != "" {
+		result.Status = AuditInconclusive
+		result.Fields[AuditFieldRawMIME] = AuditInconclusive
+		result.Error = textutil.FirstLine(evidence.RawMIMEError)
+		return result, true
+	}
+	parsed, err := mime.Parse(evidence.RawMIME)
+	if err != nil {
+		result.Status = AuditInconclusive
+		result.Fields[AuditFieldRawMIME] = AuditInconclusive
+		result.Error = textutil.FirstLine(err.Error())
+		return result, true
+	}
+	result.Fields[AuditFieldRawMIME] = AuditMatch
+	result.Fields[AuditFieldRFC822MessageID] = compareOptionalString(
+		evidence.RFC822MessageID.Valid, evidence.RFC822MessageID.String, parsed.MessageID,
+	)
+	result.Fields[AuditFieldSubject] = compareOptionalString(
+		evidence.Subject.Valid, evidence.Subject.String, textutil.EnsureUTF8(parsed.Subject),
+	)
+	result.Fields[AuditFieldBodyText] = compareOptionalString(
+		evidence.BodyText.Valid, evidence.BodyText.String, textutil.EnsureUTF8(parsed.GetBodyText()),
+	)
+	result.Fields[AuditFieldBodyHTML] = compareOptionalString(
+		evidence.BodyHTML.Valid, evidence.BodyHTML.String, textutil.EnsureUTF8(parsed.BodyHTML),
+	)
+
+	storedAddresses, complete := storedAuditAddresses(evidence.Recipients)
+	parsedAddresses := map[string][]string{
+		"from": normalizedAddressMultiset(parsed.From),
+		"to":   normalizedAddressMultiset(parsed.To),
+		"cc":   normalizedAddressMultiset(parsed.Cc),
+		"bcc":  normalizedAddressMultiset(parsed.Bcc),
+	}
+	for field, recipientType := range map[string]string{
+		AuditFieldFrom: "from", AuditFieldTo: "to", AuditFieldCC: "cc", AuditFieldBCC: "bcc",
+	} {
+		if !complete[recipientType] {
+			result.Fields[field] = AuditInconclusive
+		} else {
+			result.Fields[field] = compareStrings(storedAddresses[recipientType], parsedAddresses[recipientType])
+		}
+	}
+
+	storedHashes := make([]string, 0, len(evidence.Attachments))
+	storedKeys := make([]string, 0, len(evidence.Attachments))
+	storedPairs := make([][2]string, 0, len(evidence.Attachments))
+	hashesComplete, keysComplete := true, true
+	for _, attachment := range evidence.Attachments {
+		if !attachment.ContentHash.Valid || attachment.ContentHash.String == "" {
+			hashesComplete = false
+		} else {
+			storedHashes = append(storedHashes, strings.ToLower(attachment.ContentHash.String))
+		}
+		if !attachment.SourcePartKey.Valid || attachment.SourcePartKey.String == "" {
+			keysComplete = false
+		} else {
+			storedKeys = append(storedKeys, attachment.SourcePartKey.String)
+		}
+		if attachment.ContentHash.Valid && attachment.ContentHash.String != "" &&
+			attachment.SourcePartKey.Valid && attachment.SourcePartKey.String != "" {
+			storedPairs = append(storedPairs, [2]string{
+				attachment.SourcePartKey.String,
+				strings.ToLower(attachment.ContentHash.String),
+			})
+		}
+	}
+	parsedHashes := make([]string, 0, len(parsed.Attachments))
+	parsedKeys := make([]string, 0, len(parsed.Attachments))
+	parsedPairs := make([][2]string, 0, len(parsed.Attachments))
+	for _, attachment := range parsed.Attachments {
+		if attachment.ContentHash == "" {
+			hashesComplete = false
+		} else {
+			parsedHashes = append(parsedHashes, strings.ToLower(attachment.ContentHash))
+		}
+		if attachment.PartKey == "" {
+			keysComplete = false
+		} else {
+			parsedKeys = append(parsedKeys, attachment.PartKey)
+		}
+		if attachment.ContentHash != "" && attachment.PartKey != "" {
+			parsedPairs = append(parsedPairs, [2]string{
+				attachment.PartKey,
+				strings.ToLower(attachment.ContentHash),
+			})
+		}
+	}
+	if !hashesComplete {
+		result.Fields[AuditFieldAttachmentHashes] = AuditInconclusive
+	} else if keysComplete {
+		// Equal hash and part-key multisets do not prove coherence: each hash
+		// must belong to the part key it was stored under, so compare the
+		// normalized (part key, content hash) pairs as a multiset.
+		result.Fields[AuditFieldAttachmentHashes] = compareAttachmentPairs(storedPairs, parsedPairs)
+	} else {
+		result.Fields[AuditFieldAttachmentHashes] = compareUnkeyedAttachmentHashes(storedHashes, parsedHashes)
+	}
+	if keysComplete {
+		result.Fields[AuditFieldAttachmentPartKeys] = compareStrings(storedKeys, parsedKeys)
+	} else {
+		result.Fields[AuditFieldAttachmentPartKeys] = AuditInconclusive
+	}
+
+	matched := false
+	for _, state := range result.Fields {
+		if state == AuditMismatch {
+			result.Status = AuditMismatch
+			return result, true
+		}
+		matched = matched || state == AuditMatch
+	}
+	if !matched {
+		result.Status = AuditInconclusive
+		return result, true
+	}
+	return result, false
+}
+
+func compareOptionalString(storedValid bool, stored, parsed string) AuditState {
+	if !storedValid {
+		return AuditInconclusive
+	}
+	if stored == parsed {
+		return AuditMatch
+	}
+	return AuditMismatch
+}
+
+func storedAuditAddresses(recipients []store.GmailAuditRecipient) (map[string][]string, map[string]bool) {
+	addresses := map[string][]string{"from": {}, "to": {}, "cc": {}, "bcc": {}}
+	complete := map[string]bool{"from": true, "to": true, "cc": true, "bcc": true}
+	for _, recipient := range recipients {
+		if _, relevant := complete[recipient.Type]; !relevant {
+			continue
+		}
+		if !recipient.EmailAddress.Valid {
+			complete[recipient.Type] = false
+			continue
+		}
+		addresses[recipient.Type] = append(addresses[recipient.Type], normalizeAuditAddress(recipient.EmailAddress.String))
+	}
+	for recipientType := range addresses {
+		sort.Strings(addresses[recipientType])
+	}
+	return addresses, complete
+}
+
+func normalizedAddressMultiset(addresses []mime.Address) []string {
+	result := make([]string, 0, len(addresses))
+	seen := make(map[string]struct{}, len(addresses))
+	for _, address := range addresses {
+		normalized := normalizeAuditAddress(address.Email)
+		if normalized == "" {
+			continue
+		}
+		if _, duplicate := seen[normalized]; duplicate {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		result = append(result, normalized)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func normalizeAuditAddress(address string) string {
+	return strings.ToLower(strings.TrimSpace(address))
+}
+
+// compareUnkeyedAttachmentHashes audits rows written before occurrence keys
+// existed. Such rows are unique per (message, content hash), so a part that
+// repeats in the MIME was stored once, and older ingests recorded small
+// nameless text parts as attachments that the current parser folds into the
+// body. A parsed hash the row never stored means the raw MIME carries a part
+// this message never had, which is the cross-assignment signature. A stored
+// hash the parse no longer yields is classification drift, not evidence.
+func compareUnkeyedAttachmentHashes(stored, parsed []string) AuditState {
+	storedSet := make(map[string]struct{}, len(stored))
+	for _, hash := range stored {
+		storedSet[hash] = struct{}{}
+	}
+	parsedSet := make(map[string]struct{}, len(parsed))
+	for _, hash := range parsed {
+		if _, known := storedSet[hash]; !known {
+			return AuditMismatch
+		}
+		parsedSet[hash] = struct{}{}
+	}
+	if len(parsedSet) == len(storedSet) {
+		return AuditMatch
+	}
+	return AuditInconclusive
+}
+
+func compareStrings(left, right []string) AuditState {
+	left = append([]string(nil), left...)
+	right = append([]string(nil), right...)
+	sort.Strings(left)
+	sort.Strings(right)
+	if len(left) != len(right) {
+		return AuditMismatch
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return AuditMismatch
+		}
+	}
+	return AuditMatch
+}
+
+func compareAttachmentPairs(stored, parsed [][2]string) AuditState {
+	stored = append([][2]string(nil), stored...)
+	parsed = append([][2]string(nil), parsed...)
+	sortAttachmentPairs(stored)
+	sortAttachmentPairs(parsed)
+	if len(stored) != len(parsed) {
+		return AuditMismatch
+	}
+	for i := range stored {
+		if stored[i] != parsed[i] {
+			return AuditMismatch
+		}
+	}
+	return AuditMatch
+}
+
+func sortAttachmentPairs(pairs [][2]string) {
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i][0] != pairs[j][0] {
+			return pairs[i][0] < pairs[j][0]
+		}
+		return pairs[i][1] < pairs[j][1]
+	})
+}

--- a/internal/sync/repair_audit_test.go
+++ b/internal/sync/repair_audit_test.go
@@ -1,0 +1,490 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+	testemail "go.kenn.io/msgvault/internal/testutil/email"
+)
+
+func TestAuditGmailMessagesReportsCrossedFieldsAndInconclusiveRaw(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	crossedID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "stored")
+	missingID := seedRepairRow(t, env.Store, source.ID, "gmail-b", "thread-b", "missing")
+	badID := seedRepairRow(t, env.Store, source.ID, "gmail-c", "thread-c", "bad")
+
+	crossedRaw := testemail.NewMessage().
+		From("other@example.com").To("different@example.com").
+		Subject("other").Header("Message-ID", "<other@example.com>").Body("other body").Bytes()
+	require.NoError(env.Store.UpsertMessageRaw(crossedID, crossedRaw))
+	_, err := env.Store.DB().Exec(`DELETE FROM message_raw WHERE message_id = ?`, missingID)
+	require.NoError(err)
+	require.NoError(env.Store.UpsertMessageRaw(badID, []byte("not MIME\x00")))
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 3)
+	byID := auditByID(results)
+	assert.Equal(AuditMismatch, byID[crossedID].Status)
+	assert.Equal(AuditMismatch, byID[crossedID].Fields[AuditFieldSubject])
+	assert.Equal(AuditMismatch, byID[crossedID].Fields[AuditFieldBodyText])
+	assert.Equal(AuditMismatch, byID[crossedID].Fields[AuditFieldTo])
+	assert.Equal(AuditInconclusive, byID[missingID].Status)
+	assert.Equal(AuditInconclusive, byID[missingID].Fields[AuditFieldRawMIME])
+	assert.Equal(AuditInconclusive, byID[badID].Status)
+	assert.Equal(AuditInconclusive, byID[badID].Fields[AuditFieldRawMIME])
+}
+
+func TestAuditGmailMessagesTreatsParsedEmptyFieldsAsAuthoritative(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	id := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "stored")
+	raw := testemail.NewMessage().NoSubject().
+		Header("Message-ID", "<gmail-a@example.com>").Body("stored body").Bytes()
+	require.NoError(env.Store.UpsertMessageRaw(id, raw))
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1)
+	assert.Equal(AuditMismatch, results[0].Status)
+	assert.Equal(AuditMismatch, results[0].Fields[AuditFieldSubject])
+}
+
+func TestAuditGmailMessagesMarksNonMIMEStoredRawInconclusive(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	id := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "stored")
+
+	_, err := env.Store.DB().Exec(
+		`UPDATE message_raw SET raw_format = 'gcal_json' WHERE message_id = ?`, id)
+	require.NoError(err)
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1)
+	assert.Equal(AuditInconclusive, results[0].Status)
+	assert.Equal(AuditInconclusive, results[0].Fields[AuditFieldRawMIME])
+}
+
+func TestAuditGmailMessagesOmitsCoherentLegacyEvidence(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "coherent", "coherent body", []byte("legacy attachment"))
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	participantID, err := env.Store.EnsureParticipant("merged@example.com", "Merged", "example.com")
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`UPDATE messages SET sender_id = ? WHERE id = ?`, participantID, id)
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`UPDATE message_recipients SET email_address = NULL WHERE message_id = ?`, id)
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`UPDATE attachments SET source_part_key = NULL WHERE message_id = ?`, id)
+	require.NoError(err)
+
+	assert.Empty(t, collectAudit(t, env.Syncer, source.ID))
+}
+
+func TestAuditGmailMessagesComparesAttachmentHashesWithoutOccurrenceKeys(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	raw := repairRaw("gmail-a", "thread-a", "subject", "body", []byte("actual attachment"))
+	env.Mock.Messages["gmail-a"] = raw
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	_, err := env.Store.DB().Exec(`UPDATE attachments SET content_hash = 'wrong', source_part_key = NULL WHERE message_id = ?`, id)
+	require.NoError(err)
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1)
+	assert.Equal(AuditMismatch, results[0].Fields[AuditFieldAttachmentHashes])
+	assert.Equal(AuditInconclusive, results[0].Fields[AuditFieldAttachmentPartKeys])
+}
+
+func TestAuditGmailMessagesAttachmentHashMultisetPreservesDuplicateCounts(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	raw := testemail.NewMessage().
+		Subject("duplicates").Body("body").
+		WithAttachment("first.bin", "application/octet-stream", []byte("same bytes")).
+		WithAttachment("second.bin", "application/octet-stream", []byte("same bytes")).Bytes()
+	env.Mock.AddMessage("gmail-a", raw, []string{"INBOX"})
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	var attachmentID int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM attachments WHERE message_id = ? ORDER BY id LIMIT 1`, id).Scan(&attachmentID))
+	_, err := env.Store.DB().Exec(`DELETE FROM attachments WHERE id = ?`, attachmentID)
+	require.NoError(err)
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1)
+	assert.Equal(t, AuditMismatch, results[0].Fields[AuditFieldAttachmentHashes])
+}
+
+func TestAuditGmailMessagesAcceptsRepeatedPartStoredOnceWithoutOccurrenceKeys(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	raw := testemail.NewMessage().
+		Subject("repeated logo").Body("body").
+		WithAttachment("logo.png", "image/png", []byte("same bytes")).
+		WithAttachment("logo-again.png", "image/png", []byte("same bytes")).Bytes()
+	env.Mock.AddMessage("gmail-a", raw, []string{"INBOX"})
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	// Archives written before occurrence keys existed hold one unkeyed row per
+	// (message, content hash), so the repeated part was stored exactly once.
+	var keep int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM attachments WHERE message_id = ? ORDER BY id LIMIT 1`, id).Scan(&keep))
+	_, err := env.Store.DB().Exec(`DELETE FROM attachments WHERE message_id = ? AND id <> ?`, id, keep)
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`UPDATE attachments SET source_part_key = NULL WHERE id = ?`, keep)
+	require.NoError(err)
+
+	assert.Empty(t, collectAudit(t, env.Syncer, source.ID))
+}
+
+func TestAuditGmailMessagesTreatsLegacyOnlyAttachmentAsInconclusive(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	raw := repairRaw("gmail-a", "thread-a", "subject", "body", []byte("actual attachment"))
+	env.Mock.Messages["gmail-a"] = raw
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	// Older ingests recorded small nameless text parts as attachments. Such a
+	// row has no counterpart in the current parse but is not corruption.
+	_, err := env.Store.DB().Exec(`UPDATE attachments SET source_part_key = NULL WHERE message_id = ?`, id)
+	require.NoError(err)
+	require.NoError(env.Store.UpsertAttachmentRecord(t.Context(), id, store.AttachmentWrite{
+		Filename: "", MIMEType: "text/plain", StoragePath: "ab/abcd", ContentHash: "abcd", Size: 150,
+	}))
+
+	assert.Empty(t, collectAudit(t, env.Syncer, source.ID))
+	fields := auditFieldsForMessage(t, env, id)
+	assert.Equal(t, AuditInconclusive, fields[AuditFieldAttachmentHashes])
+}
+
+func TestAuditGmailMessagesFlagsSwappedAttachmentHashes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	raw := testemail.NewMessage().
+		Subject("swap").Body("body").
+		WithAttachment("first.bin", "application/octet-stream", []byte("first bytes")).
+		WithAttachment("second.bin", "application/octet-stream", []byte("second bytes")).Bytes()
+	env.Mock.AddMessage("gmail-a", raw, []string{"INBOX"})
+	env.Mock.Profile.MessagesTotal = 1
+	env.Mock.Profile.HistoryID = 10
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = filepath.Join(env.TmpDir, "attachments") })
+	runFullSync(t, env)
+	var id int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_id = ? AND source_message_id = 'gmail-a'`, source.ID).Scan(&id))
+	rows, err := env.Store.DB().Query(
+		`SELECT id, content_hash FROM attachments WHERE message_id = ? ORDER BY id`, id)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	type storedAttachment struct {
+		id   int64
+		hash string
+	}
+	var stored []storedAttachment
+	for rows.Next() {
+		var attachment storedAttachment
+		require.NoError(rows.Scan(&attachment.id, &attachment.hash))
+		stored = append(stored, attachment)
+	}
+	require.NoError(rows.Err())
+	require.Len(stored, 2)
+	require.NotEqual(stored[0].hash, stored[1].hash)
+	_, err = env.Store.DB().Exec(`UPDATE attachments SET content_hash = ? WHERE id = ?`, stored[1].hash, stored[0].id)
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`UPDATE attachments SET content_hash = ? WHERE id = ?`, stored[0].hash, stored[1].id)
+	require.NoError(err)
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1)
+	assert.Equal(AuditMismatch, results[0].Status)
+	assert.Equal(AuditMismatch, results[0].Fields[AuditFieldAttachmentHashes],
+		"hashes swapped between part keys must not compare as a coherent multiset")
+	assert.Equal(AuditMatch, results[0].Fields[AuditFieldAttachmentPartKeys])
+}
+
+func TestAuditGmailMessagesIsReadOnlyAndKeysetPaged(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	testutil.SkipIfPostgres(t, "filesystem and SQLite query-only proof")
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	var firstID, secondPageID int64
+	for i := range auditPageSize + 1 {
+		id := seedRepairRow(t, env.Store, source.ID, fmt.Sprintf("gmail-%03d", i), "thread", "coherent")
+		if i == 0 {
+			firstID = id
+		}
+		if i == auditPageSize {
+			secondPageID = id
+		}
+	}
+	_, err := env.Store.DB().Exec(`UPDATE message_raw SET raw_data = ?, compression = 'zlib' WHERE message_id = ?`, []byte("not-zlib"), firstID)
+	require.NoError(err)
+	require.NoError(env.Store.UpsertMessageRaw(secondPageID,
+		testemail.NewMessage().Subject("second-page-mismatch").Body("different").Bytes()))
+	dbPath := filepath.Join(env.TmpDir, "test.db")
+	before, err := os.Stat(dbPath)
+	require.NoError(err)
+	readOnly, err := store.OpenReadOnly(dbPath)
+	require.NoError(err)
+	t.Cleanup(func() { _ = readOnly.Close() })
+	auditor := New(env.Mock, readOnly, &Options{AttachmentsDir: filepath.Join(env.TmpDir, "attachments")})
+
+	results := collectAudit(t, auditor, source.ID)
+	require.Len(results, 2)
+	assert.Equal(firstID, results[0].InternalID)
+	assert.Equal(AuditInconclusive, results[0].Status)
+	assert.Contains(results[0].Error, "zlib")
+	assert.Equal(secondPageID, results[1].InternalID,
+		"an emitted candidate must prove the second keyset page was processed")
+	assert.Equal(AuditMismatch, results[1].Status)
+	after, err := os.Stat(dbPath)
+	require.NoError(err)
+	assert.Equal(before.Size(), after.Size())
+	assert.Equal(before.ModTime(), after.ModTime())
+	_, statErr := os.Stat(filepath.Join(env.TmpDir, "attachments"))
+	assert.ErrorIs(statErr, os.ErrNotExist)
+}
+
+func TestAuditGmailMessagesStopsLoadedPageOnCancellation(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	firstID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread", "stored")
+	secondID := seedRepairRow(t, env.Store, source.ID, "gmail-b", "thread", "stored")
+	require.NoError(env.Store.UpsertMessageRaw(firstID, testemail.NewMessage().Subject("first mismatch").Body("different").Bytes()))
+	require.NoError(env.Store.UpsertMessageRaw(secondID, testemail.NewMessage().Subject("second mismatch").Body("different").Bytes()))
+	ctx, cancel := context.WithCancel(t.Context())
+	var emitted []int64
+
+	err := env.Syncer.AuditGmailMessages(ctx, source.ID, func(result RepairAuditResult) error {
+		emitted = append(emitted, result.InternalID)
+		cancel()
+		return nil
+	})
+	require.ErrorIs(err, context.Canceled)
+	assert.Equal(t, []int64{firstID}, emitted)
+}
+
+type cancelAfterArmedChecks struct {
+	context.Context
+
+	cancel context.CancelFunc
+	armed  atomic.Bool
+	checks atomic.Int32
+}
+
+func (c *cancelAfterArmedChecks) Err() error {
+	if c.armed.Load() && c.checks.Add(1) == 3 {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+func (c *cancelAfterArmedChecks) arm() {
+	c.checks.Store(0)
+	c.armed.Store(true)
+}
+
+func TestAuditGmailMessagesReturnsCancellationAfterCoherentFinalRow(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	firstID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread", "stored")
+	seedRepairRow(t, env.Store, source.ID, "gmail-b", "thread", "coherent")
+	require.NoError(t, env.Store.UpsertMessageRaw(firstID,
+		testemail.NewMessage().Subject("mismatch").Body("different").Bytes()))
+	base, cancel := context.WithCancel(t.Context())
+	ctx := &cancelAfterArmedChecks{Context: base, cancel: cancel}
+	var emitted []int64
+
+	err := env.Syncer.AuditGmailMessages(ctx, source.ID, func(result RepairAuditResult) error {
+		emitted = append(emitted, result.InternalID)
+		ctx.arm()
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, []int64{firstID}, emitted)
+}
+
+func TestRepairedMessageWithProviderAttachmentIsNotAuditedAgain(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	id := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	_, err := env.Store.DB().Exec(`INSERT INTO attachments (
+		message_id, filename, mime_type, size, content_hash, storage_path,
+		source_attachment_id, attachment_role, role_source
+	) VALUES (?, 'provider.bin', 'application/octet-stream', 8, 'providerhash', 'pr/provider',
+		'provider:1', 'standalone', 'provider_explicit')`, id)
+	require.NoError(err)
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "new", "new body", nil)
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.NoError(err)
+	assert.Empty(collectAudit(t, env.Syncer, source.ID))
+	var providerRows int
+	require.NoError(env.Store.DB().QueryRow(`SELECT COUNT(*) FROM attachments WHERE message_id = ? AND source_attachment_id IS NOT NULL`, id).Scan(&providerRows))
+	assert.Equal(1, providerRows)
+}
+
+func TestAuditGmailMessagesScopesPositiveSourceAndRejectsNonGmail(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	gmailSource := env.CreateSource(t)
+	imapSource, err := env.Store.GetOrCreateSource("imap", "imap@example.com")
+	require.NoError(err)
+	gmailID := seedRepairRow(t, env.Store, gmailSource.ID, "gmail-a", "thread", "stored")
+	seedRepairRow(t, env.Store, imapSource.ID, "imap-a", "thread", "stored")
+	require.NoError(env.Store.UpsertMessageRaw(gmailID, testemail.NewMessage().Subject("different").Body("different").Bytes()))
+
+	results := collectAudit(t, env.Syncer, gmailSource.ID)
+	require.Len(results, 1)
+	assert.Equal(t, gmailSource.ID, results[0].SourceID)
+	err = env.Syncer.AuditGmailMessages(t.Context(), -1, func(RepairAuditResult) error { return nil })
+	require.ErrorContains(err, "source ID must be positive")
+	err = env.Syncer.AuditGmailMessages(t.Context(), imapSource.ID, func(RepairAuditResult) error { return nil })
+	require.ErrorContains(err, "not gmail")
+}
+
+// TestAuditGmailMessagesMarksOversizedRawInconclusive proves the audit bounds
+// raw-MIME decompression. The stored payload is a valid MIME message whose
+// decompressed size lands just over the audit's 64 MiB cap; such a record
+// must be reported inconclusive instead of being fully materialized, because
+// raw storage has no size limit and unbounded decompression could exhaust
+// memory on a corrupt or hostile archive.
+func TestAuditGmailMessagesMarksOversizedRawInconclusive(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// The cap under test is the named production constant (64 MiB).
+	const gmailAuditRawMIMECapBytes = store.GmailAuditMaxRawMIMEBytes
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	id := seedGmailAuditRow(t, env.Store, source.ID, "gmail-oversized", "oversized subject")
+
+	body := strings.Repeat("a", int(gmailAuditRawMIMECapBytes)+4096)
+	raw := testemail.NewMessage().
+		From("sender@example.com").To("recipient@example.com").
+		Subject("oversized subject").
+		Header("Message-ID", "<gmail-oversized@example.com>").
+		Body(body).Bytes()
+	require.Greater(len(raw), int(gmailAuditRawMIMECapBytes),
+		"fixture must decompress just over the audit cap")
+	require.NoError(env.Store.UpsertMessageRaw(id, raw))
+
+	results := collectAudit(t, env.Syncer, source.ID)
+	require.Len(results, 1,
+		"oversized raw MIME must be reported instead of silently passing or failing on field comparisons")
+	assert.Equal(AuditInconclusive, results[0].Status)
+	assert.Equal(AuditInconclusive, results[0].Fields[AuditFieldRawMIME])
+	assert.Contains(results[0].Error, "exceeds")
+	assert.Contains(results[0].Error, "67108864")
+}
+
+func seedGmailAuditRow(
+	t *testing.T, st *store.Store, sourceID int64, sourceMessageID, subject string,
+) int64 {
+	t.Helper()
+	require := require.New(t)
+	convID, err := st.EnsureConversation(sourceID, "thread-"+sourceMessageID, subject)
+	require.NoError(err)
+	participants, err := st.EnsureParticipantsBatch([]mime.Address{
+		{Email: "sender@example.com", Domain: "example.com"},
+		{Email: "recipient@example.com", Domain: "example.com"},
+	})
+	require.NoError(err)
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID: convID, SourceID: sourceID, SourceMessageID: sourceMessageID,
+			MessageType:     store.MessageTypeEmail,
+			RFC822MessageID: sql.NullString{String: "<" + sourceMessageID + "@example.com>", Valid: true},
+			Subject:         sql.NullString{String: subject, Valid: true},
+			SenderID:        sql.NullInt64{Int64: participants["sender@example.com"], Valid: true},
+		},
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: []int64{participants["sender@example.com"]}, EmailAddresses: []string{"sender@example.com"}},
+			{Type: "to", ParticipantIDs: []int64{participants["recipient@example.com"]}, EmailAddresses: []string{"recipient@example.com"}},
+		},
+	})
+	require.NoError(err)
+	return id
+}
+
+func auditFieldsForMessage(t *testing.T, env *TestEnv, id int64) map[string]AuditState {
+	t.Helper()
+	var fields map[string]AuditState
+	_, err := env.Store.StreamGmailAuditEvidencePageContext(
+		t.Context(), 0, id-1, 1, func(evidence store.GmailAuditEvidence) error {
+			result, _ := auditGmailEvidence(evidence)
+			fields = result.Fields
+			return nil
+		})
+	require.NoError(t, err)
+	return fields
+}
+
+func collectAudit(t *testing.T, syncer *Syncer, sourceID int64) []RepairAuditResult {
+	t.Helper()
+	var results []RepairAuditResult
+	require.NoError(t, syncer.AuditGmailMessages(t.Context(), sourceID, func(result RepairAuditResult) error {
+		results = append(results, result)
+		return nil
+	}))
+	return results
+}
+
+func auditByID(results []RepairAuditResult) map[int64]RepairAuditResult {
+	byID := make(map[int64]RepairAuditResult, len(results))
+	for _, result := range results {
+		byID[result.InternalID] = result
+	}
+	return byID
+}

--- a/internal/sync/repair_test.go
+++ b/internal/sync/repair_test.go
@@ -1,0 +1,511 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	testemail "go.kenn.io/msgvault/internal/testutil/email"
+)
+
+func TestRepairMessageResolvesExactTargetAndSourceScope(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	sourceA := env.CreateSource(t)
+	sourceB, err := env.Store.GetOrCreateSource("gmail", "other@example.com")
+	require.NoError(err)
+	internalA := seedRepairRow(t, env.Store, sourceA.ID, "123", "thread-a", "A")
+	internalB := seedRepairRow(t, env.Store, sourceB.ID, "123", "thread-b", "B")
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "123"})
+	require.ErrorContains(err, "ambiguous")
+	assert.Empty(env.Mock.GetMessageCalls)
+
+	env.Mock.Messages["123"] = repairRaw("123", "thread-a", "repaired", "body", nil)
+	result, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{
+		Reference: "123",
+		SourceID:  sourceA.ID,
+	})
+	require.NoError(err)
+	assert.Equal(internalA, result.InternalID)
+	assert.Equal(sourceA.ID, result.SourceID)
+	assert.Equal("123", result.SourceMessageID)
+	assert.Equal("repaired", result.Subject)
+	assert.Equal([]string{"123"}, env.Mock.GetMessageCalls)
+	assert.NotEqual(internalB, result.InternalID)
+}
+
+func TestRepairMessageLeavesSentAttributionToIdentityDiscovery(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-sent", "thread-a", "old")
+	raw := repairRaw("gmail-sent", "thread-a", "repaired", "repaired body", nil)
+	raw.LabelIDs = []string{"SENT"}
+	env.Mock.Messages["gmail-sent"] = raw
+
+	_, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{
+		Reference: "gmail-sent",
+		SourceID:  source.ID,
+	})
+	require.NoError(err)
+	var sourceIsFromMe, identityIsFromMe bool
+	require.NoError(env.Store.DB().QueryRow(`
+		SELECT source_is_from_me, identity_is_from_me
+		FROM messages WHERE id = ?`, internalID).Scan(&sourceIsFromMe, &identityIsFromMe))
+	assert.False(t, sourceIsFromMe,
+		"Gmail ingest never writes source-native attribution; repair must match sync")
+	assert.False(t, identityIsFromMe,
+		"identity attribution comes from confirmed identities, not the SENT label")
+}
+
+func TestRepairMessageRejectsAmbiguousNumericInterpretations(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internal := seedRepairRow(t, env.Store, source.ID, "provider-a", "thread-a", "A")
+	seedRepairRow(t, env.Store, source.ID, strconv.FormatInt(internal, 10), "thread-b", "B")
+
+	_, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{
+		Reference: strconv.FormatInt(internal, 10),
+		SourceID:  source.ID,
+	})
+	require.ErrorContains(t, err, "ambiguous")
+	assert.Empty(t, env.Mock.GetMessageCalls)
+}
+
+func TestRepairMessageRejectsNonGmailAndInvalidSourceScope(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	imapSource, err := env.Store.GetOrCreateSource("imap", "imap@example.com")
+	require.NoError(err)
+	internal := seedRepairRow(t, env.Store, imapSource.ID, "imap:1", "thread", "subject")
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: strconv.FormatInt(internal, 10)})
+	require.ErrorContains(err, "not gmail")
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "imap:1", SourceID: -1})
+	require.ErrorContains(err, "source ID must be positive")
+	assert.Empty(t, env.Mock.GetMessageCalls)
+}
+
+func TestRepairMessageRejectsAuthenticatedMailboxMismatchBeforeFetch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source, err := env.Store.GetOrCreateSource("gmail", "mailbox-b@example.com")
+	require.NoError(err)
+	internalID := seedRepairRow(t, env.Store, source.ID, "shared-gmail-id", "thread-b", "mailbox B")
+	before := readRepairSnapshot(t, env.Store, internalID)
+	env.Mock.Profile.EmailAddress = "mailbox-a@example.com"
+	env.Mock.Messages["shared-gmail-id"] = repairRaw(
+		"shared-gmail-id", "thread-a", "mailbox A", "wrong mailbox body", nil,
+	)
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{
+		Reference: "shared-gmail-id",
+		SourceID:  source.ID,
+	})
+	require.ErrorContains(err, "authenticated Gmail account")
+	assert.Equal(1, env.Mock.ProfileCalls)
+	assert.Empty(env.Mock.GetMessageCalls)
+	assert.Zero(env.Mock.LabelsCalls)
+	assert.Equal(before, readRepairSnapshot(t, env.Store, internalID))
+}
+
+func TestRepairMessageRejectsUndescribedProviderLabelWithoutErasingLabels(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	labelID, err := env.Store.EnsureLabel(source.ID, "OLD", "Old label", "user")
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`INSERT INTO message_labels (message_id, label_id) VALUES (?, ?)`, internalID, labelID)
+	require.NoError(err)
+	before := readRepairSnapshot(t, env.Store, internalID)
+	raw := repairRaw("gmail-a", "thread-a", "new", "new body", nil)
+	raw.LabelIDs = []string{"UNDESCRIBED"}
+	env.Mock.Messages["gmail-a"] = raw
+	env.Mock.Labels = []*gmail.Label{{ID: "INBOX", Name: "Inbox", Type: "system"}}
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.ErrorContains(err, "label \"UNDESCRIBED\" is missing from provider catalog")
+	assert.Equal(t, before, readRepairSnapshot(t, env.Store, internalID))
+}
+
+func TestRepairMessageProviderMIMESourcePartCollisionRollsBack(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	raw := repairRaw("gmail-a", "thread-a", "new", "new body", []byte("MIME bytes"))
+	parsed, err := mime.Parse(raw.Raw)
+	require.NoError(err)
+	require.Len(parsed.Attachments, 1)
+	require.NotEmpty(parsed.Attachments[0].ContentHash)
+	require.NoError(env.Store.UpsertAttachmentRecord(t.Context(), internalID, store.AttachmentWrite{
+		Filename: "provider.bin", MIMEType: "application/octet-stream",
+		StoragePath: "provider.bin", ContentHash: "provider-hash", Size: 8,
+		SourceAttachmentID: "provider:1", SourcePartKey: parsed.Attachments[0].PartKey,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceProviderExplicit,
+	}))
+	require.NoError(env.Store.RecomputeMessageAttachmentStats(internalID))
+	before := readRepairSnapshot(t, env.Store, internalID)
+	env.Mock.Messages["gmail-a"] = raw
+	attachmentsDir := filepath.Join(env.TmpDir, "attachments")
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = attachmentsDir })
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.ErrorContains(err, "provider-owned attachment source-part collision")
+	assert.Equal(t, before, readRepairSnapshot(t, env.Store, internalID))
+	assert.NoFileExists(t, filepath.Join(
+		attachmentsDir,
+		parsed.Attachments[0].ContentHash[:2],
+		parsed.Attachments[0].ContentHash,
+	), "failed repair must remove its newly published attachment blob")
+}
+
+func TestRepairMessageStoreFailurePreservesPreexistingMIMEBlob(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	raw := repairRaw("gmail-a", "thread-a", "new", "new body", []byte("MIME bytes"))
+	parsed, err := mime.Parse(raw.Raw)
+	require.NoError(err)
+	require.Len(parsed.Attachments, 1)
+	require.NoError(env.Store.UpsertAttachmentRecord(t.Context(), internalID, store.AttachmentWrite{
+		Filename: "provider.bin", MIMEType: "application/octet-stream",
+		StoragePath: "provider.bin", ContentHash: "provider-hash", Size: 8,
+		SourceAttachmentID: "provider:1", SourcePartKey: parsed.Attachments[0].PartKey,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceProviderExplicit,
+	}))
+	attachmentsDir := filepath.Join(env.TmpDir, "attachments")
+	receipt, err := export.StoreAttachmentFileDurable(attachmentsDir, &parsed.Attachments[0])
+	require.NoError(err)
+	require.True(receipt.Created)
+	blobPath := filepath.Join(attachmentsDir, filepath.FromSlash(receipt.StoragePath))
+	require.FileExists(blobPath)
+	env.Mock.Messages["gmail-a"] = raw
+	env.SetOptions(t, func(options *Options) { options.AttachmentsDir = attachmentsDir })
+
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.ErrorContains(err, "provider-owned attachment source-part collision")
+	assert.FileExists(t, blobPath, "failed repair must preserve a pre-existing deduplicated blob")
+}
+
+type cancelingLabelsAPI struct {
+	*gmail.MockAPI
+
+	cancel context.CancelFunc
+}
+
+func (a *cancelingLabelsAPI) ListLabels(ctx context.Context) ([]*gmail.Label, error) {
+	labels, err := a.MockAPI.ListLabels(ctx)
+	a.cancel()
+	return labels, err
+}
+
+func TestRepairMessageChecksCancellationBeforeAttachmentPublication(t *testing.T) {
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	before := readRepairSnapshot(t, env.Store, internalID)
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "new", "new body", []byte("attachment"))
+	ctx, cancel := context.WithCancel(t.Context())
+	client := &cancelingLabelsAPI{MockAPI: env.Mock, cancel: cancel}
+	attachmentsDir := filepath.Join(env.TmpDir, "attachments")
+	env.Syncer = New(client, env.Store, &Options{AttachmentsDir: attachmentsDir})
+
+	_, err := env.Syncer.RepairMessage(ctx, RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.ErrorIs(t, err, context.Canceled)
+	_, statErr := os.Stat(attachmentsDir)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+	assert.Equal(t, before, readRepairSnapshot(t, env.Store, internalID))
+}
+
+func TestRepairMessagePreStoreFailuresLeaveArchiveUnchanged(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(t *testing.T, env *TestEnv, source *store.Source, internalID int64)
+		wantError string
+	}{
+		{
+			name: "provider 404",
+			configure: func(_ *testing.T, env *TestEnv, _ *store.Source, _ int64) {
+				env.Mock.GetMessageError["gmail-a"] = &gmail.NotFoundError{Path: "/messages/gmail-a"}
+			},
+			wantError: "fetch Gmail message",
+		},
+		{
+			name: "returned ID mismatch",
+			configure: func(_ *testing.T, env *TestEnv, _ *store.Source, _ int64) {
+				env.Mock.Messages["gmail-a"] = repairRaw("wrong-id", "thread-a", "new", "new", nil)
+			},
+			wantError: "returned message ID",
+		},
+		{
+			name: "strict MIME parse",
+			configure: func(_ *testing.T, env *TestEnv, _ *store.Source, _ int64) {
+				env.Mock.Messages["gmail-a"] = &gmail.RawMessage{ID: "gmail-a", Raw: []byte("not a MIME message\x00")}
+			},
+			wantError: "strictly parse",
+		},
+		{
+			name: "durable attachment publication",
+			configure: func(t *testing.T, env *TestEnv, _ *store.Source, _ int64) {
+				t.Helper()
+				blocked := filepath.Join(env.TmpDir, "not-a-directory")
+				require.NoError(t, os.WriteFile(blocked, []byte("file"), 0o600))
+				env.Syncer = New(env.Mock, env.Store, &Options{AttachmentsDir: blocked})
+				env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "new", "new", []byte("attachment"))
+			},
+			wantError: "publish attachment",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			source := env.CreateSource(t)
+			internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+			siblingID := seedRepairRow(t, env.Store, source.ID, "gmail-b", "thread-b", "sibling")
+			before := readRepairSnapshot(t, env.Store, internalID)
+			siblingBefore := readRepairSnapshot(t, env.Store, siblingID)
+			tc.configure(t, env, source, internalID)
+
+			_, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+			require.ErrorContains(t, err, tc.wantError)
+			assert.Equal(t, before, readRepairSnapshot(t, env.Store, internalID))
+			assert.Equal(t, siblingBefore, readRepairSnapshot(t, env.Store, siblingID))
+		})
+	}
+}
+
+type identityRaceAPI struct {
+	*gmail.MockAPI
+
+	change func() error
+}
+
+func (a *identityRaceAPI) ListLabels(ctx context.Context) ([]*gmail.Label, error) {
+	if err := a.change(); err != nil {
+		return nil, err
+	}
+	return a.MockAPI.ListLabels(ctx)
+}
+
+func TestRepairMessageIdentityRaceLeavesArchiveRowsUnchanged(t *testing.T) {
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "new", "new body", nil)
+	racing := &identityRaceAPI{MockAPI: env.Mock, change: func() error {
+		_, err := env.Store.DB().Exec(`UPDATE messages SET source_message_id = 'raced' WHERE id = ?`, internalID)
+		return err
+	}}
+	env.Syncer = New(racing, env.Store, nil)
+
+	_, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: "gmail-a", SourceID: source.ID})
+	require.ErrorContains(t, err, "identity guard mismatch")
+	snapshot := readRepairSnapshot(t, env.Store, internalID)
+	assert.Equal("raced", snapshot.SourceMessageID)
+	assert.Equal("old", snapshot.Subject)
+	assert.Contains(snapshot.Body, "old body")
+}
+
+func TestRepairMessagePreservesConversationParticipants(t *testing.T) {
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	internalID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "old")
+	var conversationID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT conversation_id FROM messages WHERE id = ?`, internalID,
+	).Scan(&conversationID))
+	participants, err := env.Store.EnsureParticipantsBatch([]mime.Address{
+		{Email: "thread-member@example.com", Domain: "example.com"},
+	})
+	require.NoError(err)
+	require.NoError(env.Store.EnsureConversationParticipant(
+		conversationID, participants["thread-member@example.com"], "member",
+	))
+
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-a", "repaired", "repaired body", nil)
+	_, err = env.Syncer.RepairMessage(t.Context(), RepairRequest{
+		Reference: "gmail-a", SourceID: source.ID,
+	})
+	require.NoError(err)
+
+	var count int
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM conversation_participants WHERE conversation_id = ?`,
+		conversationID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "repair without a membership snapshot must preserve thread membership")
+}
+
+func TestRepairMessageReplacesOnlyTargetSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSource(t)
+	targetID := seedRepairRow(t, env.Store, source.ID, "gmail-a", "thread-a", "crossed")
+	siblingID := seedRepairRow(t, env.Store, source.ID, "gmail-b", "thread-b", "sibling")
+	siblingBefore := readRepairSnapshot(t, env.Store, siblingID)
+	require.NoError(env.Store.UpsertMessageRaw(targetID, []byte(siblingBefore.Raw)))
+	_, err := env.Store.DB().Exec(`UPDATE message_bodies SET body_text = ? WHERE message_id = ?`, siblingBefore.Body, targetID)
+	require.NoError(err)
+	attachmentsDir := filepath.Join(env.TmpDir, "attachments")
+	env.Syncer = New(env.Mock, env.Store, &Options{AttachmentsDir: attachmentsDir})
+	env.Mock.Labels = []*gmail.Label{{ID: "INBOX", Name: "Inbox", Type: "system"}}
+	env.Mock.Messages["gmail-a"] = repairRaw("gmail-a", "thread-repaired", "repaired", "repaired body", []byte("fresh attachment"))
+
+	result, err := env.Syncer.RepairMessage(t.Context(), RepairRequest{Reference: strconv.FormatInt(targetID, 10)})
+	require.NoError(err)
+	assert.Equal(targetID, result.InternalID)
+	target := readRepairSnapshot(t, env.Store, targetID)
+	assert.Equal("repaired", target.Subject)
+	assert.Contains(target.Body, "repaired body")
+	assert.Equal("gmail-a", target.SourceMessageID)
+	assert.Equal(siblingBefore, readRepairSnapshot(t, env.Store, siblingID))
+	assert.Equal([]string{"gmail-a"}, env.Mock.GetMessageCalls)
+
+	var attachmentCount int
+	require.NoError(env.Store.DB().QueryRow(`SELECT COUNT(*) FROM attachments WHERE message_id = ?`, targetID).Scan(&attachmentCount))
+	assert.Equal(1, attachmentCount)
+}
+
+type repairSnapshot struct {
+	SourceMessageID string
+	Subject         string
+	Body            string
+	Raw             string
+	Conversation    string
+	Recipients      []string
+	Labels          []string
+	Attachments     []string
+}
+
+func readRepairSnapshot(t *testing.T, st *store.Store, id int64) repairSnapshot {
+	t.Helper()
+	var got repairSnapshot
+	var conversationID int64
+	var conversationType, conversationSourceID, conversationTitle string
+	require.NoError(t, st.DB().QueryRow(`
+		SELECT m.source_message_id, COALESCE(m.subject, ''), COALESCE(mb.body_text, ''),
+		       c.id, c.conversation_type, COALESCE(c.source_conversation_id, ''), COALESCE(c.title, '')
+		FROM messages m
+		JOIN conversations c ON c.id = m.conversation_id
+		LEFT JOIN message_bodies mb ON mb.message_id = m.id
+		WHERE m.id = ?`, id).Scan(
+		&got.SourceMessageID, &got.Subject, &got.Body,
+		&conversationID, &conversationType, &conversationSourceID, &conversationTitle,
+	))
+	got.Conversation = fmt.Sprintf("%d|%s|%s|%s", conversationID, conversationType, conversationSourceID, conversationTitle)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(t, err)
+	got.Raw = string(raw)
+	recipients, err := st.DB().Query(`
+		SELECT recipient_type, participant_id, COALESCE(display_name, ''), COALESCE(email_address, '')
+		FROM message_recipients WHERE message_id = ?
+		ORDER BY recipient_type, participant_id, email_address`, id)
+	require.NoError(t, err)
+	defer func() { _ = recipients.Close() }()
+	for recipients.Next() {
+		var recipientType, displayName, emailAddress string
+		var participantID int64
+		require.NoError(t, recipients.Scan(&recipientType, &participantID, &displayName, &emailAddress))
+		got.Recipients = append(got.Recipients, fmt.Sprintf("%s|%d|%s|%s", recipientType, participantID, displayName, emailAddress))
+	}
+	require.NoError(t, recipients.Err())
+	labels, err := st.DB().Query(`
+		SELECT l.id, COALESCE(l.source_label_id, ''), l.name, COALESCE(l.label_type, ''), COALESCE(l.system_role, '')
+		FROM message_labels ml JOIN labels l ON l.id = ml.label_id
+		WHERE ml.message_id = ? ORDER BY l.id`, id)
+	require.NoError(t, err)
+	defer func() { _ = labels.Close() }()
+	for labels.Next() {
+		var labelID int64
+		var sourceLabelID, name, labelType, systemRole string
+		require.NoError(t, labels.Scan(&labelID, &sourceLabelID, &name, &labelType, &systemRole))
+		got.Labels = append(got.Labels, fmt.Sprintf("%d|%s|%s|%s|%s", labelID, sourceLabelID, name, labelType, systemRole))
+	}
+	require.NoError(t, labels.Err())
+	attachments, err := st.DB().Query(`
+		SELECT id, COALESCE(filename, ''), COALESCE(content_hash, ''), storage_path,
+		       COALESCE(source_attachment_id, ''), attachment_role, role_source, COALESCE(source_part_key, '')
+		FROM attachments WHERE message_id = ? ORDER BY id`, id)
+	require.NoError(t, err)
+	defer func() { _ = attachments.Close() }()
+	for attachments.Next() {
+		var attachmentID int64
+		var filename, contentHash, storagePath, sourceAttachmentID, role, roleSource, sourcePartKey string
+		require.NoError(t, attachments.Scan(
+			&attachmentID, &filename, &contentHash, &storagePath, &sourceAttachmentID, &role, &roleSource, &sourcePartKey,
+		))
+		got.Attachments = append(got.Attachments, fmt.Sprintf(
+			"%d|%s|%s|%s|%s|%s|%s|%s",
+			attachmentID, filename, contentHash, storagePath, sourceAttachmentID, role, roleSource, sourcePartKey,
+		))
+	}
+	require.NoError(t, attachments.Err())
+	return got
+}
+
+func seedRepairRow(t *testing.T, st *store.Store, sourceID int64, sourceMessageID, threadID, subject string) int64 {
+	t.Helper()
+	convID, err := st.EnsureConversation(sourceID, threadID, subject)
+	require.NoError(t, err)
+	raw := testemail.NewMessage().
+		From("sender@example.com").
+		To("recipient@example.com").
+		Subject(subject).
+		Header("Message-ID", "<"+sourceMessageID+"@example.com>").
+		Body(subject + " body").Bytes()
+	parsed, err := mime.Parse(raw)
+	require.NoError(t, err)
+	participants, err := st.EnsureParticipantsBatch([]mime.Address{
+		{Email: "sender@example.com", Domain: "example.com"},
+		{Email: "recipient@example.com", Domain: "example.com"},
+	})
+	require.NoError(t, err)
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID: convID, SourceID: sourceID, SourceMessageID: sourceMessageID,
+			MessageType: store.MessageTypeEmail, RFC822MessageID: sql.NullString{String: "<" + sourceMessageID + "@example.com>", Valid: true},
+			Subject: sql.NullString{String: subject, Valid: true}, SenderID: sql.NullInt64{Int64: participants["sender@example.com"], Valid: true},
+		},
+		BodyText: sql.NullString{String: parsed.GetBodyText(), Valid: parsed.GetBodyText() != ""},
+		RawMIME:  raw,
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: []int64{participants["sender@example.com"]}, EmailAddresses: []string{"sender@example.com"}},
+			{Type: "to", ParticipantIDs: []int64{participants["recipient@example.com"]}, EmailAddresses: []string{"recipient@example.com"}},
+		},
+	})
+	require.NoError(t, err)
+	return id
+}
+
+func repairRaw(id, threadID, subject, body string, attachment []byte) *gmail.RawMessage {
+	builder := testemail.NewMessage().
+		From("new-sender@example.com").
+		To("new-recipient@example.com").
+		Subject(subject).
+		Header("Message-ID", "<"+id+"@example.com>").
+		Body(body)
+	if attachment != nil {
+		builder.WithAttachment("fresh.bin", "application/octet-stream", attachment)
+	}
+	return &gmail.RawMessage{ID: id, ThreadID: threadID, LabelIDs: []string{"INBOX"}, Raw: builder.Bytes()}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1253,21 +1253,69 @@ func (s *Syncer) syncLabels(ctx context.Context, sourceID int64) (map[string]int
 
 // messageData holds all parsed data for a message before persistence.
 type messageData struct {
-	message        *store.Message
-	bodyText       string
-	bodyHTML       string
-	rawMIME        []byte
-	from           []mime.Address
-	to             []mime.Address
-	cc             []mime.Address
-	bcc            []mime.Address
-	gmailLabelIDs  []string
-	attachments    []mime.Attachment
-	participantMap map[string]int64
+	message           *store.Message
+	threadID          string
+	conversationType  string
+	conversationTitle string
+	bodyText          string
+	bodyHTML          string
+	rawMIME           []byte
+	from              []mime.Address
+	to                []mime.Address
+	cc                []mime.Address
+	bcc               []mime.Address
+	gmailLabelIDs     []string
+	attachments       []mime.Attachment
+	participantMap    map[string]int64
 }
 
 // parseToModel parses a raw Gmail message into a messageData struct.
 func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID string) (*messageData, error) {
+	data, err := s.prepareMessage(sourceID, raw, threadID, false)
+	if err != nil {
+		return nil, err
+	}
+
+	allAddresses := make([]mime.Address, 0, len(data.from)+len(data.to)+len(data.cc)+len(data.bcc))
+	allAddresses = append(allAddresses, data.from...)
+	allAddresses = append(allAddresses, data.to...)
+	allAddresses = append(allAddresses, data.cc...)
+	allAddresses = append(allAddresses, data.bcc...)
+	participantMap, err := s.store.EnsureParticipantsBatch(allAddresses)
+	if err != nil {
+		return nil, fmt.Errorf("ensure participants: %w", err)
+	}
+
+	if len(data.from) > 0 && data.from[0].Email != "" {
+		if id, ok := participantMap[data.from[0].Email]; ok {
+			data.message.SenderID = sql.NullInt64{Int64: id, Valid: true}
+		}
+	}
+
+	var conversationID int64
+	if data.conversationType == conversationTypeChat {
+		conversationID, err = s.store.EnsureConversationWithType(
+			sourceID, data.threadID, data.conversationType, data.conversationTitle,
+		)
+	} else {
+		conversationID, err = s.store.EnsureConversation(
+			sourceID, data.threadID, data.conversationTitle,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ensure conversation: %w", err)
+	}
+	data.message.ConversationID = conversationID
+	data.participantMap = participantMap
+	return data, nil
+}
+
+// prepareMessage converts one provider payload into an immutable in-memory
+// snapshot without touching the store. Repair selects strict parsing; ordinary
+// ingest keeps recovery parsing and performs its writes only after this returns.
+func (s *Syncer) prepareMessage(
+	sourceID int64, raw *gmail.RawMessage, threadID string, strict bool,
+) (*messageData, error) {
 	// Validate raw MIME data exists
 	if len(raw.Raw) == 0 {
 		return nil, fmt.Errorf("missing raw MIME data for message %s", raw.ID)
@@ -1284,10 +1332,19 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 
 	// Parse MIME - on failure, salvage headers and store a placeholder body
 	// (threading override for IMAP happens after parsing below)
-	parsed, parseErr := mime.ParseWithRecovery(
-		raw.Raw,
-		extractSubjectFromSnippet(raw.Snippet),
-	)
+	var parsed *mime.Message
+	var parseErr error
+	if strict {
+		parsed, parseErr = mime.Parse(raw.Raw)
+		if parseErr != nil {
+			return nil, fmt.Errorf("strictly parse MIME message %s: %w", raw.ID, parseErr)
+		}
+	} else {
+		parsed, parseErr = mime.ParseWithRecovery(
+			raw.Raw,
+			extractSubjectFromSnippet(raw.Snippet),
+		)
+	}
 	if parseErr != nil {
 		// Extract just the first line of error (enmime includes full stack traces)
 		errMsg := textutil.FirstLine(parseErr.Error())
@@ -1324,42 +1381,16 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		parsed.Attachments[i].ContentType = textutil.EnsureUTF8(parsed.Attachments[i].ContentType)
 	}
 
-	// Ensure participants exist in database
-	allAddresses := make([]mime.Address, 0, len(parsed.From)+len(parsed.To)+len(parsed.Cc)+len(parsed.Bcc))
-	allAddresses = append(allAddresses, parsed.From...)
-	allAddresses = append(allAddresses, parsed.To...)
-	allAddresses = append(allAddresses, parsed.Cc...)
-	allAddresses = append(allAddresses, parsed.Bcc...)
-	participantMap, err := s.store.EnsureParticipantsBatch(allAddresses)
-	if err != nil {
-		return nil, fmt.Errorf("ensure participants: %w", err)
-	}
-
-	// Get sender ID
-	var senderID sql.NullInt64
-	if len(parsed.From) > 0 && parsed.From[0].Email != "" {
-		if id, ok := participantMap[parsed.From[0].Email]; ok {
-			senderID = sql.NullInt64{Int64: id, Valid: true}
-		}
-	}
-
 	// Use placeholder for conversation matching only (subject can be empty for storage)
 	convSubject := subject
 	if convSubject == "" {
 		convSubject = "(no subject)"
 	}
 	messageType := store.MessageTypeEmail
-	var conversationID int64
+	conversationType := "email_thread"
 	if s.isGmailChat(raw.LabelIDs) {
 		messageType = store.MessageTypeGoogleChat
-		conversationID, err = s.store.EnsureConversationWithType(
-			sourceID, threadID, conversationTypeChat, convSubject,
-		)
-	} else {
-		conversationID, err = s.store.EnsureConversation(sourceID, threadID, convSubject)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("ensure conversation: %w", err)
+		conversationType = conversationTypeChat
 	}
 
 	// Build message record
@@ -1374,13 +1405,11 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 		listID = sql.NullString{String: parsed.ListID, Valid: true}
 	}
 	msg := &store.Message{
-		ConversationID:  conversationID,
 		SourceID:        sourceID,
 		SourceMessageID: raw.ID,
 		RFC822MessageID: rfc822ID,
 		ListID:          listID,
 		MessageType:     messageType,
-		SenderID:        senderID,
 		Subject:         sql.NullString{String: subject, Valid: subject != ""},
 		Snippet:         sql.NullString{String: snippet, Valid: snippet != ""},
 		SizeEstimate:    raw.SizeEstimate,
@@ -1414,17 +1443,19 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 	}
 
 	return &messageData{
-		message:        msg,
-		bodyText:       bodyText,
-		bodyHTML:       bodyHTML,
-		rawMIME:        raw.Raw,
-		from:           parsed.From,
-		to:             parsed.To,
-		cc:             parsed.Cc,
-		bcc:            parsed.Bcc,
-		gmailLabelIDs:  raw.LabelIDs,
-		attachments:    parsed.Attachments,
-		participantMap: participantMap,
+		message:           msg,
+		threadID:          threadID,
+		conversationType:  conversationType,
+		conversationTitle: convSubject,
+		bodyText:          bodyText,
+		bodyHTML:          bodyHTML,
+		rawMIME:           raw.Raw,
+		from:              parsed.From,
+		to:                parsed.To,
+		cc:                parsed.Cc,
+		bcc:               parsed.Bcc,
+		gmailLabelIDs:     raw.LabelIDs,
+		attachments:       parsed.Attachments,
 	}, nil
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -3131,6 +3131,99 @@ func TestIncrementalSyncDedupesMessageAddedAndLabelAddedForSameUnknownMessage(t 
 	assert.Zero(itemCount, "sync_run_items")
 }
 
+func TestIncrementalSyncKeepsSiblingPayloadsDistinctWhenAddsRepeatAsLabelChanges(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.CreateSourceWithHistory(t, "12340")
+
+	rawByID := map[string][]byte{
+		"sibling-a": testemail.NewMessage().
+			From("sender-a@example.test").
+			To("recipient-a@example.test").
+			Subject("Sibling A subject").
+			Body("Sibling A body").
+			Bytes(),
+		"sibling-b": testemail.NewMessage().
+			From("sender-b@example.test").
+			To("recipient-b@example.test").
+			Subject("Sibling B subject").
+			Body("Sibling B body").
+			Bytes(),
+	}
+	env.Mock.Profile.MessagesTotal = 2
+	for id, raw := range rawByID {
+		env.Mock.AddMessage(id, raw, []string{"INBOX", "STARRED"})
+	}
+
+	env.SetHistory(12350, gmail.HistoryRecord{
+		MessagesAdded: []gmail.HistoryMessage{
+			{Message: gmail.MessageID{ID: "sibling-a", ThreadID: "thread-sibling-a"}},
+			{Message: gmail.MessageID{ID: "sibling-b", ThreadID: "thread-sibling-b"}},
+		},
+		LabelsAdded: []gmail.HistoryLabelChange{
+			{
+				Message:  gmail.MessageID{ID: "sibling-a", ThreadID: "thread-sibling-a"},
+				LabelIDs: []string{"STARRED"},
+			},
+			{
+				Message:  gmail.MessageID{ID: "sibling-b", ThreadID: "thread-sibling-b"},
+				LabelIDs: []string{"STARRED"},
+			},
+		},
+	})
+
+	summary := runIncrementalSync(t, env)
+	assertSummary(t, summary, WantSummary{Found: new(int64(2)), Added: new(int64(2)), Errors: new(int64(0))})
+	assert.ElementsMatch([]string{"sibling-a", "sibling-b"}, env.Mock.GetMessageCalls,
+		"each provider message is fetched once despite appearing in both event categories")
+	assertMessageCount(t, env.Store, 2)
+
+	wants := map[string]struct {
+		subject string
+		body    string
+		from    string
+		to      string
+	}{
+		"sibling-a": {
+			subject: "Sibling A subject",
+			body:    "Sibling A body\n",
+			from:    "sender-a@example.test",
+			to:      "recipient-a@example.test",
+		},
+		"sibling-b": {
+			subject: "Sibling B subject",
+			body:    "Sibling B body\n",
+			from:    "sender-b@example.test",
+			to:      "recipient-b@example.test",
+		},
+	}
+	internalIDs := make(map[string]int64, len(wants))
+	for sourceMessageID, want := range wants {
+		var internalID int64
+		err := env.Store.DB().QueryRow(
+			env.Store.Rebind(`SELECT id FROM messages WHERE source_id = (SELECT id FROM sources WHERE identifier = ?) AND source_message_id = ?`),
+			testEmail,
+			sourceMessageID,
+		).Scan(&internalID)
+		require.NoError(err, "look up %s", sourceMessageID)
+		internalIDs[sourceMessageID] = internalID
+
+		message, err := env.Store.GetMessage(internalID)
+		require.NoError(err, "GetMessage %s", sourceMessageID)
+		assert.Equal(want.subject, message.Subject, "%s subject", sourceMessageID)
+		assert.Equal(want.body, message.BodyText, "%s body", sourceMessageID)
+		assert.Equal(want.from, message.FromEmail, "%s from envelope", sourceMessageID)
+		assert.Equal([]string{want.to}, message.To, "%s to envelope", sourceMessageID)
+
+		persistedRaw, err := env.Store.GetMessageRaw(internalID)
+		require.NoError(err, "GetMessageRaw %s", sourceMessageID)
+		assert.Equal(rawByID[sourceMessageID], persistedRaw, "%s raw MIME", sourceMessageID)
+	}
+	assert.NotEqual(internalIDs["sibling-a"], internalIDs["sibling-b"],
+		"provider siblings must persist as distinct internal rows")
+}
+
 // TestIncrementalSyncMixedOperations tests a history page with adds, deletes,
 // and label changes all at once.
 func TestIncrementalSyncMixedOperations(t *testing.T) {

--- a/pkg/client/generated/client.go
+++ b/pkg/client/generated/client.go
@@ -259,6 +259,10 @@ type ClientInterface interface {
 	RepairEncodingCLI(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*RepairEncodingCLIResponse, error)
 	RepairEncodingCLIWithResponse(ctx context.Context, reqEditors ...runtime.RequestEditorFn) (*RepairEncodingCLIResp, error)
 
+	// RepairMessageCLI Repair or audit Gmail message snapshots
+	RepairMessageCLI(ctx context.Context, options *RepairMessageCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RepairMessageCLIResponse, error)
+	RepairMessageCLIWithResponse(ctx context.Context, options *RepairMessageCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RepairMessageCLIResp, error)
+
 	// RunCLI Run an allowlisted CLI command
 	RunCLI(ctx context.Context, options *RunCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RunCLIResponse, error)
 	RunCLIWithResponse(ctx context.Context, options *RunCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RunCLIResp, error)
@@ -4396,6 +4400,56 @@ func (c *Client) RepairEncodingCLI(ctx context.Context, reqEditors ...runtime.Re
 	}
 
 	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/repair-encoding")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+	return responseParser(ctx, resp)
+}
+
+// RepairMessageCLI Repair or audit Gmail message snapshots
+func (c *Client) RepairMessageCLI(ctx context.Context, options *RepairMessageCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RepairMessageCLIResponse, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/repair-message",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	responseParser := func(ctx context.Context, resp *runtime.Response) (*RepairMessageCLIResponse, error) {
+		bodyBytes := resp.Content
+		if resp.StatusCode != 200 {
+			target := new(RepairMessageCLIErrorResponse)
+			// Handle empty error response body gracefully - skip unmarshal if no content
+			if len(bodyBytes) > 0 {
+				if err = json.Unmarshal(bodyBytes, target); err != nil {
+					return nil, &runtime.ResponseDecodeError{
+						StatusCode:    resp.StatusCode,
+						ContentType:   resp.Headers.Get("Content-Type"),
+						ContentLength: len(bodyBytes),
+						TargetType:    "RepairMessageCLIErrorResponse",
+						Body:          bodyBytes,
+						Err:           err,
+					}
+				}
+			}
+			// Return error with (possibly empty) target
+			if errTarget, ok := any(*target).(error); ok {
+				return nil, runtime.NewClientAPIError(errTarget, runtime.WithStatusCode(resp.StatusCode))
+			}
+			return nil, runtime.NewClientAPIError(fmt.Errorf("API error (status %d): %v", resp.StatusCode, *target),
+				runtime.WithStatusCode(resp.StatusCode))
+		}
+		result := RepairMessageCLIResponse(bodyBytes)
+		return &result, nil
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/repair-message")
 	if err != nil {
 		return nil, fmt.Errorf("error executing request: %w", err)
 	}

--- a/pkg/client/generated/client_options.go
+++ b/pkg/client/generated/client_options.go
@@ -2014,6 +2014,50 @@ func (o *GetCLIMessageRawRequestOptions) GetHeader() (map[string]string, error) 
 	return nil, nil
 }
 
+// RepairMessageCLIRequestOptions is the options needed to make a request to RepairMessageCLI.
+type RepairMessageCLIRequestOptions struct {
+	Body *RepairMessageCLIBody
+}
+
+// Validate validates all the fields in the options.
+// Use it if fields validation was not run.
+func (o *RepairMessageCLIRequestOptions) Validate() error {
+	var errors runtime.ValidationErrors
+
+	if o.Body != nil {
+		if v, ok := any(o.Body).(runtime.Validator); ok {
+			if err := v.Validate(); err != nil {
+				errors = errors.Append("Body", err)
+			}
+		}
+	}
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors
+}
+
+// GetPathParams returns the path params as a map.
+func (o *RepairMessageCLIRequestOptions) GetPathParams() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetQuery returns the query params as a map.
+func (o *RepairMessageCLIRequestOptions) GetQuery() (map[string]any, error) {
+	return nil, nil
+}
+
+// GetBody returns the payload in any type that can be marshalled to JSON by the client.
+func (o *RepairMessageCLIRequestOptions) GetBody() any {
+	return o.Body
+}
+
+// GetHeader returns the headers as a map.
+func (o *RepairMessageCLIRequestOptions) GetHeader() (map[string]string, error) {
+	return nil, nil
+}
+
 // RunCLIRequestOptions is the options needed to make a request to RunCLI.
 type RunCLIRequestOptions struct {
 	Body *RunCLIBody

--- a/pkg/client/generated/client_with_response.go
+++ b/pkg/client/generated/client_with_response.go
@@ -4844,6 +4844,42 @@ func (c *Client) RepairEncodingCLIWithResponse(ctx context.Context, reqEditors .
 	}
 }
 
+// RepairMessageCLI Repair or audit Gmail message snapshots
+func (c *Client) RepairMessageCLIWithResponse(ctx context.Context, options *RepairMessageCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RepairMessageCLIResp, error) {
+	var err error
+	reqParams := runtime.RequestOptionsParameters{
+		RequestURL:  c.apiClient.GetBaseURL() + "/api/v1/cli/repair-message",
+		Method:      "POST",
+		Options:     options,
+		ContentType: "application/json",
+	}
+
+	req, err := c.apiClient.CreateRequest(ctx, reqParams, reqEditors...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+
+	resp, err := c.apiClient.ExecuteRequest(ctx, req, "/api/v1/cli/repair-message")
+	if err != nil {
+		return nil, fmt.Errorf("error executing request: %w", err)
+	}
+
+	out := &RepairMessageCLIResp{
+		HTTPResponse: resp.Raw,
+		Body:         resp.Content,
+		StatusCode:   resp.StatusCode,
+	}
+
+	switch resp.StatusCode {
+	case 200:
+		return out, nil
+	case 500:
+		return out, runtime.NewClientAPIError(fmt.Errorf("API error (status %d)", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	default:
+		return out, runtime.NewClientAPIError(fmt.Errorf("unexpected status code: %d", resp.StatusCode), runtime.WithStatusCode(resp.StatusCode))
+	}
+}
+
 // RunCLI Run an allowlisted CLI command
 func (c *Client) RunCLIWithResponse(ctx context.Context, options *RunCLIRequestOptions, reqEditors ...runtime.RequestEditorFn) (*RunCLIResp, error) {
 	var err error

--- a/pkg/client/generated/payloads.go
+++ b/pkg/client/generated/payloads.go
@@ -54,6 +54,8 @@ type DiscoverCLIIdentitiesBody = DiscoverRequest
 
 type ImportCLIIdentitiesBody = ImportRequest
 
+type RepairMessageCLIBody = CLIRepairMessageRequest
+
 type RunCLIBody = CLIRunRequest
 
 type CreateCommunicationServiceBody = CreateCommunicationServiceRequest

--- a/pkg/client/generated/responses.go
+++ b/pkg/client/generated/responses.go
@@ -443,6 +443,10 @@ type RepairEncodingCLIResponse = []byte
 
 type RepairEncodingCLIErrorResponse = ErrorResponse
 
+type RepairMessageCLIResponse = []byte
+
+type RepairMessageCLIErrorResponse = ErrorResponse
+
 type RunCLIResponse = []byte
 
 type RunCLIErrorResponse = ErrorResponse
@@ -3204,6 +3208,12 @@ type RebuildCLIFTSResp struct {
 }
 
 type RepairEncodingCLIResp struct {
+	HTTPResponse *http.Response
+	Body         []byte
+	StatusCode   int
+}
+
+type RepairMessageCLIResp struct {
 	HTTPResponse *http.Response
 	Body         []byte
 	StatusCode   int

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -716,6 +716,23 @@ func (c CLIRepairEncodingEvent) Validate() error {
 	return runtime.ConvertValidatorError(typesValidator.Struct(c))
 }
 
+type CLIRepairMessageEvent struct {
+	Data      *string `json:"data,omitempty"`
+	ErrorData *string `json:"error,omitempty"`
+	Type      string  `json:"type" validate:"required"`
+}
+
+func (c CLIRepairMessageEvent) Validate() error {
+	return runtime.ConvertValidatorError(typesValidator.Struct(c))
+}
+
+type CLIRepairMessageRequest struct {
+	Audit     *bool   `json:"audit,omitempty"`
+	JSON      *bool   `json:"json,omitempty"`
+	Reference *string `json:"reference,omitempty"`
+	SourceID  *int64  `json:"source_id,omitempty"`
+}
+
 type CLIRunEvent struct {
 	Data      *string `json:"data,omitempty"`
 	ErrorData *string `json:"error,omitempty"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -847,6 +847,30 @@ components:
       required:
         - type
       type: object
+    CLIRepairMessageEvent:
+      properties:
+        data:
+          type: string
+        error:
+          type: string
+        type:
+          type: string
+      required:
+        - type
+      type: object
+    CLIRepairMessageRequest:
+      additionalProperties: false
+      properties:
+        audit:
+          type: boolean
+        json:
+          type: boolean
+        reference:
+          type: string
+        source_id:
+          format: int64
+          type: integer
+      type: object
     CLIRunEvent:
       properties:
         data:
@@ -10671,7 +10695,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.14.0
+  version: 2.15.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -13224,6 +13248,33 @@ paths:
       security:
         - apiKey: []
       summary: Repair CLI archive encoding
+      tags:
+        - API
+  /api/v1/cli/repair-message:
+    post:
+      operationId: repairMessageCLI
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CLIRepairMessageRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/x-ndjson:
+              schema:
+                $ref: "#/components/schemas/CLIRepairMessageEvent"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+          description: Error
+      security:
+        - apiKey: []
+      summary: Repair or audit Gmail message snapshots
       tags:
         - API
   /api/v1/cli/run:

--- a/web/src/lib/api/generated/schema.d.ts
+++ b/web/src/lib/api/generated/schema.d.ts
@@ -797,6 +797,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/cli/repair-message": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Repair or audit Gmail message snapshots */
+        post: operations["repairMessageCLI"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/cli/run": {
         parameters: {
             query?: never;
@@ -3565,6 +3582,20 @@ export interface components {
             type: string;
         } & {
             [key: string]: unknown;
+        };
+        CLIRepairMessageEvent: {
+            data?: string;
+            error?: string;
+            type: string;
+        } & {
+            [key: string]: unknown;
+        };
+        CLIRepairMessageRequest: {
+            audit?: boolean;
+            json?: boolean;
+            reference?: string;
+            /** Format: int64 */
+            source_id?: number;
         };
         CLIRunEvent: {
             data?: string;
@@ -11010,6 +11041,39 @@ export interface operations {
                 };
                 content: {
                     "application/x-ndjson": components["schemas"]["CLIRepairEncodingEvent"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    repairMessageCLI: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CLIRepairMessageRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/x-ndjson": components["schemas"]["CLIRepairMessageEvent"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
Archives written between February and May 2026 can hold Gmail rows whose raw MIME, parsed body, and recipients belong to a sibling message while the `messages` row itself is correct (#147). This adds `repair-message` to find those rows and replace them from Gmail, one message at a time.

## Cause

The store read the new message ID with `LastInsertId()` after `INSERT ... ON CONFLICT DO UPDATE`. When the update branch ran, SQLite reported the rowid of the previous real insert on that connection, so the conflicting message's raw MIME, body, and recipients were written under the sibling that had just been inserted. Incremental sync reached that branch whenever a `labelAdded` history record ingested a new message before the `messagesAdded` batch upserted it again. Both reports in #147 match this: a correct message row carrying a sibling's raw MIME, and only in sync runs that added two or more messages. The RETURNING-based path in #328 removed the cause; Gmail never returned a mismatched payload, so this change adds no sync-side guard.

## What changed

- `repair-message <internal-id-or-gmail-id>` re-fetches one Gmail message, strictly parses its raw MIME, and atomically replaces the stored snapshot. Sibling messages, provider-owned attachments, and conversation membership are untouched. Repaired rows get the same attribution a resync would produce.
- `repair-message --audit` compares every stored Gmail row against a fresh parse of its own raw MIME and prints mismatches and inconclusive rows, in human or NDJSON form. Rows written before attachment occurrence keys existed are compared by distinct content hash: those rows stored a repeated part once, and older ingests recorded small nameless `text/plain` parts as attachments. On a 15,000-row sample of a real archive the audit reported one genuine recipient inconsistency and nothing else.
- Repair and audit run through `POST /api/v1/cli/repair-message`, gated on API schema `2.15.0`. Older daemons fail closed before any repair request. SQLite and PostgreSQL behave the same. No database migration is required.

## Usage

```sh
msgvault repair-message <internal-id-or-gmail-id>
msgvault repair-message <internal-id-or-gmail-id> --source-id <source-id>
msgvault repair-message --audit
msgvault repair-message --audit --source-id <source-id> --json
```

Fixes #147
