### PR TITLE
fix(imap): stop incomplete responses from becoming mailbox state

### DIFF
--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -927,7 +927,13 @@ func TestIMAPQresyncEndToEndMoveAndFinalExpunge(t *testing.T) {
 			queryScriptedRFC7162Memberships(t, st, source.ID))
 		_, deleted, _ := queryScriptedRFC7162MessageState(t, st, source.ID, "move@example.test")
 		assertions.False(deleted)
-		assertions.NotContains(server.commandsFor(2), "UID SEARCH")
+		// The message left INBOX mid-run, so no FETCH returns UID 1 and the run
+		// confirms that with a UID SEARCH naming it. What QRESYNC must not do
+		// is enumerate the mailbox, which is an open-ended range search.
+		assertions.NotRegexp(`UID SEARCH UID \d+:\*`, server.commandsFor(2),
+			"valid QRESYNC must not fall back to enumerating a mailbox")
+		assertions.Contains(server.commandsFor(2), "UID SEARCH UID 1",
+			"a UID no FETCH returned is confirmed before it counts as gone")
 	})
 
 	t.Run("final expunge tombstones the archived message", func(t *testing.T) {

--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -383,27 +383,32 @@ func writeScriptedRFC7162Fetch(
 	command string,
 	mailbox scriptedRFC7162Mailbox,
 ) {
-	headerOnly := strings.Contains(strings.ToUpper(command), "HEADER.FIELDS")
+	upper := strings.ToUpper(command)
+	headerOnly := strings.Contains(upper, "HEADER.FIELDS")
 	for _, uid := range parseScriptedRFC7162UIDSet(command) {
 		message, ok := scriptedRFC7162MessageByUID(mailbox.Messages, uid)
 		if !ok {
 			continue
 		}
 		sequence := scriptedRFC7162Sequence(mailbox.Messages, uid)
+		modSeq := ""
+		if strings.Contains(upper, "MODSEQ") {
+			modSeq = fmt.Sprintf(" MODSEQ (%d)", message.ModSeq)
+		}
 		if headerOnly {
 			body := "\r\n"
 			if message.MessageID != "" {
 				body = fmt.Sprintf("Message-ID: <%s>\r\n\r\n", message.MessageID)
 			}
 			_, _ = fmt.Fprintf(w,
-				"* %d FETCH (UID %d FLAGS (%s) BODY[HEADER.FIELDS (MESSAGE-ID)] {%d}\r\n%s)\r\n",
-				sequence, uid, formatScriptedRFC7162Flags(message.Flags), len(body), body)
+				"* %d FETCH (UID %d FLAGS (%s)%s BODY[HEADER.FIELDS (MESSAGE-ID)] {%d}\r\n%s)\r\n",
+				sequence, uid, formatScriptedRFC7162Flags(message.Flags), modSeq, len(body), body)
 			continue
 		}
 		raw := scriptedRFC7162RawMessage(message)
 		_, _ = fmt.Fprintf(w,
-			"* %d FETCH (UID %d FLAGS (%s) INTERNALDATE \"01-Jan-2024 00:00:00 +0000\" RFC822.SIZE %d BODY[] {%d}\r\n%s)\r\n",
-			sequence, uid, formatScriptedRFC7162Flags(message.Flags), len(raw), len(raw), raw)
+			"* %d FETCH (UID %d FLAGS (%s)%s INTERNALDATE \"01-Jan-2024 00:00:00 +0000\" RFC822.SIZE %d BODY[] {%d}\r\n%s)\r\n",
+			sequence, uid, formatScriptedRFC7162Flags(message.Flags), modSeq, len(raw), len(raw), raw)
 	}
 }
 

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -30,6 +30,13 @@ var errIMAPFetchResultMissing = fmt.Errorf(
 var errIMAPLabelBodyMissing = errors.New("IMAP fetch result did not include message headers")
 var errIMAPSkippedAfterChunkFailed = errors.New("IMAP fetch skipped after earlier chunk failure")
 
+// errIMAPOmittedButPresent marks a UID that no FETCH response returned and
+// that a UID SEARCH then reported as still in the mailbox. The message is
+// there, so this is a fetch failure, and it must not reach
+// gmailapi.ErrMessageGone: acknowledging it would drop a live message.
+var errIMAPOmittedButPresent = errors.New(
+	"IMAP fetch returned no result for a UID the mailbox still reports")
+
 type batchFetchItem struct {
 	idx int
 	uid imap.UID
@@ -336,10 +343,8 @@ func (c *Client) fetchMailboxBatch(
 				return fatalErr
 			}
 		}
-		for _, item := range omitted {
-			results[item.idx].Err = errIMAPFetchResultMissing
-			c.forgetMembershipLocked(mailbox, item.uid)
-		}
+		c.markOmittedOutcome(mailbox, omitted,
+			func(item batchFetchItem, err error) { results[item.idx].Err = err })
 	}
 	return nil
 }
@@ -384,6 +389,77 @@ func (c *Client) recheckOmittedRaw(
 		return nil, nil
 	}
 	return c.applyFetchResults(results, uidToIdx, mailbox, omitted, msgs), nil
+}
+
+// confirmOmittedPresent asks the server which of the UIDs it left out of both
+// FETCH attempts it still holds.
+//
+// Two omissions are still two answers to the same question: both attempts are
+// the same command against the same mailbox, so a server that drops a UID for
+// a structural reason drops it from the retry as well. UID SEARCH is different
+// evidence, and it costs one command for the whole set. A UID it reports is a
+// live message, and calling that gone lets the run acknowledge it, forget its
+// membership and advance the mailbox cursor past it.
+//
+// The search names the omitted UIDs exactly and carries none of the
+// since/before filters enumerateMailbox applies: a date filter here would hide
+// a live message behind the same silence this exists to distrust.
+//
+// An error means nothing was learned. Callers must then record a fetch error
+// rather than an absence, which holds the commit back instead of acting on a
+// guess.
+func (c *Client) confirmOmittedPresent(
+	mailbox string, omitted []imap.UID,
+) (map[imap.UID]bool, error) {
+	present := make(map[imap.UID]bool, len(omitted))
+	if len(omitted) == 0 {
+		return present, nil
+	}
+
+	var uidSet imap.UIDSet
+	for _, uid := range omitted {
+		uidSet.AddNum(uid)
+	}
+	searchData, err := c.conn.UIDSearch(
+		&imap.SearchCriteria{UID: []imap.UIDSet{uidSet}}, nil).Wait()
+	if err != nil {
+		c.logger.Warn("could not confirm UIDs missing from a FETCH response",
+			"mailbox", mailbox, "uids", len(omitted), "error", err)
+		return nil, fmt.Errorf(
+			"UID SEARCH confirming UIDs missing from a FETCH in mailbox %q: %w",
+			mailbox, err)
+	}
+
+	for _, uid := range searchData.AllUIDs() {
+		present[uid] = true
+	}
+	return present, nil
+}
+
+// markOmittedOutcome records what confirmOmittedPresent established about the
+// UIDs no FETCH response returned, and forgets the membership observed during
+// enumeration for the ones the mailbox no longer reports.
+func (c *Client) markOmittedOutcome(
+	mailbox string,
+	omitted []batchFetchItem,
+	setErr func(item batchFetchItem, err error),
+) {
+	uids := make([]imap.UID, len(omitted))
+	for i, item := range omitted {
+		uids[i] = item.uid
+	}
+	present, searchErr := c.confirmOmittedPresent(mailbox, uids)
+	for _, item := range omitted {
+		switch {
+		case searchErr != nil:
+			setErr(item, searchErr)
+		case present[item.uid]:
+			setErr(item, errIMAPOmittedButPresent)
+		default:
+			setErr(item, errIMAPFetchResultMissing)
+			c.forgetMembershipLocked(mailbox, item.uid)
+		}
+	}
 }
 
 // GetMessagesRawBatchWithErrors fetches multiple messages, grouping by mailbox for efficiency.
@@ -559,10 +635,8 @@ func (c *Client) fetchMailboxLabelBatch(
 				return fatalErr
 			}
 		}
-		for _, item := range omitted {
-			results[item.idx].Err = errIMAPFetchResultMissing
-			c.forgetMembershipLocked(mailbox, item.uid)
-		}
+		c.markOmittedOutcome(mailbox, omitted,
+			func(item batchFetchItem, err error) { results[item.idx].Err = err })
 	}
 	return nil
 }

--- a/internal/imap/batch_fetch_test.go
+++ b/internal/imap/batch_fetch_test.go
@@ -763,9 +763,10 @@ func startMalformedEnvelopeIMAPServer(t *testing.T, raw []byte) (string, <-chan 
 	return listener.Addr().String(), fetchCommand
 }
 
