### PR TITLE
perf(imap): load durable UID aliases for the UIDs a run lists

### DIFF
--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -1415,7 +1415,7 @@ func TestIMAPQresyncEndToEndGmailAllIncrementalUnidentifiedMembershipUsesDurable
 	})
 	second, _ := requireScriptedRFC7162Sync(t, st, identifier, addr)
 	requirements.NoError(second.Close())
-	aliases, err := st.GetIMAPSourceMessageAliases(source.ID)
+	aliases, err := st.GetIMAPSourceMessageAliases(source.ID, "INBOX", []uint32{1})
 	requirements.NoError(err)
 	assertions.Equal("[Gmail]/All Mail|1", aliases["INBOX|1"])
 

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -381,12 +381,10 @@ func imapFolderStateOptions(
 	} else if len(states) > 0 {
 		opts = append(opts, imaplib.WithFolderStates(states))
 	}
-	aliases, err := s.GetIMAPSourceMessageAliases(src.ID)
-	if err != nil {
-		logger.Warn("failed to load IMAP source message aliases", "source", src.Identifier, "error", err)
-	} else if len(aliases) > 0 {
-		opts = append(opts, imaplib.WithSourceMessageAliases(aliases))
-	}
+	opts = append(opts, imaplib.WithSourceMessageAliasLoader(
+		func(mailbox string, uids []uint32) (map[string]string, error) {
+			return s.GetIMAPSourceMessageAliases(src.ID, mailbox, uids)
+		}))
 	if forceRescan {
 		opts = append(opts, imaplib.WithForceFullEnumeration())
 	}

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -117,6 +118,15 @@ func (c *Client) applyFetchResults(
 	msgs []*imapclient.FetchMessageBuffer,
 ) []batchFetchItem {
 	seenReturnedUIDs := make(map[imap.UID]bool, len(msgs))
+	// Only a message with no Message-ID header needs a durable alias, so the
+	// chunk's aliases are read once, and only if one turns up.
+	loadAliases := sync.OnceFunc(func() {
+		uids := make([]imap.UID, len(chunk))
+		for i, item := range chunk {
+			uids[i] = item.uid
+		}
+		c.loadSourceMessageAliases(mailbox, uids)
+	})
 	for _, msgBuf := range msgs {
 		idx, ok := uidToIdx[msgBuf.UID]
 		if !ok {
@@ -158,6 +168,7 @@ func (c *Client) applyFetchResults(
 			} else {
 				priorState, sameMailboxEpoch := c.priorFolderStates[mailbox]
 				if sameMailboxEpoch && priorState.UIDValidity == c.selectedUIDValidity {
+					loadAliases()
 					canonicalSourceMessageID = c.sourceMessageAliases[msgID]
 				}
 				if canonicalSourceMessageID == "" {

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -98,6 +98,11 @@ type Client struct {
 	since                 time.Time            // IMAP SINCE date filter (zero = no filter)
 	before                time.Time            // IMAP BEFORE date filter (zero = no filter)
 
+	// aliasLoader resolves durable aliases for the mailbox UIDs a listing
+	// actually touches. Nil when the caller keeps no durable state.
+	aliasLoader     func(mailbox string, uids []uint32) (map[string]string, error)
+	aliasLoadWarned bool // one failing load must not warn once per request
+
 	// folderFilter overrides which mailboxes are included in the sync.
 	// Zero-valued (empty include and exclude) means "all mailboxes".
 	folderFilterInclude, folderFilterExclude []string
@@ -1083,6 +1088,10 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			trackState.KnownUIDs = knownUIDs
 			trackState.UIDNext = baselineUIDNext(trackState.UIDNext, knownUIDs)
 			c.trackFolderMessages(mailbox, trackState, uids)
+		}
+		if prior, ok := c.priorFolderStates[mailbox]; ok &&
+			prior.UIDValidity == trackState.UIDValidity {
+			c.loadSourceMessageAliases(mailbox, uids)
 		}
 		for _, uid := range uids {
 			sourceMessageID := compositeID(mailbox, uid)

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1249,3 +1249,41 @@ func TestAllMailSnapshotSavesUIDNextAboveKnownUIDs(t *testing.T) {
 	assert.Greater(saved["All Mail"].UIDNext, uint32(4),
 		"the snapshot must not save a UIDNEXT its own baseline exceeds")
 }
+
+type aliasLoadCall struct {
+	mailbox string
+	uids    []uint32
+}
+
+func TestSourceMessageAliasLoaderRequestsOnlyListedUIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{"INBOX": 2, "Archive": 3})
+
+	first := newTestClient(t, addr)
+	require.Len(listAllMessages(t, first), 5)
+	saved := first.ObservedFolderStates()
+	require.NoError(first.Close())
+
+	testutil.AppendIMAPMessage(t, user, "INBOX")
+
+	var calls []aliasLoadCall
+	second := newTestClient(t, addr,
+		WithFolderStates(saved),
+		WithSourceMessageAliasLoader(
+			func(mailbox string, uids []uint32) (map[string]string, error) {
+				calls = append(calls, aliasLoadCall{mailbox: mailbox, uids: uids})
+				return map[string]string{"INBOX|3": "[Gmail]/All Mail|9"}, nil
+			}))
+	require.Equal([]string{"INBOX|3"}, listAllMessages(t, second))
+
+	// The run listed one UID, so it must ask for that UID alone. Loading every
+	// stored alias of the source reads the whole membership table to use one.
+	require.Len(calls, 1)
+	assert.Equal("INBOX", calls[0].mailbox)
+	assert.Equal([]uint32{3}, calls[0].uids)
+
+	canonical, ok := second.CanonicalSourceMessageID("INBOX|3")
+	assert.True(ok)
+	assert.Equal("[Gmail]/All Mail|9", canonical)
+}

--- a/internal/imap/folderstate.go
+++ b/internal/imap/folderstate.go
@@ -130,14 +130,45 @@ func WithFolderStates(states map[string]FolderState) Option {
 	}
 }
 
-// WithSourceMessageAliases supplies durable mailbox-UID aliases from the last
-// completed sync. They prevent a changed secondary copy without a Message-ID
-// from being re-imported under its secondary mailbox identity.
-func WithSourceMessageAliases(aliases map[string]string) Option {
-	return func(c *Client) {
-		c.sourceMessageAliases = make(map[string]string, len(aliases))
-		maps.Copy(c.sourceMessageAliases, aliases)
+// WithSourceMessageAliasLoader supplies durable mailbox-UID aliases from the
+// last completed sync. They prevent a changed secondary copy without a
+// Message-ID from being re-imported under its secondary mailbox identity. The
+// client asks for the UIDs one listing touches, which on an incremental run is
+// a handful of the source's stored memberships.
+func WithSourceMessageAliasLoader(
+	load func(mailbox string, uids []uint32) (map[string]string, error),
+) Option {
+	return func(c *Client) { c.aliasLoader = load }
+}
+
+// loadSourceMessageAliases merges the durable aliases of these mailbox UIDs
+// into the session map. A load failure costs the run its aliases and nothing
+// else: an unresolved copy is re-imported under its own identity.
+// Caller must hold mu.
+func (c *Client) loadSourceMessageAliases(mailbox string, uids []imap.UID) {
+	if c.aliasLoader == nil || len(uids) == 0 {
+		return
 	}
+	requested := make([]uint32, len(uids))
+	for i, uid := range uids {
+		requested[i] = uint32(uid)
+	}
+	aliases, err := c.aliasLoader(mailbox, requested)
+	if err != nil {
+		// One unreadable database would otherwise warn once per mailbox and
+		// once per fetch chunk. Later requests still run: an alias this run
+		// misses costs a re-imported copy.
+		if !c.aliasLoadWarned {
+			c.aliasLoadWarned = true
+			c.logger.Warn("failed to load IMAP source message aliases",
+				"mailbox", mailbox, "error", err)
+		}
+		return
+	}
+	if c.sourceMessageAliases == nil {
+		c.sourceMessageAliases = make(map[string]string, len(aliases))
+	}
+	maps.Copy(c.sourceMessageAliases, aliases)
 }
 
 // CanonicalSourceMessageID returns a durable alias only after this session

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -132,6 +132,7 @@ func (c *Client) tryBuildQresyncMessageList(
 		if len(delta.ChangedUIDs) == 0 && len(delta.VanishedUIDs) == 0 {
 			unchanged++
 		}
+		c.loadSourceMessageAliases(mailbox, delta.ChangedUIDs)
 		for _, uid := range delta.ChangedUIDs {
 			sourceMessageID := compositeID(mailbox, uid)
 			messages = append(messages, gmailapi.MessageID{ID: sourceMessageID})

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -77,37 +77,73 @@ func (s *Store) GetIMAPKnownUIDs(sourceID int64) (map[string][]uint32, error) {
 	return known, nil
 }
 
+// aliasUIDChunkSize bounds one alias query's bound parameters, well under
+// SQLite's per-statement limit.
+const aliasUIDChunkSize = 900
+
 // GetIMAPSourceMessageAliases returns the canonical archived source identity
-// for every mailbox UID in the current saved epoch.
-func (s *Store) GetIMAPSourceMessageAliases(sourceID int64) (map[string]string, error) {
+// for the named mailbox UIDs that are in the current saved epoch. Callers ask
+// for the UIDs one run actually fetches: resolving the whole source instead
+// reads every stored membership to use a handful of them.
+func (s *Store) GetIMAPSourceMessageAliases(
+	sourceID int64,
+	mailbox string,
+	uids []uint32,
+) (map[string]string, error) {
+	aliases := make(map[string]string, len(uids))
+	for chunk := range slices.Chunk(uids, aliasUIDChunkSize) {
+		if err := s.readIMAPMessageAliases(sourceID, mailbox, chunk, aliases); err != nil {
+			return nil, err
+		}
+	}
+	return aliases, nil
+}
+
+// readIMAPMessageAliases adds one chunk of UIDs to aliases. It is a separate
+// function so each chunk closes its rows before the next query runs.
+func (s *Store) readIMAPMessageAliases(
+	sourceID int64,
+	mailbox string,
+	uids []uint32,
+	aliases map[string]string,
+) error {
+	if len(uids) == 0 {
+		return nil
+	}
+	args := make([]any, 0, len(uids)+2)
+	args = append(args, sourceID, mailbox)
+	for _, uid := range uids {
+		args = append(args, uid)
+	}
 	rows, err := s.db.Query(`
-		SELECT membership.mailbox, membership.uid, messages.source_message_id
+		SELECT membership.uid, messages.source_message_id
 		FROM imap_message_memberships membership
 		JOIN imap_folder_state state
 		  ON state.source_id = membership.source_id
 		 AND state.mailbox = membership.mailbox
 		 AND state.uidvalidity = membership.uidvalidity
 		JOIN messages ON messages.id = membership.message_id
-		WHERE membership.source_id = ? AND messages.source_message_id IS NOT NULL
-	`, sourceID)
+		WHERE membership.source_id = ? AND membership.mailbox = ?
+		  AND messages.source_message_id IS NOT NULL
+		  AND membership.uid IN (?`+strings.Repeat(",?", len(uids)-1)+`)
+	`, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query IMAP source message aliases: %w", err)
+		return fmt.Errorf("query IMAP source message aliases: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	aliases := make(map[string]string)
 	for rows.Next() {
-		var mailbox, canonicalSourceMessageID string
+		var canonicalSourceMessageID string
 		var uid uint32
-		if err := rows.Scan(&mailbox, &uid, &canonicalSourceMessageID); err != nil {
-			return nil, fmt.Errorf("scan IMAP source message alias: %w", err)
+		if err := rows.Scan(&uid, &canonicalSourceMessageID); err != nil {
+			return fmt.Errorf("scan IMAP source message alias: %w", err)
 		}
 		aliases[fmt.Sprintf("%s|%d", mailbox, uid)] = canonicalSourceMessageID
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate IMAP source message aliases: %w", err)
+		return fmt.Errorf("iterate IMAP source message aliases: %w", err)
 	}
-	return aliases, nil
+	return nil
 }
 
 // ApplyIMAPMailboxDeltas atomically replaces the source's authoritative IMAP

--- a/internal/store/imap_memberships_test.go
+++ b/internal/store/imap_memberships_test.go
@@ -806,3 +806,69 @@ func TestApplyIMAPMailboxDeltas_ConflictingDeltaIdentityRollsBackEverything(t *t
 		})
 	}
 }
+
+func TestGetIMAPSourceMessageAliases_ReturnsOnlyRequestedUIDs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	f.createMessage(t, "[Gmail]/All Mail|1", "")
+	f.createMessage(t, "INBOX|1", "")
+	f.createMessage(t, "INBOX|2", "")
+	f.createMessage(t, "INBOX|3", "")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 17, UIDNext: 4, HighestModSeq: 100,
+		},
+		Memberships: []store.IMAPMembershipObservation{
+			{UID: 1, SourceMessageID: "INBOX|1",
+				CanonicalSourceMessageID: "[Gmail]/All Mail|1"},
+			{UID: 2, SourceMessageID: "INBOX|2"},
+			{UID: 3, SourceMessageID: "INBOX|3"},
+		},
+	}}))
+
+	aliases, err := f.store.GetIMAPSourceMessageAliases(f.source.ID, "INBOX", []uint32{1, 3})
+	require.NoError(err)
+	assert.Equal(map[string]string{
+		"INBOX|1": "[Gmail]/All Mail|1",
+		"INBOX|3": "INBOX|3",
+	}, aliases, "UID 2 was not asked for, so it must not be read")
+
+	empty, err := f.store.GetIMAPSourceMessageAliases(f.source.ID, "INBOX", nil)
+	require.NoError(err)
+	assert.Empty(empty, "a run that lists nothing must not query at all")
+}
+
+func TestGetIMAPSourceMessageAliases_AccumulatesEveryUIDChunk(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	f.createMessage(t, "INBOX|1", "")
+	f.createMessage(t, "INBOX|950", "")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State: store.IMAPFolderState{
+			Mailbox: "INBOX", UIDValidity: 17, UIDNext: 951, HighestModSeq: 100,
+		},
+		Memberships: []store.IMAPMembershipObservation{
+			{UID: 1, SourceMessageID: "INBOX|1"},
+			{UID: 950, SourceMessageID: "INBOX|950"},
+		},
+	}}))
+
+	// A full mailbox listing asks for every UID it enumerated, which crosses
+	// the bound-parameter chunk size. Both chunks must reach the same map.
+	uids := make([]uint32, 1000)
+	for i := range uids {
+		uids[i] = uint32(i + 1)
+	}
+	aliases, err := f.store.GetIMAPSourceMessageAliases(f.source.ID, "INBOX", uids)
+	require.NoError(err)
+	assert.Equal(map[string]string{
+		"INBOX|1":   "INBOX|1",
+		"INBOX|950": "INBOX|950",
+	}, aliases)
+}


### PR DESCRIPTION
Closes #745

Every IMAP sync loaded the whole source's mailbox-UID aliases before the client
knew what it would fetch, then used them for the few messages it listed. The
store now returns the aliases of one mailbox and one UID set, and the client
asks for the UIDs it is about to use: the UIDs a listing produced, the UIDs
QRESYNC reports as changed, or a fetch chunk's UIDs.

The existing primary key already serves that query, so there is no new index
and no migration. A load that fails costs the run the aliases of one request
rather than all of them, and an unresolved message is imported under its own
identity, as before.

On a 40-mailbox Microsoft 365 account with ~118k messages, a sync with ten
messages to examine spent 470 ms reading all 118,127 aliases before it touched
a mailbox. It now reads those ten UIDs in three queries of under a millisecond
each, with the same final memberships and folder states.

No configuration or usage changes.
