### PR TITLE
feat(cli): stage deletions from search criteria

### DIFF
--- a/cmd/msgvault/cmd/stage_delete.go
+++ b/cmd/msgvault/cmd/stage_delete.go
@@ -199,13 +199,25 @@ func runStageDelete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// stageDeleteDaemonErr turns the daemon's structured cache-unavailable
-// response into an actionable message instead of a bare API error.
+// stageDeleteDaemonErr turns the daemon's structured rejections into
+// actionable messages instead of bare API errors.
 func stageDeleteDaemonErr(op string, err error) error {
 	var apiErr *daemonclient.APIError
-	if errors.As(err, &apiErr) && apiErr.APIErrorCode() == analyticalCacheUnavailableCode {
+	if !errors.As(err, &apiErr) {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	switch apiErr.APIErrorCode() {
+	case analyticalCacheUnavailableCode:
 		return fmt.Errorf("%s: %s; retry shortly if the analytical cache is still building, "+
 			"or run 'msgvault build-cache' and rerun stage-delete", op, apiErr.Message)
+	case "selection_not_deletable":
+		return fmt.Errorf("%s: %s; the search matches items that cannot be deleted from "+
+			"their source, such as chats, meetings, or non-Gmail mail. Narrow the search, "+
+			"for example with message_type:email or --source-id <gmail-source-id>",
+			op, apiErr.Message)
+	case "multi_account_selection":
+		return fmt.Errorf("%s: %s; rerun stage-delete once per source with --source-id",
+			op, apiErr.Message)
 	}
 	return fmt.Errorf("%s: %w", op, err)
 }

--- a/cmd/msgvault/cmd/stage_delete.go
+++ b/cmd/msgvault/cmd/stage_delete.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/search"
+	apiclient "go.kenn.io/msgvault/pkg/client"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+var stageDeleteDryRun bool
+
+const (
+	stageDeleteListIDMinAPISchemaVersion = "2.14.0"
+	analyticalCacheUnavailableCode       = "analytical_cache_unavailable"
+)
+
+func newStageDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stage-delete <query>",
+		Short: "Stage active messages matching search criteria for deletion",
+		Long: `Stage every active message matching a search query for deletion.
+
+The daemon resolves and preflights the search before creating a pending
+deletion batch. Use --dry-run to report the match count without creating one.
+Review a created batch with show-deletion before running delete-staged.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: runStageDelete,
+	}
+	cmd.Flags().BoolVar(&stageDeleteDryRun, "dry-run", false, "Show the match count without creating a deletion batch")
+	cmd.Flags().Int64("source-id", 0, "Restrict staging to one exact source ID")
+	return cmd
+}
+
+func runStageDelete(cmd *cobra.Command, args []string) error {
+	queryText := strings.TrimSpace(strings.Join(args, " "))
+	parsed := search.Parse(queryText)
+	if err := parsed.Err(); err != nil {
+		return usageErr(cmd, err)
+	}
+	if parsed.IsEmpty() {
+		return usageErr(cmd, errors.New("empty search query"))
+	}
+	if hasEmptyAddressFilter(parsed) {
+		return usageErr(cmd, errors.New("empty address filter"))
+	}
+	sourceID, err := cmd.Flags().GetInt64("source-id")
+	if err != nil {
+		return usageErr(cmd, fmt.Errorf("invalid source ID: %w", err))
+	}
+	if cmd.Flags().Changed("source-id") && sourceID <= 0 {
+		return usageErr(cmd, errors.New("source ID must be positive"))
+	}
+
+	// Default cache intent: a daemon this command has to spawn builds its
+	// analytical cache before Explore runs, instead of answering 503.
+	store, _, err := openHTTPStoreWithStartupCacheIntent(cmd.Context(), startupCacheBuildIntentDefault)
+	if err != nil {
+		return fmt.Errorf("open store: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+	if len(parsed.ListIDs) > 0 {
+		supported, err := store.SupportsAPISchemaVersion(cmd.Context(), stageDeleteListIDMinAPISchemaVersion)
+		if err != nil {
+			return fmt.Errorf("check daemon List-ID filter capability: %w", err)
+		}
+		if !supported {
+			return fmt.Errorf("List-ID filter requires daemon API schema %s or newer", stageDeleteListIDMinAPISchemaVersion)
+		}
+	}
+
+	// Staging trusts the full-text index as the complete match set, so an
+	// index still being verified or backfilled must block staging instead of
+	// silently omitting messages. The probe also starts the daemon's
+	// background completeness check, so a retry succeeds once it finishes.
+	indexProbe, err := store.GetCLISearch(cmd.Context(), daemonclient.CLISearchRequest{
+		Query: queryText,
+		Limit: 1,
+	})
+	if err != nil {
+		return fmt.Errorf("check search index readiness: %w", err)
+	}
+	switch indexProbe.IndexState {
+	case "building":
+		return errors.New("the full-text search index is being rebuilt in the background, " +
+			"so staging from search criteria could miss matching messages; " +
+			"retry when the rebuild finishes")
+	case "checking":
+		return errors.New("full-text search index completeness is still being verified, " +
+			"so staging from search criteria could miss matching messages; retry shortly")
+	}
+
+	searchMode := generated.ExploreHTTPRequestSearchModeFullText
+	limit := int64(1)
+	filters := []generated.ExploreFilter{{
+		Dimension: generated.ExploreFilterDimensionDeletion,
+		Values:    []string{"active"},
+	}}
+	if cmd.Flags().Changed("source-id") {
+		filters = append(filters, generated.ExploreFilter{
+			Dimension: generated.ExploreFilterDimensionSource,
+			Values:    []string{strconv.FormatInt(sourceID, 10)},
+		})
+	}
+	predicate := generated.ExploreHTTPRequest{
+		Query:      &queryText,
+		Filters:    filters,
+		SearchMode: &searchMode,
+	}
+	exploreResp, err := daemonclient.APIResponse(store, func(client *apiclient.Client) (*generated.ExploreResp, error) {
+		return client.ExploreWithResponse(cmd.Context(), &generated.ExploreRequestOptions{
+			Body: &generated.ExploreBody{
+				Filters:    predicate.Filters,
+				Query:      predicate.Query,
+				SearchMode: predicate.SearchMode,
+				Limit:      &limit,
+			},
+		})
+	})
+	if err != nil {
+		return stageDeleteDaemonErr("explore search", err)
+	}
+	if exploreResp == nil || exploreResp.JSON200 == nil {
+		return errors.New("explore search returned no response")
+	}
+
+	selection := generated.ExploreSelection{
+		CacheRevision:       exploreResp.JSON200.CacheRevision,
+		CandidateSnapshotID: exploreResp.JSON200.CandidateSnapshotID,
+		Mode:                generated.ExploreSelectionModeAllMatching,
+		Predicate:           predicate,
+		SearchProvenance:    exploreResp.JSON200.SearchProvenance,
+	}
+	preflightResp, err := daemonclient.APIResponse(store, func(client *apiclient.Client) (*generated.PreflightExploreSelectionResp, error) {
+		return client.PreflightExploreSelectionWithResponse(cmd.Context(), &generated.PreflightExploreSelectionRequestOptions{
+			Body: &generated.PreflightExploreSelectionBody{Selection: selection},
+		})
+	})
+	if err != nil {
+		return stageDeleteDaemonErr("preflight search selection", err)
+	}
+	if preflightResp == nil || preflightResp.JSON200 == nil {
+		return errors.New("preflight search selection returned no response")
+	}
+
+	description := "staged from CLI search"
+	operationToken := preflightResp.JSON200.OperationToken
+	stageResp, err := daemonclient.APIResponseWithStatuses(store, []int{200, 201}, func(client *apiclient.Client) (*generated.StageDeletionResp, error) {
+		return client.StageDeletionWithResponse(cmd.Context(), &generated.StageDeletionRequestOptions{
+			Body: &generated.StageDeletionBody{
+				Description:    &description,
+				DryRun:         &stageDeleteDryRun,
+				OperationToken: &operationToken,
+				Selection:      &selection,
+			},
+		})
+	})
+	if err != nil {
+		return stageDeleteDaemonErr("stage deletion", err)
+	}
+	if stageResp == nil {
+		return errors.New("stage deletion returned no response")
+	}
+
+	var result *generated.StageDeletionResponse
+	switch {
+	case stageResp.JSON200 != nil:
+		result = stageResp.JSON200
+	case stageResp.JSON201 != nil:
+		result = stageResp.JSON201
+	default:
+		return errors.New("stage deletion returned no response body")
+	}
+	if result == nil {
+		return errors.New("stage deletion returned no response body")
+	}
+
+	w := cmd.OutOrStdout()
+	if result.DryRun {
+		if _, err = fmt.Fprintf(w, "Dry run: %d message(s) match the search; no deletion batch was created.\n", result.MessageCount); err != nil {
+			return fmt.Errorf("write dry-run summary: %w", err)
+		}
+		return nil
+	}
+	if result.ID == nil || strings.TrimSpace(*result.ID) == "" {
+		return errors.New("stage deletion response did not include a batch ID")
+	}
+	if _, err = fmt.Fprintf(w, "Staged %d message(s) for deletion in batch %s.\n", result.MessageCount, *result.ID); err != nil {
+		return fmt.Errorf("write staging summary: %w", err)
+	}
+	if _, err = fmt.Fprintf(w, "Review with 'msgvault show-deletion %s', then execute with 'msgvault delete-staged %s'.\n", *result.ID, *result.ID); err != nil {
+		return fmt.Errorf("write staging summary: %w", err)
+	}
+	return nil
+}
+
+// stageDeleteDaemonErr turns the daemon's structured cache-unavailable
+// response into an actionable message instead of a bare API error.
+func stageDeleteDaemonErr(op string, err error) error {
+	var apiErr *daemonclient.APIError
+	if errors.As(err, &apiErr) && apiErr.APIErrorCode() == analyticalCacheUnavailableCode {
+		return fmt.Errorf("%s: %s; retry shortly if the analytical cache is still building, "+
+			"or run 'msgvault build-cache' and rerun stage-delete", op, apiErr.Message)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
+func hasEmptyAddressFilter(q *search.Query) bool {
+	for _, values := range [][]string{q.FromAddrs, q.ToAddrs, q.CcAddrs, q.BccAddrs} {
+		for _, value := range values {
+			if strings.TrimSpace(value) == "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func init() {
+	rootCmd.AddCommand(newStageDeleteCommand())
+}

--- a/cmd/msgvault/cmd/stage_delete_test.go
+++ b/cmd/msgvault/cmd/stage_delete_test.go
@@ -1,0 +1,504 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/pkg/client/generated"
+)
+
+func newRegisteredStageDeleteTestRoot(t *testing.T) *cobra.Command {
+	t.Helper()
+	registered, _, err := rootCmd.Find([]string{"stage-delete"})
+	require.NoError(t, err, "find registered stage-delete command")
+	require.NotNil(t, registered, "registered stage-delete command")
+
+	stageDeleteDryRun = false
+	require.NoError(t, registered.Flags().Set("dry-run", "false"))
+	require.NoError(t, registered.Flags().Set("source-id", "0"))
+	registered.Flags().Lookup("source-id").Changed = false
+	root := &cobra.Command{Use: "msgvault"}
+	root.AddCommand(registered)
+	return root
+}
+
+func TestStageDeleteCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      []string
+		flags      []string
+		dryRun     bool
+		status     int
+		wantQuery  string
+		wantSource int64
+		wantOutput string
+	}{
+		{
+			name:       "search_criteria",
+			query:      []string{"from:alice@example.com", "older_than:1y"},
+			status:     http.StatusCreated,
+			wantQuery:  "from:alice@example.com older_than:1y",
+			wantOutput: "Staged 3 message(s) for deletion in batch batch-191.\nReview with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+		},
+		{
+			name:       "filter_only_criteria",
+			query:      []string{"label:INBOX"},
+			status:     http.StatusCreated,
+			wantQuery:  "label:INBOX",
+			wantOutput: "Staged 3 message(s) for deletion in batch batch-191.\nReview with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+		},
+		{
+			name:       "dry_run",
+			query:      []string{"subject:receipt"},
+			dryRun:     true,
+			status:     http.StatusOK,
+			wantQuery:  "subject:receipt",
+			wantOutput: "Dry run: 3 message(s) match the search; no deletion batch was created.\n",
+		},
+		{
+			name:       "source_id",
+			query:      []string{"from:alice@example.com"},
+			flags:      []string{"--source-id", "42"},
+			status:     http.StatusCreated,
+			wantQuery:  "from:alice@example.com",
+			wantSource: 42,
+			wantOutput: "Staged 3 message(s) for deletion in batch batch-191.\nReview with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+		},
+		{
+			name:       "list_id",
+			query:      []string{"list:announce.example.org"},
+			status:     http.StatusCreated,
+			wantQuery:  "list:announce.example.org",
+			wantOutput: "Staged 3 message(s) for deletion in batch batch-191.\nReview with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+		},
+		{
+			name:       "list_id_alias",
+			query:      []string{"list-id:announce.example.org"},
+			status:     http.StatusCreated,
+			wantQuery:  "list-id:announce.example.org",
+			wantOutput: "Staged 3 message(s) for deletion in batch batch-191.\nReview with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wantSource []int64
+			if tt.wantSource != 0 {
+				wantSource = []int64{tt.wantSource}
+			}
+			server, routes := newStageDeleteTestServer(t, tt.wantQuery, tt.dryRun, tt.status, wantSource...)
+			withStoreResolverConfig(t, &config.Config{
+				Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+			})
+
+			var stdout bytes.Buffer
+			root := newRegisteredStageDeleteTestRoot(t)
+			root.SetOut(&stdout)
+			args := append([]string{"stage-delete"}, tt.query...)
+			args = append(args, tt.flags...)
+			args = append(args, boolFlag(tt.dryRun, "--dry-run")...)
+			root.SetArgs(args)
+
+			require.NoError(t, root.Execute(), tt.name)
+			assert.Equal(t, tt.wantOutput, stdout.String())
+			assert.Equal(t, []string{"/api/v1/cli/search", "/api/v1/explore", "/api/v1/explore/preflight", "/api/v1/deletions"}, *routes)
+		})
+	}
+
+	t.Run("configured_remote_routing", func(t *testing.T) {
+		server, routes := newStageDeleteTestServer(t, "from:bob@example.com", false, http.StatusCreated)
+		withStoreResolverConfig(t, &config.Config{
+			Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+		})
+
+		var stdout bytes.Buffer
+		root := newRegisteredStageDeleteTestRoot(t)
+		root.SetOut(&stdout)
+		root.SetArgs([]string{"stage-delete", "from:bob@example.com"})
+
+		require.NoError(t, root.Execute())
+		assert.Contains(t, stdout.String(), "batch-191")
+		assert.Equal(t, []string{"/api/v1/cli/search", "/api/v1/explore", "/api/v1/explore/preflight", "/api/v1/deletions"}, *routes)
+	})
+
+	t.Run("invalid_and_empty", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			args []string
+			want string
+		}{
+			{name: "invalid", args: []string{"before:not-a-date"}, want: "invalid value"},
+			{name: "empty", args: []string{"   "}, want: "empty search query"},
+			{name: "empty_from", args: []string{"from:"}, want: "empty address filter"},
+			{name: "empty_to", args: []string{"to:"}, want: "empty address filter"},
+			{name: "empty_cc", args: []string{"cc:"}, want: "empty address filter"},
+			{name: "empty_bcc", args: []string{"bcc:"}, want: "empty address filter"},
+			{name: "zero_source_id", args: []string{"subject:test", "--source-id", "0"}, want: "source ID must be positive"},
+			{name: "negative_source_id", args: []string{"subject:test", "--source-id", "-1"}, want: "source ID must be positive"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				requests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					requests++
+				}))
+				defer server.Close()
+				withStoreResolverConfig(t, &config.Config{
+					Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+				})
+
+				root := newRegisteredStageDeleteTestRoot(t)
+				root.SetArgs(append([]string{"stage-delete"}, tt.args...))
+				err := root.Execute()
+
+				require.ErrorContains(t, err, tt.want)
+				assert.Zero(t, requests, "invalid input must not make an HTTP request")
+			})
+		}
+	})
+
+	t.Run("cache_unavailable_reports_recovery", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/cli/search":
+				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
+			case "/api/v1/explore":
+				writeStageDeleteJSON(t, w, http.StatusServiceUnavailable, map[string]any{
+					"error":     "analytical_cache_unavailable",
+					"message":   "The analytical cache is being prepared",
+					"readiness": "building",
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+		withStoreResolverConfig(t, &config.Config{
+			Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+		})
+
+		root := newRegisteredStageDeleteTestRoot(t)
+		root.SetArgs([]string{"stage-delete", "subject:receipt"})
+		err := root.Execute()
+
+		require.ErrorContains(t, err, "The analytical cache is being prepared")
+		require.ErrorContains(t, err, "msgvault build-cache")
+	})
+
+	t.Run("incomplete_search_index_blocks_staging", func(t *testing.T) {
+		exploreRequests := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/cli/search":
+				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+					"results":     []any{},
+					"index_state": "building",
+				})
+			case "/api/v1/explore":
+				exploreRequests++
+				http.Error(w, "unexpected Explore request", http.StatusInternalServerError)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+		withStoreResolverConfig(t, &config.Config{
+			Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+		})
+
+		root := newRegisteredStageDeleteTestRoot(t)
+		root.SetArgs([]string{"stage-delete", "subject:receipt"})
+		err := root.Execute()
+
+		require.ErrorContains(t, err, "could miss matching messages")
+		assert.Zero(t, exploreRequests, "an incomplete search index must block staging before Explore")
+	})
+
+	t.Run("list_id_rejects_old_daemon_before_explore", func(t *testing.T) {
+		for _, tt := range []struct {
+			name  string
+			query string
+		}{
+			{name: "list", query: "list:announce.example.org"},
+			{name: "list_id", query: "list-id:announce.example.org"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				exploreRequests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v1/health":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+							"status":             "ok",
+							"api_schema_version": "2.13.0",
+						})
+					case "/api/v1/explore":
+						exploreRequests++
+						http.Error(w, "unexpected Explore request", http.StatusInternalServerError)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer server.Close()
+				withStoreResolverConfig(t, &config.Config{
+					Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+				})
+
+				root := newRegisteredStageDeleteTestRoot(t)
+				root.SetArgs([]string{"stage-delete", tt.query})
+				err := root.Execute()
+
+				require.ErrorContains(t, err, "List-ID filter requires daemon API schema 2.14.0 or newer")
+				assert.Zero(t, exploreRequests, "an older daemon must reject List-ID queries before Explore")
+			})
+		}
+	})
+
+	t.Run("list_id_capability_probe_failures_before_explore", func(t *testing.T) {
+		for _, tt := range []struct {
+			name          string
+			status        int
+			body          string
+			closeBefore   bool
+			wantHealthReq int
+		}{
+			{name: "http_error", status: http.StatusInternalServerError, body: "health failed", wantHealthReq: 1},
+			{name: "malformed_response", status: http.StatusOK, body: "{", wantHealthReq: 1},
+			{name: "connection_failure", closeBefore: true},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				exploreRequests := 0
+				healthRequests := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/api/v1/health" {
+						healthRequests++
+						if tt.status == http.StatusOK {
+							w.WriteHeader(tt.status)
+							_, err := w.Write([]byte(tt.body))
+							assert.NoError(t, err)
+							return
+						}
+						http.Error(w, tt.body, tt.status)
+						return
+					}
+					if r.URL.Path == "/api/v1/explore" {
+						exploreRequests++
+					}
+					http.NotFound(w, r)
+				}))
+				if tt.closeBefore {
+					server.Close()
+				} else {
+					defer server.Close()
+				}
+				withStoreResolverConfig(t, &config.Config{
+					Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+				})
+
+				root := newRegisteredStageDeleteTestRoot(t)
+				root.SetArgs([]string{"stage-delete", "list:announce.example.org"})
+				err := root.Execute()
+
+				require.ErrorContains(t, err, "check daemon List-ID filter capability")
+				assert.Equal(t, tt.wantHealthReq, healthRequests)
+				assert.Zero(t, exploreRequests, "a failed capability probe must happen before Explore")
+			})
+		}
+	})
+
+	t.Run("newer_daemon_and_ordinary_query", func(t *testing.T) {
+		t.Run("newer_daemon", func(t *testing.T) {
+			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "list:announce.example.org", false, http.StatusCreated, "2.15.0")
+			withStoreResolverConfig(t, &config.Config{
+				Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+			})
+
+			root := newRegisteredStageDeleteTestRoot(t)
+			root.SetArgs([]string{"stage-delete", "list:announce.example.org"})
+			require.NoError(t, root.Execute())
+			assert.Equal(t, []string{"/api/v1/cli/search", "/api/v1/explore", "/api/v1/explore/preflight", "/api/v1/deletions"}, *routes)
+			assert.Equal(t, 2, *healthRequests,
+				"the stage-delete gate and the search-index probe each verify List-ID capability")
+		})
+
+		t.Run("ordinary_query_skips_probe", func(t *testing.T) {
+			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "subject:test", false, http.StatusCreated, "2.15.0")
+			withStoreResolverConfig(t, &config.Config{
+				Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+			})
+
+			root := newRegisteredStageDeleteTestRoot(t)
+			root.SetArgs([]string{"stage-delete", "subject:test"})
+			require.NoError(t, root.Execute())
+			assert.Equal(t, []string{"/api/v1/cli/search", "/api/v1/explore", "/api/v1/explore/preflight", "/api/v1/deletions"}, *routes)
+			assert.Zero(t, *healthRequests)
+		})
+	})
+}
+
+func boolFlag(enabled bool, flag string) []string {
+	if enabled {
+		return []string{flag}
+	}
+	return nil
+}
+
+func newStageDeleteTestServer(t *testing.T, wantQuery string, dryRun bool, stageStatus int, wantSourceID ...int64) (*httptest.Server, *[]string) {
+	t.Helper()
+	server, routes, _ := newStageDeleteTestServerWithSchema(t, wantQuery, dryRun, stageStatus, "2.14.0", wantSourceID...)
+	return server, routes
+}
+
+func newStageDeleteTestServerWithSchema(t *testing.T, wantQuery string, dryRun bool, stageStatus int, schemaVersion string, wantSourceID ...int64) (*httptest.Server, *[]string, *int) {
+	t.Helper()
+	routes := make([]string, 0, 3)
+	healthRequests := 0
+	var expectedSourceID *int64
+	if len(wantSourceID) > 0 {
+		expectedSourceID = &wantSourceID[0]
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		healthRequests++
+		writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+			"status":             "ok",
+			"api_schema_version": schemaVersion,
+		})
+	})
+	mux.HandleFunc("/api/v1/cli/search", func(w http.ResponseWriter, r *http.Request) {
+		routes = append(routes, r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, wantQuery, r.URL.Query().Get("q"))
+		writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
+	})
+	mux.HandleFunc("/api/v1/explore", func(w http.ResponseWriter, r *http.Request) {
+		routes = append(routes, r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		var request generated.ExploreHTTPRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			http.Error(w, "malformed explore request", http.StatusBadRequest)
+			return
+		}
+		if !assert.NotNil(t, request.Query) || !assert.NotNil(t, request.SearchMode) || !assert.NotNil(t, request.Limit) {
+			http.Error(w, "missing explore request fields", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, wantQuery, *request.Query)
+		assert.Equal(t, generated.ExploreHTTPRequestSearchModeFullText, *request.SearchMode)
+		assert.Equal(t, int64(1), *request.Limit)
+		assertStageDeleteFilters(t, request.Filters, expectedSourceID)
+		writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+			"cache_revision":        "cache-191",
+			"rows":                  []any{},
+			"search_provenance":     map[string]any{"lexical_index_revision": "lex-191"},
+			"candidate_snapshot_id": "snapshot-191",
+		})
+	})
+	mux.HandleFunc("/api/v1/explore/preflight", func(w http.ResponseWriter, r *http.Request) {
+		routes = append(routes, r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		var request generated.ExplorePreflightRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			http.Error(w, "malformed preflight request", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, generated.ExploreSelectionModeAllMatching, request.Selection.Mode)
+		assert.Equal(t, "cache-191", request.Selection.CacheRevision)
+		if !assert.NotNil(t, request.Selection.Predicate.Query) || !assert.NotNil(t, request.Selection.Predicate.SearchMode) {
+			http.Error(w, "missing preflight request fields", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, wantQuery, *request.Selection.Predicate.Query)
+		assert.Equal(t, generated.ExploreHTTPRequestSearchModeFullText, *request.Selection.Predicate.SearchMode)
+		assertStageDeleteFilters(t, request.Selection.Predicate.Filters, expectedSourceID)
+		if assert.NotNil(t, request.Selection.SearchProvenance.LexicalIndexRevision) {
+			assert.Equal(t, "lex-191", *request.Selection.SearchProvenance.LexicalIndexRevision)
+		}
+		writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+			"cache_revision":      "cache-191",
+			"count":               3,
+			"operation_token":     "operation-191",
+			"expires_at":          "2099-01-01T00:00:00Z",
+			"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},
+			"action_targets":      []any{},
+			"unavailable_actions": []any{},
+		})
+	})
+	mux.HandleFunc("/api/v1/deletions", func(w http.ResponseWriter, r *http.Request) {
+		routes = append(routes, r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		var request generated.StageDeletionRequest
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+			http.Error(w, "malformed stage deletion request", http.StatusBadRequest)
+			return
+		}
+		if !assert.NotNil(t, request.Selection) || !assert.NotNil(t, request.OperationToken) ||
+			!assert.NotNil(t, request.Description) || !assert.NotNil(t, request.DryRun) {
+			http.Error(w, "missing stage deletion request fields", http.StatusBadRequest)
+			return
+		}
+		assert.Equal(t, "operation-191", *request.OperationToken)
+		assert.Equal(t, "staged from CLI search", *request.Description)
+		assert.Equal(t, dryRun, *request.DryRun)
+		assert.Equal(t, generated.ExploreSelectionModeAllMatching, request.Selection.Mode)
+		assertStageDeleteFilters(t, request.Selection.Predicate.Filters, expectedSourceID)
+		response := map[string]any{
+			"dry_run":       dryRun,
+			"message_count": 3,
+			"account":       "alice@example.com",
+		}
+		if !dryRun {
+			response["id"] = "batch-191"
+			response["status"] = "pending"
+		}
+		writeStageDeleteJSON(t, w, stageStatus, response)
+	})
+	mux.HandleFunc("/api/v1/cli/run", func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "stage-delete must not use the daemon CLI runner", r.URL.Path)
+		http.Error(w, "unexpected CLI runner request", http.StatusInternalServerError)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "unexpected stage-delete route", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	return httptest.NewServer(mux), &routes, &healthRequests
+}
+
+func assertStageDeleteFilters(t *testing.T, filters []generated.ExploreFilter, wantSourceID *int64) {
+	t.Helper()
+	expected := []generated.ExploreFilter{{
+		Dimension: generated.ExploreFilterDimensionDeletion,
+		Values:    []string{"active"},
+	}}
+	if wantSourceID != nil {
+		expected = append(expected, generated.ExploreFilter{
+			Dimension: generated.ExploreFilterDimensionSource,
+			Values:    []string{strconv.FormatInt(*wantSourceID, 10)},
+		})
+	}
+	assert.Equal(t, expected, filters)
+}
+
+func writeStageDeleteJSON(t *testing.T, w http.ResponseWriter, status int, value map[string]any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	assert.NoError(t, json.NewEncoder(w).Encode(value))
+}
+
+func TestStageDeleteCommandRegistration(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	command, _, err := rootCmd.Find([]string{"stage-delete"})
+	require.NoError(err)
+	require.NotNil(command)
+	assert.Equal("stage-delete", command.Name())
+	assert.Equal("stage-delete <query>", command.Use)
+}

--- a/cmd/msgvault/cmd/stage_delete_test.go
+++ b/cmd/msgvault/cmd/stage_delete_test.go
@@ -192,6 +192,61 @@ func TestStageDeleteCommand(t *testing.T) {
 		require.ErrorContains(t, err, "msgvault build-cache")
 	})
 
+	t.Run("staging_rejections_guide_narrowing", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			code string
+			want string
+		}{
+			{name: "non_deletable", code: "selection_not_deletable", want: "message_type:email"},
+			{name: "multi_source", code: "multi_account_selection", want: "once per source with --source-id"},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v1/cli/search":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
+					case "/api/v1/explore":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+							"cache_revision":        "cache-191",
+							"rows":                  []any{},
+							"search_provenance":     map[string]any{"lexical_index_revision": "lex-191"},
+							"candidate_snapshot_id": "snapshot-191",
+						})
+					case "/api/v1/explore/preflight":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+							"cache_revision":      "cache-191",
+							"count":               3,
+							"operation_token":     "operation-191",
+							"expires_at":          "2099-01-01T00:00:00Z",
+							"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},
+							"action_targets":      []any{},
+							"unavailable_actions": []any{},
+						})
+					case "/api/v1/deletions":
+						writeStageDeleteJSON(t, w, http.StatusConflict, map[string]any{
+							"error":   tt.code,
+							"message": "the daemon rejected the reviewed selection",
+						})
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer server.Close()
+				withStoreResolverConfig(t, &config.Config{
+					Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+				})
+
+				root := newRegisteredStageDeleteTestRoot(t)
+				root.SetArgs([]string{"stage-delete", "from:alice@example.com"})
+				err := root.Execute()
+
+				require.ErrorContains(t, err, "the daemon rejected the reviewed selection")
+				require.ErrorContains(t, err, tt.want)
+			})
+		}
+	})
+
 	t.Run("incomplete_search_index_blocks_staging", func(t *testing.T) {
 		exploreRequests := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,10 @@ All notable changes to msgvault, grouped by release.
   `media_max_participants`, `max_media_mb`, and `accounts_config` keys are now
   documented for every chat provider.
 
+- Add `msgvault stage-delete <query>` to stage active messages matching search
+  criteria, with optional exact-source narrowing and `--dry-run` support for
+  reviewing the match count first.
+
 - Starting in v0.20.0, remote deletion remains permanently opt-in. The
   invoking CLI can grant durable consent with
   `[deletion] remote_enabled = true`; `MSGVAULT_ENABLE_REMOTE_DELETE=1`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1918,6 +1918,39 @@ analytics cache is rebuilt automatically.
 
 ---
 
+## stage-delete
+
+Stage all active messages matching Gmail-like search criteria as a pending deletion
+batch. The command uses the daemon's search and preflight checks before staging,
+and it does not delete messages from a provider. If the search matches more than
+one source, run the command once for each source with its exact numeric ID.
+
+Staging is refused while the daemon is still verifying or rebuilding its
+full-text search index, or while its analytical cache is unavailable, because an
+incomplete index could silently omit matching messages. Both states resolve in
+the background; retry when they finish.
+
+```bash
+msgvault stage-delete <query>
+```
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Show the match count without creating a deletion batch |
+| `--source-id ID` | Restrict staging to one exact source ID |
+
+For a query that resolves to one source, the source selector is optional. For a
+multi-source query, provide `--source-id` for each source:
+
+```bash
+msgvault stage-delete --source-id 42 "from:newsletter@example.com older_than:1y"
+```
+
+Review a created batch with `msgvault show-deletion <batch-id>`, then execute it
+with `msgvault delete-staged <batch-id>`.
+
+---
+
 ## list-deletions
 
 List pending and recent deletion batches.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1945,6 +1945,13 @@ msgvault stage-delete <query>
 | `--dry-run` | Show the match count without creating a deletion batch |
 | `--source-id ID` | Restrict staging to one exact source ID |
 
+Deletion staging covers Gmail-source email only. The daemon rejects a selection
+that includes anything else — chats, meetings, calendar entries, or mail from
+non-Gmail sources such as Apple Mail imports — rather than staging a subset of
+what matched. Narrow the search until it matches only deletable mail, for
+example with `message_type:email` in the query and `--source-id` for the Gmail
+source.
+
 For a query that resolves to one source, the source selector is optional. For a
 multi-source query, provide `--source-id` for each source:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1930,6 +1930,12 @@ full-text search index, or while its analytical cache is unavailable, because an
 incomplete index could silently omit matching messages. Both states resolve in
 the background; retry when they finish.
 
+Like deletion staging in the TUI and Web UI, the selection is resolved against
+the committed analytical snapshot, so messages synced after the most recent
+cache build are not included until the daemon refreshes the cache (it does so
+automatically after each sync). Re-run the command after a refresh to stage
+newly synced matches.
+
 ```bash
 msgvault stage-delete <query>
 ```


### PR DESCRIPTION
`msgvault stage-delete` stages active messages for deletion from search criteria, with `--dry-run` output and optional `--source-id` narrowing for searches that span multiple sources. Messages already deleted at the source are excluded, and an exact source selector keeps each pending deletion batch tied to one source. The existing review and execution flow is preserved.

The daemon already provides revision-pinned search, preflight, and staging, but the CLI previously had no non-interactive entry point for that safe path. `stage-delete "from:newsletter@example.com older_than:1y"` stages the matches; for a search spanning multiple sources, stage it once per source with `--source-id 42`. Review the batch with `show-deletion`, then use the existing `delete-staged` flow.

Closes #191