-// markConfirmedGone is what the chunk loops do once a second FETCH has also
-// left a UID out. It is inlined here so these tests cover the same end state
-// they covered before the recheck moved the decision out of the apply step.
+// markConfirmedGone is what the chunk loops do once a second FETCH and the
+// confirming UID SEARCH have both left a UID out. It is inlined here so these
+// tests cover the same end state they covered before the recheck moved the
+// decision out of the apply step.
 func markConfirmedGone(
 	c *Client,
 	raw []gmailapi.RawMessageBatchResult,
@@ -988,4 +989,63 @@ func TestRecheckReconnectFailureEndsTheBatch(t *testing.T) {
 		t.Context(), []string{"INBOX|1", "INBOX|2"})
 
 	require.Error(err, "a failed reconnect during the recheck must end the batch")
+}
+
+// TestUIDTheMailboxStillReportsIsNotGone covers the evidence the recheck
+// cannot supply. Both fetch attempts are the same command against the same
+// mailbox, so a server that drops a UID for a structural reason drops it
+// twice, and the run would call a live message gone on the strength of two
+// identical silences.
+//
+// UID SEARCH is a different question. When it reports the UID, the message is
+// in the mailbox and the omission was the server's, so the run must record a
+// fetch error and keep the membership rather than acknowledge the message and
+// advance past it.
+func TestUIDTheMailboxStillReportsIsNotGone(t *testing.T) {
+	t.Run("label fetch", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		addr, _ := testutil.StartIMAPMemServerOmittingUIDFromEveryFetch(
+			t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+		client := newTestClient(t, addr)
+		// The observation enumeration records for a UID it listed. A run that
+		// believed the omission would drop it here.
+		client.observedMemberships = []MembershipObservation{
+			{Mailbox: "INBOX", UID: 2, SourceMessageID: "INBOX|2"},
+		}
+
+		results, err := client.GetMessageLabelsBatch(
+			t.Context(), []string{"INBOX|1", "INBOX|2"})
+
+		require.NoError(err)
+		require.Len(results, 2)
+		require.NoError(results[0].Err)
+		require.ErrorIs(results[1].Err, errIMAPOmittedButPresent)
+		require.NotErrorIs(results[1].Err, gmailapi.ErrMessageGone,
+			"a UID the mailbox still reports has not left it")
+		assert.Contains(observedUIDs(client), uint32(2),
+			"a live message keeps the membership the commit publishes")
+	})
+
+	t.Run("raw fetch", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		addr, _ := testutil.StartIMAPMemServerOmittingUIDFromEveryFetch(
+			t, map[string]int{"INBOX": 2}, "INBOX", imapapi.UID(2))
+		client := newTestClient(t, addr)
+		client.observedMemberships = []MembershipObservation{
+			{Mailbox: "INBOX", UID: 2, SourceMessageID: "INBOX|2"},
+		}
+
+		results, err := client.GetMessagesRawBatchWithErrors(
+			t.Context(), []string{"INBOX|1", "INBOX|2"})
+
+		require.NoError(err)
+		require.Len(results, 2)
+		require.NoError(results[0].Err)
+		require.ErrorIs(results[1].Err, errIMAPOmittedButPresent)
+		require.NotErrorIs(results[1].Err, gmailapi.ErrMessageGone,
+			"a UID the mailbox still reports has not left it")
+		assert.Contains(observedUIDs(client), uint32(2))
+	})
 }

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -1153,10 +1153,10 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			}
 			for _, mailbox := range allMailboxes {
 				state := folderStatuses[mailbox]
-				if deltaIndex, ok := deltaByMailbox[mailbox]; ok {
+				deltaIndex, hasDelta := deltaByMailbox[mailbox]
+				if hasDelta {
 					state.KnownUIDs = append(
 						[]uint32(nil), c.observedMailboxDeltas[deltaIndex].State.KnownUIDs...)
-					c.observedMailboxDeltas[deltaIndex].State = state
 				} else {
 					state.KnownUIDs = make([]uint32, 0)
 					for _, observation := range c.observedMemberships {
@@ -1165,6 +1165,15 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 						}
 					}
 					slices.Sort(state.KnownUIDs)
+				}
+				// The snapshot rebuilds the state from STATUS, whose UIDNEXT was
+				// read before the enumeration that produced these UIDs. A message
+				// delivered in between belongs to the baseline and sits at or
+				// above that mark, so the saved UIDNEXT has to cover it.
+				state.UIDNext = baselineUIDNext(state.UIDNext, state.KnownUIDs)
+				if hasDelta {
+					c.observedMailboxDeltas[deltaIndex].State = state
+				} else {
 					c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
 						Mailbox: mailbox,
 						State:   state,

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -621,66 +621,138 @@ func (c *Client) enumerateMailbox(
 // UIDs in the given mailbox. Returns the valid Message-IDs and the UIDs whose
 // header had no usable Message-ID, so callers can fetch those copies raw.
 // Caller must hold mu.
+// fetchMailboxMessageIDs reads the Message-ID header of every supplied UID and
+// returns the membership map for the mailbox, the UIDs whose header was empty,
+// and the UIDs the server never returned at all.
+//
+// The last of those three is not the same as the second. A UID with an empty
+// header is a live message this run could not identify. A UID left out of the
+// response is a message the run learned nothing about, and reading that
+// silence as absence removes the message from the published topology.
 func (c *Client) fetchMailboxMessageIDs(
 	ctx context.Context, mailbox string, uids []imap.UID,
-) (map[string]bool, []imap.UID, error) {
+) (map[string]bool, []imap.UID, []imap.UID, error) {
 	if len(uids) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	if err := c.selectMailbox(mailbox); err != nil {
 		if !isNetworkError(err) {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		c.logger.Warn("network error selecting mailbox for label map, reconnecting",
 			"mailbox", mailbox, "error", err)
 		if reconErr := c.reconnect(ctx); reconErr != nil {
-			return nil, nil, fmt.Errorf(
+			return nil, nil, nil, fmt.Errorf(
 				"reconnect failed building label map for %q: %w",
 				mailbox, reconErr)
 		}
 		if err := c.selectMailbox(mailbox); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 
 	result := make(map[string]bool, len(uids))
 	var unidentified []imap.UID
+	var missing []imap.UID
 	fetchOpts := messageIDHeaderFetchOptions()
 
 	for chunkStart := 0; chunkStart < len(uids); chunkStart += fetchChunkSize {
 		if ctx.Err() != nil {
-			return result, unidentified, ctx.Err()
+			return result, unidentified, missing, ctx.Err()
 		}
 
 		end := min(chunkStart+fetchChunkSize, len(uids))
+		chunk := uids[chunkStart:end]
 
 		var uidSet imap.UIDSet
-		for _, uid := range uids[chunkStart:end] {
+		for _, uid := range chunk {
 			uidSet.AddNum(uid)
 		}
 
 		msgs, _, err := c.fetchChunk(ctx, mailbox, uidSet, fetchOpts)
 		if err != nil {
-			return result, unidentified, fmt.Errorf(
+			return result, unidentified, missing, fmt.Errorf(
 				"message-ID fetch failed in %q: %w", mailbox, err)
 		}
+		seen := c.recordMessageIDResults(mailbox, result, &unidentified, msgs)
 
-		for _, msg := range msgs {
-			var rfc822MessageID string
-			if len(msg.BodySection) > 0 {
-				rfc822MessageID = rawMIMEMessageID(msg.BodySection[0].Bytes)
-			}
-			c.recordMembershipLocked(
-				mailbox, msg.UID, "", rfc822MessageID, [32]byte{}, 0, msg.Flags)
-			if rfc822MessageID == "" {
-				unidentified = append(unidentified, msg.UID)
-			} else {
-				result[rfc822MessageID] = true
+		omitted := uidsNotIn(chunk, seen)
+		if len(omitted) == 0 {
+			continue
+		}
+		// The server left these out of a response it answered successfully.
+		// Ask once more before concluding anything: an omission is a fact
+		// about the response, not about the mailbox.
+		var recheckSet imap.UIDSet
+		for _, uid := range omitted {
+			recheckSet.AddNum(uid)
+		}
+		recheckMsgs, _, err := c.fetchChunk(ctx, mailbox, recheckSet, fetchOpts)
+		if err != nil {
+			return result, unidentified, missing, fmt.Errorf(
+				"message-ID recheck failed in %q: %w", mailbox, err)
+		}
+		seenAgain := c.recordMessageIDResults(mailbox, result, &unidentified, recheckMsgs)
+		withheld := uidsNotIn(omitted, seenAgain)
+		present, err := c.confirmOmittedPresent(mailbox, withheld)
+		if err != nil {
+			// The search proved nothing, so the map cannot claim to describe
+			// every message in the mailbox.
+			missing = append(missing, withheld...)
+			continue
+		}
+		// A UID the mailbox no longer reports left it, and deletion detection
+		// retires its stored membership. Only a UID the mailbox still holds is
+		// a hole in the map.
+		for _, uid := range withheld {
+			if present[uid] {
+				missing = append(missing, uid)
 			}
 		}
 	}
-	return result, unidentified, nil
+	if len(missing) > 0 {
+		c.logger.Warn("label map is missing UIDs the server did not return",
+			"mailbox", mailbox, "uids", len(missing))
+	}
+	return result, unidentified, missing, nil
+}
+
+// recordMessageIDResults records a membership for every message the server
+// returned and reports which UIDs those were.
+func (c *Client) recordMessageIDResults(
+	mailbox string,
+	result map[string]bool,
+	unidentified *[]imap.UID,
+	msgs []*imapclient.FetchMessageBuffer,
+) map[imap.UID]bool {
+	seen := make(map[imap.UID]bool, len(msgs))
+	for _, msg := range msgs {
+		seen[msg.UID] = true
+		var rfc822MessageID string
+		if len(msg.BodySection) > 0 {
+			rfc822MessageID = rawMIMEMessageID(msg.BodySection[0].Bytes)
+		}
+		c.recordMembershipLocked(
+			mailbox, msg.UID, "", rfc822MessageID, [32]byte{}, 0, msg.Flags)
+		if rfc822MessageID == "" {
+			*unidentified = append(*unidentified, msg.UID)
+		} else {
+			result[rfc822MessageID] = true
+		}
+	}
+	return seen
+}
+
+// uidsNotIn returns the UIDs of want that seen does not contain.
+func uidsNotIn(want []imap.UID, seen map[imap.UID]bool) []imap.UID {
+	var absent []imap.UID
+	for _, uid := range want {
+		if !seen[uid] {
+			absent = append(absent, uid)
+		}
+	}
+	return absent
 }
 
 // buildLabelMap enumerates every mailbox except \All (whose memberships come
@@ -731,12 +803,20 @@ func (c *Client) buildLabelMap(
 			continue
 		}
 
-		msgIDs, unidentifiedUIDs, err := c.fetchMailboxMessageIDs(ctx, mailbox, uids)
+		msgIDs, unidentifiedUIDs, missingUIDs, err := c.fetchMailboxMessageIDs(ctx, mailbox, uids)
 		if err != nil {
 			complete = false
 			c.logger.Warn("failed to fetch envelopes for label map",
 				"mailbox", mailbox, "error", err)
 			continue
+		}
+		if len(missingUIDs) > 0 {
+			// The map does not describe every message in this mailbox, so the
+			// topology built from it is not authoritative. Saying so is what
+			// stops a republish deleting the rows of the messages that are
+			// absent from it, which for a label-only mailbox is the only
+			// record of their membership.
+			complete = false
 		}
 		for _, uid := range unidentifiedUIDs {
 			unidentified = append(unidentified, gmailapi.MessageID{

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -1076,10 +1076,12 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 		if observed != nil {
 			observed.KnownUIDs = knownUIDs
+			observed.UIDNext = baselineUIDNext(observed.UIDNext, knownUIDs)
 			c.observedFolderStates[mailbox] = *observed
 		}
 		if canTrackFolder {
 			trackState.KnownUIDs = knownUIDs
+			trackState.UIDNext = baselineUIDNext(trackState.UIDNext, knownUIDs)
 			c.trackFolderMessages(mailbox, trackState, uids)
 		}
 		for _, uid := range uids {

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1219,3 +1219,33 @@ func TestSourceMessageExistsIsNotDefiniteWhenHeadersMissing(t *testing.T) {
 	require.Error(err, "a live message without headers is not definitive absence")
 	require.NotErrorIs(err, errIMAPFetchResultMissing)
 }
+
+// TestAllMailSnapshotSavesUIDNextAboveKnownUIDs covers the third place a
+// baseline is saved. The \All snapshot rebuilds every folder state from
+// STATUS, whose UIDNEXT was read before the enumeration that produced the
+// UIDs, so a message delivered between the two commands leaves a baseline the
+// saved UIDNEXT does not cover.
+func TestAllMailSnapshotSavesUIDNextAboveKnownUIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// STATUS reports UIDNEXT 4. The SEARCH that follows reports UID 4.
+	addr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1"},
+		mailboxes:     []string{"All Mail", "Projects"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{})
+	client.mailboxCache = []string{"All Mail", "Projects"}
+	client.allMailFolder = "All Mail"
+
+	listAllMessages(t, client)
+
+	saved := client.ObservedFolderStates()
+	require.Contains(saved, "All Mail")
+	require.Contains(saved["All Mail"].KnownUIDs, uint32(4))
+	assert.Greater(saved["All Mail"].UIDNext, uint32(4),
+		"the snapshot must not save a UIDNEXT its own baseline exceeds")
+}

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1189,13 +1189,14 @@ func TestLabelMapSelectReconnectsAfterDroppedConnection(t *testing.T) {
 	// client holding a dead socket it has not noticed yet.
 	require.NoError(client.conn.Close())
 
-	labels, unidentified, err := client.fetchMailboxMessageIDs(
+	labels, unidentified, missing, err := client.fetchMailboxMessageIDs(
 		ctx, "Archive", []imapv2.UID{1})
 
 	require.NoError(err,
 		"a dropped connection must not fail the label map, which discards the run")
 	assert.Equal(map[string]bool{messageID: true}, labels)
 	assert.Empty(unidentified)
+	assert.Empty(missing)
 }
 
 // TestSourceMessageExistsIsNotDefiniteWhenHeadersMissing pins the boundary of

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -219,6 +219,16 @@ func (c *Client) collectQresyncMailbox(
 			vanishedSet[uid] = struct{}{}
 		}
 	}
+	if err := c.verifyQresyncCoverage(
+		ctx, mailbox, prior, uint32(selected.UIDNext), changedSet, vanishedSet,
+	); err != nil {
+		return MailboxDelta{}, err
+	}
+	if err := c.refreshExistingQresyncChanges(
+		ctx, mailbox, prior, selected.HighestModSeq, changedSet, vanishedSet,
+	); err != nil {
+		return MailboxDelta{}, err
+	}
 	for uid := range vanishedSet {
 		delete(changedSet, uid)
 	}
@@ -242,12 +252,6 @@ func (c *Client) collectQresyncMailbox(
 	knownUIDs := slices.Collect(maps.Keys(known))
 	slices.Sort(knownUIDs)
 
-	if err := c.verifyQresyncCoverage(
-		ctx, mailbox, prior, uint32(selected.UIDNext), changedSet, vanishedSet,
-	); err != nil {
-		return MailboxDelta{}, err
-	}
-
 	return MailboxDelta{
 		Mailbox: mailbox,
 		State: FolderState{
@@ -260,6 +264,73 @@ func (c *Client) collectQresyncMailbox(
 		VanishedUIDs: vanishedUIDs,
 		Incremental:  true,
 	}, nil
+}
+
+// refreshExistingQresyncChanges independently checks the mod-sequence of each
+// message in the saved baseline. UIDNEXT proves how many new UIDs a
+// CHANGEDSINCE response must cover, but it says nothing about how many existing
+// messages changed. A plain FETCH provides that missing coverage: every live
+// baseline UID must be returned, and its mod-sequence says whether it belongs
+// in the delta. The normal delta fetch then reads and persists that UID's
+// current flags.
+func (c *Client) refreshExistingQresyncChanges(
+	ctx context.Context,
+	mailbox string,
+	prior FolderState,
+	currentHighestModSeq uint64,
+	changedSet, vanishedSet map[imap.UID]struct{},
+) error {
+	if currentHighestModSeq == prior.HighestModSeq || len(prior.KnownUIDs) == 0 {
+		return nil
+	}
+
+	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += fetchChunkSize {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		end := min(chunkStart+fetchChunkSize, len(prior.KnownUIDs))
+		expected := make(map[imap.UID]struct{}, end-chunkStart)
+		var requested imap.UIDSet
+		for _, value := range prior.KnownUIDs[chunkStart:end] {
+			uid := imap.UID(value)
+			if uid == 0 || value >= prior.UIDNext {
+				return fmt.Errorf("QRESYNC %q has invalid baseline UID %d", mailbox, value)
+			}
+			expected[uid] = struct{}{}
+			requested.AddNum(uid)
+		}
+
+		msgs, err := c.conn.Fetch(requested, &imap.FetchOptions{
+			UID: true, Flags: true, ModSeq: true,
+		}).Collect()
+		if err != nil {
+			return fmt.Errorf("QRESYNC existing-message refresh in %q: %w", mailbox, err)
+		}
+		for _, msg := range msgs {
+			if _, wanted := expected[msg.UID]; !wanted {
+				continue
+			}
+			if msg.ModSeq == 0 {
+				return fmt.Errorf(
+					"QRESYNC existing-message refresh in %q returned no modseq for UID %d",
+					mailbox, msg.UID)
+			}
+			delete(expected, msg.UID)
+			if msg.ModSeq > prior.HighestModSeq {
+				changedSet[msg.UID] = struct{}{}
+			}
+		}
+		for uid := range vanishedSet {
+			delete(expected, uid)
+		}
+		if len(expected) != 0 {
+			missing := slices.Collect(maps.Keys(expected))
+			slices.Sort(missing)
+			return fmt.Errorf(
+				"QRESYNC existing-message refresh in %q omitted UIDs %v", mailbox, missing)
+		}
+	}
+	return nil
 }
 
 func (c *Client) beginQresyncCapture() {
@@ -355,11 +426,11 @@ func mergeKnownUIDs(prior []uint32, additions []imap.UID) []uint32 {
 // error is recorded, and HIGHESTMODSEQ still advances past it. No later run
 // has a reason to ask about it again, so the message is lost for good.
 //
-// Only UIDs at or above the previous UIDNEXT can be checked, and they are the
-// only ones that need it. A message with a UID that high was appended after
-// the last run read UIDNEXT, so its mod-sequence is above the one this fetch
-// asked about and the server was obliged to report it. An omission below that
-// mark costs nothing, because the message is already in the baseline.
+// Only UIDs at or above the previous UIDNEXT can be checked by this arithmetic.
+// A message with a UID that high was appended after the last run read UIDNEXT,
+// so its mod-sequence is above the one this fetch asked about and the server was
+// obliged to report it. refreshExistingQresyncChanges separately checks UIDs
+// below that mark because UIDNEXT cannot reveal an omitted flag change there.
 //
 // UIDs are handed out in sequence, so the growth in UIDNEXT is exactly how
 // many were assigned since the last run, and each of them has to come back

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -124,7 +124,7 @@ func (c *Client) tryBuildQresyncMessageList(
 		}
 		prior := c.priorFolderStates[mailbox]
 		var delta MailboxDelta
-		delta, err := c.collectQresyncMailbox(mailbox, prior)
+		delta, err := c.collectQresyncMailbox(ctx, mailbox, prior)
 		if err != nil {
 			return false, err
 		}
@@ -151,7 +151,9 @@ func (c *Client) tryBuildQresyncMessageList(
 	return true, nil
 }
 
-func (c *Client) collectQresyncMailbox(mailbox string, prior FolderState) (MailboxDelta, error) {
+func (c *Client) collectQresyncMailbox(
+	ctx context.Context, mailbox string, prior FolderState,
+) (MailboxDelta, error) {
 	c.clearQresyncCapture()
 	selected, err := c.conn.Select(mailbox, &imap.SelectOptions{CondStore: true}).Wait()
 	if err != nil {
@@ -239,6 +241,12 @@ func (c *Client) collectQresyncMailbox(mailbox string, prior FolderState) (Mailb
 	}
 	knownUIDs := slices.Collect(maps.Keys(known))
 	slices.Sort(knownUIDs)
+
+	if err := c.verifyQresyncCoverage(
+		ctx, mailbox, prior, uint32(selected.UIDNext), changedSet, vanishedSet,
+	); err != nil {
+		return MailboxDelta{}, err
+	}
 
 	return MailboxDelta{
 		Mailbox: mailbox,
@@ -336,4 +344,86 @@ func mergeKnownUIDs(prior []uint32, additions []imap.UID) []uint32 {
 	values := slices.Collect(maps.Keys(known))
 	slices.Sort(values)
 	return values
+}
+
+// verifyQresyncCoverage checks that the CHANGEDSINCE response accounted for
+// every message that arrived since the last run.
+//
+// A server that leaves a live UID out of that response looks exactly like one
+// that had nothing to report for it, and nothing downstream can tell the two
+// apart: the UID never reaches KnownUIDs, it is never listed or fetched, no
+// error is recorded, and HIGHESTMODSEQ still advances past it. No later run
+// has a reason to ask about it again, so the message is lost for good.
+//
+// Only UIDs at or above the previous UIDNEXT can be checked, and they are the
+// only ones that need it. A message with a UID that high was appended after
+// the last run read UIDNEXT, so its mod-sequence is above the one this fetch
+// asked about and the server was obliged to report it. An omission below that
+// mark costs nothing, because the message is already in the baseline.
+//
+// UIDs are handed out in sequence, so the growth in UIDNEXT is exactly how
+// many were assigned since the last run, and each of them has to come back
+// either as changed or as vanished. When that many are accounted for the
+// response is complete by arithmetic alone and nothing is asked of the server:
+// the ordinary case of new mail arriving costs nothing, which is what QRESYNC
+// is for.
+//
+// Only a shortfall is worth a question, and then the question goes to UID
+// SEARCH, which is independent of the FETCH that misbehaved.
+//
+// Neither the message count nor the size of KnownUIDs appears here. KnownUIDs
+// is read back from stored memberships, so it drifts from the server in both
+// directions -- short when an earlier run failed to ingest something, long
+// when messages left without the server reporting VANISHED -- and drift in the
+// second direction hides exactly the omission this is looking for.
+func (c *Client) verifyQresyncCoverage(
+	ctx context.Context,
+	mailbox string,
+	prior FolderState,
+	currentUIDNext uint32,
+	changedSet, vanishedSet map[imap.UID]struct{},
+) error {
+	if currentUIDNext <= prior.UIDNext {
+		return nil
+	}
+	// Unsigned throughout: prior.UIDNext is below currentUIDNext here, so the
+	// difference is a real count, and int is 32 bits wide on a 32-bit build.
+	assigned := currentUIDNext - prior.UIDNext
+
+	accounted := uint32(0)
+	for uid := range changedSet {
+		if uint32(uid) >= prior.UIDNext {
+			accounted++
+		}
+	}
+	for uid := range vanishedSet {
+		if uint32(uid) >= prior.UIDNext {
+			accounted++
+		}
+	}
+	if accounted >= assigned {
+		return nil
+	}
+
+	present, err := c.enumerateMailbox(ctx, mailbox, imap.UID(prior.UIDNext))
+	if err != nil {
+		return fmt.Errorf("QRESYNC coverage search in %q: %w", mailbox, err)
+	}
+	for _, uid := range present {
+		// "UID SEARCH UID n:*" returns the last message even when n is past
+		// it, so a UID below the high water mark here is an artefact of the
+		// search and not a new message. RFC 3501 6.4.8.
+		if uint32(uid) < prior.UIDNext {
+			continue
+		}
+		if _, changed := changedSet[uid]; changed {
+			continue
+		}
+		if _, vanished := vanishedSet[uid]; vanished {
+			continue
+		}
+		return fmt.Errorf(
+			"QRESYNC %q left UID %d out of the CHANGEDSINCE response", mailbox, uid)
+	}
+	return nil
 }

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -477,6 +477,7 @@ func (c *Client) verifyQresyncCoverage(
 	currentUIDNext uint32,
 	changedSet, vanishedSet map[imap.UID]struct{},
 ) error {
+	priorUIDValidity := c.selectedUIDValidity
 	if currentUIDNext <= prior.UIDNext {
 		return nil
 	}
@@ -524,6 +525,15 @@ func (c *Client) verifyQresyncCoverage(
 	if !c.enableQresync() {
 		return fmt.Errorf(
 			"QRESYNC unavailable after the coverage search in %q", mailbox)
+	}
+	// The reconnect also reselects the mailbox, and the mailbox it selects may
+	// be a different one wearing the same name. A delta built under the old
+	// epoch describes UIDs that no longer mean what they meant, so the mailbox
+	// has to be enumerated in full instead.
+	if c.selectedUIDValidity != priorUIDValidity {
+		return fmt.Errorf(
+			"QRESYNC %q changed UIDVALIDITY from %d to %d during the coverage search",
+			mailbox, priorUIDValidity, c.selectedUIDValidity)
 	}
 	for _, uid := range present {
 		// "UID SEARCH UID n:*" returns the last message even when n is past

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -296,6 +296,19 @@ func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
 	return highest + 1
 }
 
+// metadataChunkSize bounds one metadata FETCH. fetchChunkSize is 50 because a
+// body fetch of more than that times out on large mailboxes. Flags and
+// mod-sequences are a few dozen bytes each, and the UID set coalesces adjacent
+// UIDs into ranges, so what bounds this fetch is the encoded command rather
+// than the response: a contiguous baseline of any size encodes as "1:N", and a
+// worst-case alternating one costs about 3 bytes per UID.
+//
+// Measured against Dovecot on a LAN with a 0.86 ms round trip, a 100k baseline
+// took 2.52 s as 2000 chunks of 50 and 0.22 s as one command. Round trips were
+// 68 % of that even at sub-millisecond latency, so the same refresh against a
+// server 30 ms away would spend about a minute per changed mailbox per run.
+const metadataChunkSize = 5000
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,
@@ -307,11 +320,11 @@ func (c *Client) refreshExistingQresyncChanges(
 		return nil
 	}
 
-	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += fetchChunkSize {
+	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += metadataChunkSize {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		end := min(chunkStart+fetchChunkSize, len(prior.KnownUIDs))
+		end := min(chunkStart+metadataChunkSize, len(prior.KnownUIDs))
 		expected := make(map[imap.UID]struct{}, end-chunkStart)
 		var requested imap.UIDSet
 		for _, value := range prior.KnownUIDs[chunkStart:end] {

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -309,6 +309,46 @@ func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
 // server 30 ms away would spend about a minute per changed mailbox per run.
 const metadataChunkSize = 5000
 
+// metadataCommandBudget bounds the encoded UID set of one metadata FETCH. The
+// count limit alone does not: a baseline of alternating UIDs cannot coalesce
+// into ranges, so 5000 high-numbered UIDs reach about 35 KB of command, and a
+// server may reject or truncate a line that long. A contiguous baseline still
+// travels as "1:N" and is never split by this.
+const metadataCommandBudget = 4000
+
+// metadataMeasureStride is how often the encoded length is measured while a
+// chunk fills. It bounds the overshoot at 320 characters, which keeps the
+// worst chunk under 4.4 KB.
+const metadataMeasureStride = 32
+
+// metadataFetchChunks splits a baseline into chunks that are bounded both in
+// UID count and in encoded command size.
+func metadataFetchChunks(knownUIDs []uint32) [][]uint32 {
+	var chunks [][]uint32
+	var set imap.UIDSet
+	start := 0
+	for i, value := range knownUIDs {
+		set.AddNum(imap.UID(value))
+		full := i-start+1 >= metadataChunkSize
+		// Measuring every UID would be quadratic, and the encoded length only
+		// grows, so measure on a stride. A chunk can therefore pass the budget
+		// by at most one stride of UIDs, which is 32 times the 10 characters a
+		// 32-bit UID and its separator can take.
+		if !full && (i-start)%metadataMeasureStride == metadataMeasureStride-1 {
+			full = len(set.String()) >= metadataCommandBudget
+		}
+		if full {
+			chunks = append(chunks, knownUIDs[start:i+1])
+			start = i + 1
+			set = nil
+		}
+	}
+	if start < len(knownUIDs) {
+		chunks = append(chunks, knownUIDs[start:])
+	}
+	return chunks
+}
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,
@@ -320,14 +360,13 @@ func (c *Client) refreshExistingQresyncChanges(
 		return nil
 	}
 
-	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += metadataChunkSize {
+	for _, chunk := range metadataFetchChunks(prior.KnownUIDs) {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		end := min(chunkStart+metadataChunkSize, len(prior.KnownUIDs))
-		expected := make(map[imap.UID]struct{}, end-chunkStart)
+		expected := make(map[imap.UID]struct{}, len(chunk))
 		var requested imap.UIDSet
-		for _, value := range prior.KnownUIDs[chunkStart:end] {
+		for _, value := range chunk {
 			uid := imap.UID(value)
 			if uid == 0 || value >= prior.UIDNext {
 				return fmt.Errorf("QRESYNC %q has invalid baseline UID %d", mailbox, value)

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 
 	imap "github.com/emersion/go-imap/v2"
@@ -256,7 +257,7 @@ func (c *Client) collectQresyncMailbox(
 		Mailbox: mailbox,
 		State: FolderState{
 			UIDValidity:   selected.UIDValidity,
-			UIDNext:       uint32(selected.UIDNext),
+			UIDNext:       baselineUIDNext(uint32(selected.UIDNext), uidsToUint32(knownUIDs)),
 			HighestModSeq: selected.HighestModSeq,
 			KnownUIDs:     uidsToUint32(knownUIDs),
 		},
@@ -273,6 +274,28 @@ func (c *Client) collectQresyncMailbox(
 // baseline UID must be returned, and its mod-sequence says whether it belongs
 // in the delta. The normal delta fetch then reads and persists that UID's
 // current flags.
+// baselineUIDNext is the UIDNEXT to save beside a baseline. UIDNEXT is
+// guaranteed larger than every UID in the mailbox (RFC 3501 2.3.1.1), so a
+// baseline that holds a UID at or above the reported UIDNEXT says the real one
+// is higher.
+//
+// A full enumeration reads UIDNEXT from STATUS and the UIDs from a later
+// SEARCH, so a message delivered between the two lands in the baseline with a
+// UID the saved UIDNEXT does not cover. Saving the reported value verbatim
+// stores a baseline that contradicts itself, and the next QRESYNC run reads
+// that as a corrupt baseline: refreshExistingQresyncChanges fails the mailbox,
+// and a QRESYNC failure discards every delta and enumerates the whole account.
+func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
+	highest := uint32(0)
+	for _, uid := range knownUIDs {
+		highest = max(highest, uid)
+	}
+	if highest < reportedUIDNext || highest == math.MaxUint32 {
+		return reportedUIDNext
+	}
+	return highest + 1
+}
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -491,6 +491,9 @@ func (c *Client) verifyQresyncCoverage(
 	inAssignedSpan := func(uid imap.UID) bool {
 		return uint32(uid) >= prior.UIDNext && uint32(uid) < currentUIDNext
 	}
+	// Count the union. The check runs before the caller removes vanished UIDs
+	// from the changed set, so a UID reported both ways is in both sets, and
+	// counting it twice lets one report account for two assigned UIDs.
 	accounted := uint32(0)
 	for uid := range changedSet {
 		if inAssignedSpan(uid) {
@@ -498,6 +501,9 @@ func (c *Client) verifyQresyncCoverage(
 		}
 	}
 	for uid := range vanishedSet {
+		if _, alsoChanged := changedSet[uid]; alsoChanged {
+			continue
+		}
 		if inAssignedSpan(uid) {
 			accounted++
 		}

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -390,14 +390,21 @@ func (c *Client) verifyQresyncCoverage(
 	// difference is a real count, and int is 32 bits wide on a 32-bit build.
 	assigned := currentUIDNext - prior.UIDNext
 
+	// Only UIDs inside the assigned span count. A report about a UID at or
+	// above the current UIDNEXT names a message the server has not assigned
+	// yet, and letting it count would let one such report stand in for a real
+	// message the response left out.
+	inAssignedSpan := func(uid imap.UID) bool {
+		return uint32(uid) >= prior.UIDNext && uint32(uid) < currentUIDNext
+	}
 	accounted := uint32(0)
 	for uid := range changedSet {
-		if uint32(uid) >= prior.UIDNext {
+		if inAssignedSpan(uid) {
 			accounted++
 		}
 	}
 	for uid := range vanishedSet {
-		if uint32(uid) >= prior.UIDNext {
+		if inAssignedSpan(uid) {
 			accounted++
 		}
 	}
@@ -408,6 +415,15 @@ func (c *Client) verifyQresyncCoverage(
 	present, err := c.enumerateMailbox(ctx, mailbox, imap.UID(prior.UIDNext))
 	if err != nil {
 		return fmt.Errorf("QRESYNC coverage search in %q: %w", mailbox, err)
+	}
+	// enumerateMailbox reconnects on a network error, and a reconnect clears
+	// the ENABLE. Every mailbox after this one would then ask for VANISHED on a
+	// connection that never enabled QRESYNC. This costs nothing when the
+	// connection survived, and fails the mailbox when the new one cannot enable
+	// it, which the caller answers with a full enumeration.
+	if !c.enableQresync() {
+		return fmt.Errorf(
+			"QRESYNC unavailable after the coverage search in %q", mailbox)
 	}
 	for _, uid := range present {
 		// "UID SEARCH UID n:*" returns the last message even when n is past

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,16 +19,25 @@ import (
 )
 
 type qresyncServerConfig struct {
-	capabilities             []string
-	mailboxes                []string
-	uidValidity              uint32
-	uidNext                  uint32
-	highestModSeq            uint64
-	selectHighestModSeq      uint64
-	selectFailureConnection  int
-	selectFailureAt          int
-	numMessages              *uint32
-	searchUIDs               []imapv2.UID
+	capabilities            []string
+	mailboxes               []string
+	uidValidity             uint32
+	uidNext                 uint32
+	highestModSeq           uint64
+	selectHighestModSeq     uint64
+	selectFailureConnection int
+	selectFailureAt         int
+	numMessages             *uint32
+	// selectExists is the EXISTS count SELECT reports. It defaults to the size
+	// of searchUIDs, which is right whenever nothing vanishes; a test whose
+	// scenario expunges messages must state the post-expunge count, because a
+	// server cannot report a message gone and still count it.
+	selectExists *uint32
+	searchUIDs   []imapv2.UID
+	// omitFromFetch names UIDs the server leaves out of a plain UID FETCH
+	// response while still reporting them from SEARCH, which is how a server
+	// that drops a live message from a response behaves.
+	omitFromFetch            []imapv2.UID
 	fetchChanged             []imapv2.UID
 	fetchVanished            []imapv2.UID
 	filterVanishedByFetchSet bool
@@ -132,8 +142,17 @@ func serveQresyncTestConn(
 				len(cfg.searchUIDs), cfg.uidValidity, cfg.uidNext, selectModSeq)
 			_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID FETCH"):
-			writeVanished(conn, qresyncVanishedForFetch(command, cfg))
-			writeFetchResponses(conn, cfg.fetchChanged, cfg.highestModSeq)
+			// Only a CHANGEDSINCE fetch is entitled to answer with a subset:
+			// that is what "changed since" means. A plain UID FETCH returns
+			// every message it was asked for, so it answers with the whole
+			// mailbox, which is what the callers of this fixture request.
+			if strings.Contains(upper, "CHANGEDSINCE") {
+				writeVanished(conn, qresyncVanishedForFetch(command, cfg))
+				writeFetchResponses(conn, cfg.fetchChanged, cfg.highestModSeq)
+			} else {
+				writeFetchResponses(
+					conn, withoutUIDs(cfg.searchUIDs, cfg.omitFromFetch), cfg.highestModSeq)
+			}
 			_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID SEARCH"):
 			_, _ = fmt.Fprintf(conn, "* SEARCH%s\r\n%s OK UID SEARCH completed\r\n",
@@ -205,6 +224,19 @@ func writeFetchResponses(w io.Writer, uids []imapv2.UID, modSeq uint64) {
 	for i, uid := range uids {
 		_, _ = fmt.Fprintf(w, "* %d FETCH (UID %d FLAGS (\\Seen) MODSEQ (%d))\r\n", i+1, uid, modSeq)
 	}
+}
+
+func withoutUIDs(uids, omit []imapv2.UID) []imapv2.UID {
+	if len(omit) == 0 {
+		return uids
+	}
+	kept := make([]imapv2.UID, 0, len(uids))
+	for _, uid := range uids {
+		if !slices.Contains(omit, uid) {
+			kept = append(kept, uid)
+		}
+	}
+	return kept
 }
 
 func formatSearchUIDs(uids []imapv2.UID) string {
@@ -769,4 +801,36 @@ func TestListMessagesQresyncErrorStillCoversSkippedMailboxes(t *testing.T) {
 		assert.Equal([]uint32{1, 2, 3}, delta.State.KnownUIDs, "%s", delta.Mailbox)
 	}
 	assert.Len(client.ObservedFolderStates(), len(mailboxes))
+}
+
+// TestLabelMapOmittedUIDSuppressesAuthoritativeSnapshot covers the label map's
+// half of reading a server's silence as fact. SEARCH reports the UID, so the
+// run knows the message is there, and then every FETCH leaves it out. Nothing
+// downstream can see that: the message is absent from the map with no error
+// against it.
+//
+// Publishing that map as authoritative is what loses the message. A republish
+// deletes every membership row the run did not observe, and for a mailbox
+// whose membership comes only from this map there is no later fetch to put it
+// back. The map must therefore declare itself incomplete, which suppresses the
+// snapshot and leaves the stored rows alone.
+func TestLabelMapOmittedUIDSuppressesAuthoritativeSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	addr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1"},
+		uidValidity:   77,
+		uidNext:       4,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+		omitFromFetch: []imapv2.UID{2},
+	})
+	client := newQresyncTestClient(t, addr, nil)
+
+	listQresyncMessages(t, client)
+
+	assert.False(client.LabelsSnapshotComplete(),
+		"a label map missing a UID the server reported is not authoritative")
+	assert.Empty(client.ObservedMailboxDeltas(),
+		"an incomplete label map must not publish a mailbox topology")
+	assert.Empty(client.ObservedFolderStates(),
+		"nor the folder states derived from it")
 }

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -943,8 +943,16 @@ func TestQresyncOmittedExistingChangeIsRecoveredIndependently(t *testing.T) {
 	commands := joinedCommands(server.commandsFor(1))
 	assert.Contains(commands, "CHANGEDSINCE 10 VANISHED",
 		"the server omission must occur on the incremental request")
-	assert.Contains(commands, "UID FETCH 1:3 (UID FLAGS MODSEQ)",
-		"existing flags need an independent complete response")
+	plainRefresh := false
+	for command := range strings.SplitSeq(commands, "\n") {
+		if strings.Contains(command, "UID FETCH 1:3") &&
+			strings.Contains(command, "MODSEQ") &&
+			!strings.Contains(command, "CHANGEDSINCE") {
+			plainRefresh = true
+			break
+		}
+	}
+	assert.True(plainRefresh, "existing flags need an independent complete response")
 	assert.Contains(listed, "INBOX|2",
 		"the independently observed change must be refreshed")
 	deltas := client.ObservedMailboxDeltas()

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -37,8 +37,11 @@ type qresyncServerConfig struct {
 	// omitFromFetch names UIDs the server leaves out of a plain UID FETCH
 	// response while still reporting them from SEARCH, which is how a server
 	// that drops a live message from a response behaves.
-	omitFromFetch            []imapv2.UID
-	fetchChanged             []imapv2.UID
+	omitFromFetch []imapv2.UID
+	fetchChanged  []imapv2.UID
+	// fetchModSeq overrides the mod-sequence returned by a plain UID FETCH.
+	// UIDs without an override are unchanged baseline messages.
+	fetchModSeq              map[imapv2.UID]uint64
 	fetchVanished            []imapv2.UID
 	filterVanishedByFetchSet bool
 	// dropOnSearchConnection closes the connection with that ID instead of
@@ -158,8 +161,13 @@ func serveQresyncTestConn(
 				writeVanished(conn, qresyncVanishedForFetch(command, cfg))
 				writeFetchResponses(conn, cfg.fetchChanged, cfg.highestModSeq)
 			} else {
-				writeFetchResponses(
-					conn, withoutUIDs(cfg.searchUIDs, cfg.omitFromFetch), cfg.highestModSeq)
+				for _, uid := range withoutUIDs(cfg.searchUIDs, cfg.omitFromFetch) {
+					modSeq := cfg.fetchModSeq[uid]
+					if modSeq == 0 {
+						modSeq = 1
+					}
+					writeFetchResponses(conn, []imapv2.UID{uid}, modSeq)
+				}
 			}
 			_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID SEARCH"):
@@ -904,6 +912,45 @@ func TestQresyncOmittedNewUIDFallsBackToFullEnumeration(t *testing.T) {
 	require.Len(t, deltas, 1)
 	assert.Contains(deltas[0].State.KnownUIDs, uint32(3),
 		"and must reach the saved baseline")
+}
+
+// TestQresyncOmittedExistingChangeIsRecoveredIndependently covers the part of
+// CHANGEDSINCE coverage that UIDNEXT cannot measure. UID 2 existed before the
+// saved high-water mark, but its flags changed afterward. The server omits it
+// from CHANGEDSINCE while still returning it from a plain FETCH with a newer
+// mod-sequence. The independent refresh must put it back into the delta before
+// HIGHESTMODSEQ advances past the change.
+func TestQresyncOmittedExistingChangeIsRecoveredIndependently(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+		fetchChanged:  []imapv2.UID{},
+		fetchModSeq:   map[imapv2.UID]uint64{2: 20},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 4, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "CHANGEDSINCE 10 VANISHED",
+		"the server omission must occur on the incremental request")
+	assert.Contains(commands, "UID FETCH 1:3 (UID FLAGS MODSEQ)",
+		"existing flags need an independent complete response")
+	assert.Contains(listed, "INBOX|2",
+		"the independently observed change must be refreshed")
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.Equal([]imapv2.UID{2}, deltas[0].ChangedUIDs)
+	assert.Equal(uint64(20), deltas[0].State.HighestModSeq)
 }
 
 // TestQresyncOmittedNewUIDAfterExpungeFallsBack pins that a mailbox losing

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -41,6 +41,10 @@ type qresyncServerConfig struct {
 	fetchChanged             []imapv2.UID
 	fetchVanished            []imapv2.UID
 	filterVanishedByFetchSet bool
+	// dropOnSearchConnection closes the connection with that ID instead of
+	// answering its first UID SEARCH, which is how a coverage search meets a
+	// connection the server has given up on.
+	dropOnSearchConnection int
 }
 
 type qresyncTestServer struct {
@@ -159,6 +163,9 @@ func serveQresyncTestConn(
 			}
 			_, _ = fmt.Fprintf(conn, "%s OK UID FETCH completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID SEARCH"):
+			if connID == cfg.dropOnSearchConnection {
+				return
+			}
 			_, _ = fmt.Fprintf(conn, "* SEARCH%s\r\n%s OK UID SEARCH completed\r\n",
 				formatSearchUIDs(cfg.searchUIDs), tag)
 		case strings.HasPrefix(upper, "LOGOUT"):
@@ -975,4 +982,85 @@ func TestQresyncStaleBaselineDoesNotMaskOmittedNewUID(t *testing.T) {
 		"a baseline larger than the mailbox must not skip the check")
 	assert.Contains(listed, "INBOX|5",
 		"the omitted message must be recovered by the fallback")
+}
+
+// TestQresyncOutOfRangeReportCannotCoverAnOmission pins what the coverage
+// arithmetic counts. The span it checks is the UIDs assigned since the last
+// run, so only a report about a UID inside that span is evidence about it. A
+// report naming a UID at or above the current UIDNEXT names a message the
+// server has not assigned yet, and counting it would let one such report stand
+// in for a real message the response left out.
+func TestQresyncOutOfRangeReportCannotCoverAnOmission(t *testing.T) {
+	assert := assert.New(t)
+	// UIDs 5 and 6 were assigned since the last run. The response reports 5 as
+	// changed, omits 6 entirely, and reports a VANISHED UID the mailbox cannot
+	// have assigned yet.
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       7,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4, 5, 6},
+		fetchChanged:  []imapv2.UID{5},
+		fetchVanished: []imapv2.UID{99},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	assert.Contains(joinedCommands(server.commandsFor(1)), "UID SEARCH UID 5:*",
+		"a report from outside the assigned span must not satisfy the count")
+	assert.Contains(listed, "INBOX|6",
+		"the omitted message must be recovered by the fallback")
+}
+
+// TestQresyncCoverageSearchReconnectKeepsQresyncEnabled covers what the
+// coverage search costs the rest of the run. It is the only command in the
+// QRESYNC loop that reconnects on a network error, and a reconnect clears the
+// ENABLE. Every mailbox after this one asks for VANISHED, which a connection
+// that never enabled QRESYNC does not answer, so the run would read an
+// expunged message as still present.
+func TestQresyncCoverageSearchReconnectKeepsQresyncEnabled(t *testing.T) {
+	assert := assert.New(t)
+	// UIDs 5 and 6 were assigned since the last run, but the server skipped 6
+	// rather than using it, so one changed UID accounts for the span and the
+	// search confirms it. The first connection dies answering that search.
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:           []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		mailboxes:              []string{"First", "Second"},
+		uidValidity:            77,
+		uidNext:                7,
+		highestModSeq:          20,
+		searchUIDs:             []imapv2.UID{1, 2, 3, 4, 5},
+		fetchChanged:           []imapv2.UID{5},
+		dropOnSearchConnection: 1,
+	})
+	states := map[string]FolderState{
+		"First": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+		"Second": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+	}
+	client := newQresyncTestClient(t, addr, states)
+
+	listQresyncMessages(t, client)
+
+	reconnected := joinedCommands(server.commandsFor(2))
+	assert.Contains(reconnected, "ENABLE QRESYNC",
+		"the connection the search left behind must enable QRESYNC again")
+	assert.Contains(reconnected, "CHANGEDSINCE",
+		"the run continues on the new connection, so the ENABLE has to hold")
+	assert.Less(
+		strings.Index(reconnected, "ENABLE QRESYNC"),
+		strings.Index(reconnected, "CHANGEDSINCE"),
+		"QRESYNC must be enabled before the next mailbox asks for VANISHED")
 }

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1119,3 +1119,57 @@ func TestQresyncCoverageSearchReconnectKeepsQresyncEnabled(t *testing.T) {
 		strings.Index(reconnected, "CHANGEDSINCE"),
 		"QRESYNC must be enabled before the next mailbox asks for VANISHED")
 }
+
+// TestFullEnumerationSavesUIDNextAboveKnownUIDs covers the one race that can
+// save a baseline holding a UID its own UIDNEXT does not cover. A full
+// enumeration reads UIDNEXT from STATUS and the UIDs from a later SEARCH, so a
+// message delivered between the two is enumerated while the saved UIDNEXT
+// still sits at or below its UID.
+//
+// The next QRESYNC run reads that as a corrupt baseline, and a QRESYNC failure
+// is not local to one mailbox: the caller discards every delta and enumerates
+// the whole account in full.
+func TestFullEnumerationSavesUIDNextAboveKnownUIDs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// STATUS reports UIDNEXT 4. The SEARCH that follows reports UID 4, which
+	// arrived in between.
+	firstAddr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+	})
+	first := newQresyncTestClient(t, firstAddr, map[string]FolderState{})
+
+	listQresyncMessages(t, first)
+
+	saved := first.ObservedFolderStates()
+	require.Contains(saved, "INBOX")
+	require.Contains(saved["INBOX"].KnownUIDs, uint32(4))
+	assert.Greater(saved["INBOX"].UIDNext, uint32(4),
+		"a saved UIDNEXT must cover every UID in the baseline saved with it")
+
+	// The next run meets a server that offers QRESYNC and reports the UIDNEXT
+	// the first enumeration implied.
+	secondAddr, secondServer := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       5,
+		highestModSeq: 25,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+		fetchChanged:  []imapv2.UID{4},
+	})
+	second := newQresyncTestClient(t, secondAddr, saved)
+
+	listQresyncMessages(t, second)
+
+	assert.Contains(joinedCommands(secondServer.commandsFor(1)), "CHANGEDSINCE",
+		"the second run must still be able to use QRESYNC")
+	// A QRESYNC failure discards every delta, reconnects, and enumerates the
+	// whole account, so a second connection is the signal that the baseline
+	// was rejected.
+	assert.Empty(secondServer.commandsFor(2),
+		"a self-consistent baseline must not force a full enumeration")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1259,3 +1259,45 @@ func TestQresyncCoverageSearchRejectsChangedEpoch(t *testing.T) {
 	assert.NotContains(joinedCommands(server.commandsFor(3)), "CHANGEDSINCE",
 		"the fallback enumerates rather than trusting the delta")
 }
+
+// TestQresyncRefreshFetchesTheBaselineInFewCommands pins what the existing
+// message refresh costs. It reads flags and mod-sequences, not bodies, and a
+// baseline of adjacent UIDs encodes as one range, so the whole mailbox fits in
+// one command. Chunking it at the body-fetch size turns a 100k mailbox into
+// 2000 round trips on every run in which anything changed.
+func TestQresyncRefreshFetchesTheBaselineInFewCommands(t *testing.T) {
+	assert := assert.New(t)
+	const baselineSize = 5000
+	searchUIDs := make([]imapv2.UID, baselineSize)
+	knownUIDs := make([]uint32, baselineSize)
+	for i := range baselineSize {
+		searchUIDs[i] = imapv2.UID(i + 1)
+		knownUIDs[i] = uint32(i + 1)
+	}
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       baselineSize + 1,
+		highestModSeq: 20,
+		searchUIDs:    searchUIDs,
+		fetchChanged:  []imapv2.UID{},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: baselineSize + 1, HighestModSeq: 10,
+			KnownUIDs: knownUIDs,
+		},
+	})
+
+	listQresyncMessages(t, client)
+
+	plainFetches := 0
+	for _, command := range server.commandsFor(1) {
+		upper := strings.ToUpper(command)
+		if strings.Contains(upper, "UID FETCH") && !strings.Contains(upper, "CHANGEDSINCE") {
+			plainFetches++
+		}
+	}
+	assert.LessOrEqual(plainFetches, 2,
+		"a metadata refresh of one mailbox must not cost a round trip per 50 messages")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -137,9 +137,13 @@ func serveQresyncTestConn(
 			if selectModSeq == 0 {
 				selectModSeq = cfg.highestModSeq
 			}
+			exists := uint32(len(cfg.searchUIDs))
+			if cfg.selectExists != nil {
+				exists = *cfg.selectExists
+			}
 			_, _ = fmt.Fprintf(conn,
 				"* FLAGS (\\Seen)\r\n* %d EXISTS\r\n* OK [UIDVALIDITY %d]\r\n* OK [UIDNEXT %d]\r\n* OK [HIGHESTMODSEQ %d]\r\n",
-				len(cfg.searchUIDs), cfg.uidValidity, cfg.uidNext, selectModSeq)
+				exists, cfg.uidValidity, cfg.uidNext, selectModSeq)
 			_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID FETCH"):
 			// Only a CHANGEDSINCE fetch is entitled to answer with a subset:
@@ -277,12 +281,16 @@ func joinedCommands(commands []string) string {
 
 func TestListMessagesQresyncUsesHighestModSeqAndCollectsDelta(t *testing.T) {
 	assert := assert.New(t)
+	// Two of the three messages are expunged by this run, so the mailbox holds
+	// one. A server cannot report a message gone and still count it.
+	postExpungeExists := uint32(1)
 	addr, server := startQresyncTestServer(t, qresyncServerConfig{
 		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
 		uidValidity:   77,
 		uidNext:       4,
 		highestModSeq: 20,
 		searchUIDs:    []imapv2.UID{1, 2, 3},
+		selectExists:  &postExpungeExists,
 		fetchChanged:  []imapv2.UID{2},
 		fetchVanished: []imapv2.UID{1, 3},
 	})
@@ -833,4 +841,138 @@ func TestLabelMapOmittedUIDSuppressesAuthoritativeSnapshot(t *testing.T) {
 		"an incomplete label map must not publish a mailbox topology")
 	assert.Empty(client.ObservedFolderStates(),
 		"nor the folder states derived from it")
+}
+
+// TestQresyncOmittedNewUIDFallsBackToFullEnumeration covers the QRESYNC half
+// of reading a server's silence as fact.
+//
+// A message that arrived since the last run has a UID at or above the previous
+// UIDNEXT, so its mod-sequence is above the one this fetch asks about and the
+// server is obliged to report it. When it does not, nothing downstream can
+// tell: the UID never reaches KnownUIDs, it is never listed or fetched, no
+// error is recorded, and HIGHESTMODSEQ still advances past it, so no later run
+// has a reason to ask about it again.
+//
+// A UID SEARCH is independent of the FETCH that misbehaved. Here the mailbox
+// reports three messages while the response accounts for two, so the search
+// runs, finds UID 3 above the high water mark and unaccounted for, and the run
+// abandons QRESYNC for a full enumeration rather than saving a cursor past a
+// message it never saw.
+func TestQresyncOmittedNewUIDFallsBackToFullEnumeration(t *testing.T) {
+	assert := assert.New(t)
+	mailboxExists := uint32(3)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3},
+		selectExists:  &mailboxExists,
+		// UID 3 arrived since the last run and the server leaves it out.
+		fetchChanged: []imapv2.UID{},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity:   77,
+			UIDNext:       3,
+			HighestModSeq: 10,
+			KnownUIDs:     []uint32{1, 2},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "CHANGEDSINCE 10 VANISHED",
+		"the run must try QRESYNC first")
+	assert.Contains(commands, "UID SEARCH UID 3:*",
+		"a mailbox short of its message count must be checked independently")
+
+	// The fallback enumerates the mailbox, so the message the CHANGEDSINCE
+	// response omitted is listed after all. The cursor does advance here, and
+	// that is correct: this run really did read the whole mailbox.
+	assert.Contains(listed, "INBOX|3",
+		"the message the response omitted must be recovered by the fallback")
+	deltas := client.ObservedMailboxDeltas()
+	require.Len(t, deltas, 1)
+	assert.Contains(deltas[0].State.KnownUIDs, uint32(3),
+		"and must reach the saved baseline")
+}
+
+// TestQresyncOmittedNewUIDAfterExpungeFallsBack pins that a mailbox losing
+// messages and gaining one in the same cycle is still checked. The vanished
+// UIDs are already out of knownUIDs by the time coverage is verified, so an
+// expunge cannot offset an addition and hide it.
+func TestQresyncOmittedNewUIDAfterExpungeFallsBack(t *testing.T) {
+	assert := assert.New(t)
+	// Started with 1 and 2. UID 1 is expunged, UID 3 arrives -> 2 messages.
+	mailboxExists := uint32(2)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{2, 3},
+		selectExists:  &mailboxExists,
+		fetchVanished: []imapv2.UID{1},
+		// UID 3 arrived since the last run and the server leaves it out.
+		fetchChanged: []imapv2.UID{},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 3, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "UID SEARCH UID 3:*",
+		"an expunge in the same cycle must not excuse the check")
+	assert.Contains(listed, "INBOX|3",
+		"the omitted message must be recovered by the fallback")
+}
+
+// TestQresyncStaleBaselineDoesNotMaskOmittedNewUID is why the check looks at
+// UIDNEXT and not at the message count.
+//
+// KnownUIDs is read back from stored memberships, so it drifts from the server
+// in both directions. Here it drifts long: three messages left the mailbox
+// without the server reporting VANISHED, so the baseline holds four UIDs while
+// the mailbox reports two. A count comparison reads that as "we already know
+// about more than exist" and asks nothing further, which is precisely when a
+// newly arrived UID the server omitted would be lost.
+//
+// UIDNEXT does not drift. It is the server's own statement that something was
+// appended, and it is what decides whether to look.
+func TestQresyncStaleBaselineDoesNotMaskOmittedNewUID(t *testing.T) {
+	assert := assert.New(t)
+	// UIDs 1-3 are gone but the server never said VANISHED. UID 5 is new and
+	// is left out of the response. The mailbox reports 2 messages.
+	mailboxExists := uint32(2)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       6,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{4, 5},
+		selectExists:  &mailboxExists,
+		fetchVanished: []imapv2.UID{},
+		fetchChanged:  []imapv2.UID{},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	commands := joinedCommands(server.commandsFor(1))
+	assert.Contains(commands, "UID SEARCH UID 5:*",
+		"a baseline larger than the mailbox must not skip the check")
+	assert.Contains(listed, "INBOX|5",
+		"the omitted message must be recovered by the fallback")
 }

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1301,3 +1301,44 @@ func TestQresyncRefreshFetchesTheBaselineInFewCommands(t *testing.T) {
 	assert.LessOrEqual(plainFetches, 2,
 		"a metadata refresh of one mailbox must not cost a round trip per 50 messages")
 }
+
+// TestMetadataFetchChunksBoundCommandSize pins both limits the refresh needs.
+// A contiguous baseline coalesces into one range and must not be split by the
+// size budget. A baseline of alternating UIDs cannot coalesce, so 5000 of them
+// would reach about 35 KB of command, and a server may reject a line that
+// long.
+func TestMetadataFetchChunksBoundCommandSize(t *testing.T) {
+	assert := assert.New(t)
+
+	contiguous := make([]uint32, 100000)
+	for i := range contiguous {
+		contiguous[i] = uint32(i + 1)
+	}
+	chunks := metadataFetchChunks(contiguous)
+	assert.Len(chunks, 20, "a contiguous baseline is bounded by the UID count alone")
+
+	sparse := make([]uint32, 20000)
+	for i := range sparse {
+		sparse[i] = uint32(500000 + i*2)
+	}
+	for _, chunk := range metadataFetchChunks(sparse) {
+		var set imapv2.UIDSet
+		for _, uid := range chunk {
+			set.AddNum(imapv2.UID(uid))
+		}
+		assert.LessOrEqual(len(set.String()), metadataCommandBudget+320,
+			"a sparse baseline must be split before the command grows too long")
+	}
+
+	assert.Equal(len(sparse), countChunkedUIDs(metadataFetchChunks(sparse)),
+		"chunking must cover every UID exactly once")
+	assert.Empty(metadataFetchChunks(nil))
+}
+
+func countChunkedUIDs(chunks [][]uint32) int {
+	total := 0
+	for _, chunk := range chunks {
+		total += len(chunk)
+	}
+	return total
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1173,3 +1173,38 @@ func TestFullEnumerationSavesUIDNextAboveKnownUIDs(t *testing.T) {
 	assert.Empty(secondServer.commandsFor(2),
 		"a self-consistent baseline must not force a full enumeration")
 }
+
+// TestQresyncOverlappingReportCannotCoverAnOmission pins that coverage counts
+// the union of the two reports. A UID may arrive as changed and as vanished in
+// one response, and the coverage check runs before the caller removes vanished
+// UIDs from the changed set. Counting that UID twice lets one message account
+// for two of the UIDs assigned since the last run.
+func TestQresyncOverlappingReportCannotCoverAnOmission(t *testing.T) {
+	assert := assert.New(t)
+	// UIDs 5, 6 and 7 were assigned since the last run. The response reports 5
+	// and 6 as changed, reports 6 as vanished as well, and omits 7.
+	mailboxExists := uint32(5)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       8,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 5, 7},
+		selectExists:  &mailboxExists,
+		fetchChanged:  []imapv2.UID{5, 6},
+		fetchVanished: []imapv2.UID{6},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	assert.Contains(joinedCommands(server.commandsFor(1)), "UID SEARCH UID 5:*",
+		"one UID reported twice must not account for two assigned UIDs")
+	assert.Contains(listed, "INBOX|7",
+		"the omitted message must be recovered by the fallback")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -48,6 +48,11 @@ type qresyncServerConfig struct {
 	// answering its first UID SEARCH, which is how a coverage search meets a
 	// connection the server has given up on.
 	dropOnSearchConnection int
+	// uidValidityAfterConnection is the UIDVALIDITY reported to every
+	// connection after that ID, which is how a mailbox recreated between two
+	// connections presents itself.
+	uidValidityAfterConnection int
+	laterUIDValidity           uint32
 }
 
 type qresyncTestServer struct {
@@ -131,7 +136,8 @@ func serveQresyncTestConn(
 			}
 			_, _ = fmt.Fprintf(conn,
 				"* STATUS %q (%sUIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
-				mailbox, messages, cfg.uidNext, cfg.uidValidity, cfg.highestModSeq, tag)
+				mailbox, messages, cfg.uidNext, connectionUIDValidity(cfg, connID),
+				cfg.highestModSeq, tag)
 		case strings.HasPrefix(upper, "ENABLE"):
 			_, _ = fmt.Fprintf(conn, "* ENABLED QRESYNC\r\n%s OK ENABLE completed\r\n", tag)
 		case strings.HasPrefix(upper, "SELECT"):
@@ -150,7 +156,7 @@ func serveQresyncTestConn(
 			}
 			_, _ = fmt.Fprintf(conn,
 				"* FLAGS (\\Seen)\r\n* %d EXISTS\r\n* OK [UIDVALIDITY %d]\r\n* OK [UIDNEXT %d]\r\n* OK [HIGHESTMODSEQ %d]\r\n",
-				exists, cfg.uidValidity, cfg.uidNext, selectModSeq)
+				exists, connectionUIDValidity(cfg, connID), cfg.uidNext, selectModSeq)
 			_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID FETCH"):
 			// Only a CHANGEDSINCE fetch is entitled to answer with a subset:
@@ -183,6 +189,16 @@ func serveQresyncTestConn(
 			_, _ = fmt.Fprintf(conn, "%s BAD unsupported synthetic command\r\n", tag)
 		}
 	}
+}
+
+// connectionUIDValidity reports the UIDVALIDITY this connection sees. A
+// mailbox recreated between two connections reports the new value from every
+// command, so STATUS and SELECT must agree.
+func connectionUIDValidity(cfg qresyncServerConfig, connID int) uint32 {
+	if cfg.uidValidityAfterConnection != 0 && connID > cfg.uidValidityAfterConnection {
+		return cfg.laterUIDValidity
+	}
+	return cfg.uidValidity
 }
 
 func qresyncVanishedForFetch(command string, cfg qresyncServerConfig) []imapv2.UID {
@@ -1207,4 +1223,39 @@ func TestQresyncOverlappingReportCannotCoverAnOmission(t *testing.T) {
 		"one UID reported twice must not account for two assigned UIDs")
 	assert.Contains(listed, "INBOX|7",
 		"the omitted message must be recovered by the fallback")
+}
+
+// TestQresyncCoverageSearchRejectsChangedEpoch covers the other thing the
+// coverage search can bring back from a reconnect. The reconnect reselects the
+// mailbox, and the mailbox that answers may be a different one wearing the
+// same name. Every UID in the delta was collected under the old UIDVALIDITY,
+// so the mailbox has to be enumerated in full rather than saved.
+func TestQresyncCoverageSearchRejectsChangedEpoch(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:               []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:                77,
+		uidNext:                    7,
+		highestModSeq:              20,
+		searchUIDs:                 []imapv2.UID{1, 2, 3, 4, 5},
+		fetchChanged:               []imapv2.UID{5},
+		dropOnSearchConnection:     1,
+		uidValidityAfterConnection: 1,
+		laterUIDValidity:           88,
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+	})
+
+	listQresyncMessages(t, client)
+
+	// A QRESYNC failure reconnects once more and enumerates the account, so
+	// the run reaches a third connection.
+	assert.NotEmpty(server.commandsFor(3),
+		"a mailbox that changed epoch mid-run must fall back to full enumeration")
+	assert.NotContains(joinedCommands(server.commandsFor(3)), "CHANGEDSINCE",
+		"the fallback enumerates rather than trusting the delta")
 }

--- a/internal/peoplesweep/codex_app_server_test.go
+++ b/internal/peoplesweep/codex_app_server_test.go
@@ -1028,13 +1028,11 @@ func TestCodexLoginAndModelsApplyConfiguredTimeout(t *testing.T) {
 		t.Run(operation, func(t *testing.T) {
 			checks := assert.New(t)
 			must := require.New(t)
-			started := make(chan struct{})
 			starter := &recordingCodexStarter{t: t, scripts: []func(*bufio.Reader, io.Writer, io.Writer) error{
 				func(reader *bufio.Reader, _, _ io.Writer) error {
 					if _, err := reader.ReadBytes('\n'); err != nil {
 						return fmt.Errorf("read silent Codex request: %w", err)
 					}
-					close(started)
 					_, err := reader.ReadBytes('\n')
 					if err != nil {
 						return fmt.Errorf("wait for silent Codex request: %w", err)
@@ -1046,18 +1044,14 @@ func TestCodexLoginAndModelsApplyConfiguredTimeout(t *testing.T) {
 			config.RequestTimeout = 30 * time.Millisecond
 			transport, err := peoplesweep.NewCodexAppServerTransport(config, starter, &recordingCodexGate{})
 			must.NoError(err)
-			parentCtx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
-			defer cancel()
-			startedAt := time.Now()
 			switch operation {
 			case "login":
-				err = transport.StartDeviceLogin(parentCtx, func(peoplesweep.DeviceLogin) error { return nil })
+				err = transport.StartDeviceLogin(t.Context(), func(peoplesweep.DeviceLogin) error { return nil })
 			case "models":
-				_, err = transport.ListModels(parentCtx)
+				_, err = transport.ListModels(t.Context())
 			}
-			<-started
 			must.ErrorIs(err, context.DeadlineExceeded)
-			checks.Less(time.Since(startedAt), 250*time.Millisecond)
+			must.NoError(t.Context().Err(), "the configured provider deadline must expire before the test context")
 			must.Len(starter.records, 1)
 			process := starter.records[0].process
 			checks.Equal(int64(1), process.kills.Load())

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -128,6 +128,12 @@ type missingUIDConfig struct {
 	// hideRemaining is negative to hide the UID from every FETCH, zero to hide
 	// it from none, and positive to hide it from that many more responses.
 	hideRemaining atomic.Int64
+	// expunged makes the message leave the mailbox for good the moment a FETCH
+	// first leaves it out, so SEARCH stops reporting it too. Until then SEARCH
+	// must still report the UID: a run has to enumerate a message before it can
+	// watch it vanish from the fetch it then asks for.
+	expunged     atomic.Bool
+	searchHidden atomic.Bool
 }
 
 // takeHide reports whether this FETCH response must leave the UID out, and
@@ -183,6 +189,9 @@ func (s *missingUIDSession) Fetch(
 	if !s.config.takeHide() {
 		return fetch(numSet)
 	}
+	if s.config.expunged.Load() {
+		s.config.searchHidden.Store(true)
+	}
 	kept := make([]imap.UID, 0, len(uids))
 	for _, uid := range uids {
 		if uid != s.config.uid {
@@ -196,10 +205,55 @@ func (s *missingUIDSession) Fetch(
 	return fetch(imap.UIDSetNum(kept...))
 }
 
+// Search drops the UID once a FETCH has reported the message gone, which is
+// what a real server does after an expunge. A server that answers a FETCH
+// without the UID and still lists it in every SEARCH is describing a live
+// message the fetch dropped, not one that left the mailbox --
+// StartIMAPMemServerOmittingUIDFromEveryFetch is that server.
+func (s *missingUIDSession) Search(
+	kind imapserver.NumKind,
+	criteria *imap.SearchCriteria,
+	options *imap.SearchOptions,
+) (*imap.SearchData, error) {
+	data, err := s.Session.Search(kind, criteria, options)
+	if err != nil {
+		return nil, fmt.Errorf("search %q: %w", s.selected, err)
+	}
+	if s.selected != s.config.mailbox || !s.config.searchHidden.Load() {
+		return data, nil
+	}
+	uidSet, ok := data.All.(imap.UIDSet)
+	if !ok || !uidSet.Contains(s.config.uid) {
+		return data, nil
+	}
+	uids, static := uidSet.Nums()
+	if !static {
+		return data, nil
+	}
+	var kept imap.UIDSet
+	filtered := imap.SearchData{ModSeq: data.ModSeq}
+	for _, uid := range uids {
+		if uid == s.config.uid {
+			continue
+		}
+		kept.AddNum(uid)
+		if filtered.Min == 0 || uint32(uid) < filtered.Min {
+			filtered.Min = uint32(uid)
+		}
+		if uint32(uid) > filtered.Max {
+			filtered.Max = uint32(uid)
+		}
+		filtered.Count++
+	}
+	filtered.All = kept
+	return &filtered, nil
+}
+
 // StartIMAPMemServerWithMissingUID runs an in-memory IMAP server that can
-// leave one UID out of every FETCH response for one mailbox. LIST, STATUS and
-// SEARCH still report it, so a run enumerates the UID and then cannot fetch
-// it. That is the expunge race as a real server presents it.
+// leave one UID out of every FETCH response for one mailbox. SEARCH reports
+// the UID until the first FETCH that omits it and never again, so a run
+// enumerates the message, cannot fetch it, and finds it gone when it asks.
+// That is the expunge race as a real server presents it.
 //
 // The returned function sets whether the UID is hidden. Call it between two
 // runs to make a message disappear, or to bring it back.
@@ -211,6 +265,7 @@ func StartIMAPMemServerWithMissingUID(
 ) (string, *imapmemserver.User, func(hidden bool)) {
 	t.Helper()
 	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
+	config.expunged.Store(true)
 	addr, user := startIMAPMemServer(
 		t, messagesPerMailbox, nil, "", 0, "", config)
 	return addr, user, func(hidden bool) {
@@ -219,7 +274,30 @@ func StartIMAPMemServerWithMissingUID(
 			return
 		}
 		config.hideRemaining.Store(0)
+		config.searchHidden.Store(false)
 	}
+}
+
+// StartIMAPMemServerOmittingUIDFromEveryFetch runs an in-memory IMAP server
+// that never returns one UID from a FETCH of one mailbox and keeps reporting
+// it in every SEARCH.
+//
+// The message is still in the mailbox: the server drops it from the fetch for
+// its own reasons, and repeating the same fetch cannot tell the two apart.
+// StartIMAPMemServerWithMissingUID is the other shape, where the message
+// really left.
+func StartIMAPMemServerOmittingUIDFromEveryFetch(
+	t *testing.T,
+	messagesPerMailbox map[string]int,
+	mailbox string,
+	uid imap.UID,
+) (string, *imapmemserver.User) {
+	t.Helper()
+	config := &missingUIDConfig{mailbox: mailbox, uid: uid}
+	config.hideRemaining.Store(-1)
+	addr, user := startIMAPMemServer(
+		t, messagesPerMailbox, nil, "", 0, "", config)
+	return addr, user
 }
 
 // StartIMAPMemServerOmittingUIDOnce runs an in-memory IMAP server that leaves


### PR DESCRIPTION
Supersedes #738.

Closes #731.

A UID omitted from a successful IMAP response is not evidence that the message left the mailbox. Treating that silence as authoritative can remove stored memberships, skip new messages permanently, or leave existing flags stale after the client advances its saved cursor.

This change requires independent evidence before publishing those conclusions:

- A UID omitted from message fetches is checked with an exact `UID SEARCH`. A UID that remains present becomes a fetch error instead of an expunge.
- The label map rechecks omitted UIDs and suppresses its authoritative snapshot when a live membership is still missing.
- QRESYNC compares new-UID coverage with the `UIDNEXT` span, confirms shortfalls by search, and independently fetches saved UIDs without `CHANGEDSINCE` to recover omitted existing-message changes. If any coverage cannot be established, the mailbox falls back to full enumeration instead of saving `HIGHESTMODSEQ` past the gap.

The Windows provider-timeout test also no longer waits forever for a request-read signal when the configured deadline expires before the fake process reads. It verifies that the provider deadline ended the operation and keeps the process-cleanup assertions.

No configuration or usage changes.
