### PR TITLE
fix(cli): stage the deletable subset of mixed-query deletions

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4072,6 +4072,9 @@ components:
         count:
           format: int64
           type: integer
+        deletable_count:
+          format: int64
+          type: integer
         estimated_bytes:
           format: int64
           type: integer
@@ -4089,6 +4092,7 @@ components:
             $ref: "#/components/schemas/ExploreUnavailableAction"
           type: array
       required:
+        - deletable_count
         - count
         - estimated_bytes
         - cache_revision

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11860,7 +11860,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.17.0
+  version: 2.18.0
 openapi: 3.1.0
 paths:
   /api/ping:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10744,6 +10744,9 @@ components:
           type: boolean
         id:
           type: string
+        matched_count:
+          format: int64
+          type: integer
         message_count:
           format: int64
           type: integer
@@ -10751,6 +10754,9 @@ components:
           items:
             type: string
           type: array
+        skipped_count:
+          format: int64
+          type: integer
         source:
           $ref: "#/components/schemas/SourceReference"
         status:

--- a/cmd/msgvault/cmd/stage_delete.go
+++ b/cmd/msgvault/cmd/stage_delete.go
@@ -25,17 +25,18 @@ func newStageDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stage-delete [query]",
 		Short: "Stage active messages matching search criteria or explicit IDs for deletion",
-		Long: `Stage every active message matching a search query for deletion.
+		Long: `Stage the deletable messages matching a search query for deletion.
 
-The daemon resolves and preflights the search before creating a pending
-deletion batch. Use --dry-run to report the match count without creating one.
-Alternatively, pass a comma-separated --ids list to stage explicit internal
+The search runs with the same semantics as msgvault search. Matches that no
+source supports deleting, such as chats, meetings, and non-Gmail mail, are
+reported and skipped rather than rejecting the whole search. Use --dry-run to
+see the same staged subset and counts without creating a batch. Alternatively, pass a comma-separated --ids list to stage explicit internal
 message IDs; this form bypasses search and analytical-cache readiness.
 Review a created batch with show-deletion before running delete-staged.`,
 		Args: cobra.ArbitraryArgs,
 		RunE: runStageDelete,
 	}
-	cmd.Flags().BoolVar(&stageDeleteDryRun, "dry-run", false, "Show the match count without creating a deletion batch")
+	cmd.Flags().BoolVar(&stageDeleteDryRun, "dry-run", false, "Show the staged subset and skipped counts without creating a deletion batch")
 	cmd.Flags().Int64("source-id", 0, "Restrict staging to one exact source ID")
 	cmd.Flags().String("ids", "", "Stage these comma-separated internal message IDs instead of a query")
 	cmd.MarkFlagsMutuallyExclusive("ids", "source-id")
@@ -196,7 +197,7 @@ func runStageDeleteFromQuery(cmd *cobra.Command, queryText string) error {
 		return errors.New("stage deletion returned no response body")
 	}
 
-	return writeStageDeleteOutcome(cmd.OutOrStdout(), result, "the search")
+	return writeStageDeleteOutcome(cmd.OutOrStdout(), result)
 }
 
 func runStageDeleteFromIDs(cmd *cobra.Command) error {
@@ -245,7 +246,7 @@ func runStageDeleteFromIDs(cmd *cobra.Command) error {
 		return errors.New("stage deletion returned no response body")
 	}
 
-	return writeStageDeleteOutcome(cmd.OutOrStdout(), result, "the requested IDs")
+	return writeStageDeleteOutcome(cmd.OutOrStdout(), result)
 }
 
 func parseStageDeleteMessageIDs(raw string) ([]int64, error) {
@@ -278,10 +279,13 @@ func stageDeleteMessageIDsDaemonErr(err error) error {
 	return stageDeleteDaemonErr("stage deletion", err)
 }
 
-func writeStageDeleteOutcome(w io.Writer, result *generated.StageDeletionResponse, criterion string) error {
+func writeStageDeleteOutcome(w io.Writer, result *generated.StageDeletionResponse) error {
 	if result.DryRun {
-		if _, err := fmt.Fprintf(w, "Dry run: %d message(s) match %s; no deletion batch was created.\n", result.MessageCount, criterion); err != nil {
+		if _, err := fmt.Fprintf(w, "Dry run: %d message(s) would be staged; no deletion batch was created.\n", result.MessageCount); err != nil {
 			return fmt.Errorf("write dry-run summary: %w", err)
+		}
+		if err := writeStageDeleteSkipped(w, result); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -291,8 +295,33 @@ func writeStageDeleteOutcome(w io.Writer, result *generated.StageDeletionRespons
 	if _, err := fmt.Fprintf(w, "Staged %d message(s) for deletion in batch %s.\n", result.MessageCount, *result.ID); err != nil {
 		return fmt.Errorf("write staging summary: %w", err)
 	}
+	if err := writeStageDeleteSkipped(w, result); err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintf(w, "Review with 'msgvault show-deletion %s', then execute with 'msgvault delete-staged %s'.\n", *result.ID, *result.ID); err != nil {
 		return fmt.Errorf("write staging summary: %w", err)
+	}
+	return nil
+}
+
+// writeStageDeleteSkipped names the matches the daemon left out, so a
+// narrower staged count than the search reported is never silent.
+func writeStageDeleteSkipped(w io.Writer, result *generated.StageDeletionResponse) error {
+	skipped := int64(0)
+	if result.SkippedCount != nil {
+		skipped = *result.SkippedCount
+	}
+	if skipped <= 0 {
+		return nil
+	}
+	matched := skipped + result.MessageCount
+	if result.MatchedCount != nil {
+		matched = *result.MatchedCount
+	}
+	if _, err := fmt.Fprintf(w,
+		"%d of %d matching item(s) cannot be deleted from their source (chats, meetings, or non-Gmail mail) and were skipped.\n",
+		skipped, matched); err != nil {
+		return fmt.Errorf("write skipped summary: %w", err)
 	}
 	return nil
 }
@@ -309,9 +338,9 @@ func stageDeleteDaemonErr(op string, err error) error {
 		return fmt.Errorf("%s: %s; retry shortly if the analytical cache is still building, "+
 			"or run 'msgvault build-cache' and rerun stage-delete", op, apiErr.Message)
 	case "selection_not_deletable":
-		return fmt.Errorf("%s: %s; the search matches items that cannot be deleted from "+
-			"their source, such as chats, meetings, or non-Gmail mail. Narrow the search, "+
-			"for example with message_type:email or --source-id <gmail-source-id>",
+		return fmt.Errorf("%s: %s; nothing the search matched can be deleted from its "+
+			"source. Deletion currently covers Gmail mail only, so widen or retarget the "+
+			"search, for example with --source-id <gmail-source-id>",
 			op, apiErr.Message)
 	case "multi_account_selection":
 		return fmt.Errorf("%s: %s; rerun stage-delete once per source with --source-id",

--- a/cmd/msgvault/cmd/stage_delete.go
+++ b/cmd/msgvault/cmd/stage_delete.go
@@ -30,7 +30,8 @@ func newStageDeleteCommand() *cobra.Command {
 The search runs with the same semantics as msgvault search. Matches that no
 source supports deleting, such as chats, meetings, and non-Gmail mail, are
 reported and skipped rather than rejecting the whole search. Use --dry-run to
-see the same staged subset and counts without creating a batch. Alternatively, pass a comma-separated --ids list to stage explicit internal
+see the same staged subset and counts without creating a batch.
+Alternatively, pass a comma-separated --ids list to stage explicit internal
 message IDs; this form bypasses search and analytical-cache readiness.
 Review a created batch with show-deletion before running delete-staged.`,
 		Args: cobra.ArbitraryArgs,
@@ -62,9 +63,6 @@ func runStageDeleteFromQuery(cmd *cobra.Command, queryText string) error {
 	}
 	if parsed.IsEmpty() {
 		return usageErr(cmd, errors.New("empty search query"))
-	}
-	if hasEmptyAddressFilter(parsed) {
-		return usageErr(cmd, errors.New("empty address filter"))
 	}
 	sourceID, err := cmd.Flags().GetInt64("source-id")
 	if err != nil {
@@ -163,6 +161,15 @@ func runStageDeleteFromQuery(cmd *cobra.Command, queryText string) error {
 	}
 	if preflightResp == nil || preflightResp.JSON200 == nil {
 		return errors.New("preflight search selection returned no response")
+	}
+
+	reviewed := preflightResp.JSON200
+	if reviewed.DeletableCount < reviewed.Count {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"Preflight: %d matching item(s); %d message(s) can be staged; %d item(s) will be skipped.\n",
+			reviewed.Count, reviewed.DeletableCount, reviewed.Count-reviewed.DeletableCount); err != nil {
+			return fmt.Errorf("write preflight summary: %w", err)
+		}
 	}
 
 	description := "staged from CLI search"
@@ -347,17 +354,6 @@ func stageDeleteDaemonErr(op string, err error) error {
 			op, apiErr.Message)
 	}
 	return fmt.Errorf("%s: %w", op, err)
