### PR TITLE
perf(imap): write only the memberships a full enumeration changes

### DIFF
--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -211,19 +212,29 @@ func (s *Store) applyIMAPMailboxDeltas(
 		}
 		for _, normalized := range normalizedDeltas {
 			delta := normalized.delta
+			// A Reset delta is authoritative for the whole mailbox, but almost
+			// every row it republishes is identical to the saved one. Read the
+			// saved rows once and diff against them, so only real changes are
+			// written and only their messages have labels rebuilt below.
+			var stored map[imapMembershipUID]storedIMAPMembership
 			if delta.Reset {
-				if err := captureIMAPMembershipMessageIDs(
-					tx, affected,
-					`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ?`,
-					sourceID, normalized.mailbox,
-				); err != nil {
-					return fmt.Errorf("capture reset memberships for mailbox %q: %w", normalized.mailbox, err)
+				loaded, err := loadIMAPMailboxMemberships(tx, sourceID, normalized.mailbox)
+				if err != nil {
+					return fmt.Errorf("load memberships for mailbox %q: %w", normalized.mailbox, err)
 				}
-				if _, err := tx.Exec(`
-					DELETE FROM imap_message_memberships
-					WHERE source_id = ? AND mailbox = ?
-				`, sourceID, normalized.mailbox); err != nil {
-					return fmt.Errorf("reset IMAP memberships for mailbox %q: %w", normalized.mailbox, err)
+				stored = loaded
+				observed := make(map[imapMembershipUID]struct{}, len(delta.Memberships))
+				for _, observation := range delta.Memberships {
+					observed[imapMembershipUID{
+						uidValidity: normalized.uidValidity, uid: observation.UID,
+					}] = struct{}{}
+				}
+				// Whatever the reset does not republish is gone from the mailbox.
+				// This runs before any insert, as the wholesale delete did.
+				if err := deleteUnobservedIMAPMemberships(
+					tx, sourceID, normalized.mailbox, stored, observed, affected,
+				); err != nil {
+					return err
 				}
 			}
 
@@ -242,6 +253,7 @@ func (s *Store) applyIMAPMailboxDeltas(
 				`, sourceID, normalized.mailbox, normalized.uidValidity, uid); err != nil {
 					return fmt.Errorf("remove vanished UID %d in mailbox %q: %w", uid, normalized.mailbox, err)
 				}
+				delete(stored, imapMembershipUID{uidValidity: normalized.uidValidity, uid: uid})
 			}
 
 			for _, observation := range delta.Memberships {
@@ -250,6 +262,23 @@ func (s *Store) applyIMAPMailboxDeltas(
 				messageID, err := resolver.resolve(observation)
 				if err != nil {
 					return err
+				}
+				flags := observation.Flags
+				if flags == nil {
+					flags = []string{}
+				}
+				if delta.Reset {
+					key := imapMembershipUID{
+						uidValidity: observation.UIDValidity, uid: observation.UID,
+					}
+					prior, saved := stored[key]
+					delete(stored, key)
+					if saved && prior.flagsDecoded &&
+						prior.messageID == messageID && slices.Equal(prior.flags, flags) {
+						// Identical membership: writing it would only move
+						// updated_at and rebuild labels that cannot have changed.
+						continue
+					}
 				}
 				if observation.SourceMessageID != "" {
 					if err := captureIMAPMembershipMessageIDs(
@@ -270,10 +299,6 @@ func (s *Store) applyIMAPMailboxDeltas(
 					return fmt.Errorf("capture replaced IMAP membership: %w", err)
 				}
 
-				flags := observation.Flags
-				if flags == nil {
-					flags = []string{}
-				}
 				flagsJSON, err := json.Marshal(flags)
 				if err != nil {
 					return fmt.Errorf("marshal IMAP flags: %w", err)
@@ -347,6 +372,107 @@ func (s *Store) applyIMAPMailboxDeltas(
 		}
 		return nil
 	})
+}
+
+// imapMembershipUID identifies one saved membership row within a mailbox.
+type imapMembershipUID struct {
+	uidValidity uint32
+	uid         uint32
+}
+
+type storedIMAPMembership struct {
+	messageID int64
+	flags     []string
+	// flagsDecoded is false when the saved flags JSON did not parse. Such a row
+	// cannot be compared, so it is always rewritten.
+	flagsDecoded bool
+}
+
+// loadIMAPMailboxMemberships reads every saved membership of one mailbox so a
+// Reset delta can diff against it. Flags are decoded rather than compared as
+// stored text: SQLite returns the JSON we wrote, PostgreSQL reformats it.
+func loadIMAPMailboxMemberships(
+	tx *loggedTx, sourceID int64, mailbox string,
+) (map[imapMembershipUID]storedIMAPMembership, error) {
+	rows, err := tx.Query(`
+		SELECT uidvalidity, uid, message_id, flags
+		FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ?
+	`, sourceID, mailbox)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	stored := make(map[imapMembershipUID]storedIMAPMembership)
+	for rows.Next() {
+		var (
+			key       imapMembershipUID
+			messageID int64
+			flagsJSON sql.NullString
+		)
+		if err := rows.Scan(&key.uidValidity, &key.uid, &messageID, &flagsJSON); err != nil {
+			return nil, err
+		}
+		saved := storedIMAPMembership{messageID: messageID, flags: []string{}, flagsDecoded: true}
+		if flagsJSON.Valid && flagsJSON.String != "" {
+			if err := json.Unmarshal([]byte(flagsJSON.String), &saved.flags); err != nil {
+				saved.flags, saved.flagsDecoded = nil, false
+			}
+		}
+		stored[key] = saved
+	}
+	return stored, rows.Err()
+}
+
+// deleteUnobservedIMAPMemberships removes the saved rows of a mailbox that a
+// Reset delta does not republish, drops them from stored, and marks their
+// messages for label reconciliation.
+func deleteUnobservedIMAPMemberships(
+	tx *loggedTx,
+	sourceID int64,
+	mailbox string,
+	stored map[imapMembershipUID]storedIMAPMembership,
+	observed map[imapMembershipUID]struct{},
+	affected map[int64]struct{},
+) error {
+	keys := make([]imapMembershipUID, 0, len(stored))
+	for key, prior := range stored {
+		if _, kept := observed[key]; kept {
+			continue
+		}
+		keys = append(keys, key)
+		affected[prior.messageID] = struct{}{}
+		delete(stored, key)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(stored) == 0 {
+		// Nothing survived: an emptied mailbox, or a new UIDVALIDITY epoch.
+		// One statement instead of one per row.
+		if _, err := tx.Exec(`
+			DELETE FROM imap_message_memberships
+			WHERE source_id = ? AND mailbox = ?
+		`, sourceID, mailbox); err != nil {
+			return fmt.Errorf("reset IMAP memberships for mailbox %q: %w", mailbox, err)
+		}
+		return nil
+	}
+	slices.SortFunc(keys, func(a, b imapMembershipUID) int {
+		if a.uidValidity != b.uidValidity {
+			return cmp.Compare(a.uidValidity, b.uidValidity)
+		}
+		return cmp.Compare(a.uid, b.uid)
+	})
+	for _, key := range keys {
+		if _, err := tx.Exec(`
+			DELETE FROM imap_message_memberships
+			WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+		`, sourceID, mailbox, key.uidValidity, key.uid); err != nil {
+			return fmt.Errorf("remove absent UID %d in mailbox %q: %w", key.uid, mailbox, err)
+		}
+	}
+	return nil
 }
 
 func captureUntrackedIMAPMessageIDs(

--- a/internal/store/imap_memberships_test.go
+++ b/internal/store/imap_memberships_test.go
@@ -806,7 +806,6 @@ func TestApplyIMAPMailboxDeltas_ConflictingDeltaIdentityRollsBackEverything(t *t
 		})
 	}
 }
-
 func TestGetIMAPSourceMessageAliases_ReturnsOnlyRequestedUIDs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -871,4 +870,146 @@ func TestGetIMAPSourceMessageAliases_AccumulatesEveryUIDChunk(t *testing.T) {
 		"INBOX|1":   "INBOX|1",
 		"INBOX|950": "INBOX|950",
 	}, aliases)
+}
+
+const membershipStamp = "1999-01-01 00:00:00"
+
+// stampMemberships rewrites updated_at on every saved membership so a later
+// apply can be measured by which rows moved off the stamp.
+func stampMemberships(t *testing.T, st *store.Store, sourceID int64) {
+	t.Helper()
+	_, err := st.DB().Exec(st.Rebind(`
+		UPDATE imap_message_memberships SET updated_at = ? WHERE source_id = ?
+	`), membershipStamp, sourceID)
+	require.NoError(t, err)
+}
+
+// membershipsWritten counts the rows an apply inserted or updated since the
+// last stampMemberships call.
+func membershipsWritten(t *testing.T, st *store.Store, sourceID int64) int {
+	t.Helper()
+	var count int
+	require.NoError(t, st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM imap_message_memberships
+		WHERE source_id = ? AND updated_at <> ?
+	`), sourceID, membershipStamp).Scan(&count))
+	return count
+}
+
+func TestApplyIMAPMailboxDeltas_UnchangedResetWritesNothing(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	firstID := f.createMessage(t, "reset-first", "<reset-first@example.com>")
+	secondID := f.createMessage(t, "reset-second", "<reset-second@example.com>")
+	delta := store.IMAPMailboxDelta{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 3, HighestModSeq: 40},
+		Memberships: []store.IMAPMembershipObservation{
+			{
+				Mailbox: "INBOX", UIDValidity: 5, UID: 1,
+				SourceMessageID: "reset-first", Flags: []string{"\\Seen"},
+			},
+			{Mailbox: "INBOX", UIDValidity: 5, UID: 2, SourceMessageID: "reset-second"},
+		},
+	}
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	stampMemberships(t, f.store, f.source.ID)
+
+	delta.Reset = true
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+
+	assert.Equal(0, membershipsWritten(t, f.store, f.source.ID),
+		"a reset that observes the saved set must rewrite no membership")
+	assert.Equal(2, membershipCount(t, f.store, f.source.ID))
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, firstID))
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, secondID))
+	assert.False(messageTombstoned(t, f.store, firstID))
+	assert.False(messageTombstoned(t, f.store, secondID))
+}
+
+func TestApplyIMAPMailboxDeltas_ResetWritesOnlyChangedMemberships(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	expungedID := f.createMessage(t, "reset-expunged", "<reset-expunged@example.com>")
+	keptID := f.createMessage(t, "reset-kept", "<reset-kept@example.com>")
+	arrivedID := f.createMessage(t, "reset-arrived", "<reset-arrived@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 3, HighestModSeq: 40},
+		Memberships: []store.IMAPMembershipObservation{
+			{Mailbox: "INBOX", UIDValidity: 5, UID: 1, SourceMessageID: "reset-expunged"},
+			{Mailbox: "INBOX", UIDValidity: 5, UID: 2, SourceMessageID: "reset-kept"},
+		},
+	}}))
+	stampMemberships(t, f.store, f.source.ID)
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 4, HighestModSeq: 41},
+		Reset:   true,
+		Memberships: []store.IMAPMembershipObservation{
+			{Mailbox: "INBOX", UIDValidity: 5, UID: 2, SourceMessageID: "reset-kept"},
+			{Mailbox: "INBOX", UIDValidity: 5, UID: 3, SourceMessageID: "reset-arrived"},
+		},
+	}}))
+
+	assert.Equal(1, membershipsWritten(t, f.store, f.source.ID),
+		"only the arrival is written; the kept UID keeps its stamp")
+	known, err := f.store.GetIMAPKnownUIDs(f.source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"INBOX": {2, 3}}, known)
+	gotKeptID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 5, 2)
+	assert.Equal(keptID, gotKeptID)
+	assert.True(messageTombstoned(t, f.store, expungedID))
+	assert.Empty(messageLabels(t, f.store, expungedID))
+	assert.Equal([]string{"INBOX"}, messageLabels(t, f.store, arrivedID))
+	assert.False(messageTombstoned(t, f.store, keptID))
+}
+
+func TestApplyIMAPMailboxDeltas_ResetPersistsFlagChange(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPMembershipFixture(t)
+	f.createMessage(t, "reset-flagged", "<reset-flagged@example.com>")
+	f.createMessage(t, "reset-steady", "<reset-steady@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 3, HighestModSeq: 40},
+		Memberships: []store.IMAPMembershipObservation{
+			{
+				Mailbox: "INBOX", UIDValidity: 5, UID: 1,
+				SourceMessageID: "reset-flagged", Flags: []string{"\\Seen"},
+			},
+			{
+				Mailbox: "INBOX", UIDValidity: 5, UID: 2,
+				SourceMessageID: "reset-steady", Flags: []string{"\\Seen"},
+			},
+		},
+	}}))
+	stampMemberships(t, f.store, f.source.ID)
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 5, UIDNext: 3, HighestModSeq: 41},
+		Reset:   true,
+		Memberships: []store.IMAPMembershipObservation{
+			{
+				Mailbox: "INBOX", UIDValidity: 5, UID: 1,
+				SourceMessageID: "reset-flagged", Flags: []string{"\\Seen", "\\Flagged"},
+			},
+			{
+				Mailbox: "INBOX", UIDValidity: 5, UID: 2,
+				SourceMessageID: "reset-steady", Flags: []string{"\\Seen"},
+			},
+		},
+	}}))
+
+	assert.Equal(1, membershipsWritten(t, f.store, f.source.ID),
+		"a flag change must still be written, and only it")
+	_, gotFlags := membershipMessageAndFlags(t, f.store, f.source.ID, 5, 1)
+	assert.JSONEq(`["\\Seen","\\Flagged"]`, gotFlags)
+	_, gotSteadyFlags := membershipMessageAndFlags(t, f.store, f.source.ID, 5, 2)
+	assert.JSONEq(`["\\Seen"]`, gotSteadyFlags)
 }


### PR DESCRIPTION
Supersedes #750. Closes #749.

A full IMAP enumeration previously rewrote every saved membership row in a
mailbox and rebuilt every message's labels, even when almost nothing changed.
The store now diffs the enumeration against saved rows, writes only memberships
whose message or flags changed, and rebuilds labels only for affected messages.

A reset that empties a mailbox, such as a new UIDVALIDITY epoch, still clears
it in one statement. Tombstone behavior is unchanged. A membership that never
changes after an earlier partial label merge is no longer repaired as a side
effect of a later full enumeration; #748 tracks an explicit repair path for
that case.

On a 118,000-message Microsoft 365 account, a forced full enumeration's store
transaction dropped from 282 seconds to 2.9 seconds while preserving final
memberships, folder states, labels, and tombstones.

No configuration or usage changes.
