### PR TITLE
fix(whatsapp): require country codes for vCard contacts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -145,6 +145,8 @@ All notable changes to msgvault, grouped by release.
 - Everything and Files now page narrow analytical metadata before enriching
   participant details, preventing default listings on multi-million-message
   archives from exhausting the interactive DuckDB memory budget.
+- WhatsApp vCard imports skip phone values without explicit international `+`
+  or `00` provenance.
 
 ---
 

--- a/internal/vcard/legacy.go
+++ b/internal/vcard/legacy.go
@@ -22,8 +22,21 @@ type Contact struct {
 	Emails   []string // lowercased
 }
 
+// ParseFileOptions controls optional vCard projection behavior.
+// NormalizePhone receives the decoded phone candidate after tel URI and
+// phone-context assembly. A nil callback uses the package normalizer.
+type ParseFileOptions struct {
+	NormalizePhone func(string) string
+}
+
 // ParseFile reads a vCard file and projects its contact identity fields.
 func ParseFile(path string) ([]Contact, error) {
+	return ParseFileWithOptions(path, ParseFileOptions{})
+}
+
+// ParseFileWithOptions reads a vCard file and projects its contact identity
+// fields with optional phone normalization.
+func ParseFileWithOptions(path string, options ParseFileOptions) ([]Contact, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open vCard %q: %w", path, err)
@@ -33,6 +46,11 @@ func ParseFile(path string) ([]Contact, error) {
 	document, err := Decode(file)
 	if err != nil {
 		return nil, fmt.Errorf("decode vCard %q: %w", path, err)
+	}
+
+	normalize := options.NormalizePhone
+	if normalize == nil {
+		normalize = normalizePhone
 	}
 
 	contacts := make([]Contact, 0, len(document.Cards))
@@ -54,7 +72,7 @@ func ParseFile(path string) ([]Contact, error) {
 				if decodeErr != nil {
 					return nil, fmt.Errorf("decode TEL in %q: %w", path, decodeErr)
 				}
-				if normalized := normalizeLegacyPhone(strings.TrimSpace(phone)); normalized != "" {
+				if normalized := normalizeLegacyPhone(strings.TrimSpace(phone), normalize); normalized != "" {
 					contact.Phones = append(contact.Phones, normalized)
 				}
 			case strings.EqualFold(property.Name, "EMAIL"):
@@ -193,9 +211,9 @@ func normalizePhone(raw string) string {
 	return normalized
 }
 
-func normalizeLegacyPhone(raw string) string {
+func normalizeLegacyPhone(raw string, normalize func(string) string) string {
 	if len(raw) < len("tel:") || !strings.EqualFold(raw[:len("tel:")], "tel:") {
-		return normalizePhone(raw)
+		return normalize(raw)
 	}
 
 	parts := strings.Split(raw[len("tel:"):], ";")
@@ -204,7 +222,7 @@ func normalizeLegacyPhone(raw string) string {
 		return ""
 	}
 	if strings.HasPrefix(subscriber, "+") {
-		return normalizePhone(subscriber)
+		return normalize(subscriber)
 	}
 
 	for _, part := range parts[1:] {
@@ -216,7 +234,7 @@ func normalizeLegacyPhone(raw string) string {
 		if err != nil || !strings.HasPrefix(context, "+") {
 			return ""
 		}
-		return normalizePhone(context + subscriber)
+		return normalize(context + subscriber)
 	}
-	return normalizePhone(subscriber)
+	return normalize(subscriber)
 }

--- a/internal/vcard/vcard_test.go
+++ b/internal/vcard/vcard_test.go
@@ -325,6 +325,8 @@ func TestParseFileReturnsMalformedContentLineError(t *testing.T) {
 }
 
 func TestParseFileWithOptions(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
 	vcf := "BEGIN:VCARD\r\n" +
 		"VERSION:4.0\r\n" +
 		"FN:Test User\r\n" +
@@ -333,14 +335,14 @@ func TestParseFileWithOptions(t *testing.T) {
 		"TEL;VALUE=uri:tel:555-0103;phone-context=+1-202\r\n" +
 		"END:VCARD\r\n"
 	path := filepath.Join(t.TempDir(), "options.vcf")
-	require.NoError(t, os.WriteFile(path, []byte(vcf), 0o600))
+	require.NoError(os.WriteFile(path, []byte(vcf), 0o600))
 
 	defaultContacts, err := ParseFile(path)
-	require.NoError(t, err)
+	require.NoError(err)
 	optionContacts, err := ParseFileWithOptions(path, ParseFileOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, defaultContacts, optionContacts)
-	assert.Equal(t, []Contact{{
+	require.NoError(err)
+	assert.Equal(defaultContacts, optionContacts)
+	assert.Equal([]Contact{{
 		FullName: "Test User",
 		Phones:   []string{"+12025551234", "+12025550101", "+12025550103"},
 	}}, defaultContacts)
@@ -352,13 +354,13 @@ func TestParseFileWithOptions(t *testing.T) {
 			return "custom:" + raw
 		},
 	})
-	require.NoError(t, err)
-	assert.Equal(t, []string{
+	require.NoError(err)
+	assert.Equal([]string{
 		"2025551234",
 		"+1-202-555-0101",
 		"+1-202555-0103",
 	}, seen)
-	assert.Equal(t, []Contact{{
+	assert.Equal([]Contact{{
 		FullName: "Test User",
 		Phones: []string{
 			"custom:2025551234",

--- a/internal/vcard/vcard_test.go
+++ b/internal/vcard/vcard_test.go
@@ -323,3 +323,47 @@ func TestParseFileReturnsMalformedContentLineError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "physical line 3")
 }
+
+func TestParseFileWithOptions(t *testing.T) {
+	vcf := "BEGIN:VCARD\r\n" +
+		"VERSION:4.0\r\n" +
+		"FN:Test User\r\n" +
+		"TEL:2025551234\r\n" +
+		"TEL:+1-202-555-0101\r\n" +
+		"TEL;VALUE=uri:tel:555-0103;phone-context=+1-202\r\n" +
+		"END:VCARD\r\n"
+	path := filepath.Join(t.TempDir(), "options.vcf")
+	require.NoError(t, os.WriteFile(path, []byte(vcf), 0o600))
+
+	defaultContacts, err := ParseFile(path)
+	require.NoError(t, err)
+	optionContacts, err := ParseFileWithOptions(path, ParseFileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, defaultContacts, optionContacts)
+	assert.Equal(t, []Contact{{
+		FullName: "Test User",
+		Phones:   []string{"+12025551234", "+12025550101", "+12025550103"},
+	}}, defaultContacts)
+
+	var seen []string
+	customContacts, err := ParseFileWithOptions(path, ParseFileOptions{
+		NormalizePhone: func(raw string) string {
+			seen = append(seen, raw)
+			return "custom:" + raw
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"2025551234",
+		"+1-202-555-0101",
+		"+1-202555-0103",
+	}, seen)
+	assert.Equal(t, []Contact{{
+		FullName: "Test User",
+		Phones: []string{
+			"custom:2025551234",
+			"custom:+1-202-555-0101",
+			"custom:+1-202555-0103",
+		},
+	}}, customContacts)
+}

--- a/internal/whatsapp/contacts.go
+++ b/internal/whatsapp/contacts.go
@@ -2,8 +2,11 @@ package whatsapp
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
 	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textimport"
 	"go.kenn.io/msgvault/internal/vcard"
 )
 
@@ -12,7 +15,9 @@ import (
 // Only updates existing participants — does not create new ones.
 // Returns the number of existing participants whose names were updated.
 func ImportContacts(s *store.Store, vcfPath string) (matched, total int, err error) {
-	contacts, err := vcard.ParseFile(vcfPath)
+	contacts, err := vcard.ParseFileWithOptions(vcfPath, vcard.ParseFileOptions{
+		NormalizePhone: normalizeWhatsAppVCardPhone,
+	})
 	if err != nil {
 		return 0, 0, fmt.Errorf("parse vcard: %w", err)
 	}
@@ -43,4 +48,28 @@ func ImportContacts(s *store.Store, vcfPath string) (matched, total int, err err
 	}
 
 	return matched, total, nil
+}
+
+func normalizeWhatsAppVCardPhone(raw string) string {
+	raw = strings.TrimSpace(strings.ReplaceAll(raw, "(0)", ""))
+	if raw == "" {
+		return ""
+	}
+
+	var digits strings.Builder
+	for _, r := range raw {
+		if unicode.IsDigit(r) {
+			digits.WriteRune(r)
+		}
+	}
+	if digits.Len() == 0 ||
+		(!strings.HasPrefix(raw, "+") && !strings.HasPrefix(digits.String(), "00")) {
+		return ""
+	}
+
+	normalized, err := textimport.NormalizePhone(raw)
+	if err != nil {
+		return ""
+	}
+	return normalized
 }

--- a/internal/whatsapp/contacts_test.go
+++ b/internal/whatsapp/contacts_test.go
@@ -1,0 +1,86 @@
+package whatsapp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestImportContactsPhoneCountryCodePolicy(t *testing.T) {
+	tests := []struct {
+		name             string
+		tel              string
+		participantPhone string
+		wantMatched      int
+		wantDisplayName  string
+	}{
+		{
+			name:             "bare ten digit issue reproduction",
+			tel:              "TEL:2025551234",
+			participantPhone: "+12025551234",
+			wantMatched:      0,
+			wantDisplayName:  "",
+		},
+		{
+			name:             "explicit plus",
+			tel:              "TEL:+1-202-555-0101",
+			participantPhone: "+12025550101",
+			wantMatched:      1,
+			wantDisplayName:  "Test User",
+		},
+		{
+			name:             "explicit zero zero",
+			tel:              "TEL:0012025550102",
+			participantPhone: "+12025550102",
+			wantMatched:      1,
+			wantDisplayName:  "Test User",
+		},
+		{
+			name:             "phone context",
+			tel:              "TEL;VALUE=uri:tel:555-0103;phone-context=+1-202",
+			participantPhone: "+12025550103",
+			wantMatched:      1,
+			wantDisplayName:  "Test User",
+		},
+		{
+			name:             "local trunk",
+			tel:              "TEL:077-555-0100",
+			participantPhone: "+10775550100",
+			wantMatched:      0,
+			wantDisplayName:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := testutil.NewTestStore(t)
+			participantID, err := st.EnsureParticipantByPhone(tt.participantPhone, "", "whatsapp")
+			require.NoError(t, err)
+
+			path := filepath.Join(t.TempDir(), "contacts.vcf")
+			vcf := "BEGIN:VCARD\r\n" +
+				"VERSION:3.0\r\n" +
+				"FN:Test User\r\n" +
+				tt.tel + "\r\n" +
+				"END:VCARD\r\n"
+			require.NoError(t, os.WriteFile(path, []byte(vcf), 0o600))
+
+			matched, total, err := ImportContacts(st, path)
+			require.NoError(t, err)
+			assert.Equal(t, 1, total)
+			assert.Equal(t, tt.wantMatched, matched)
+
+			displayNames, err := st.ParticipantDisplayNamesContext(t.Context(), []int64{participantID})
+			require.NoError(t, err)
+			if tt.wantDisplayName == "" {
+				assert.Equal(t, map[int64]string{}, displayNames)
+			} else {
+				assert.Equal(t, map[int64]string{participantID: tt.wantDisplayName}, displayNames)
+			}
+		})
+	}
+}

--- a/internal/whatsapp/contacts_test.go
+++ b/internal/whatsapp/contacts_test.go
@@ -34,7 +34,7 @@ func TestImportContactsPhoneCountryCodePolicy(t *testing.T) {
 		},
 		{
 			name:             "explicit zero zero",
-			tel:              "TEL:0012025550102",
+			tel:              "TEL:00 1 202-555-0102",
 			participantPhone: "+12025550102",
 			wantMatched:      1,
 			wantDisplayName:  "Test User",

--- a/internal/whatsapp/contacts_test.go
+++ b/internal/whatsapp/contacts_test.go
@@ -57,9 +57,11 @@ func TestImportContactsPhoneCountryCodePolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 			st := testutil.NewTestStore(t)
 			participantID, err := st.EnsureParticipantByPhone(tt.participantPhone, "", "whatsapp")
-			require.NoError(t, err)
+			require.NoError(err)
 
 			path := filepath.Join(t.TempDir(), "contacts.vcf")
 			vcf := "BEGIN:VCARD\r\n" +
@@ -67,19 +69,19 @@ func TestImportContactsPhoneCountryCodePolicy(t *testing.T) {
 				"FN:Test User\r\n" +
 				tt.tel + "\r\n" +
 				"END:VCARD\r\n"
-			require.NoError(t, os.WriteFile(path, []byte(vcf), 0o600))
+			require.NoError(os.WriteFile(path, []byte(vcf), 0o600))
 
 			matched, total, err := ImportContacts(st, path)
-			require.NoError(t, err)
-			assert.Equal(t, 1, total)
-			assert.Equal(t, tt.wantMatched, matched)
+			require.NoError(err)
+			assert.Equal(1, total)
+			assert.Equal(tt.wantMatched, matched)
 
 			displayNames, err := st.ParticipantDisplayNamesContext(t.Context(), []int64{participantID})
-			require.NoError(t, err)
+			require.NoError(err)
 			if tt.wantDisplayName == "" {
-				assert.Equal(t, map[int64]string{}, displayNames)
+				assert.Equal(map[int64]string{}, displayNames)
 			} else {
-				assert.Equal(t, map[int64]string{participantID: tt.wantDisplayName}, displayNames)
+				assert.Equal(map[int64]string{participantID: tt.wantDisplayName}, displayNames)
 			}
 		})
 	}


### PR DESCRIPTION
WhatsApp contact imports now require vCard phone numbers to carry an explicit `+` or `00` country-code marker before matching existing participants. Generic vCard parsing and iMessage's ten-digit `+1` default remain unchanged.

The WhatsApp boundary supplies the strict policy to the shared vCard parser, so an ambiguous value such as `TEL:2025551234` is skipped while explicit international values still use shared normalization. [Issue #320](https://github.com/kenn-io/msgvault/issues/320) traces the regression from the original WhatsApp parser through the shared vCard and text-import path.

Closes #320