-}
-
-func hasEmptyAddressFilter(q *search.Query) bool {
-	for _, values := range [][]string{q.FromAddrs, q.ToAddrs, q.CcAddrs, q.BccAddrs} {
-		for _, value := range values {
-			if strings.TrimSpace(value) == "" {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func init() {

--- a/cmd/msgvault/cmd/stage_delete.go
+++ b/cmd/msgvault/cmd/stage_delete.go
@@ -17,8 +17,8 @@ import (
 var stageDeleteDryRun bool
 
 const (
-	stageDeleteListIDMinAPISchemaVersion = "2.14.0"
-	analyticalCacheUnavailableCode       = "analytical_cache_unavailable"
+	stageDeleteMinAPISchemaVersion = "2.18.0"
+	analyticalCacheUnavailableCode = "analytical_cache_unavailable"
 )
 
 func newStageDeleteCommand() *cobra.Command {
@@ -79,14 +79,12 @@ func runStageDeleteFromQuery(cmd *cobra.Command, queryText string) error {
 		return fmt.Errorf("open store: %w", err)
 	}
 	defer func() { _ = store.Close() }()
-	if len(parsed.ListIDs) > 0 {
-		supported, err := store.SupportsAPISchemaVersion(cmd.Context(), stageDeleteListIDMinAPISchemaVersion)
-		if err != nil {
-			return fmt.Errorf("check daemon List-ID filter capability: %w", err)
-		}
-		if !supported {
-			return fmt.Errorf("List-ID filter requires daemon API schema %s or newer", stageDeleteListIDMinAPISchemaVersion)
-		}
+	supported, err := store.SupportsAPISchemaVersion(cmd.Context(), stageDeleteMinAPISchemaVersion)
+	if err != nil {
+		return fmt.Errorf("check daemon query staging capability: %w", err)
+	}
+	if !supported {
+		return fmt.Errorf("query staging requires daemon API schema %s or newer; upgrade the daemon", stageDeleteMinAPISchemaVersion)
 	}
 
 	// Staging trusts the full-text index as the complete match set, so an

--- a/cmd/msgvault/cmd/stage_delete_test.go
+++ b/cmd/msgvault/cmd/stage_delete_test.go
@@ -195,6 +195,8 @@ func TestStageDeleteCommand(t *testing.T) {
 	t.Run("cache_unavailable_reports_recovery", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
+			case "/api/v1/health":
+				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"status": "ok", "api_schema_version": "2.18.0"})
 			case "/api/v1/cli/search":
 				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
 			case "/api/v1/explore":
@@ -246,6 +248,8 @@ func TestStageDeleteCommand(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
+					case "/api/v1/health":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"status": "ok", "api_schema_version": "2.18.0"})
 					case "/api/v1/cli/search":
 						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
 					case "/api/v1/explore":
@@ -311,6 +315,8 @@ func TestStageDeleteCommand(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
+					case "/api/v1/health":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"status": "ok", "api_schema_version": "2.18.0"})
 					case "/api/v1/cli/search":
 						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
 					case "/api/v1/explore":
@@ -359,6 +365,8 @@ func TestStageDeleteCommand(t *testing.T) {
 		exploreRequests := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
+			case "/api/v1/health":
+				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"status": "ok", "api_schema_version": "2.18.0"})
 			case "/api/v1/cli/search":
 				writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
 					"results":     []any{},
@@ -384,11 +392,12 @@ func TestStageDeleteCommand(t *testing.T) {
 		assert.Zero(t, exploreRequests, "an incomplete search index must block staging before Explore")
 	})
 
-	t.Run("list_id_rejects_old_daemon_before_explore", func(t *testing.T) {
+	t.Run("query_staging_rejects_old_daemon_before_explore", func(t *testing.T) {
 		for _, tt := range []struct {
 			name  string
 			query string
 		}{
+			{name: "ordinary", query: "subject:receipt"},
 			{name: "list", query: "list:announce.example.org"},
 			{name: "list_id", query: "list-id:announce.example.org"},
 		} {
@@ -399,7 +408,7 @@ func TestStageDeleteCommand(t *testing.T) {
 					case "/api/v1/health":
 						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
 							"status":             "ok",
-							"api_schema_version": "2.13.0",
+							"api_schema_version": "2.17.0",
 						})
 					case "/api/v1/explore":
 						exploreRequests++
@@ -417,13 +426,13 @@ func TestStageDeleteCommand(t *testing.T) {
 				root.SetArgs([]string{"stage-delete", tt.query})
 				err := root.Execute()
 
-				require.ErrorContains(t, err, "List-ID filter requires daemon API schema 2.14.0 or newer")
-				assert.Zero(t, exploreRequests, "an older daemon must reject List-ID queries before Explore")
+				require.ErrorContains(t, err, "query staging requires daemon API schema 2.18.0 or newer")
+				assert.Zero(t, exploreRequests, "an older daemon must reject query staging before Explore")
 			})
 		}
 	})
 
-	t.Run("list_id_capability_probe_failures_before_explore", func(t *testing.T) {
+	t.Run("query_staging_capability_probe_failures_before_explore", func(t *testing.T) {
 		for _, tt := range []struct {
 			name          string
 			status        int
@@ -468,7 +477,7 @@ func TestStageDeleteCommand(t *testing.T) {
 				root.SetArgs([]string{"stage-delete", "list:announce.example.org"})
 				err := root.Execute()
 
-				require.ErrorContains(t, err, "check daemon List-ID filter capability")
+				require.ErrorContains(t, err, "check daemon query staging capability")
 				assert.Equal(t, tt.wantHealthReq, healthRequests)
 				assert.Zero(t, exploreRequests, "a failed capability probe must happen before Explore")
 			})
@@ -477,7 +486,7 @@ func TestStageDeleteCommand(t *testing.T) {
 
 	t.Run("newer_daemon_and_ordinary_query", func(t *testing.T) {
 		t.Run("newer_daemon", func(t *testing.T) {
-			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "list:announce.example.org", false, http.StatusCreated, "2.15.0")
+			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "list:announce.example.org", false, http.StatusCreated, "2.18.0")
 			withStoreResolverConfig(t, &config.Config{
 				Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
 			})
@@ -490,8 +499,8 @@ func TestStageDeleteCommand(t *testing.T) {
 				"the stage-delete gate and the search-index probe each verify List-ID capability")
 		})
 
-		t.Run("ordinary_query_skips_probe", func(t *testing.T) {
-			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "subject:test", false, http.StatusCreated, "2.15.0")
+		t.Run("ordinary_query_checks_contract", func(t *testing.T) {
+			server, routes, healthRequests := newStageDeleteTestServerWithSchema(t, "subject:test", false, http.StatusCreated, "2.18.0")
 			withStoreResolverConfig(t, &config.Config{
 				Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
 			})
@@ -500,7 +509,7 @@ func TestStageDeleteCommand(t *testing.T) {
 			root.SetArgs([]string{"stage-delete", "subject:test"})
 			require.NoError(t, root.Execute())
 			assert.Equal(t, []string{"/api/v1/cli/search", "/api/v1/explore", "/api/v1/explore/preflight", "/api/v1/deletions"}, *routes)
-			assert.Zero(t, *healthRequests)
+			assert.Equal(t, 1, *healthRequests)
 		})
 	})
 }
@@ -514,7 +523,7 @@ func boolFlag(enabled bool, flag string) []string {
 
 func newStageDeleteTestServer(t *testing.T, wantQuery string, dryRun bool, stageStatus int, wantSourceID ...int64) (*httptest.Server, *[]string) {
 	t.Helper()
-	server, routes, _ := newStageDeleteTestServerWithSchema(t, wantQuery, dryRun, stageStatus, "2.14.0", wantSourceID...)
+	server, routes, _ := newStageDeleteTestServerWithSchema(t, wantQuery, dryRun, stageStatus, "2.18.0", wantSourceID...)
 	return server, routes
 }
 

--- a/cmd/msgvault/cmd/stage_delete_test.go
+++ b/cmd/msgvault/cmd/stage_delete_test.go
@@ -165,10 +165,10 @@ func TestStageDeleteCommand(t *testing.T) {
 		}{
 			{name: "invalid", args: []string{"before:not-a-date"}, want: "invalid value"},
 			{name: "empty", args: []string{"   "}, want: "empty search query"},
-			{name: "empty_from", args: []string{"from:"}, want: "empty address filter"},
-			{name: "empty_to", args: []string{"to:"}, want: "empty address filter"},
-			{name: "empty_cc", args: []string{"cc:"}, want: "empty address filter"},
-			{name: "empty_bcc", args: []string{"bcc:"}, want: "empty address filter"},
+			{name: "empty_from", args: []string{"from:"}, want: "non-empty address filter"},
+			{name: "empty_to", args: []string{"to:"}, want: "non-empty address filter"},
+			{name: "empty_cc", args: []string{"cc:"}, want: "non-empty address filter"},
+			{name: "empty_bcc", args: []string{"bcc:"}, want: "non-empty address filter"},
 			{name: "zero_source_id", args: []string{"subject:test", "--source-id", "0"}, want: "source ID must be positive"},
 			{name: "negative_source_id", args: []string{"subject:test", "--source-id", "-1"}, want: "source ID must be positive"},
 		} {
@@ -231,13 +231,15 @@ func TestStageDeleteCommand(t *testing.T) {
 		}{
 			{
 				name: "staged", status: http.StatusCreated,
-				wantOutput: "Staged 2 message(s) for deletion in batch batch-191.\n" +
+				wantOutput: "Preflight: 3 matching item(s); 2 message(s) can be staged; 1 item(s) will be skipped.\n" +
+					"Staged 2 message(s) for deletion in batch batch-191.\n" +
 					"1 of 3 matching item(s) cannot be deleted from their source (chats, meetings, or non-Gmail mail) and were skipped.\n" +
 					"Review with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
 			},
 			{
 				name: "dry_run", dryRun: true, status: http.StatusOK,
-				wantOutput: "Dry run: 2 message(s) would be staged; no deletion batch was created.\n" +
+				wantOutput: "Preflight: 3 matching item(s); 2 message(s) can be staged; 1 item(s) will be skipped.\n" +
+					"Dry run: 2 message(s) would be staged; no deletion batch was created.\n" +
 					"1 of 3 matching item(s) cannot be deleted from their source (chats, meetings, or non-Gmail mail) and were skipped.\n",
 			},
 		} {
@@ -257,6 +259,7 @@ func TestStageDeleteCommand(t *testing.T) {
 						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
 							"cache_revision":      "cache-191",
 							"count":               3,
+							"deletable_count":     2,
 							"operation_token":     "operation-191",
 							"expires_at":          "2099-01-01T00:00:00Z",
 							"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},
@@ -321,6 +324,7 @@ func TestStageDeleteCommand(t *testing.T) {
 						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
 							"cache_revision":      "cache-191",
 							"count":               3,
+							"deletable_count":     3,
 							"operation_token":     "operation-191",
 							"expires_at":          "2099-01-01T00:00:00Z",
 							"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},
@@ -583,6 +587,7 @@ func newStageDeleteTestServerWithSchema(t *testing.T, wantQuery string, dryRun b
 		writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
 			"cache_revision":      "cache-191",
 			"count":               3,
+			"deletable_count":     3,
 			"operation_token":     "operation-191",
 			"expires_at":          "2099-01-01T00:00:00Z",
 			"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},

--- a/cmd/msgvault/cmd/stage_delete_test.go
+++ b/cmd/msgvault/cmd/stage_delete_test.go
@@ -89,7 +89,7 @@ func TestStageDeleteCommand(t *testing.T) {
 			dryRun:     true,
 			status:     http.StatusOK,
 			wantQuery:  "subject:receipt",
-			wantOutput: "Dry run: 3 message(s) match the search; no deletion batch was created.\n",
+			wantOutput: "Dry run: 3 message(s) would be staged; no deletion batch was created.\n",
 		},
 		{
 			name:       "source_id",
@@ -220,13 +220,89 @@ func TestStageDeleteCommand(t *testing.T) {
 		require.ErrorContains(t, err, "msgvault build-cache")
 	})
 
+	// Issue #768: a mixed search stages its deletable subset, and the command
+	// names what it left out instead of reporting a quietly smaller number.
+	t.Run("reports_skipped_non_deletable_matches", func(t *testing.T) {
+		for _, tt := range []struct {
+			name       string
+			dryRun     bool
+			status     int
+			wantOutput string
+		}{
+			{
+				name: "staged", status: http.StatusCreated,
+				wantOutput: "Staged 2 message(s) for deletion in batch batch-191.\n" +
+					"1 of 3 matching item(s) cannot be deleted from their source (chats, meetings, or non-Gmail mail) and were skipped.\n" +
+					"Review with 'msgvault show-deletion batch-191', then execute with 'msgvault delete-staged batch-191'.\n",
+			},
+			{
+				name: "dry_run", dryRun: true, status: http.StatusOK,
+				wantOutput: "Dry run: 2 message(s) would be staged; no deletion batch was created.\n" +
+					"1 of 3 matching item(s) cannot be deleted from their source (chats, meetings, or non-Gmail mail) and were skipped.\n",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v1/cli/search":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{"results": []any{}})
+					case "/api/v1/explore":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+							"cache_revision":        "cache-191",
+							"rows":                  []any{},
+							"search_provenance":     map[string]any{"lexical_index_revision": "lex-191"},
+							"candidate_snapshot_id": "snapshot-191",
+						})
+					case "/api/v1/explore/preflight":
+						writeStageDeleteJSON(t, w, http.StatusOK, map[string]any{
+							"cache_revision":      "cache-191",
+							"count":               3,
+							"operation_token":     "operation-191",
+							"expires_at":          "2099-01-01T00:00:00Z",
+							"search_provenance":   map[string]any{"lexical_index_revision": "lex-191"},
+							"action_targets":      []any{},
+							"unavailable_actions": []any{},
+						})
+					case "/api/v1/deletions":
+						response := map[string]any{
+							"dry_run":       tt.dryRun,
+							"message_count": 2,
+							"matched_count": 3,
+							"skipped_count": 1,
+							"account":       "alice@example.com",
+						}
+						if !tt.dryRun {
+							response["id"] = "batch-191"
+							response["status"] = "pending"
+						}
+						writeStageDeleteJSON(t, w, tt.status, response)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				defer server.Close()
+				withStoreResolverConfig(t, &config.Config{
+					Remote: config.RemoteConfig{URL: server.URL, AllowInsecure: true},
+				})
+
+				var stdout bytes.Buffer
+				root := newRegisteredStageDeleteTestRoot(t)
+				root.SetOut(&stdout)
+				root.SetArgs(append([]string{"stage-delete", "subject:receipt"}, boolFlag(tt.dryRun, "--dry-run")...))
+
+				require.NoError(t, root.Execute())
+				assert.Equal(t, tt.wantOutput, stdout.String())
+			})
+		}
+	})
+
 	t.Run("staging_rejections_guide_narrowing", func(t *testing.T) {
 		for _, tt := range []struct {
 			name string
 			code string
 			want string
 		}{
-			{name: "non_deletable", code: "selection_not_deletable", want: "message_type:email"},
+			{name: "non_deletable", code: "selection_not_deletable", want: "nothing the search matched can be deleted"},
 			{name: "multi_source", code: "multi_account_selection", want: "once per source with --source-id"},
 		} {
 			t.Run(tt.name, func(t *testing.T) {
@@ -663,7 +739,7 @@ func TestStageDeleteCommandByIDs(t *testing.T) {
 		assert.Nil(request.OperationToken)
 		assert.Nil(request.Selection)
 		assert.Equal([]string{"/api/v1/deletions"}, routes)
-		assert.Equal("Dry run: 3 message(s) match the requested IDs; no deletion batch was created.\n", stdout.String())
+		assert.Equal("Dry run: 3 message(s) would be staged; no deletion batch was created.\n", stdout.String())
 	})
 
 	t.Run("multi_source", func(t *testing.T) {

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -1397,6 +1397,7 @@ explore contract is in the generated OpenAPI document (`/openapi.json`).
 ```json
 {
   "count": 1234,
+  "deletable_count": 1200,
   "estimated_bytes": 52428800,
   "cache_revision": "<current cache revision>",
   "search_provenance": {},
@@ -1409,6 +1410,10 @@ explore contract is in the generated OpenAPI document (`/openapi.json`).
   "expires_at": "2026-07-06T15:35:00Z"
 }
 ```
+
+`count` includes all selected items after exclusions. `deletable_count` is the
+Gmail subset that can be staged; the difference is the number of items staging
+will skip. A chat conversation counts as one item.
 
 `unavailable_actions` lists actions this selection does not support. A
 `stage_deletion` entry means nothing in the selection can be deleted from its
@@ -1424,7 +1429,8 @@ reused or expired token is rejected with `409 operation_token_invalid`.
 
 Malformed selections return `400` with `invalid_selection` (bad `mode`,
 missing `cache_revision`, or `mode: "explicit"` without `row_keys`) or
-`invalid_selection_predicate`. If the analytical cache or search index changes
+`invalid_selection_predicate`. Malformed search operators return `400 invalid_query`.
+If the analytical cache or search index changes
 after the explore response was produced, preflight fails with
 `409 archive_revision_changed` or `409 search_revision_changed` — re-run
 explore and preflight against the new revision. Staging repeats all of these
@@ -1529,7 +1535,7 @@ re-evaluated filter — is what gets staged:
 1. `POST /api/v1/explore` with the predicate; review the rows and note
    `cache_revision` (plus `search_provenance` and `candidate_snapshot_id` for
    search-backed predicates).
-2. `POST /api/v1/explore/preflight` with the `selection`; review `count` and
+2. `POST /api/v1/explore/preflight` with the `selection`; review `count`, `deletable_count`, and
    `estimated_bytes`, and keep the `operation_token`.
 3. `POST /api/v1/deletions` with the same `selection` and the token:
 

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -1411,9 +1411,10 @@ explore contract is in the generated OpenAPI document (`/openapi.json`).
 ```
 
 `unavailable_actions` lists actions this selection does not support. A
-`stage_deletion` entry means the selection includes items that cannot be
-deleted from their source; staging it would fail with
-`409 selection_not_deletable`.
+`stage_deletion` entry means nothing in the selection can be deleted from its
+source; staging it would fail with `409 selection_not_deletable`. A selection
+that mixes deletable and non-deletable items carries no entry: staging takes
+the deletable subset and reports the rest as skipped.
 
 The `operation_token` is bound to this exact selection, its match count, and
 the current cache revision. It expires at `expires_at` (five minutes after
@@ -1550,13 +1551,35 @@ re-evaluated filter — is what gets staged:
 }
 ```
 
-The response is the same `201` manifest shape as above. `selection` cannot be
-combined with `filter` or `message_ids` (`400 invalid_request`). The server
-re-validates the selection against the preflight grant before staging: the
-selection, its match count, and the cache/search revisions must be unchanged,
-and every selected item must be deletable. `"dry_run": true` may be combined
-with a selection to preview the resolved count and sample; the token is
-validated but not consumed.
+The response is the same `201` manifest shape as above, plus `matched_count`
+and `skipped_count`:
+
+```json
+{
+  "dry_run": false,
+  "message_count": 2,
+  "matched_count": 3,
+  "skipped_count": 1,
+  "account": "you@gmail.com",
+  "source": {"id": 1, "type": "gmail", "identifier": "you@gmail.com"},
+  "id": "20260706-153000-old-example-com-mail-a1b2",
+  "status": "pending"
+}
+```
+
+`message_count` is the staged subset, `matched_count` the reviewed match set,
+and `skipped_count` the items no source supports deleting. Deletion covers
+Gmail-source email, so a mixed selection stages its Gmail rows and reports the
+rest as skipped rather than failing; only a selection with nothing deletable
+returns `409 selection_not_deletable`. Legacy Gmail rows with a blank
+`message_type` count as email.
+
+`selection` cannot be combined with `filter` or `message_ids`
+(`400 invalid_request`). The server re-validates the selection against the
+preflight grant before staging: the selection, its match count, and the
+cache/search revisions must be unchanged. `"dry_run": true` may be combined
+with a selection to preview the same staged subset, counts, and sample; the
+token is validated but not consumed.
 
 #### Errors
 
@@ -1571,7 +1594,8 @@ validated but not consumed.
 | `409` | `operation_token_invalid` | Token expired, already used, or does not match the selection, count, and revision |
 | `409` | `archive_revision_changed` | The analytical cache changed since preflight |
 | `409` | `search_revision_changed` | The search index revision changed since preflight |
-| `409` | `selection_not_deletable` | The selection contains items that cannot be deleted from their source |
+| `400` | `invalid_selection_predicate` | The predicate query carries an empty `from` / `to` / `cc` / `bcc` value |
+| `409` | `selection_not_deletable` | No item in the selection can be deleted from its source |
 | `409` | `selection_changed` | The matching messages changed between preflight and staging |
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -168,6 +168,12 @@ All notable changes to msgvault, grouped by release.
   archives from exhausting the interactive DuckDB memory budget.
 - WhatsApp vCard imports skip phone values without explicit international `+`
   or `00` provenance.
+- Deletion staging over a search that also matches chats, meetings, or
+  non-Gmail mail now stages the deletable subset and reports the skipped count
+  instead of rejecting the whole selection, dry run included. `message_type:email`
+  matches legacy Gmail rows whose stored type is blank, as the search
+  documentation already described, and an empty `from` / `to` / `cc` / `bcc`
+  value in a deletion selection is rejected instead of matching everything.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -173,7 +173,7 @@ All notable changes to msgvault, grouped by release.
   instead of rejecting the whole selection, dry run included. `message_type:email`
   matches legacy Gmail rows whose stored type is blank, as the search
   documentation already described, and an empty `from` / `to` / `cc` / `bcc`
-  value in a deletion selection is rejected instead of matching everything.
+  value in a search is rejected instead of matching everything.
 
 ---
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2028,16 +2028,21 @@ exclusive, and `--ids` is also mutually exclusive with `--source-id`.
 
 | Flag | Description |
 |---|---|
-| `--dry-run` | Show the match count without creating a deletion batch |
+| `--dry-run` | Show the staged subset and skipped counts without creating a deletion batch |
 | `--source-id ID` | Restrict staging to one exact source ID |
 | `--ids IDS` | Stage positive, unique, comma-separated internal message IDs instead of a query |
 
-Deletion staging covers Gmail-source email only. The daemon rejects a selection
-that includes anything else — chats, meetings, calendar entries, or mail from
-non-Gmail sources such as Apple Mail imports — rather than staging a subset of
-what matched. Narrow the search until it matches only deletable mail, for
-example with `message_type:email` in the query and `--source-id` for the Gmail
-source. This query narrowing guidance applies to query mode. In ID mode, the
+The query resolves with the same search semantics as `msgvault search`, and
+`--dry-run` prints the set that staging would create.
+
+Deletion staging covers Gmail-source email only. A search that also matches
+chats, meetings, calendar entries, or mail from non-Gmail sources such as Apple
+Mail imports stages the Gmail subset and reports how many items it skipped. Only
+a search with nothing deletable in it is refused. Legacy Gmail messages imported
+before message types existed carry a blank type and count as email, so
+`message_type:email` stages them too.
+
+In ID mode, the
 daemon resolves live Gmail targets and source boundaries for the requested IDs;
 IDs that do not resolve to live deletable Gmail messages with provider message
 IDs are omitted, so the

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2032,6 +2032,10 @@ exclusive, and `--ids` is also mutually exclusive with `--source-id`.
 | `--source-id ID` | Restrict staging to one exact source ID |
 | `--ids IDS` | Stage positive, unique, comma-separated internal message IDs instead of a query |
 
+Query staging requires daemon API schema 2.18.0 or newer so the preflight
+reports the exact deletable subset. Upgrade the daemon if the CLI rejects its
+schema version.
+
 The query resolves with the same search semantics as `msgvault search`, and
 `--dry-run` prints the set that staging would create.
 

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -12,6 +12,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/search"
 )
 
 // stageDeletionSampleSize caps the dry-run Gmail-ID preview.
@@ -99,9 +100,14 @@ type StageDeletionRequest struct {
 }
 
 // StageDeletionResponse covers both dry-run (200) and create (201).
+// MessageCount is the staged subset. MatchedCount and SkippedCount are
+// reported for reviewed selections, where the match set may contain items
+// no source supports deleting.
 type StageDeletionResponse struct {
 	DryRun         bool                      `json:"dry_run"`
 	MessageCount   int                       `json:"message_count"`
+	MatchedCount   int                       `json:"matched_count,omitempty"`
+	SkippedCount   int                       `json:"skipped_count,omitempty"`
 	Account        string                    `json:"account,omitempty"`
 	SampleGmailIDs []string                  `json:"sample_gmail_ids,omitempty"`
 	ID             string                    `json:"id,omitempty"`
@@ -187,9 +193,10 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 
 	var targets []query.DeletionTarget
 	var claim *deletionOperationClaim
+	var matched int
 	if req.Selection != nil {
 		var ok bool
-		targets, claim, ok = s.resolveAuthorizedDeletionSelection(w, r, *req.Selection, req.OperationToken)
+		targets, claim, matched, ok = s.resolveAuthorizedDeletionSelection(w, r, *req.Selection, req.OperationToken)
 		if !ok {
 			return
 		}
@@ -222,6 +229,8 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, StageDeletionResponse{
 			DryRun:         true,
 			MessageCount:   len(gmailIDs),
+			MatchedCount:   matched,
+			SkippedCount:   max(matched-len(gmailIDs), 0),
 			Account:        account,
 			Source:         source,
 			SampleGmailIDs: sample,
@@ -272,6 +281,8 @@ func (s *Server) handleStageDeletion(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusCreated, StageDeletionResponse{
 		MessageCount: len(gmailIDs),
+		MatchedCount: matched,
+		SkippedCount: max(matched-len(gmailIDs), 0),
 		Account:      account,
 		ID:           manifest.ID,
 		Status:       string(manifest.Status),
@@ -319,42 +330,48 @@ func (c *deletionOperationClaim) rollback() { c.state.rollbackOperation(c.token)
 // resolveAuthorizedDeletionSelection validates the reviewed selection
 // against the preflight grant without consuming it; the returned claim
 // lets the caller reserve/commit/rollback the token around manifest
-// persistence.
+// persistence. The returned targets are the deletable subset of the
+// reviewed match set, and the returned count is the full match set so the
+// caller can report what was left out.
 func (s *Server) resolveAuthorizedDeletionSelection(
 	w http.ResponseWriter,
 	r *http.Request,
 	selection ExploreSelection,
 	token string,
-) ([]query.DeletionTarget, *deletionOperationClaim, bool) {
+) ([]query.DeletionTarget, *deletionOperationClaim, int, bool) {
 	if token == "" {
 		writeError(w, http.StatusPreconditionRequired, "preflight_required",
 			"operation_token from deletion preflight is required")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	if selection.Mode != "explicit" && selection.Mode != "all_matching" {
 		writeError(w, http.StatusBadRequest, "invalid_selection", "selection mode must be explicit or all_matching")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	predicate, err := s.prepareResolvedExplorePredicate(r.Context(), selection.Predicate)
 	if err != nil {
 		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
-		return nil, nil, false
+		return nil, nil, 0, false
+	}
+	if httpErr := validateSelectionAddressFilters(predicate.request.Query); httpErr != nil {
+		writeAPIHTTPError(w, httpErr)
+		return nil, nil, 0, false
 	}
 	if selection.CacheRevision == "" {
 		writeError(w, http.StatusBadRequest, "invalid_selection", "cache_revision is required")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	if predicate.request.SearchMode == exploreSearchModeSemantic || predicate.request.SearchMode == exploreSearchModeHybrid {
 		if selection.CandidateSnapshotID == "" {
 			writeError(w, http.StatusBadRequest, "candidate_snapshot_required",
 				"Semantic and hybrid deletion staging require the server-issued candidate snapshot")
-			return nil, nil, false
+			return nil, nil, 0, false
 		}
 		predicate.request.CandidateSnapshotID = selection.CandidateSnapshotID
 	}
 	searchSpec, _, resolved := s.resolveExploreSearch(r.Context(), w, predicate.request)
 	if !resolved || !requireCompleteCandidatePool(w, searchSpec) {
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	predicate.query.Search = searchSpec
 	selectionRequest := query.ExploreSelectionRequest{
@@ -363,7 +380,7 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	if selection.Mode == "explicit" {
 		if selection.RowKeys == nil {
 			writeError(w, http.StatusBadRequest, "invalid_selection", "explicit selection requires row_keys")
-			return nil, nil, false
+			return nil, nil, 0, false
 		}
 		selectionRequest.IncludedKeys = selection.RowKeys
 	}
@@ -371,60 +388,85 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	analyzer, ok := engine.(query.Explorer)
 	if !ok {
 		s.writeExploreUnavailable(r.Context(), w, query.CacheAbsent)
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	stats, err := analyzer.ExploreSelectionStats(r.Context(), selectionRequest)
 	if err != nil {
 		s.writeExploreError(r.Context(), w, err)
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	if selection.CacheRevision != stats.CacheRevision {
 		writeError(w, http.StatusConflict, "archive_revision_changed", "The committed analytical cache changed; run preflight again")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	if searchSpec.Mode != query.SearchNone && !sameSearchProvenance(selection.SearchProvenance, stats.SearchProvenance) {
 		writeError(w, http.StatusConflict, "search_revision_changed", "The search index revision changed; run preflight again")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	selectionHash := hashCanonicalValue(&selection, false)
 	state := s.exploreState
 	if state == nil {
 		writeError(w, http.StatusConflict, "operation_token_invalid", "Deletion preflight expired; run preflight again")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	grant, authorized := state.operation(token, selectionHash)
 	if !authorized || grant.Revision != stats.CacheRevision || grant.Count != stats.Count {
 		writeError(w, http.StatusConflict, "operation_token_invalid", "Deletion preflight expired or no longer matches; run preflight again")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	if stats.Count == 0 {
 		writeError(w, http.StatusBadRequest, "no_messages_matched", "No messages matched the reviewed selection")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
-	if stats.DeletableCount != stats.Count {
+	// A mixed selection stages its deletable subset instead of failing as a
+	// whole. Only a selection with nothing deletable is a dead end.
+	if stats.DeletableCount == 0 {
 		writeError(w, http.StatusConflict, "selection_not_deletable",
-			"The reviewed selection contains items that cannot be deleted from their source")
-		return nil, nil, false
+			"No item in the reviewed selection can be deleted from its source")
+		return nil, nil, 0, false
 	}
 	resolver, ok := engine.(deletionMessageIDResolver)
 	if !ok {
 		writeError(w, http.StatusServiceUnavailable, "engine_unavailable",
 			"selection deletion staging is not supported by this query engine")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	targets, err := resolver.GetDeletionTargetsByMessageIDs(r.Context(), stats.DeletableMessageIDs)
 	if err != nil {
 		s.logger.Error("stage deletion selection resolution failed", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error", "Gmail ID query failed")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
-	if int64(len(targets)) != stats.Count {
+	if int64(len(targets)) != stats.DeletableCount {
 		writeError(w, http.StatusConflict, "selection_changed",
 			"The reviewed selection changed before staging; run preflight again")
-		return nil, nil, false
+		return nil, nil, 0, false
 	}
 	claim := &deletionOperationClaim{state: state, token: token, selectionHash: selectionHash}
-	return targets, claim, true
+	return targets, claim, int(stats.Count), true
+}
+
+// validateSelectionAddressFilters rejects address operators whose value is
+// empty or whitespace-only. The store renders those as LIKE '%%', which
+// widens a deletion selection to the whole archive instead of narrowing it.
+func validateSelectionAddressFilters(queryText string) *apiHTTPError {
+	if strings.TrimSpace(queryText) == "" {
+		return nil
+	}
+	// A query that fails to parse carries its own error from the search
+	// resolver, so only a parsed query is worth inspecting here.
+	parsed := search.Parse(queryText)
+	if parsed.Err() == nil {
+		for _, values := range [][]string{parsed.FromAddrs, parsed.ToAddrs, parsed.CcAddrs, parsed.BccAddrs} {
+			for _, value := range values {
+				if strings.TrimSpace(value) == "" {
+					return newAPIHTTPError(http.StatusBadRequest, "invalid_selection_predicate",
+						"address filters (from, to, cc, bcc) require a non-empty value")
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // resolveStageDeletionTargets unions filter-resolved and explicitly selected

--- a/internal/api/deletions.go
+++ b/internal/api/deletions.go
@@ -12,7 +12,6 @@ import (
 
 	"go.kenn.io/msgvault/internal/deletion"
 	"go.kenn.io/msgvault/internal/query"
-	"go.kenn.io/msgvault/internal/search"
 )
 
 // stageDeletionSampleSize caps the dry-run Gmail-ID preview.
@@ -353,10 +352,6 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
 		return nil, nil, 0, false
 	}
-	if httpErr := validateSelectionAddressFilters(predicate.request.Query); httpErr != nil {
-		writeAPIHTTPError(w, httpErr)
-		return nil, nil, 0, false
-	}
 	if selection.CacheRevision == "" {
 		writeError(w, http.StatusBadRequest, "invalid_selection", "cache_revision is required")
 		return nil, nil, 0, false
@@ -444,29 +439,6 @@ func (s *Server) resolveAuthorizedDeletionSelection(
 	}
 	claim := &deletionOperationClaim{state: state, token: token, selectionHash: selectionHash}
 	return targets, claim, int(stats.Count), true
-}
-
-// validateSelectionAddressFilters rejects address operators whose value is
-// empty or whitespace-only. The store renders those as LIKE '%%', which
-// widens a deletion selection to the whole archive instead of narrowing it.
-func validateSelectionAddressFilters(queryText string) *apiHTTPError {
-	if strings.TrimSpace(queryText) == "" {
-		return nil
-	}
-	// A query that fails to parse carries its own error from the search
-	// resolver, so only a parsed query is worth inspecting here.
-	parsed := search.Parse(queryText)
-	if parsed.Err() == nil {
-		for _, values := range [][]string{parsed.FromAddrs, parsed.ToAddrs, parsed.CcAddrs, parsed.BccAddrs} {
-			for _, value := range values {
-				if strings.TrimSpace(value) == "" {
-					return newAPIHTTPError(http.StatusBadRequest, "invalid_selection_predicate",
-						"address filters (from, to, cc, bcc) require a non-empty value")
-				}
-			}
-		}
-	}
-	return nil
 }
 
 // resolveStageDeletionTargets unions filter-resolved and explicitly selected

--- a/internal/api/deletions_test.go
+++ b/internal/api/deletions_test.go
@@ -435,6 +435,128 @@ func TestStageDeletionConcurrentDoubleSubmitStagesExactlyOnce(t *testing.T) {
 	assertions.Equal([]string{"m2"}, st.saved[0].GmailIDs)
 }
 
+// mixedDeletabilityFixtureMessages puts a live Gmail email, a calendar event,
+// and a legacy blank-typed Gmail email in one source, so a selection over the
+// source matches three items of which two can be deleted.
+const mixedDeletabilityFixtureMessages = `(1::BIGINT, 1::BIGINT, 'm1', 101::BIGINT, 'Receipt', 'alpha', TIMESTAMP '2026-07-18 10:00:00', 100::BIGINT, true, 1::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, NULL::BIGINT, 'email', NULL::VARCHAR, false, 2026, 7),
+	(2::BIGINT, 1::BIGINT, 'm2', 102::BIGINT, 'Standup', 'beta', TIMESTAMP '2026-07-18 11:00:00', 200::BIGINT, true, 1::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, NULL::BIGINT, 'calendar_event', NULL::VARCHAR, false, 2026, 7),
+	(3::BIGINT, 1::BIGINT, 'm3', 103::BIGINT, 'Old receipt', 'gamma', TIMESTAMP '2026-07-18 09:00:00', 300::BIGINT, false, 0::INTEGER, NULL::TIMESTAMP, NULL::BIGINT, NULL::BIGINT, '', NULL::VARCHAR, false, 2026, 7)`
+
+// TestStageDeletionStagesDeletableSubsetOfMixedSelection is the issue #768
+// reproduction: a search that also matches items no source can delete used to
+// reject the whole selection, dry run included. It must stage the deletable
+// subset instead and report what it left out, with the legacy blank-typed
+// Gmail row counted as email.
+func TestStageDeletionStagesDeletableSubsetOfMixedSelection(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	engine, _ := newExploreDuckDBFixtureWithMessages(t, mixedDeletabilityFixtureMessages, 3)
+	st := &deletionMockStore{}
+	srv := newDeletionTestServer(t, st, engine)
+
+	explore := postExploreJSON(t, srv, "/api/v1/explore", `{"filters":[{"dimension":"source","values":["1"]}]}`)
+	requirements.Equal(http.StatusOK, explore.Code, explore.Body.String())
+	var explored struct {
+		CacheRevision string `json:"cache_revision"`
+	}
+	requirements.NoError(json.Unmarshal(explore.Body.Bytes(), &explored))
+	selection := fmt.Sprintf(
+		`{"mode":"all_matching","predicate":{"filters":[{"dimension":"source","values":["1"]}]},"cache_revision":%q}`,
+		explored.CacheRevision)
+
+	preflight := postExploreJSON(t, srv, "/api/v1/explore/preflight", `{"selection":`+selection+`}`)
+	requirements.Equal(http.StatusOK, preflight.Code, preflight.Body.String())
+	var reviewed ExplorePreflightResponse
+	requirements.NoError(json.Unmarshal(preflight.Body.Bytes(), &reviewed))
+	assertions.Equal(int64(3), reviewed.Count, "all three items match")
+	assertions.NotContains(reviewed.UnavailableActions, ExploreUnavailableAction{
+		Action: "stage_deletion", Reason: "selection_contains_items_that_cannot_be_deleted_from_source",
+	}, "a partly deletable selection can still be staged")
+
+	dryRun := postDeletions(t, srv, fmt.Sprintf(
+		`{"selection":%s,"operation_token":%q,"dry_run":true}`, selection, reviewed.OperationToken))
+	requirements.Equal(http.StatusOK, dryRun.Code, dryRun.Body.String())
+	var preview StageDeletionResponse
+	requirements.NoError(json.Unmarshal(dryRun.Body.Bytes(), &preview))
+	assertions.True(preview.DryRun)
+	assertions.Equal(2, preview.MessageCount, "dry run previews the deletable subset")
+	assertions.Equal(3, preview.MatchedCount)
+	assertions.Equal(1, preview.SkippedCount)
+	assertions.ElementsMatch([]string{"m1", "m3"}, preview.SampleGmailIDs)
+	assertions.Empty(st.saved, "dry run persists nothing")
+
+	stage := postDeletions(t, srv, fmt.Sprintf(
+		`{"selection":%s,"operation_token":%q,"description":"mixed batch"}`, selection, reviewed.OperationToken))
+	requirements.Equal(http.StatusCreated, stage.Code, stage.Body.String())
+	var staged StageDeletionResponse
+	requirements.NoError(json.Unmarshal(stage.Body.Bytes(), &staged))
+	assertions.Equal(2, staged.MessageCount, "staging matches the dry run")
+	assertions.Equal(3, staged.MatchedCount)
+	assertions.Equal(1, staged.SkippedCount)
+	requirements.Len(st.saved, 1)
+	assertions.ElementsMatch([]string{"m1", "m3"}, st.saved[0].GmailIDs)
+}
+
+// TestStageDeletionRejectsSelectionWithNothingDeletable keeps the dead-end
+// case an error: partial staging only helps when something is stageable.
+func TestStageDeletionRejectsSelectionWithNothingDeletable(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	engine := newExploreDuckDBFixture(t)
+	st := &deletionMockStore{}
+	srv := newDeletionTestServer(t, st, engine)
+
+	explore := postExploreJSON(t, srv, "/api/v1/explore", `{"filters":[{"dimension":"source","values":["2"]}]}`)
+	requirements.Equal(http.StatusOK, explore.Code, explore.Body.String())
+	var explored struct {
+		CacheRevision string `json:"cache_revision"`
+	}
+	requirements.NoError(json.Unmarshal(explore.Body.Bytes(), &explored))
+	selection := fmt.Sprintf(
+		`{"mode":"all_matching","predicate":{"filters":[{"dimension":"source","values":["2"]}]},"cache_revision":%q}`,
+		explored.CacheRevision)
+
+	preflight := postExploreJSON(t, srv, "/api/v1/explore/preflight", `{"selection":`+selection+`}`)
+	requirements.Equal(http.StatusOK, preflight.Code, preflight.Body.String())
+	var reviewed ExplorePreflightResponse
+	requirements.NoError(json.Unmarshal(preflight.Body.Bytes(), &reviewed))
+	assertions.Contains(reviewed.UnavailableActions, ExploreUnavailableAction{
+		Action: "stage_deletion", Reason: "selection_contains_items_that_cannot_be_deleted_from_source",
+	})
+
+	stage := postDeletions(t, srv, fmt.Sprintf(
+		`{"selection":%s,"operation_token":%q}`, selection, reviewed.OperationToken))
+	assertions.Equal(http.StatusConflict, stage.Code, stage.Body.String())
+	assertions.Contains(stage.Body.String(), "selection_not_deletable")
+	assertions.Empty(st.saved)
+}
+
+// TestDeletionSelectionRejectsEmptyAddressFilter covers the widening form of
+// a narrowing typo: from: with no value renders as LIKE '%%' and would stage
+// the whole archive.
+func TestDeletionSelectionRejectsEmptyAddressFilter(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	engine := newExploreDuckDBFixture(t)
+	st := &deletionMockStore{}
+	srv := newDeletionTestServer(t, st, engine)
+
+	for _, queryText := range []string{"from:", `to:"   "`, `cc:""`, "bcc:"} {
+		selection := fmt.Sprintf(
+			`{"mode":"all_matching","predicate":{"query":%q,"search_mode":"full_text","filters":[{"dimension":"source","values":["1"]}]},"cache_revision":"cache-1"}`,
+			queryText)
+
+		preflight := postExploreJSON(t, srv, "/api/v1/explore/preflight", `{"selection":`+selection+`}`)
+		assertions.Equal(http.StatusBadRequest, preflight.Code, "query %q -> preflight status", queryText)
+		assertions.Contains(preflight.Body.String(), "invalid_selection_predicate", "query %q -> preflight code", queryText)
+
+		stage := postDeletions(t, srv, `{"selection":`+selection+`,"operation_token":"token-1"}`)
+		assertions.Equal(http.StatusBadRequest, stage.Code, "query %q -> stage status", queryText)
+		assertions.Contains(stage.Body.String(), "invalid_selection_predicate", "query %q -> stage code", queryText)
+	}
+	requirements.Empty(st.saved, "nothing staged from a wildcard address filter")
+}
+
 func TestStageDeletionRejectsEmptyFilter(t *testing.T) {
 	st := &deletionMockStore{}
 	srv := newDeletionTestServer(t, st, &querytest.MockEngine{})

--- a/internal/api/deletions_test.go
+++ b/internal/api/deletions_test.go
@@ -469,6 +469,7 @@ func TestStageDeletionStagesDeletableSubsetOfMixedSelection(t *testing.T) {
 	var reviewed ExplorePreflightResponse
 	requirements.NoError(json.Unmarshal(preflight.Body.Bytes(), &reviewed))
 	assertions.Equal(int64(3), reviewed.Count, "all three items match")
+	assertions.Equal(int64(2), reviewed.DeletableCount, "preflight discloses the deletable subset")
 	assertions.NotContains(reviewed.UnavailableActions, ExploreUnavailableAction{
 		Action: "stage_deletion", Reason: "selection_contains_items_that_cannot_be_deleted_from_source",
 	}, "a partly deletable selection can still be staged")
@@ -546,13 +547,17 @@ func TestDeletionSelectionRejectsEmptyAddressFilter(t *testing.T) {
 			`{"mode":"all_matching","predicate":{"query":%q,"search_mode":"full_text","filters":[{"dimension":"source","values":["1"]}]},"cache_revision":"cache-1"}`,
 			queryText)
 
+		explore := postExploreJSON(t, srv, "/api/v1/explore", fmt.Sprintf(`{"query":%q,"search_mode":"full_text"}`, queryText))
+		assertions.Equal(http.StatusBadRequest, explore.Code, explore.Body.String())
+		assertions.Contains(explore.Body.String(), "non-empty address filter")
+
 		preflight := postExploreJSON(t, srv, "/api/v1/explore/preflight", `{"selection":`+selection+`}`)
 		assertions.Equal(http.StatusBadRequest, preflight.Code, "query %q -> preflight status", queryText)
-		assertions.Contains(preflight.Body.String(), "invalid_selection_predicate", "query %q -> preflight code", queryText)
+		assertions.Contains(preflight.Body.String(), "invalid_query", "query %q -> preflight code", queryText)
 
 		stage := postDeletions(t, srv, `{"selection":`+selection+`,"operation_token":"token-1"}`)
 		assertions.Equal(http.StatusBadRequest, stage.Code, "query %q -> stage status", queryText)
-		assertions.Contains(stage.Body.String(), "invalid_selection_predicate", "query %q -> stage code", queryText)
+		assertions.Contains(stage.Body.String(), "invalid_query", "query %q -> stage code", queryText)
 	}
 	requirements.Empty(st.saved, "nothing staged from a wildcard address filter")
 }

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -540,6 +540,10 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
 		return
 	}
+	if httpErr := validateSelectionAddressFilters(predicate.request.Query); httpErr != nil {
+		writeAPIHTTPError(w, httpErr)
+		return
+	}
 	if selection.CacheRevision == "" {
 		writeError(w, http.StatusBadRequest, "invalid_selection", "cache_revision is required")
 		return
@@ -592,7 +596,9 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 	token := state.issueOperation(selectionHash, stats.Count, stats.CacheRevision)
 	unavailableActions := make([]ExploreUnavailableAction, 0, 4)
 	actionTargets := make([]ExploreActionTarget, 0, 1)
-	if stats.DeletableCount != stats.Count {
+	// Staging takes the deletable subset of a mixed selection, so only a
+	// selection with nothing deletable makes the action unavailable.
+	if stats.DeletableCount == 0 {
 		unavailableActions = append(unavailableActions, ExploreUnavailableAction{
 			Action: "stage_deletion", Reason: "selection_contains_items_that_cannot_be_deleted_from_source",
 		})

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -175,6 +175,7 @@ type ExploreActionTarget struct {
 }
 
 type ExplorePreflightResponse struct {
+	DeletableCount      int64                      `json:"deletable_count"`
 	Count               int64                      `json:"count"`
 	EstimatedBytes      int64                      `json:"estimated_bytes"`
 	CacheRevision       string                     `json:"cache_revision"`
@@ -540,10 +541,6 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		s.writeExploreFilterError(w, err, "invalid_selection_predicate")
 		return
 	}
-	if httpErr := validateSelectionAddressFilters(predicate.request.Query); httpErr != nil {
-		writeAPIHTTPError(w, httpErr)
-		return
-	}
 	if selection.CacheRevision == "" {
 		writeError(w, http.StatusBadRequest, "invalid_selection", "cache_revision is required")
 		return
@@ -638,7 +635,8 @@ func (s *Server) handleExplorePreflight(w http.ResponseWriter, r *http.Request) 
 		Action: "open_in_source", Reason: "trusted_source_link_unavailable",
 	})
 	writeJSON(w, http.StatusOK, ExplorePreflightResponse{
-		Count: stats.Count, EstimatedBytes: stats.EstimatedBytes, CacheRevision: stats.CacheRevision,
+		DeletableCount: stats.DeletableCount,
+		Count:          stats.Count, EstimatedBytes: stats.EstimatedBytes, CacheRevision: stats.CacheRevision,
 		SearchProvenance: stats.SearchProvenance, UnavailableActions: unavailableActions,
 		ActionTargets:  actionTargets,
 		OperationToken: token, ExpiresAt: state.now().Add(exploreOperationTokenTTL),

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -272,7 +272,10 @@ import (
 // closed when an older daemon ignores an additive source scope instead of
 // widening the result to all sources. Text search also accepts source_id
 // and confirms it with applied_source_id.
-const APISchemaVersion = "2.17.0"
+// 2.18.0 adds deletable_count to selection preflight and matched/skipped
+// counts to deletion staging. Query staging accepts the deletable subset of
+// mixed selections; clients can disclose that subset before confirmation.
+const APISchemaVersion = "2.18.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -34,8 +34,8 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 	assert.NotEmpty(t, doc.Paths, "paths")
 }
 
-func TestOpenAPISchemaVersionAsyncImportsIs2160(t *testing.T) {
-	assert.Equal(t, "2.17.0", APISchemaVersion)
+func TestOpenAPISchemaVersionDeletionSubsetIs2180(t *testing.T) {
+	assert.Equal(t, "2.18.0", APISchemaVersion)
 }
 
 func TestOpenAPIImportJobContract(t *testing.T) {
@@ -192,7 +192,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.17.0", APISchemaVersion)
+	assert.Equal("2.18.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -214,11 +214,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.17.0", APISchemaVersion)
+	assert.Equal(t, "2.18.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.17.0", APISchemaVersion)
+	assert.Equal(t, "2.18.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -242,7 +242,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.17.0", APISchemaVersion,
+	assert.Equal(t, "2.18.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -566,7 +566,7 @@ func TestOpenAPISearchDocumentsConversationID(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.17.0", APISchemaVersion,
+	assert.Equal("2.18.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -680,7 +680,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.17.0", APISchemaVersion,
+	assertions.Equal("2.18.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -700,7 +700,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.17.0", APISchemaVersion,
+	assert.Equal("2.18.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -728,7 +728,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.17.0", APISchemaVersion,
+	assertions.Equal("2.18.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -778,9 +778,9 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// scope in 2.12.0, Directory people and deduplicate planning in 2.13.0,
 	// CardDAV status and run history plus List-ID filtering in 2.14.0, Gmail
 	// repair in 2.15.0, complete TUI search and statistics contracts plus
-	// historical import jobs in 2.16.0, and collection source scopes in 2.17.0
-	// did not touch it.
-	assert.Equal("2.17.0", APISchemaVersion, "meeting import is an additive schema release")
+	// historical import jobs in 2.16.0, collection source scopes in 2.17.0,
+	// and deletion subset counts in 2.18.0 did not touch it.
+	assert.Equal("2.18.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]

--- a/internal/api/relationship_calendar_test.go
+++ b/internal/api/relationship_calendar_test.go
@@ -177,7 +177,7 @@ func TestRelationshipCalendarRequestRejectsTrailingJSON(t *testing.T) {
 func TestRelationshipCalendarOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.Equal("2.17.0", APISchemaVersion)
+	assert.Equal("2.18.0", APISchemaVersion)
 	document := OpenAPIDocument()
 	path := document.Paths["/api/v1/relationships/{id}/calendar"]
 	require.NotNil(path)

--- a/internal/query/explore.go
+++ b/internal/query/explore.go
@@ -873,7 +873,7 @@ func exploreLogicalEntriesCTE(withParticipantLists bool) string {
 		CASE WHEN candidate_rank IS NOT NULL THEN message_id ELSE NULL END AS strongest_matched_message_id,
 		1::BIGINT AS message_count,
 		(size_estimate + attachment_size)::BIGINT AS estimated_bytes,
-		(entry_kind = 'email' AND lower(source_type) = 'gmail' AND NOT deleted_from_source
+		(entry_kind = 'email' AND lower(source_type) = 'gmail' AND NOT internally_deleted AND NOT deleted_from_source
 			AND COALESCE(source_message_id, '') <> '') AS deletable,
 		has_attachments,
 		is_from_me,

--- a/internal/query/explore_analysis_test.go
+++ b/internal/query/explore_analysis_test.go
@@ -360,6 +360,33 @@ func TestExploreSelectionStatsCanResolveExactDeletableMessageIDs(t *testing.T) {
 	assertions.NotContains(result.DeletableMessageIDs, first)
 }
 
+func TestExploreSelectionStatsExcludesDedupHiddenDeletionTargets(t *testing.T) {
+	for _, deletion := range []DeletionFilter{DeletionAny, DeletionActive} {
+		t.Run(string(deletion), func(t *testing.T) {
+			b := NewTestDataBuilder(t)
+			source := b.AddSource("archive@example.com")
+			live := b.AddMessage(MessageOpt{SourceID: source, Subject: "Live message"})
+			hiddenAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			b.AddMessage(MessageOpt{SourceID: source, Subject: "Hidden duplicate", InternalDeletedAt: &hiddenAt})
+			engine := b.BuildEngine()
+
+			stats, err := engine.ExploreSelectionStats(context.Background(), ExploreSelectionRequest{
+				Explore:                    ExploreRequest{Context: Context{Deletion: deletion}},
+				IncludeDeletableMessageIDs: true,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, int64(2), stats.Count, "the selection still includes both matching entries")
+			assert.Equal(t, int64(1), stats.DeletableCount, "only the live message can be staged")
+			assert.Equal(t, []int64{live}, stats.DeletableMessageIDs)
+
+			targets, err := engine.GetDeletionTargetsByMessageIDs(context.Background(), stats.DeletableMessageIDs)
+			require.NoError(t, err)
+			require.Len(t, targets, 1)
+			assert.Equal(t, stats.DeletableCount, int64(len(targets)), "preflight and staging resolve the same subset")
+		})
+	}
+}
+
 func TestExploreSelectionStatsCanResolveExactRawExportMessageID(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)

--- a/internal/query/explore_analysis_test.go
+++ b/internal/query/explore_analysis_test.go
@@ -363,6 +363,8 @@ func TestExploreSelectionStatsCanResolveExactDeletableMessageIDs(t *testing.T) {
 func TestExploreSelectionStatsExcludesDedupHiddenDeletionTargets(t *testing.T) {
 	for _, deletion := range []DeletionFilter{DeletionAny, DeletionActive} {
 		t.Run(string(deletion), func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
 			b := NewTestDataBuilder(t)
 			source := b.AddSource("archive@example.com")
 			live := b.AddMessage(MessageOpt{SourceID: source, Subject: "Live message"})
@@ -374,15 +376,15 @@ func TestExploreSelectionStatsExcludesDedupHiddenDeletionTargets(t *testing.T) {
 				Explore:                    ExploreRequest{Context: Context{Deletion: deletion}},
 				IncludeDeletableMessageIDs: true,
 			})
-			require.NoError(t, err)
-			assert.Equal(t, int64(2), stats.Count, "the selection still includes both matching entries")
-			assert.Equal(t, int64(1), stats.DeletableCount, "only the live message can be staged")
-			assert.Equal(t, []int64{live}, stats.DeletableMessageIDs)
+			requirements.NoError(err)
+			assertions.Equal(int64(2), stats.Count, "the selection still includes both matching entries")
+			assertions.Equal(int64(1), stats.DeletableCount, "only the live message can be staged")
+			assertions.Equal([]int64{live}, stats.DeletableMessageIDs)
 
 			targets, err := engine.GetDeletionTargetsByMessageIDs(context.Background(), stats.DeletableMessageIDs)
-			require.NoError(t, err)
-			require.Len(t, targets, 1)
-			assert.Equal(t, stats.DeletableCount, int64(len(targets)), "preflight and staging resolve the same subset")
+			requirements.NoError(err)
+			requirements.Len(targets, 1)
+			assertions.Equal(stats.DeletableCount, int64(len(targets)), "preflight and staging resolve the same subset")
 		})
 	}
 }

--- a/internal/search/parser.go
+++ b/internal/search/parser.go
@@ -393,6 +393,15 @@ func (p *Parser) Parse(queryStr string) *Query {
 		if op, value, ok := splitOperatorToken(token); ok {
 			value = unquote(value)
 
+			// Empty address filters would become LIKE '%%' in store searches.
+			// Reject the query instead of silently widening its match set.
+			switch op {
+			case "from", "to", "cc", "bcc":
+				if strings.TrimSpace(value) == "" {
+					q.parseErrs = append(q.parseErrs, operatorValueError(op, value, "expected a non-empty address filter"))
+					continue
+				}
+			}
 			if handler, ok := operators[op]; ok {
 				if err := handler(q, value, now); err != nil {
 					q.parseErrs = append(q.parseErrs, err)

--- a/internal/search/parser_test.go
+++ b/internal/search/parser_test.go
@@ -433,6 +433,10 @@ func TestParse_InvalidOperatorValues(t *testing.T) {
 		{"smaller bad size", "smaller:abc", "abc", "smaller:"},
 		{"older_than bad age", "older_than:99q", "99q", "older_than:"},
 		{"newer_than bad age", "newer_than:7z", "7z", "newer_than:"},
+		{"empty from", "from:", "non-empty address", "from:"},
+		{"empty to with text", `receipt to:""`, "non-empty address", "to:"},
+		{"whitespace cc", `cc:"   "`, "non-empty address", "cc:"},
+		{"empty bcc", "bcc:", "non-empty address", "bcc:"},
 		{"has bad value", "has:banana", "banana", "has:"},
 	}
 	for _, tc := range cases {

--- a/internal/store/api.go
+++ b/internal/store/api.go
@@ -656,15 +656,35 @@ func (s *Store) searchMessagesQueryImpl(
 		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
 
-	// message_type: / message_type= filter.
+	// message_type: / message_type= filter. An "email" value also matches an
+	// empty or NULL message_type. Rows imported before the column existed
+	// carry a blank value on current schemas and NULL on pre-constraint
+	// archives (see newLegacyNullableMessageTypeStore coverage); both count
+	// as email everywhere else (IsEmailMessageType, the analytical email
+	// filters), so a plain IN list would drop legacy mail from
+	// message_type:email searches.
 	if len(q.MessageTypes) > 0 {
-		placeholders := make([]string, len(q.MessageTypes))
-		for i, typ := range q.MessageTypes {
-			placeholders[i] = "?"
-			args = append(args, typ)
+		var parts, exact []string
+		for _, typ := range q.MessageTypes {
+			if IsEmailMessageType(typ) {
+				continue
+			}
+			exact = append(exact, typ)
 		}
-		conditions = append(conditions,
-			"m.message_type IN ("+strings.Join(placeholders, ",")+")")
+		if len(exact) < len(q.MessageTypes) {
+			parts = append(parts,
+				"(m.message_type = ? OR m.message_type = '' OR m.message_type IS NULL)")
+			args = append(args, MessageTypeEmail)
+		}
+		if len(exact) > 0 {
+			placeholders := make([]string, len(exact))
+			for i, typ := range exact {
+				placeholders[i] = "?"
+				args = append(args, typ)
+			}
+			parts = append(parts, "m.message_type IN ("+strings.Join(placeholders, ",")+")")
+		}
+		conditions = append(conditions, "("+strings.Join(parts, " OR ")+")")
 	}
 
 	// Account scoping (in: / API account/collection filter). The HTTP

--- a/internal/store/api_search_test.go
+++ b/internal/store/api_search_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil/storetest"
 )
 
@@ -184,6 +185,91 @@ func TestSearchMessagesQuery_MessageTypeFilter(t *testing.T) {
 	require.Len(msgs, 1, "messages")
 	assert.Equal("sms", msgs[0].MessageType, "MessageType")
 	assert.Equal(smsMsg, msgs[0].ID, "ID")
+}
+
+// TestSearchMessagesQuery_MessageTypeEmailIncludesLegacyBlankRows pins the
+// blank-type half of the email filter: Gmail messages imported before
+// message_type existed carry an empty value and must still answer
+// message_type:email, or narrowing a deletion search by type silently drops
+// exactly the oldest mail.
+func TestSearchMessagesQuery_MessageTypeEmailIncludesLegacyBlankRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := storetest.New(t)
+
+	typed := f.NewMessage().
+		WithSourceMessageID("typed-email").
+		WithSubject("receipt for lunch").
+		WithSnippet("typed").
+		Create(t, f.Store)
+	legacyBlank := f.NewMessage().
+		WithSourceMessageID("legacy-blank-email").
+		WithSubject("receipt for lunch").
+		WithSnippet("legacy blank").
+		Create(t, f.Store)
+	sms := f.NewMessage().
+		WithSourceMessageID("typed-sms").
+		WithSubject("receipt for lunch").
+		WithSnippet("text message").
+		Create(t, f.Store)
+
+	for id, value := range map[int64]string{legacyBlank: "", sms: "sms"} {
+		_, err := f.Store.DB().Exec(
+			f.Store.Rebind(`UPDATE messages SET message_type = ? WHERE id = ?`), value, id)
+		require.NoError(err, "set message_type for %d", id)
+	}
+	_, err := f.Store.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	msgs, total, err := f.Store.SearchMessagesQuery(search.Parse("message_type:email receipt"), 0, 50)
+	require.NoError(err, "SearchMessagesQuery")
+	got := make([]int64, 0, len(msgs))
+	for _, msg := range msgs {
+		got = append(got, msg.ID)
+	}
+	assert.ElementsMatch([]int64{typed, legacyBlank}, got, "legacy blank-typed rows match message_type:email")
+	assert.Equal(int64(2), total, "total")
+	assert.NotContains(got, sms, "typed non-email rows stay excluded")
+}
+
+// TestSearchMessagesQuery_MessageTypeEmailIncludesLegacyNullRows pins the
+// NULL half of the same legacy contract: archives written before the NOT
+// NULL constraint carry NULL message_type, and message_type:email must match
+// them exactly as the repair and analytical paths already do.
+func TestSearchMessagesQuery_MessageTypeEmailIncludesLegacyNullRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	st, sourceID, conversationID := newLegacyNullableMessageTypeStore(t)
+
+	typed, err := st.UpsertMessage(&store.Message{
+		SourceID: sourceID, ConversationID: conversationID,
+		SourceMessageID: "typed-email-null-fixture",
+		Subject:         sql.NullString{String: "receipt for lunch", Valid: true},
+		Snippet:         sql.NullString{String: "typed", Valid: true}, MessageType: store.MessageTypeEmail,
+	})
+	require.NoError(err, "create typed email")
+	legacyNull, err := st.UpsertMessage(&store.Message{
+		SourceID: sourceID, ConversationID: conversationID,
+		SourceMessageID: "legacy-null-email",
+		Subject:         sql.NullString{String: "receipt for lunch", Valid: true},
+		Snippet:         sql.NullString{String: "legacy null", Valid: true}, MessageType: store.MessageTypeEmail,
+	})
+	require.NoError(err, "create legacy email")
+	_, err = st.DB().Exec(st.Rebind(
+		`UPDATE messages SET message_type = NULL WHERE id = ?`), legacyNull)
+	require.NoError(err, "clear legacy message type")
+	_, err = st.BackfillFTS(nil)
+	require.NoError(err, "BackfillFTS")
+
+	msgs, total, err := st.SearchMessagesQuery(search.Parse("message_type:email receipt"), 0, 50)
+	require.NoError(err, "SearchMessagesQuery")
+	got := make([]int64, 0, len(msgs))
+	for _, msg := range msgs {
+		got = append(got, msg.ID)
+	}
+	assert.ElementsMatch([]int64{typed, legacyNull}, got,
+		"legacy NULL-typed rows match message_type:email")
+	assert.Equal(int64(2), total, "total")
 }
 
 // TestSearchMessagesQuery_ListIDFilters catches Store searches that treat

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -10174,8 +10174,10 @@ type StageDeletionResponse struct {
 	Account        *string          `json:"account,omitempty"`
 	DryRun         bool             `json:"dry_run"`
 	ID             *string          `json:"id,omitempty"`
+	MatchedCount   *int64           `json:"matched_count,omitempty"`
 	MessageCount   int64            `json:"message_count"`
 	SampleGmailIds []string         `json:"sample_gmail_ids,omitempty"`
+	SkippedCount   *int64           `json:"skipped_count,omitempty"`
 	Source         *SourceReference `json:"source,omitempty"`
 	Status         *string          `json:"status,omitempty"`
 }

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -3645,6 +3645,7 @@ type ExplorePreflightResponse struct {
 	ActionTargets       []ExploreActionTarget      `json:"action_targets" validate:"required"`
 	CacheRevision       string                     `json:"cache_revision" validate:"required"`
 	Count               int64                      `json:"count"`
+	DeletableCount      int64                      `json:"deletable_count"`
 	EstimatedBytes      int64                      `json:"estimated_bytes"`
 	ExpiresAt           time.Time                  `json:"expires_at" validate:"required"`
 	OperationToken      string                     `json:"operation_token" validate:"required"`

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -4041,6 +4041,9 @@ components:
         count:
           format: int64
           type: integer
+        deletable_count:
+          format: int64
+          type: integer
         estimated_bytes:
           format: int64
           type: integer
@@ -4058,6 +4061,7 @@ components:
             $ref: "#/components/schemas/ExploreUnavailableAction"
           type: array
       required:
+        - deletable_count
         - count
         - estimated_bytes
         - cache_revision

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -11524,7 +11524,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.17.0
+  version: 2.18.0
 openapi: 3.0.3
 paths:
   /api/ping:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -10442,6 +10442,9 @@ components:
           type: boolean
         id:
           type: string
+        matched_count:
+          format: int64
+          type: integer
         message_count:
           format: int64
           type: integer
@@ -10449,6 +10452,9 @@ components:
           items:
             type: string
           type: array
+        skipped_count:
+          format: int64
+          type: integer
         source:
           $ref: "#/components/schemas/SourceReference"
         status:

--- a/web/src/lib/api/generated/models/explorePreflightResponse.ts
+++ b/web/src/lib/api/generated/models/explorePreflightResponse.ts
@@ -9,6 +9,7 @@ export interface ExplorePreflightResponse {
   action_targets: ExploreActionTarget[];
   cache_revision: string;
   count: number;
+  deletable_count: number;
   estimated_bytes: number;
   expires_at: string;
   operation_token: string;

--- a/web/src/lib/api/generated/models/stageDeletionResponse.ts
+++ b/web/src/lib/api/generated/models/stageDeletionResponse.ts
@@ -7,8 +7,10 @@ export interface StageDeletionResponse {
   account?: string;
   dry_run: boolean;
   id?: string;
+  matched_count?: number;
   message_count: number;
   sample_gmail_ids?: string[];
+  skipped_count?: number;
   source?: SourceReference;
   status?: string;
   [key: string]: unknown;

--- a/web/src/lib/components/deletions/DeletionsWorkspace.svelte
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.svelte
@@ -14,11 +14,13 @@
     DeletionManifestSummary as GeneratedDeletionManifestSummary,
     ExplorePreflightResponse as GeneratedExplorePreflightResponse,
     ExploreSelection as GeneratedExploreSelection,
+    StageDeletionResponse as GeneratedStageDeletionResponse,
   } from '../../api/generated/models';
   type ExploreSelection = GeneratedExploreSelection;
   type Preflight = GeneratedExplorePreflightResponse;
   type ManifestSummary = GeneratedDeletionManifestSummary;
   type ManifestDetail = GeneratedDeletionManifestDetail;
+  type StageDeletionResponse = GeneratedStageDeletionResponse;
   let {
     client,
     selection = undefined,
@@ -37,7 +39,7 @@
   let loading = $state(true);
   let pending = $state(false);
   let error = $state('');
-  let preview = $state('');
+  let preview = $state<StageDeletionResponse>();
   let confirmStage = $state<'explicit' | 'all_matching'>();
   let confirmCancel = $state<ManifestSummary>();
   let listController: AbortController | undefined;
@@ -76,7 +78,7 @@
   function reviewedIsCurrent(): boolean {
     if (!reviewed || reviewedFingerprint !== fingerprint(selection)) {
       reviewed = undefined;
-      preview = '';
+      preview = undefined;
       error = 'The selection changed. Review it again before continuing.';
       return false;
     }
@@ -108,7 +110,7 @@
     if (!selection || pending) return;
     pending = true;
     error = '';
-    preview = '';
+    preview = undefined;
     const candidate = selection;
     const candidateFingerprint = fingerprint(candidate);
     try {
@@ -133,18 +135,24 @@
     if (!selection || !reviewedIsCurrent()) return;
     pending = true;
     error = '';
+    const dryRunSelection = selection;
+    const dryRunFingerprint = fingerprint(dryRunSelection);
     try {
       const { data, error: responseError } = await generatedStageDeletion(
         {
-          selection,
+          selection: dryRunSelection,
           operation_token: reviewed!.operation_token,
           dry_run: true,
         },
         client,
       );
       if (!data) throw new Error(messageFor(responseError, 'Unable to run the deletion preview.'));
-      preview = `Dry run: ${data.message_count.toLocaleString()} ${data.message_count === 1 ? 'item' : 'items'} in ${data.account ?? 'the reviewed source'}`;
+      if (dryRunFingerprint !== fingerprint(selection)) {
+        throw new Error('The selection changed while it was being reviewed. Review it again.');
+      }
+      preview = data;
     } catch (cause) {
+      preview = undefined;
       error = cause instanceof Error ? cause.message : 'Unable to run the deletion preview.';
     } finally {
       pending = false;
@@ -173,10 +181,11 @@
       if (!data || response.status !== 201)
         throw new Error(messageFor(responseError, 'Unable to stage this deletion.'));
       reviewed = undefined;
-      preview = '';
+      preview = data;
       confirmStage = undefined;
       await loadManifests();
     } catch (cause) {
+      preview = undefined;
       error = cause instanceof Error ? cause.message : 'Unable to stage this deletion.';
     } finally {
       pending = false;
@@ -214,13 +223,32 @@
       pending = false;
     }
   }
-  function selectionDescription(): string {
-    if (!selection || !reviewed) return '';
-    if (selection.mode === 'all_matching') {
-      const excluded = selection.exclusions?.length ?? 0;
-      return `${reviewed.count.toLocaleString()} matching items minus ${excluded.toLocaleString()} ${excluded === 1 ? 'exclusion' : 'exclusions'}`;
+  function stageCounts(value: StageDeletionResponse): { matched: number; staged: number; skipped: number } {
+    const staged = value.message_count;
+    const skipped = value.skipped_count ?? Math.max((value.matched_count ?? staged) - staged, 0);
+    const matched = value.matched_count ?? staged + skipped;
+    return { matched, staged, skipped };
+  }
+  function resultSummary(value: StageDeletionResponse): string {
+    const { matched, staged, skipped } = stageCounts(value);
+    const prefix = value.dry_run ? 'Dry run' : 'Staged';
+    const account = value.account ? ` in ${value.account}` : '';
+    const batch = !value.dry_run && value.id ? ` · Batch ID: ${value.id}` : '';
+    return `${prefix}: Matched: ${matched.toLocaleString()} · Staged: ${staged.toLocaleString()} · Skipped: ${skipped.toLocaleString()}${account}${batch}`;
+  }
+  function partialWarning(value: StageDeletionResponse): string {
+    const { staged, skipped } = stageCounts(value);
+    if (value.dry_run) {
+      return `Partial staging: only the deletable Gmail subset (${staged.toLocaleString()}) will be staged; ${skipped.toLocaleString()} unsupported ${skipped === 1 ? 'match may be' : 'matches may be'} skipped.`;
     }
-    return `${reviewed.count.toLocaleString()} selected ${reviewed.count === 1 ? 'item' : 'items'}`;
+    return `Partial staging: only the deletable Gmail subset (${staged.toLocaleString()}) was staged; ${skipped.toLocaleString()} unsupported ${skipped === 1 ? 'match was' : 'matches were'} skipped.`;
+  }
+  function confirmationDescription(): string {
+    if (preview?.dry_run) {
+      const partial = stageCounts(preview).skipped > 0;
+      return `${resultSummary(preview)} ${partial ? 'Only the deletable Gmail subset will be staged.' : 'These reviewed matches will be staged.'} This creates a staged manifest; it does not execute deletion.`;
+    }
+    return 'The server stages only deletable Gmail matches and may skip unsupported matches. This creates a staged manifest; it does not execute deletion.';
   }
   function messageFor(value: unknown, fallback: string): string {
     return typeof value === 'object' && value !== null && 'message' in value && typeof value.message === 'string'
@@ -282,7 +310,10 @@
           />
         </div>
       {/if}
-      {#if preview}<p class="preview" role="status">{preview}</p>{/if}
+      {#if preview}
+        <p class="preview" role="status">{resultSummary(preview)}</p>
+        {#if stageCounts(preview).skipped > 0}<p class="notice" role="alert">{partialWarning(preview)}</p>{/if}
+      {/if}
     </section>
   </Card>
 
@@ -338,7 +369,7 @@
       confirmStage = undefined;
     }}
   >
-    <p>{selectionDescription()}. This creates a staged manifest; it does not execute deletion.</p>
+    <p>{confirmationDescription()}</p>
     {#snippet footer()}
       <Button
         surface="soft"

--- a/web/src/lib/components/deletions/DeletionsWorkspace.svelte
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.svelte
@@ -116,6 +116,9 @@
     try {
       const { data, error: responseError } = await generatedPreflightExploreSelection({ selection: candidate }, client);
       if (!data) throw new Error(messageFor(responseError, 'Unable to review this selection.'));
+      if (typeof data.deletable_count !== 'number') {
+        throw new Error('Deletion review requires daemon API schema 2.18.0 or newer. Upgrade the daemon and review again.');
+      }
       if (candidateFingerprint !== fingerprint(selection)) {
         throw new Error('The selection changed while it was being reviewed. Review it again.');
       }

--- a/web/src/lib/components/deletions/DeletionsWorkspace.svelte
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.svelte
@@ -239,16 +239,21 @@
   function partialWarning(value: StageDeletionResponse): string {
     const { staged, skipped } = stageCounts(value);
     if (value.dry_run) {
-      return `Partial staging: only the deletable Gmail subset (${staged.toLocaleString()}) will be staged; ${skipped.toLocaleString()} unsupported ${skipped === 1 ? 'match may be' : 'matches may be'} skipped.`;
+      return `Partial staging: only the deletable Gmail subset (${staged.toLocaleString()}) will be staged; ${skipped.toLocaleString()} unsupported ${skipped === 1 ? 'match will be' : 'matches will be'} skipped.`;
     }
     return `Partial staging: only the deletable Gmail subset (${staged.toLocaleString()}) was staged; ${skipped.toLocaleString()} unsupported ${skipped === 1 ? 'match was' : 'matches were'} skipped.`;
   }
+  function selectionExclusions(): string {
+    const count = selection?.exclusions?.length ?? 0;
+    return selection?.mode === 'all_matching' && count > 0
+      ? ` After ${count.toLocaleString()} ${count === 1 ? 'exclusion' : 'exclusions'}.`
+      : '';
+  }
   function confirmationDescription(): string {
-    if (preview?.dry_run) {
-      const partial = stageCounts(preview).skipped > 0;
-      return `${resultSummary(preview)} ${partial ? 'Only the deletable Gmail subset will be staged.' : 'These reviewed matches will be staged.'} This creates a staged manifest; it does not execute deletion.`;
-    }
-    return 'The server stages only deletable Gmail matches and may skip unsupported matches. This creates a staged manifest; it does not execute deletion.';
+    const counts = preview?.dry_run
+      ? resultSummary(preview)
+      : `Matched: ${reviewed!.count.toLocaleString()} · Will stage: ${reviewed!.deletable_count.toLocaleString()} · Will skip: ${(reviewed!.count - reviewed!.deletable_count).toLocaleString()}`;
+    return `${counts}.${selectionExclusions()} Only deletable Gmail messages will be staged. This creates a staged manifest; it does not execute deletion.`;
   }
   function messageFor(value: unknown, fallback: string): string {
     return typeof value === 'object' && value !== null && 'message' in value && typeof value.message === 'string'
@@ -289,6 +294,9 @@
             >{reviewed.count.toLocaleString()}
             {reviewed.count === 1 ? 'item' : 'items'} · {reviewed.estimated_bytes.toLocaleString()} bytes</strong
           >
+          <span>
+            {reviewed.deletable_count.toLocaleString()} can be staged · {(reviewed.count - reviewed.deletable_count).toLocaleString()} will be skipped.{selectionExclusions()}
+          </span>
           <span>Authority expires {reviewed.expires_at}</span>
           {#if reviewed.search_deletion_scope === 'active'}
             <span>Semantic search covers active messages only.</span>

--- a/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
@@ -66,9 +66,9 @@ describe('DeletionsWorkspace', () => {
       if (request.method === 'POST') {
         deletionPosts += 1;
         return deletionPosts === 1
-          ? Response.json({ dry_run: true, message_count: 1, account: 'archive@example.com', sample_gmail_ids: ['m1'] })
+          ? Response.json({ dry_run: true, matched_count: 1, message_count: 1, skipped_count: 0, account: 'archive@example.com', sample_gmail_ids: ['m1'] })
           : Response.json(
-              { dry_run: false, message_count: 1, account: 'archive@example.com', id: 'batch-2', status: 'pending' },
+              { dry_run: false, matched_count: 1, message_count: 1, skipped_count: 0, account: 'archive@example.com', id: 'batch-2', status: 'pending' },
               { status: 201 },
             );
       }
@@ -80,13 +80,15 @@ describe('DeletionsWorkspace', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
     expect(await screen.findByText('1 item · 120 bytes')).toBeDefined();
     await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
-    expect(await screen.findByText('Dry run: 1 item in archive@example.com')).toBeDefined();
+    expect(await screen.findByText(/Dry run: Matched: 1 · Staged: 1 · Skipped: 0 in archive@example.com/)).toBeDefined();
+    expect(screen.queryByRole('alert')).toBeNull();
 
     await fireEvent.click(screen.getByRole('button', { name: 'Stage deletion' }));
     expect(screen.getByRole('dialog', { name: 'Confirm selected deletion' })).toBeDefined();
     expect(deletionPosts).toBe(1);
     await fireEvent.click(screen.getByRole('button', { name: 'Confirm stage deletion' }));
     await waitFor(() => expect(deletionPosts).toBe(2));
+    expect(await screen.findByText(/Batch ID: batch-2/)).toBeDefined();
 
     const preflightBody = await requests
       .find((request) => new URL(request.url).pathname.endsWith('/explore/preflight'))!
@@ -99,6 +101,163 @@ describe('DeletionsWorkspace', () => {
       .clone()
       .json();
     expect(stageBody).toMatchObject({ selection: explicit, operation_token: 'operation-1', dry_run: false });
+  });
+
+  it('shows mixed dry-run and staged counts with a partial-staging warning', async () => {
+    const requests: Request[] = [];
+    let deletionPosts = 0;
+    const mixed = { dry_run: true, matched_count: 3, message_count: 2, skipped_count: 1, account: 'archive@example.com' };
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      requests.push(request);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3 }));
+      if (request.method === 'POST') {
+        deletionPosts += 1;
+        return deletionPosts === 1
+          ? Response.json(mixed)
+          : Response.json({ ...mixed, dry_run: false, id: 'batch-2', status: 'pending' }, { status: 201 });
+      }
+      return Response.json({ manifests: [] });
+    });
+    render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit });
+
+    await screen.findByText('No deletion manifests yet.');
+    await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
+    await screen.findByText('3 items · 120 bytes');
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1 in archive@example.com/)).toBeDefined();
+    expect(screen.getByRole('alert').textContent).toMatch(/Partial staging.*deletable Gmail subset.*unsupported match may be skipped/);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Stage deletion' }));
+    const dialog = screen.getByRole('dialog', { name: 'Confirm selected deletion' });
+    expect(dialog.textContent).toMatch(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1/);
+    expect(dialog.textContent).toMatch(/deletable Gmail subset/);
+    expect(deletionPosts).toBe(1);
+    await fireEvent.click(screen.getByRole('button', { name: 'Confirm stage deletion' }));
+    await waitFor(() => expect(deletionPosts).toBe(2));
+    expect(await screen.findByText(/Staged: Matched: 3 · Staged: 2 · Skipped: 1 in archive@example.com/)).toBeDefined();
+    expect(screen.getByRole('alert').textContent).toMatch(/was staged.*unsupported match was skipped/);
+    expect(requests.filter((request) => request.method === 'POST').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('derives optional counts when the response omits one field at a time', async () => {
+    let deletionPosts = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3 }));
+      if (request.method === 'POST') {
+        deletionPosts += 1;
+        return deletionPosts === 1
+          ? Response.json({ dry_run: true, message_count: 2, skipped_count: 1 })
+          : Response.json({ dry_run: true, matched_count: 3, message_count: 2 });
+      }
+      return Response.json({ manifests: [] });
+    });
+    render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit });
+
+    await screen.findByText('No deletion manifests yet.');
+    await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
+    await screen.findByText('3 items · 120 bytes');
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1/)).toBeDefined();
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1/)).toBeDefined();
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('discards a late dry-run response after the selection changes', async () => {
+    let resolveDryRun!: (response: Response) => void;
+    const pendingDryRun = new Promise<Response>((resolve) => {
+      resolveDryRun = resolve;
+    });
+    let posts = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight());
+      if (request.method === 'POST') {
+        posts += 1;
+        return pendingDryRun;
+      }
+      return Response.json({ manifests: [] });
+    });
+    const rendered = render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit });
+
+    await screen.findByText('No deletion manifests yet.');
+    await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
+    await screen.findByText('1 item · 120 bytes');
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    await waitFor(() => expect(posts).toBe(1));
+    await rendered.rerender({ client: createAPIClient(fetchFn), selection: matching });
+    resolveDryRun(Response.json({ dry_run: true, message_count: 1 }));
+
+    expect(await screen.findByText('The selection changed while it was being reviewed. Review it again.')).toBeDefined();
+    expect(screen.queryByText(/Dry run: Matched/)).toBeNull();
+    rendered.unmount();
+  });
+
+  it('keeps a committed stage result and refreshes manifests after the selection changes', async () => {
+    let resolveStage!: (response: Response) => void;
+    const pendingStage = new Promise<Response>((resolve) => {
+      resolveStage = resolve;
+    });
+    let listCalls = 0;
+    let stagePosts = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      const path = new URL(request.url).pathname;
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight());
+      if (request.method === 'POST') {
+        stagePosts += 1;
+        return pendingStage;
+      }
+      listCalls += 1;
+      return listCalls === 1
+        ? Response.json({ manifests: [] })
+        : Response.json({
+            manifests: [
+              {
+                id: 'batch-committed',
+                status: 'pending',
+                created_at: '2026-07-19T10:00:00Z',
+                created_by: 'api',
+                description: 'reviewed selection',
+                message_count: 1,
+              },
+            ],
+          });
+    });
+    const rendered = render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit });
+
+    await screen.findByText('No deletion manifests yet.');
+    await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
+    await screen.findByText('1 item · 120 bytes');
+    await fireEvent.click(screen.getByRole('button', { name: 'Stage deletion' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Confirm stage deletion' }));
+    await waitFor(() => expect(stagePosts).toBe(1));
+    await rendered.rerender({ client: createAPIClient(fetchFn), selection: matching });
+
+    resolveStage(
+      Response.json(
+        {
+          dry_run: false,
+          matched_count: 1,
+          message_count: 1,
+          skipped_count: 0,
+          account: 'archive@example.com',
+          id: 'batch-committed',
+          status: 'pending',
+        },
+        { status: 201 },
+      ),
+    );
+
+    expect(await screen.findByText(/Staged: Matched: 1 · Staged: 1 · Skipped: 0 in archive@example.com · Batch ID: batch-committed/)).toBeDefined();
+    expect(await screen.findByText('batch-committed')).toBeDefined();
+    expect(listCalls).toBe(2);
+    rendered.unmount();
   });
 
   it('uses d/D shortcuts to preflight the matching selection and never acts before confirmation', async () => {
@@ -119,7 +278,8 @@ describe('DeletionsWorkspace', () => {
       await screen.findByText('No deletion manifests yet.');
       await fireEvent.keyDown(window, { key: 'D', shiftKey: true });
       expect(await screen.findByRole('dialog', { name: 'Confirm matching deletion' })).toBeDefined();
-      expect(screen.getByText(/8 matching items minus 1 exclusion/)).toBeDefined();
+      expect(screen.getByText(/server stages only deletable Gmail matches and may skip unsupported matches/)).toBeDefined();
+      expect(screen.queryByText(/8 matching items minus 1 exclusion/)).toBeNull();
       expect(staged).toBe(0);
       await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
       expect(staged).toBe(0);
@@ -221,5 +381,37 @@ describe('DeletionsWorkspace', () => {
     await fireEvent.click(await screen.findByRole('button', { name: 'Review selection' }));
     expect(await screen.findByText(/selection_contains_items_that_cannot_be_deleted_from_source/)).toBeDefined();
     expect((screen.getByRole('button', { name: 'Stage deletion' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('clears stale result counts when dry-run and create requests fail', async () => {
+    let deletionPosts = 0;
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      if (new URL(request.url).pathname.endsWith('/explore/preflight')) return Response.json(preflight());
+      if (request.method === 'POST') {
+        deletionPosts += 1;
+        if (deletionPosts === 1 || deletionPosts === 3)
+          return Response.json({ dry_run: true, message_count: 1 });
+        return Response.json({ message: deletionPosts === 2 ? 'dry run failed' : 'create failed' }, { status: 500 });
+      }
+      return Response.json({ manifests: [] });
+    });
+    render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit });
+
+    await screen.findByText('No deletion manifests yet.');
+    await fireEvent.click(screen.getByRole('button', { name: 'Review selection' }));
+    await screen.findByText('1 item · 120 bytes');
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText(/Dry run: Matched: 1/)).toBeDefined();
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText('dry run failed')).toBeDefined();
+    expect(screen.queryByText(/Dry run: Matched: 1/)).toBeNull();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
+    expect(await screen.findByText(/Dry run: Matched: 1/)).toBeDefined();
+    await fireEvent.click(screen.getByRole('button', { name: 'Stage deletion' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Confirm stage deletion' }));
+    expect(await screen.findByText('create failed')).toBeDefined();
+    expect(screen.queryByText(/Dry run: Matched: 1/)).toBeNull();
   });
 });

--- a/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
@@ -27,6 +27,7 @@ const matching: ExploreSelection = {
 function preflight(overrides: Record<string, unknown> = {}) {
   return {
     count: 1,
+    deletable_count: 1,
     estimated_bytes: 120,
     cache_revision: 'cache-1',
     search_provenance: {},
@@ -111,7 +112,7 @@ describe('DeletionsWorkspace', () => {
       const request = input instanceof Request ? input : new Request(input);
       requests.push(request);
       const path = new URL(request.url).pathname;
-      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3 }));
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3, deletable_count: 2 }));
       if (request.method === 'POST') {
         deletionPosts += 1;
         return deletionPosts === 1
@@ -127,12 +128,12 @@ describe('DeletionsWorkspace', () => {
     await screen.findByText('3 items · 120 bytes');
     await fireEvent.click(screen.getByRole('button', { name: 'Dry run' }));
     expect(await screen.findByText(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1 in archive@example.com/)).toBeDefined();
-    expect(screen.getByRole('alert').textContent).toMatch(/Partial staging.*deletable Gmail subset.*unsupported match may be skipped/);
+    expect(screen.getByRole('alert').textContent).toMatch(/Partial staging.*deletable Gmail subset.*unsupported match will be skipped/);
 
     await fireEvent.click(screen.getByRole('button', { name: 'Stage deletion' }));
     const dialog = screen.getByRole('dialog', { name: 'Confirm selected deletion' });
     expect(dialog.textContent).toMatch(/Dry run: Matched: 3 · Staged: 2 · Skipped: 1/);
-    expect(dialog.textContent).toMatch(/deletable Gmail subset/);
+    expect(dialog.textContent).toMatch(/Only deletable Gmail messages will be staged/);
     expect(deletionPosts).toBe(1);
     await fireEvent.click(screen.getByRole('button', { name: 'Confirm stage deletion' }));
     await waitFor(() => expect(deletionPosts).toBe(2));
@@ -146,7 +147,7 @@ describe('DeletionsWorkspace', () => {
     const fetchFn = vi.fn<typeof fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       const path = new URL(request.url).pathname;
-      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3 }));
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 3, deletable_count: 2 }));
       if (request.method === 'POST') {
         deletionPosts += 1;
         return deletionPosts === 1
@@ -266,7 +267,7 @@ describe('DeletionsWorkspace', () => {
     const fetchFn = vi.fn<typeof fetch>(async (input) => {
       const request = input instanceof Request ? input : new Request(input);
       const path = new URL(request.url).pathname;
-      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 8 }));
+      if (path.endsWith('/explore/preflight')) return Response.json(preflight({ count: 8, deletable_count: 6 }));
       if (request.method === 'POST') {
         staged += 1;
         return Response.json({ dry_run: false, message_count: 8, id: 'batch-2', status: 'pending' }, { status: 201 });
@@ -278,8 +279,8 @@ describe('DeletionsWorkspace', () => {
       await screen.findByText('No deletion manifests yet.');
       await fireEvent.keyDown(window, { key: 'D', shiftKey: true });
       expect(await screen.findByRole('dialog', { name: 'Confirm matching deletion' })).toBeDefined();
-      expect(screen.getByText(/server stages only deletable Gmail matches and may skip unsupported matches/)).toBeDefined();
-      expect(screen.queryByText(/8 matching items minus 1 exclusion/)).toBeNull();
+      expect(screen.getByText(/Matched: 8 · Will stage: 6 · Will skip: 2.*After 1 exclusion/)).toBeDefined();
+      expect(screen.getByText(/6 can be staged · 2 will be skipped/)).toBeDefined();
       expect(staged).toBe(0);
       await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
       expect(staged).toBe(0);

--- a/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
+++ b/web/src/lib/components/deletions/DeletionsWorkspace.test.ts
@@ -56,6 +56,21 @@ function listResponse() {
 afterEach(() => document.body.replaceChildren());
 
 describe('DeletionsWorkspace', () => {
+  it('requires the deletable-count contract before offering staging', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      if (new URL(request.url).pathname.endsWith('/explore/preflight')) {
+        return Response.json(preflight({ deletable_count: undefined }));
+      }
+      return Response.json({ manifests: [] });
+    });
+    render(DeletionsWorkspace, { client: createAPIClient(fetchFn), selection: explicit, reviewOnMount: true });
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Upgrade the daemon and review again.');
+    expect(screen.queryByRole('button', { name: 'Stage deletion' })).toBeNull();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
   it('preflights, dry-runs, and explicitly confirms an exact selection before staging', async () => {
     const requests: Request[] = [];
     let deletionPosts = 0;

--- a/web/src/lib/components/explore/SelectionBar.test.ts
+++ b/web/src/lib/components/explore/SelectionBar.test.ts
@@ -15,6 +15,7 @@ describe('SelectionBar', () => {
     unavailable_actions: GeneratedExploreUnavailableAction[] = [],
   ): GeneratedExplorePreflightResponse => ({
     count: 2,
+    deletable_count: 2,
     estimated_bytes: 20,
     cache_revision: 'cache-1',
     search_provenance: {},

--- a/web/src/lib/components/shell/EverythingWorkspace.test.ts
+++ b/web/src/lib/components/shell/EverythingWorkspace.test.ts
@@ -369,7 +369,7 @@ describe('EverythingWorkspace', () => {
       if (new URL(request.url).pathname.endsWith('/explore/preflight')) {
         preflightRequests.push(request);
         return Response.json({
-          count: 1, estimated_bytes: 10, cache_revision: 'cache-1', search_provenance: {},
+          count: 1, deletable_count: 1, estimated_bytes: 10, cache_revision: 'cache-1', search_provenance: {},
           unavailable_actions: [
             { action: 'export', reason: 'selection_contains_items_without_exportable_files' },
             { action: 'open_in_source', reason: 'trusted_source_link_unavailable' }
@@ -411,7 +411,7 @@ describe('EverythingWorkspace', () => {
       requests.push(request);
       const path = new URL(request.url).pathname;
       if (path.endsWith('/explore/preflight')) return Response.json({
-        count: 1, estimated_bytes: 10, cache_revision: 'cache-1', search_provenance: {},
+        count: 1, deletable_count: 1, estimated_bytes: 10, cache_revision: 'cache-1', search_provenance: {},
         unavailable_actions: [{ action: 'open_in_source', reason: 'trusted_source_link_unavailable' }],
         action_targets: [{ action: 'export', message_id: 1, filename: 'message-1.eml' }],
         operation_token: 'operation-1', expires_at: '2026-07-19T10:05:00Z'

--- a/web/tests/archive-management.spec.ts
+++ b/web/tests/archive-management.spec.ts
@@ -29,7 +29,7 @@ test('archive management workspaces preserve reviewed authority and daemon job b
   await page.route('**/api/v1/explore/preflight', (route) => {
     preflights.push(route.request().postDataJSON());
     return route.fulfill({ json: {
-      count: 1, estimated_bytes: 20, cache_revision: 'cache-management', search_provenance: {},
+      count: 1, deletable_count: 1, estimated_bytes: 20, cache_revision: 'cache-management', search_provenance: {},
       unavailable_actions: [{ action: 'open_in_source', reason: 'trusted_source_link_unavailable' }],
       action_targets: [{ action: 'export', message_id: 1, filename: 'message-1.eml' }],
       operation_token: 'operation-1', expires_at: '2026-07-19T10:05:00Z'

--- a/web/tests/e2e/fixtures/mixed-archive.ts
+++ b/web/tests/e2e/fixtures/mixed-archive.ts
@@ -152,6 +152,7 @@ export async function installMixedArchive(page: Page): Promise<InstalledMixedArc
     route.fulfill({
       json: {
         count: 1,
+        deletable_count: 1,
         estimated_bytes: 2048,
         cache_revision: 'mixed-100k',
         search_provenance: {},

--- a/web/tests/e2e/keyboard.spec.ts
+++ b/web/tests/e2e/keyboard.spec.ts
@@ -51,7 +51,7 @@ test('pointer-free archive journey preserves focus, announcements, and history',
     cache_revision: 'keyboard-100k', search_provenance: {}
   } }));
   await page.route('**/api/v1/explore/preflight', (route) => route.fulfill({ json: {
-    count: 1, estimated_bytes: 20, cache_revision: 'keyboard-100k', search_provenance: {},
+    count: 1, deletable_count: 1, estimated_bytes: 20, cache_revision: 'keyboard-100k', search_provenance: {},
     unavailable_actions: [], action_targets: [], operation_token: 'keyboard-operation',
     expires_at: '2026-01-03T12:05:00Z'
   } }));


### PR DESCRIPTION
`msgvault stage-delete` and the web Deletions workspace now stage the deletable subset of a mixed selection and report matched, staged, and skipped counts. On an archive that mixes Gmail with Slack, Teams, or Apple Mail, a query like `from:notifications older_than:2y` used to fail with `selection_not_deletable` and stage nothing, dry run included, because it matched a few non-Gmail items.

Preflight reports the exact deletable count before staging. The web confirmation also keeps the exclusion count. Query staging requires daemon API schema 2.18.0; the CLI rejects older daemons, and the web review asks for an upgrade if the required count is missing.

`message_type:email` also includes legacy Gmail rows whose stored type is blank or NULL. Empty address operators now fail in the shared search parser before they can widen a query. Staging makes no exactness claim about the search index; the dry-run preview and the review before `delete-staged` remain the review boundary, and deletion still covers Gmail email only.

Closes #768
