### PR TITLE
fix(imap): answer the QRESYNC coverage review on #739

### DIFF
--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -1153,10 +1153,10 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			}
 			for _, mailbox := range allMailboxes {
 				state := folderStatuses[mailbox]
-				if deltaIndex, ok := deltaByMailbox[mailbox]; ok {
+				deltaIndex, hasDelta := deltaByMailbox[mailbox]
+				if hasDelta {
 					state.KnownUIDs = append(
 						[]uint32(nil), c.observedMailboxDeltas[deltaIndex].State.KnownUIDs...)
-					c.observedMailboxDeltas[deltaIndex].State = state
 				} else {
 					state.KnownUIDs = make([]uint32, 0)
 					for _, observation := range c.observedMemberships {
@@ -1165,6 +1165,15 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 						}
 					}
 					slices.Sort(state.KnownUIDs)
+				}
+				// The snapshot rebuilds the state from STATUS, whose UIDNEXT was
+				// read before the enumeration that produced these UIDs. A message
+				// delivered in between belongs to the baseline and sits at or
+				// above that mark, so the saved UIDNEXT has to cover it.
+				state.UIDNext = baselineUIDNext(state.UIDNext, state.KnownUIDs)
+				if hasDelta {
+					c.observedMailboxDeltas[deltaIndex].State = state
+				} else {
 					c.observedMailboxDeltas = append(c.observedMailboxDeltas, MailboxDelta{
 						Mailbox: mailbox,
 						State:   state,

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -1076,10 +1076,12 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		}
 		if observed != nil {
 			observed.KnownUIDs = knownUIDs
+			observed.UIDNext = baselineUIDNext(observed.UIDNext, knownUIDs)
 			c.observedFolderStates[mailbox] = *observed
 		}
 		if canTrackFolder {
 			trackState.KnownUIDs = knownUIDs
+			trackState.UIDNext = baselineUIDNext(trackState.UIDNext, knownUIDs)
 			c.trackFolderMessages(mailbox, trackState, uids)
 		}
 		for _, uid := range uids {

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1219,3 +1219,33 @@ func TestSourceMessageExistsIsNotDefiniteWhenHeadersMissing(t *testing.T) {
 	require.Error(err, "a live message without headers is not definitive absence")
 	require.NotErrorIs(err, errIMAPFetchResultMissing)
 }
+
+// TestAllMailSnapshotSavesUIDNextAboveKnownUIDs covers the third place a
+// baseline is saved. The \All snapshot rebuilds every folder state from
+// STATUS, whose UIDNEXT was read before the enumeration that produced the
+// UIDs, so a message delivered between the two commands leaves a baseline the
+// saved UIDNEXT does not cover.
+func TestAllMailSnapshotSavesUIDNextAboveKnownUIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	// STATUS reports UIDNEXT 4. The SEARCH that follows reports UID 4.
+	addr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1"},
+		mailboxes:     []string{"All Mail", "Projects"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{})
+	client.mailboxCache = []string{"All Mail", "Projects"}
+	client.allMailFolder = "All Mail"
+
+	listAllMessages(t, client)
+
+	saved := client.ObservedFolderStates()
+	require.Contains(saved, "All Mail")
+	require.Contains(saved["All Mail"].KnownUIDs, uint32(4))
+	assert.Greater(saved["All Mail"].UIDNext, uint32(4),
+		"the snapshot must not save a UIDNEXT its own baseline exceeds")
+}

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -477,6 +477,7 @@ func (c *Client) verifyQresyncCoverage(
 	currentUIDNext uint32,
 	changedSet, vanishedSet map[imap.UID]struct{},
 ) error {
+	priorUIDValidity := c.selectedUIDValidity
 	if currentUIDNext <= prior.UIDNext {
 		return nil
 	}
@@ -524,6 +525,15 @@ func (c *Client) verifyQresyncCoverage(
 	if !c.enableQresync() {
 		return fmt.Errorf(
 			"QRESYNC unavailable after the coverage search in %q", mailbox)
+	}
+	// The reconnect also reselects the mailbox, and the mailbox it selects may
+	// be a different one wearing the same name. A delta built under the old
+	// epoch describes UIDs that no longer mean what they meant, so the mailbox
+	// has to be enumerated in full instead.
+	if c.selectedUIDValidity != priorUIDValidity {
+		return fmt.Errorf(
+			"QRESYNC %q changed UIDVALIDITY from %d to %d during the coverage search",
+			mailbox, priorUIDValidity, c.selectedUIDValidity)
 	}
 	for _, uid := range present {
 		// "UID SEARCH UID n:*" returns the last message even when n is past

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -296,6 +296,19 @@ func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
 	return highest + 1
 }
 
+// metadataChunkSize bounds one metadata FETCH. fetchChunkSize is 50 because a
+// body fetch of more than that times out on large mailboxes. Flags and
+// mod-sequences are a few dozen bytes each, and the UID set coalesces adjacent
+// UIDs into ranges, so what bounds this fetch is the encoded command rather
+// than the response: a contiguous baseline of any size encodes as "1:N", and a
+// worst-case alternating one costs about 3 bytes per UID.
+//
+// Measured against Dovecot on a LAN with a 0.86 ms round trip, a 100k baseline
+// took 2.52 s as 2000 chunks of 50 and 0.22 s as one command. Round trips were
+// 68 % of that even at sub-millisecond latency, so the same refresh against a
+// server 30 ms away would spend about a minute per changed mailbox per run.
+const metadataChunkSize = 5000
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,
@@ -307,11 +320,11 @@ func (c *Client) refreshExistingQresyncChanges(
 		return nil
 	}
 
-	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += fetchChunkSize {
+	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += metadataChunkSize {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		end := min(chunkStart+fetchChunkSize, len(prior.KnownUIDs))
+		end := min(chunkStart+metadataChunkSize, len(prior.KnownUIDs))
 		expected := make(map[imap.UID]struct{}, end-chunkStart)
 		var requested imap.UIDSet
 		for _, value := range prior.KnownUIDs[chunkStart:end] {

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -309,6 +309,46 @@ func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
 // server 30 ms away would spend about a minute per changed mailbox per run.
 const metadataChunkSize = 5000
 
+// metadataCommandBudget bounds the encoded UID set of one metadata FETCH. The
+// count limit alone does not: a baseline of alternating UIDs cannot coalesce
+// into ranges, so 5000 high-numbered UIDs reach about 35 KB of command, and a
+// server may reject or truncate a line that long. A contiguous baseline still
+// travels as "1:N" and is never split by this.
+const metadataCommandBudget = 4000
+
+// metadataMeasureStride is how often the encoded length is measured while a
+// chunk fills. It bounds the overshoot at 320 characters, which keeps the
+// worst chunk under 4.4 KB.
+const metadataMeasureStride = 32
+
+// metadataFetchChunks splits a baseline into chunks that are bounded both in
+// UID count and in encoded command size.
+func metadataFetchChunks(knownUIDs []uint32) [][]uint32 {
+	var chunks [][]uint32
+	var set imap.UIDSet
+	start := 0
+	for i, value := range knownUIDs {
+		set.AddNum(imap.UID(value))
+		full := i-start+1 >= metadataChunkSize
+		// Measuring every UID would be quadratic, and the encoded length only
+		// grows, so measure on a stride. A chunk can therefore pass the budget
+		// by at most one stride of UIDs, which is 32 times the 10 characters a
+		// 32-bit UID and its separator can take.
+		if !full && (i-start)%metadataMeasureStride == metadataMeasureStride-1 {
+			full = len(set.String()) >= metadataCommandBudget
+		}
+		if full {
+			chunks = append(chunks, knownUIDs[start:i+1])
+			start = i + 1
+			set = nil
+		}
+	}
+	if start < len(knownUIDs) {
+		chunks = append(chunks, knownUIDs[start:])
+	}
+	return chunks
+}
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,
@@ -320,14 +360,13 @@ func (c *Client) refreshExistingQresyncChanges(
 		return nil
 	}
 
-	for chunkStart := 0; chunkStart < len(prior.KnownUIDs); chunkStart += metadataChunkSize {
+	for _, chunk := range metadataFetchChunks(prior.KnownUIDs) {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		end := min(chunkStart+metadataChunkSize, len(prior.KnownUIDs))
-		expected := make(map[imap.UID]struct{}, end-chunkStart)
+		expected := make(map[imap.UID]struct{}, len(chunk))
 		var requested imap.UIDSet
-		for _, value := range prior.KnownUIDs[chunkStart:end] {
+		for _, value := range chunk {
 			uid := imap.UID(value)
 			if uid == 0 || value >= prior.UIDNext {
 				return fmt.Errorf("QRESYNC %q has invalid baseline UID %d", mailbox, value)

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 
 	imap "github.com/emersion/go-imap/v2"
@@ -256,7 +257,7 @@ func (c *Client) collectQresyncMailbox(
 		Mailbox: mailbox,
 		State: FolderState{
 			UIDValidity:   selected.UIDValidity,
-			UIDNext:       uint32(selected.UIDNext),
+			UIDNext:       baselineUIDNext(uint32(selected.UIDNext), uidsToUint32(knownUIDs)),
 			HighestModSeq: selected.HighestModSeq,
 			KnownUIDs:     uidsToUint32(knownUIDs),
 		},
@@ -273,6 +274,28 @@ func (c *Client) collectQresyncMailbox(
 // baseline UID must be returned, and its mod-sequence says whether it belongs
 // in the delta. The normal delta fetch then reads and persists that UID's
 // current flags.
+// baselineUIDNext is the UIDNEXT to save beside a baseline. UIDNEXT is
+// guaranteed larger than every UID in the mailbox (RFC 3501 2.3.1.1), so a
+// baseline that holds a UID at or above the reported UIDNEXT says the real one
+// is higher.
+//
+// A full enumeration reads UIDNEXT from STATUS and the UIDs from a later
+// SEARCH, so a message delivered between the two lands in the baseline with a
+// UID the saved UIDNEXT does not cover. Saving the reported value verbatim
+// stores a baseline that contradicts itself, and the next QRESYNC run reads
+// that as a corrupt baseline: refreshExistingQresyncChanges fails the mailbox,
+// and a QRESYNC failure discards every delta and enumerates the whole account.
+func baselineUIDNext(reportedUIDNext uint32, knownUIDs []uint32) uint32 {
+	highest := uint32(0)
+	for _, uid := range knownUIDs {
+		highest = max(highest, uid)
+	}
+	if highest < reportedUIDNext || highest == math.MaxUint32 {
+		return reportedUIDNext
+	}
+	return highest + 1
+}
+
 func (c *Client) refreshExistingQresyncChanges(
 	ctx context.Context,
 	mailbox string,

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -491,6 +491,9 @@ func (c *Client) verifyQresyncCoverage(
 	inAssignedSpan := func(uid imap.UID) bool {
 		return uint32(uid) >= prior.UIDNext && uint32(uid) < currentUIDNext
 	}
+	// Count the union. The check runs before the caller removes vanished UIDs
+	// from the changed set, so a UID reported both ways is in both sets, and
+	// counting it twice lets one report account for two assigned UIDs.
 	accounted := uint32(0)
 	for uid := range changedSet {
 		if inAssignedSpan(uid) {
@@ -498,6 +501,9 @@ func (c *Client) verifyQresyncCoverage(
 		}
 	}
 	for uid := range vanishedSet {
+		if _, alsoChanged := changedSet[uid]; alsoChanged {
+			continue
+		}
 		if inAssignedSpan(uid) {
 			accounted++
 		}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1119,3 +1119,57 @@ func TestQresyncCoverageSearchReconnectKeepsQresyncEnabled(t *testing.T) {
 		strings.Index(reconnected, "CHANGEDSINCE"),
 		"QRESYNC must be enabled before the next mailbox asks for VANISHED")
 }
+
+// TestFullEnumerationSavesUIDNextAboveKnownUIDs covers the one race that can
+// save a baseline holding a UID its own UIDNEXT does not cover. A full
+// enumeration reads UIDNEXT from STATUS and the UIDs from a later SEARCH, so a
+// message delivered between the two is enumerated while the saved UIDNEXT
+// still sits at or below its UID.
+//
+// The next QRESYNC run reads that as a corrupt baseline, and a QRESYNC failure
+// is not local to one mailbox: the caller discards every delta and enumerates
+// the whole account in full.
+func TestFullEnumerationSavesUIDNextAboveKnownUIDs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	// STATUS reports UIDNEXT 4. The SEARCH that follows reports UID 4, which
+	// arrived in between.
+	firstAddr, _ := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1"},
+		uidValidity:   77,
+		uidNext:       4,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+	})
+	first := newQresyncTestClient(t, firstAddr, map[string]FolderState{})
+
+	listQresyncMessages(t, first)
+
+	saved := first.ObservedFolderStates()
+	require.Contains(saved, "INBOX")
+	require.Contains(saved["INBOX"].KnownUIDs, uint32(4))
+	assert.Greater(saved["INBOX"].UIDNext, uint32(4),
+		"a saved UIDNEXT must cover every UID in the baseline saved with it")
+
+	// The next run meets a server that offers QRESYNC and reports the UIDNEXT
+	// the first enumeration implied.
+	secondAddr, secondServer := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       5,
+		highestModSeq: 25,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 4},
+		fetchChanged:  []imapv2.UID{4},
+	})
+	second := newQresyncTestClient(t, secondAddr, saved)
+
+	listQresyncMessages(t, second)
+
+	assert.Contains(joinedCommands(secondServer.commandsFor(1)), "CHANGEDSINCE",
+		"the second run must still be able to use QRESYNC")
+	// A QRESYNC failure discards every delta, reconnects, and enumerates the
+	// whole account, so a second connection is the signal that the baseline
+	// was rejected.
+	assert.Empty(secondServer.commandsFor(2),
+		"a self-consistent baseline must not force a full enumeration")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1259,3 +1259,45 @@ func TestQresyncCoverageSearchRejectsChangedEpoch(t *testing.T) {
 	assert.NotContains(joinedCommands(server.commandsFor(3)), "CHANGEDSINCE",
 		"the fallback enumerates rather than trusting the delta")
 }
+
+// TestQresyncRefreshFetchesTheBaselineInFewCommands pins what the existing
+// message refresh costs. It reads flags and mod-sequences, not bodies, and a
+// baseline of adjacent UIDs encodes as one range, so the whole mailbox fits in
+// one command. Chunking it at the body-fetch size turns a 100k mailbox into
+// 2000 round trips on every run in which anything changed.
+func TestQresyncRefreshFetchesTheBaselineInFewCommands(t *testing.T) {
+	assert := assert.New(t)
+	const baselineSize = 5000
+	searchUIDs := make([]imapv2.UID, baselineSize)
+	knownUIDs := make([]uint32, baselineSize)
+	for i := range baselineSize {
+		searchUIDs[i] = imapv2.UID(i + 1)
+		knownUIDs[i] = uint32(i + 1)
+	}
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       baselineSize + 1,
+		highestModSeq: 20,
+		searchUIDs:    searchUIDs,
+		fetchChanged:  []imapv2.UID{},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: baselineSize + 1, HighestModSeq: 10,
+			KnownUIDs: knownUIDs,
+		},
+	})
+
+	listQresyncMessages(t, client)
+
+	plainFetches := 0
+	for _, command := range server.commandsFor(1) {
+		upper := strings.ToUpper(command)
+		if strings.Contains(upper, "UID FETCH") && !strings.Contains(upper, "CHANGEDSINCE") {
+			plainFetches++
+		}
+	}
+	assert.LessOrEqual(plainFetches, 2,
+		"a metadata refresh of one mailbox must not cost a round trip per 50 messages")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1301,3 +1301,44 @@ func TestQresyncRefreshFetchesTheBaselineInFewCommands(t *testing.T) {
 	assert.LessOrEqual(plainFetches, 2,
 		"a metadata refresh of one mailbox must not cost a round trip per 50 messages")
 }
+
+// TestMetadataFetchChunksBoundCommandSize pins both limits the refresh needs.
+// A contiguous baseline coalesces into one range and must not be split by the
+// size budget. A baseline of alternating UIDs cannot coalesce, so 5000 of them
+// would reach about 35 KB of command, and a server may reject a line that
+// long.
+func TestMetadataFetchChunksBoundCommandSize(t *testing.T) {
+	assert := assert.New(t)
+
+	contiguous := make([]uint32, 100000)
+	for i := range contiguous {
+		contiguous[i] = uint32(i + 1)
+	}
+	chunks := metadataFetchChunks(contiguous)
+	assert.Len(chunks, 20, "a contiguous baseline is bounded by the UID count alone")
+
+	sparse := make([]uint32, 20000)
+	for i := range sparse {
+		sparse[i] = uint32(500000 + i*2)
+	}
+	for _, chunk := range metadataFetchChunks(sparse) {
+		var set imapv2.UIDSet
+		for _, uid := range chunk {
+			set.AddNum(imapv2.UID(uid))
+		}
+		assert.LessOrEqual(len(set.String()), metadataCommandBudget+320,
+			"a sparse baseline must be split before the command grows too long")
+	}
+
+	assert.Equal(len(sparse), countChunkedUIDs(metadataFetchChunks(sparse)),
+		"chunking must cover every UID exactly once")
+	assert.Empty(metadataFetchChunks(nil))
+}
+
+func countChunkedUIDs(chunks [][]uint32) int {
+	total := 0
+	for _, chunk := range chunks {
+		total += len(chunk)
+	}
+	return total
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -1173,3 +1173,38 @@ func TestFullEnumerationSavesUIDNextAboveKnownUIDs(t *testing.T) {
 	assert.Empty(secondServer.commandsFor(2),
 		"a self-consistent baseline must not force a full enumeration")
 }
+
+// TestQresyncOverlappingReportCannotCoverAnOmission pins that coverage counts
+// the union of the two reports. A UID may arrive as changed and as vanished in
+// one response, and the coverage check runs before the caller removes vanished
+// UIDs from the changed set. Counting that UID twice lets one message account
+// for two of the UIDs assigned since the last run.
+func TestQresyncOverlappingReportCannotCoverAnOmission(t *testing.T) {
+	assert := assert.New(t)
+	// UIDs 5, 6 and 7 were assigned since the last run. The response reports 5
+	// and 6 as changed, reports 6 as vanished as well, and omits 7.
+	mailboxExists := uint32(5)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:  []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:   77,
+		uidNext:       8,
+		highestModSeq: 20,
+		searchUIDs:    []imapv2.UID{1, 2, 3, 5, 7},
+		selectExists:  &mailboxExists,
+		fetchChanged:  []imapv2.UID{5, 6},
+		fetchVanished: []imapv2.UID{6},
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3},
+		},
+	})
+
+	listed := listQresyncMessages(t, client)
+
+	assert.Contains(joinedCommands(server.commandsFor(1)), "UID SEARCH UID 5:*",
+		"one UID reported twice must not account for two assigned UIDs")
+	assert.Contains(listed, "INBOX|7",
+		"the omitted message must be recovered by the fallback")
+}

--- a/internal/imap/qresync_test.go
+++ b/internal/imap/qresync_test.go
@@ -48,6 +48,11 @@ type qresyncServerConfig struct {
 	// answering its first UID SEARCH, which is how a coverage search meets a
 	// connection the server has given up on.
 	dropOnSearchConnection int
+	// uidValidityAfterConnection is the UIDVALIDITY reported to every
+	// connection after that ID, which is how a mailbox recreated between two
+	// connections presents itself.
+	uidValidityAfterConnection int
+	laterUIDValidity           uint32
 }
 
 type qresyncTestServer struct {
@@ -131,7 +136,8 @@ func serveQresyncTestConn(
 			}
 			_, _ = fmt.Fprintf(conn,
 				"* STATUS %q (%sUIDNEXT %d UIDVALIDITY %d HIGHESTMODSEQ %d)\r\n%s OK STATUS completed\r\n",
-				mailbox, messages, cfg.uidNext, cfg.uidValidity, cfg.highestModSeq, tag)
+				mailbox, messages, cfg.uidNext, connectionUIDValidity(cfg, connID),
+				cfg.highestModSeq, tag)
 		case strings.HasPrefix(upper, "ENABLE"):
 			_, _ = fmt.Fprintf(conn, "* ENABLED QRESYNC\r\n%s OK ENABLE completed\r\n", tag)
 		case strings.HasPrefix(upper, "SELECT"):
@@ -150,7 +156,7 @@ func serveQresyncTestConn(
 			}
 			_, _ = fmt.Fprintf(conn,
 				"* FLAGS (\\Seen)\r\n* %d EXISTS\r\n* OK [UIDVALIDITY %d]\r\n* OK [UIDNEXT %d]\r\n* OK [HIGHESTMODSEQ %d]\r\n",
-				exists, cfg.uidValidity, cfg.uidNext, selectModSeq)
+				exists, connectionUIDValidity(cfg, connID), cfg.uidNext, selectModSeq)
 			_, _ = fmt.Fprintf(conn, "%s OK [READ-WRITE] SELECT completed\r\n", tag)
 		case strings.HasPrefix(upper, "UID FETCH"):
 			// Only a CHANGEDSINCE fetch is entitled to answer with a subset:
@@ -183,6 +189,16 @@ func serveQresyncTestConn(
 			_, _ = fmt.Fprintf(conn, "%s BAD unsupported synthetic command\r\n", tag)
 		}
 	}
+}
+
+// connectionUIDValidity reports the UIDVALIDITY this connection sees. A
+// mailbox recreated between two connections reports the new value from every
+// command, so STATUS and SELECT must agree.
+func connectionUIDValidity(cfg qresyncServerConfig, connID int) uint32 {
+	if cfg.uidValidityAfterConnection != 0 && connID > cfg.uidValidityAfterConnection {
+		return cfg.laterUIDValidity
+	}
+	return cfg.uidValidity
 }
 
 func qresyncVanishedForFetch(command string, cfg qresyncServerConfig) []imapv2.UID {
@@ -1207,4 +1223,39 @@ func TestQresyncOverlappingReportCannotCoverAnOmission(t *testing.T) {
 		"one UID reported twice must not account for two assigned UIDs")
 	assert.Contains(listed, "INBOX|7",
 		"the omitted message must be recovered by the fallback")
+}
+
+// TestQresyncCoverageSearchRejectsChangedEpoch covers the other thing the
+// coverage search can bring back from a reconnect. The reconnect reselects the
+// mailbox, and the mailbox that answers may be a different one wearing the
+// same name. Every UID in the delta was collected under the old UIDVALIDITY,
+// so the mailbox has to be enumerated in full rather than saved.
+func TestQresyncCoverageSearchRejectsChangedEpoch(t *testing.T) {
+	assert := assert.New(t)
+	addr, server := startQresyncTestServer(t, qresyncServerConfig{
+		capabilities:               []string{"IMAP4rev1 ENABLE QRESYNC CONDSTORE"},
+		uidValidity:                77,
+		uidNext:                    7,
+		highestModSeq:              20,
+		searchUIDs:                 []imapv2.UID{1, 2, 3, 4, 5},
+		fetchChanged:               []imapv2.UID{5},
+		dropOnSearchConnection:     1,
+		uidValidityAfterConnection: 1,
+		laterUIDValidity:           88,
+	})
+	client := newQresyncTestClient(t, addr, map[string]FolderState{
+		"INBOX": {
+			UIDValidity: 77, UIDNext: 5, HighestModSeq: 10,
+			KnownUIDs: []uint32{1, 2, 3, 4},
+		},
+	})
+
+	listQresyncMessages(t, client)
+
+	// A QRESYNC failure reconnects once more and enumerates the account, so
+	// the run reaches a third connection.
+	assert.NotEmpty(server.commandsFor(3),
+		"a mailbox that changed epoch mid-run must fall back to full enumeration")
+	assert.NotContains(joinedCommands(server.commandsFor(3)), "CHANGEDSINCE",
+		"the fallback enumerates rather than trusting the delta")
 }


### PR DESCRIPTION
Four changes on top of #739.

Two answer the roborev review there. Coverage counted a UID reported as changed
and as vanished twice, so one message could cover two assigned UIDs. A mailbox
whose UIDVALIDITY changed during the coverage-search reconnect was accepted
rather than enumerated.

The third is older than this PR. A full enumeration reads UIDNEXT from STATUS
and the UIDs from a later SEARCH. A message delivered between them lands in the
baseline with a UID the saved UIDNEXT does not cover. The refresh reads
that as corruption and enumerates the whole account. RFC 3501 2.3.1.1 allows
the saved value to be `max(reported, highest known UID + 1)`.

The fourth is a chunk size. The refresh reused the body-fetch size of 50 to
read flags and mod-sequences. Against Dovecot with 100k messages, one arriving
message took 6 s of sync at chunk 50 and 3 s at 5000. Both runs saved the same
memberships and folder states.

No configuration or usage changes.
