### PR TITLE
docs: document embeddings upgrade behavior for existing users

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,20 @@ All notable changes to msgvault, grouped by release.
   In the TUI, press `a` to filter by account before staging again; MCP callers
   should pass `account` or stage each source separately.
 
+**Upgrade notes**
+
+- Archives with existing embeddings are migrated to generation-based coverage
+  tracking on the first writable open. Active vectors are preserved with no
+  expected data loss: msgvault adds and stamps `messages.embed_gen`, backfills
+  coverage from the active generation so already-embedded messages are marked
+  covered, leaves messages with a pending re-embed against the active generation
+  uncovered so they are re-embedded, then drops the legacy `pending_embeddings`
+  table. The corpus is not re-queued just from upgrading. Finish any remaining coverage with
+  `msgvault embeddings resume --backstop`; if the active generation's
+  fingerprint no longer matches your embedding config, vector search reports
+  the index stale until you run `msgvault embeddings build --full-rebuild`. See
+  [Vector Search: Upgrading an existing archive](/usage/vector-search/#upgrading-an-existing-archive).
+
 **Features**
 
 - Web Directory workspace: browse and search promoted durable people, filter

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,7 +46,7 @@ All notable changes to msgvault, grouped by release.
   report `index_stale` until a full rebuild completes:
   `msgvault embeddings build --full-rebuild --yes`. This includes older
   fingerprints such as v0.14's, even with unchanged configuration. See
-  [Vector Search: Upgrading an existing archive](/usage/vector-search/#upgrading-an-existing-archive).
+  [Vector Search: Upgrading an existing archive](usage/vector-search.md#upgrading-an-existing-archive).
 
 **Features**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,15 +35,17 @@ All notable changes to msgvault, grouped by release.
 **Upgrade notes**
 
 - Archives with existing embeddings are migrated to generation-based coverage
-  tracking on the first writable open. Active vectors are preserved with no
-  expected data loss: msgvault adds and stamps `messages.embed_gen`, backfills
-  coverage from the active generation so already-embedded messages are marked
-  covered, leaves messages with a pending re-embed against the active generation
-  uncovered so they are re-embedded, then drops the legacy `pending_embeddings`
-  table. The corpus is not re-queued just from upgrading. Finish any remaining coverage with
-  `msgvault embeddings resume --backstop`; if the active generation's
-  fingerprint no longer matches your embedding config, vector search reports
-  the index stale until you run `msgvault embeddings build --full-rebuild`. See
+  tracking on the first writable open. Active vectors are preserved, and coverage
+  is backfilled from the active generation except for messages awaiting a
+  re-embed; the legacy `pending_embeddings` table is then dropped. An in-flight
+  rebuild is not backfilled and re-embeds its existing messages when resumed.
+  For a matching generation, scheduled embedding in `msgvault serve` handles
+  stragglers automatically with its default periodic backstop, or run
+  `msgvault embeddings resume --backstop` manually. If the fingerprint no longer
+  matches the current embedding policy or configuration, vector and hybrid search
+  report `index_stale` until a full rebuild completes:
+  `msgvault embeddings build --full-rebuild --yes`. This includes older
+  fingerprints such as v0.14's, even with unchanged configuration. See
   [Vector Search: Upgrading an existing archive](/usage/vector-search/#upgrading-an-existing-archive).
 
 **Features**

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1627,7 +1627,7 @@ msgvault embeddings <subcommand> [flags]
 | Subcommand | Description |
 |---|---|
 | `build` | Build or update the index. Incremental by default; `--full-rebuild` starts a new generation. |
-| `resume` | Continue scan-and-fill embedding for the building or active generation. Always incremental. |
+| `resume` | Continue scan-and-fill embedding for the building or active generation. Incremental by default; `--backstop` also scans below the watermark. |
 | `list` | List index generations with their state, model, dimension, and pending count. |
 | `activate <generation-id>` | Activate a completed building generation, retiring the current active one. |
 | `retire <generation-id>` | Retire a generation. |
@@ -1642,6 +1642,7 @@ msgvault embeddings build [flags]
 |---|---|
 | `--full-rebuild` | Create a new index generation and rebuild from scratch. The new generation is activated atomically once coverage reaches zero. Same-model rebuilds keep serving the previous active generation in the meantime, but active-generation top-ups are frozen until activation; model or dimension changes return `index_stale` for vector/hybrid search until the new generation activates. |
 | `--yes` | Skip the confirmation prompt that `--full-rebuild` otherwise requires. |
+| `--backstop` | Run a full-scan pass that ignores the per-generation watermark to recover missing coverage skipped by incremental scans. Already-covered messages are skipped. |
 | `--account <identifier>` | Limit embedding to this account, by identifier or display name — numeric source IDs are rejected (repeatable). Overrides `[vector.embed.scope] accounts` for this run; configured `message_types` still apply. After activating this one-off scope, add the equivalent accounts to config and restart the daemon before searching. |
 | `--collection <name>` | Limit embedding to this collection's accounts (repeatable). Can be combined with `--account`; the scope is the union. This is a one-run override; persist the resolved accounts in config before restarting the daemon. |
 
@@ -1655,10 +1656,18 @@ different `--account`/`--collection` set than the active generation requires
 ### embeddings resume
 
 ```bash
-msgvault embeddings resume
+msgvault embeddings resume [flags]
 ```
 
 Continue embedding work and finish the current generation. If a generation matching the configured embedding settings is building, this embeds its remaining rows and activates it once coverage reaches zero; otherwise it tops up the active generation. Equivalent to `msgvault embeddings build` with no flags, but never starts a full rebuild. Accepts the same `--account`/`--collection` scope flags as `embeddings build`.
+
+Pass `--backstop` to scan for missing coverage below the per-generation watermark
+as well. This fills gaps in the selected generation without starting a full
+rebuild; it only activates a generation if that generation is building.
+
+```bash
+msgvault embeddings resume --backstop
+```
 
 ### embeddings list
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -343,6 +343,60 @@ self-recovers: the next edit to that message bumps `last_modified` (and
 (`embeddings build --full-rebuild`) or the periodic full-scan backstop
 re-embeds it regardless.
 
+## Upgrading an existing archive
+
+Archives that already had embeddings before the generation-based coverage
+tracking landed are migrated in place on the first writable open. There is no
+expected data loss: existing active vectors are preserved and keep serving
+vector and hybrid search.
+
+The migration runs the first time you start a writable daemon or run an
+embeddings command against an older database. It:
+
+- adds and stamps `messages.embed_gen`, then backfills coverage from the
+  active vector generation, so messages that already have active embeddings are
+  marked covered. The whole corpus is not re-queued just because you upgraded.
+- leaves messages that had a pending re-embed against the active generation
+  uncovered rather than marking them covered, so they stay missing and the
+  scan-based worker re-embeds them on the next `msgvault embeddings build` or
+  `resume`. The legacy `pending_embeddings` table is consulted for this, then
+  dropped once the migration completes.
+
+After the upgrade, coverage is tracked entirely through `messages.embed_gen`:
+a new or changed message becomes "missing" by clearing its `embed_gen` rather
+than by being queued in a separate table. The scan-and-fill worker finds those
+rows and tops up the active generation.
+
+To finish coverage for any stragglers left after the migration, run:
+
+```bash
+msgvault embeddings resume --backstop
+```
+
+`--backstop` runs a full-scan pass that ignores the per-generation watermark, so
+it catches below-watermark rows a normal incremental resume would skip, then
+activates the generation once coverage reaches zero.
+
+### When a full rebuild is required
+
+If the active generation's fingerprint no longer matches your current embedding
+policy and configuration (model, dimension, prefixes, preprocessing,
+`max_input_chars`, policy, or scope), vector and hybrid search report the index
+as stale (`index_stale`) instead of serving from a mismatched generation. Build
+a fresh generation:
+
+```bash
+msgvault embeddings build --full-rebuild
+```
+
+While that rebuild is in flight, the building generation is the worker's target.
+A same-fingerprint rebuild keeps serving the previous active generation in the
+meantime, but that generation is effectively frozen until the new one activates,
+so messages that are new or changed after the rebuild starts may not appear in
+vector or hybrid results until the rebuilt generation activates. Any rebuild that
+changes the fingerprint (model, dimension, prefixes, preprocessing,
+`max_input_chars`, policy, or scope) returns `index_stale` until activation.
+
 ## Scoped Generations
 
 Large mixed archives can build a vector index for only selected message types:

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -347,55 +347,56 @@ re-embeds it regardless.
 
 Archives that already had embeddings before the generation-based coverage
 tracking landed are migrated in place on the first writable open. There is no
-expected data loss: existing active vectors are preserved and keep serving
-vector and hybrid search.
+expected data loss: existing active vectors are preserved. They keep serving
+vector and hybrid search only if their fingerprint matches the current embedding
+policy and configuration. For example, generations built by v0.14 use an older
+fingerprint and require a full rebuild even with unchanged configuration; see
+[When a full rebuild is required](#when-a-full-rebuild-is-required).
 
 The migration runs the first time you start a writable daemon or run an
 embeddings command against an older database. It:
 
 - adds and stamps `messages.embed_gen`, then backfills coverage from the
   active vector generation, so messages that already have active embeddings are
-  marked covered. The whole corpus is not re-queued just because you upgraded.
+  marked covered. This backfill does not re-queue the active generation's corpus.
 - leaves messages that had a pending re-embed against the active generation
   uncovered rather than marking them covered, so they stay missing and the
-  scan-based worker re-embeds them on the next `msgvault embeddings build` or
-  `resume`. The legacy `pending_embeddings` table is consulted for this, then
+  scan-based worker can find and re-embed them, including below-watermark rows
+  on a backstop pass. The legacy `pending_embeddings` table is consulted for this, then
   dropped once the migration completes.
+
+Only the active generation is backfilled. A rebuild already in flight at upgrade
+time receives no coverage stamps for its existing vectors and re-embeds those
+messages when resumed.
 
 After the upgrade, coverage is tracked entirely through `messages.embed_gen`:
 a new or changed message becomes "missing" by clearing its `embed_gen` rather
 than by being queued in a separate table. The scan-and-fill worker finds those
 rows and tops up the active generation.
 
-To finish coverage for any stragglers left after the migration, run:
+For a generation whose fingerprint still matches, `msgvault serve` with an embed
+schedule runs a backstop automatically on its first embed pass for each generation
+and then at the first pass after each backstop interval (24 hours by default,
+unless disabled). To finish coverage manually for stragglers left after the
+migration, run:
 
 ```bash
 msgvault embeddings resume --backstop
 ```
 
 `--backstop` runs a full-scan pass that ignores the per-generation watermark, so
-it catches below-watermark rows a normal incremental resume would skip, then
-activates the generation once coverage reaches zero.
+it catches below-watermark rows a normal incremental resume would skip. It tops
+up an already-active generation; if a rebuild is in flight, it activates the
+building generation once missing coverage reaches zero.
 
 ### When a full rebuild is required
 
-If the active generation's fingerprint no longer matches your current embedding
-policy and configuration (model, dimension, prefixes, preprocessing,
-`max_input_chars`, policy, or scope), vector and hybrid search report the index
-as stale (`index_stale`) instead of serving from a mismatched generation. Build
-a fresh generation:
-
-```bash
-msgvault embeddings build --full-rebuild
-```
-
-While that rebuild is in flight, the building generation is the worker's target.
-A same-fingerprint rebuild keeps serving the previous active generation in the
-meantime, but that generation is effectively frozen until the new one activates,
-so messages that are new or changed after the rebuild starts may not appear in
-vector or hybrid results until the rebuilt generation activates. Any rebuild that
-changes the fingerprint (model, dimension, prefixes, preprocessing,
-`max_input_chars`, policy, or scope) returns `index_stale` until activation.
+If the active generation's fingerprint no longer matches the current embedding
+policy or configuration, including a policy change shipped in an upgrade, vector
+and hybrid search report `index_stale`; run
+`msgvault embeddings build --full-rebuild --yes` to build a matching generation.
+See [Model Rotation](#model-rotation) for fingerprint inputs and search behavior
+while the rebuild runs.
 
 ## Scoped Generations
 
@@ -544,8 +545,8 @@ msgvault embeddings build --full-rebuild --yes
 
 This builds a new generation with the new fingerprint and activates
 it atomically when the build completes. The fingerprint includes the
-model, dimension, task prefixes, preprocessing policy, `max_input_chars`, and
-embedding output policy. While the rebuild is in flight,
+model, dimension, task prefixes, preprocessing policy, `max_input_chars`,
+embedding output policy, and [scope](#scoped-generations). While the rebuild is in flight,
 `mode=vector` and `mode=hybrid` return `index_stale` (the
 previously-active generation no longer matches the configured
 fingerprint, so search refuses to serve potentially-mismatched


### PR DESCRIPTION
The vector-search guide now explains what happens when an existing archive with embeddings is upgraded, which #411 changed and left undocumented. A new "Upgrading an existing archive" section covers it: active vectors are preserved, coverage is backfilled from the active generation so already-embedded messages aren't re-queued, pending re-embeds are picked up by the scan worker, and the legacy `pending_embeddings` table is read once and dropped.

It also covers recovery with `msgvault embeddings resume --backstop`, when a stale fingerprint needs `msgvault embeddings build --full-rebuild`, and the frozen active index during an in-flight rebuild. A matching changelog entry links to it.

Closes #420
