### PR TITLE
refactor(people): derive provider profile projections from one schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,18 @@ follow-up work.
 tests. pgvector tests require a PostgreSQL instance with the `vector`
 extension and the `pgvector` build tag.
 
+The PostgreSQL deadlock tests also require permission to set
+`deadlock_timeout`. They defer the blocker transaction's deadlock detector
+so the write under test is the deadlock victim. For a non-superuser test
+role, have the database administrator run:
+
+```sql
+GRANT SET ON PARAMETER deadlock_timeout TO test_role;
+```
+
+Replace `test_role` with the role in `MSGVAULT_TEST_DB`. This parameter grant
+is sufficient; the test role does not need superuser access.
+
 There are two PostgreSQL configurations to cover: the pgvector build
 (`make test-pg`) and the shipped build, which has no pgvector tag
 (`make test-pg-shipped`). Run `make test-pg-both` rather than both of those —

--- a/cmd/msgvault/cmd/person_provider_setup.go
+++ b/cmd/msgvault/cmd/person_provider_setup.go
@@ -779,47 +779,7 @@ func personProviderBudgetEdit(prices *peoplesweep.BudgetConfig) config.TableEdit
 }
 
 func personProviderTableValues(provider peoplesweep.ProviderConfig) map[string]any {
-	sources := make([]string, len(provider.AllowedSources))
-	for index, source := range provider.AllowedSources {
-		sources[index] = string(source)
-	}
-	values := map[string]any{
-		"protocol": provider.Protocol, "model": provider.Model,
-		"auth": provider.Auth, "credential": provider.Credential,
-		"output_mode":       provider.OutputMode,
-		"retention_posture": provider.RetentionPosture, "training_posture": provider.TrainingPosture,
-		"allowed_sources": sources, "source_since": provider.SourceSince,
-		"allow_sensitive": provider.AllowSensitive, "request_timeout": provider.RequestTimeout,
-	}
-	// Protocol-optional fields stay absent when unconfigured: endpoint and the
-	// Codex isolation fields keep codex_app_server profiles in their
-	// documented endpoint-free shape, and token_limit_parameter belongs to
-	// openai_chat profiles only.
-	if provider.Endpoint != "" {
-		values["endpoint"] = provider.Endpoint
-	}
-	if provider.TokenLimitParameter != "" {
-		values["token_limit_parameter"] = provider.TokenLimitParameter
-	}
-	if provider.Executable != "" {
-		values["executable"] = provider.Executable
-	}
-	if provider.ExecutionBoundary != "" {
-		values["execution_boundary"] = provider.ExecutionBoundary
-	}
-	if provider.CredentialEnv != "" {
-		values["credential_env"] = provider.CredentialEnv
-	}
-	if provider.SourceUntil != "" {
-		values["source_until"] = provider.SourceUntil
-	}
-	if provider.ReasoningEffort != "" {
-		values["reasoning_effort"] = provider.ReasoningEffort
-	}
-	if provider.ReasoningMode != "" {
-		values["reasoning_mode"] = provider.ReasoningMode
-	}
-	return values
+	return peoplesweep.ProviderTOMLValues(provider)
 }
 
 func acceptedPersonProviderCatalogPrices(

--- a/cmd/msgvault/cmd/person_provider_setup_test.go
+++ b/cmd/msgvault/cmd/person_provider_setup_test.go
@@ -25,6 +25,40 @@ import (
 
 const providerSetupSecretCanary = "provider-setup-secret-canary"
 
+func TestPersonProviderTableValuesUsesCanonicalProjection(t *testing.T) {
+	httpProvider := peoplesweep.ProviderConfig{
+		Protocol: peoplesweep.ProtocolOpenAIChat, Endpoint: "https://provider.example.test/v1",
+		Model: "test-model", Auth: peoplesweep.AuthBearer, Credential: peoplesweep.CredentialEnv,
+		CredentialEnv: "TEST_PROVIDER_KEY", OutputMode: peoplesweep.OutputModeNativeJSONSchema,
+		TokenLimitParameter: "max_completion_tokens", RetentionPosture: "zero_retention",
+		TrainingPosture: "no_training", AllowedSources: []peoplesweep.SourceClass{
+			peoplesweep.SourceMeetingText, peoplesweep.SourceConversationText,
+		}, SourceSince: "2025-01-01", SourceUntil: "2025-12-31",
+		ReasoningEffort: "medium", ReasoningMode: "enabled",
+	}
+	httpValues := personProviderTableValues(httpProvider)
+	assert.Equal(t, []string{"conversation_text", "meeting_text"}, httpValues["allowed_sources"])
+	assert.Equal(t, httpProvider.Endpoint, httpValues["endpoint"])
+	assert.Equal(t, httpProvider.CredentialEnv, httpValues["credential_env"])
+
+	codexProvider := peoplesweep.ProviderConfig{
+		Protocol: peoplesweep.ProtocolCodexAppServer, Model: "codex-model",
+		Auth: peoplesweep.AuthNone, Credential: peoplesweep.CredentialNone,
+		OutputMode: peoplesweep.OutputModeNativeJSONSchema, RetentionPosture: "zero_retention",
+		TrainingPosture: "no_training", AllowedSources: []peoplesweep.SourceClass{
+			peoplesweep.SourceConversationText,
+		}, SourceSince: "2025-01-01",
+	}
+	codexValues := personProviderTableValues(codexProvider)
+	assert.Equal(t, []string{"conversation_text"}, codexValues["allowed_sources"])
+	for _, key := range []string{
+		"endpoint", "credential_env", "token_limit_parameter", "reasoning_effort",
+		"reasoning_mode", "executable", "execution_boundary", "source_until",
+	} {
+		assert.NotContains(t, codexValues, key)
+	}
+}
+
 type providerCredentialChunkReader struct {
 	chunks [][]byte
 }

--- a/cmd/msgvault/cmd/person_provider_setup_test.go
+++ b/cmd/msgvault/cmd/person_provider_setup_test.go
@@ -26,6 +26,7 @@ import (
 const providerSetupSecretCanary = "provider-setup-secret-canary"
 
 func TestPersonProviderTableValuesUsesCanonicalProjection(t *testing.T) {
+	assert := assert.New(t)
 	httpProvider := peoplesweep.ProviderConfig{
 		Protocol: peoplesweep.ProtocolOpenAIChat, Endpoint: "https://provider.example.test/v1",
 		Model: "test-model", Auth: peoplesweep.AuthBearer, Credential: peoplesweep.CredentialEnv,
@@ -37,9 +38,9 @@ func TestPersonProviderTableValuesUsesCanonicalProjection(t *testing.T) {
 		ReasoningEffort: "medium", ReasoningMode: "enabled",
 	}
 	httpValues := personProviderTableValues(httpProvider)
-	assert.Equal(t, []string{"conversation_text", "meeting_text"}, httpValues["allowed_sources"])
-	assert.Equal(t, httpProvider.Endpoint, httpValues["endpoint"])
-	assert.Equal(t, httpProvider.CredentialEnv, httpValues["credential_env"])
+	assert.Equal([]string{"conversation_text", "meeting_text"}, httpValues["allowed_sources"])
+	assert.Equal(httpProvider.Endpoint, httpValues["endpoint"])
+	assert.Equal(httpProvider.CredentialEnv, httpValues["credential_env"])
 
 	codexProvider := peoplesweep.ProviderConfig{
 		Protocol: peoplesweep.ProtocolCodexAppServer, Model: "codex-model",
@@ -50,12 +51,12 @@ func TestPersonProviderTableValuesUsesCanonicalProjection(t *testing.T) {
 		}, SourceSince: "2025-01-01",
 	}
 	codexValues := personProviderTableValues(codexProvider)
-	assert.Equal(t, []string{"conversation_text"}, codexValues["allowed_sources"])
+	assert.Equal([]string{"conversation_text"}, codexValues["allowed_sources"])
 	for _, key := range []string{
 		"endpoint", "credential_env", "token_limit_parameter", "reasoning_effort",
 		"reasoning_mode", "executable", "execution_boundary", "source_until",
 	} {
-		assert.NotContains(t, codexValues, key)
+		assert.NotContains(codexValues, key)
 	}
 }
 

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"reflect"
 	"regexp"
 	"slices"
 	"strings"
@@ -131,25 +132,52 @@ type BudgetConfig struct {
 // that must be consented before use.
 type ProviderConfig struct {
 	Protocol            Protocol         `toml:"protocol"`
-	Endpoint            string           `toml:"endpoint"`
+	Endpoint            string           `toml:"endpoint,omitempty"`
 	Model               string           `toml:"model"`
 	Auth                AuthScheme       `toml:"auth"`
 	Credential          CredentialSource `toml:"credential"`
-	CredentialEnv       string           `toml:"credential_env"`
+	CredentialEnv       string           `toml:"credential_env,omitempty"`
 	OutputMode          OutputMode       `toml:"output_mode"`
-	TokenLimitParameter string           `toml:"token_limit_parameter"`
-	ReasoningEffort     string           `toml:"reasoning_effort"`
-	ReasoningMode       string           `toml:"reasoning_mode"`
+	TokenLimitParameter string           `toml:"token_limit_parameter,omitempty"`
+	ReasoningEffort     string           `toml:"reasoning_effort,omitempty"`
+	ReasoningMode       string           `toml:"reasoning_mode,omitempty"`
 	DriverVersion       string           `toml:"-"`
 	RetentionPosture    string           `toml:"retention_posture"`
 	TrainingPosture     string           `toml:"training_posture"`
 	AllowedSources      []SourceClass    `toml:"allowed_sources"`
 	SourceSince         string           `toml:"source_since"`
-	SourceUntil         string           `toml:"source_until"`
+	SourceUntil         string           `toml:"source_until,omitempty"`
 	AllowSensitive      bool             `toml:"allow_sensitive"`
-	Executable          string           `toml:"executable"`
-	ExecutionBoundary   string           `toml:"execution_boundary"`
+	Executable          string           `toml:"executable,omitempty"`
+	ExecutionBoundary   string           `toml:"execution_boundary,omitempty"`
 	RequestTimeout      time.Duration    `toml:"request_timeout"`
+}
+
+// ProviderTOMLValues derives the editable provider table from ProviderConfig's tags.
+func ProviderTOMLValues(provider ProviderConfig) map[string]any {
+	values := make(map[string]any)
+	value := reflect.ValueOf(provider)
+	typeOfProvider := value.Type()
+	for index := 0; index < value.NumField(); index++ {
+		field := typeOfProvider.Field(index)
+		tag := field.Tag.Get("toml")
+		name, options, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" || (options == "omitempty" && value.Field(index).IsZero()) {
+			continue
+		}
+		fieldValue := value.Field(index).Interface()
+		if sources, ok := fieldValue.([]SourceClass); ok {
+			sorted := slices.Clone(sources)
+			slices.Sort(sorted)
+			encoded := make([]string, len(sorted))
+			for sourceIndex, source := range sorted {
+				encoded[sourceIndex] = string(source)
+			}
+			fieldValue = encoded
+		}
+		values[name] = fieldValue
+	}
+	return values
 }
 
 // ProviderProfile is one immutable, fingerprinted egress policy. PolicyJSON is
@@ -179,30 +207,6 @@ type ProviderProfile struct {
 	ProgramFingerprint    string           `json:"program_fingerprint"`
 	DisclosedPacketFields []string         `json:"disclosed_packet_fields"`
 	PolicyJSON            json.RawMessage  `json:"-"`
-}
-
-type providerPolicy struct {
-	Protocol              Protocol         `json:"protocol"`
-	Endpoint              string           `json:"endpoint"`
-	Model                 string           `json:"model"`
-	Auth                  AuthScheme       `json:"auth"`
-	Credential            CredentialSource `json:"credential"`
-	CredentialRef         string           `json:"credential_ref"`
-	OutputMode            OutputMode       `json:"output_mode"`
-	TokenLimitParameter   string           `json:"token_limit_parameter"`
-	ReasoningEffort       string           `json:"reasoning_effort"`
-	ReasoningMode         string           `json:"reasoning_mode"`
-	DriverVersion         string           `json:"driver_version"`
-	RetentionPosture      string           `json:"retention_posture"`
-	TrainingPosture       string           `json:"training_posture"`
-	AllowedSources        []SourceClass    `json:"allowed_sources"`
-	SourceSince           string           `json:"source_since"`
-	SourceUntil           string           `json:"source_until"`
-	AllowSensitive        bool             `json:"allow_sensitive"`
-	ExecutionBoundary     string           `json:"execution_boundary"`
-	PacketRendererPolicy  string           `json:"packet_renderer_policy"`
-	ProgramFingerprint    string           `json:"program_fingerprint"`
-	DisclosedPacketFields []string         `json:"disclosed_packet_fields"`
 }
 
 // ApplyDefaults fills operational defaults without enabling inference.
@@ -538,7 +542,7 @@ func (c Config) Profile() (ProviderProfile, error) {
 	}
 	sources := slices.Clone(provider.AllowedSources)
 	slices.Sort(sources)
-	policy := providerPolicy{
+	profile := ProviderProfile{
 		Protocol: provider.Protocol, Model: strings.TrimSpace(provider.Model),
 		Auth: provider.Auth, Credential: provider.Credential, CredentialRef: credentialRef,
 		OutputMode: provider.OutputMode, TokenLimitParameter: provider.TokenLimitParameter,
@@ -551,31 +555,43 @@ func (c Config) Profile() (ProviderProfile, error) {
 		DisclosedPacketFields: slices.Clone(disclosedPacketFieldsV1),
 	}
 	if endpoint != nil {
-		policy.Endpoint = canonicalEndpoint(endpoint)
+		profile.Endpoint = canonicalEndpoint(endpoint)
 	}
-	policyJSON, err := json.Marshal(policy)
+	policyJSON, err := policyJSONForProviderProfile(profile)
 	if err != nil {
 		return ProviderProfile{}, fmt.Errorf("encode people inference provider policy: %w", err)
 	}
 	digest := sha256.Sum256(policyJSON)
-	return ProviderProfile{
-		Fingerprint: hex.EncodeToString(digest[:]), Protocol: policy.Protocol,
-		Endpoint: policy.Endpoint, Model: policy.Model, Auth: policy.Auth,
-		Credential: policy.Credential, CredentialRef: policy.CredentialRef,
-		OutputMode: policy.OutputMode, TokenLimitParameter: policy.TokenLimitParameter,
-		ReasoningEffort: policy.ReasoningEffort, ReasoningMode: policy.ReasoningMode,
-		DriverVersion: policy.DriverVersion, RetentionPosture: policy.RetentionPosture,
-		TrainingPosture: policy.TrainingPosture, AllowedSources: slices.Clone(policy.AllowedSources),
-		SourceSince: policy.SourceSince, SourceUntil: policy.SourceUntil,
-		AllowSensitive: policy.AllowSensitive, ExecutionBoundary: policy.ExecutionBoundary,
-		PacketRendererPolicy: policy.PacketRendererPolicy, ProgramFingerprint: policy.ProgramFingerprint,
-		DisclosedPacketFields: slices.Clone(policy.DisclosedPacketFields), PolicyJSON: policyJSON,
-	}, nil
+	profile.Fingerprint = hex.EncodeToString(digest[:])
+	profile.PolicyJSON = policyJSON
+	return profile, nil
 }
 
 // Validate proves the profile fields, canonical policy bytes, and fingerprint
 // still describe exactly the same policy.
 func (p ProviderProfile) Validate() error {
+	want, err := CanonicalProviderProfile(p)
+	if err != nil {
+		return err
+	}
+	if p.Fingerprint != want.Fingerprint {
+		return errors.New("people inference provider profile fingerprint does not match policy")
+	}
+	if !bytes.Equal(p.PolicyJSON, want.PolicyJSON) {
+		return errors.New("people inference provider profile policy is not canonical")
+	}
+	canonicalJSON, err := policyJSONForProviderProfile(p)
+	if err != nil {
+		return fmt.Errorf("encode people inference provider policy: %w", err)
+	}
+	if !bytes.Equal(canonicalJSON, want.PolicyJSON) {
+		return errors.New("people inference provider profile fields are not canonical")
+	}
+	return nil
+}
+
+// CanonicalProviderProfile rebuilds a profile through the validated config path.
+func CanonicalProviderProfile(p ProviderProfile) (ProviderProfile, error) {
 	name := "profile"
 	provider := ProviderConfig{
 		Protocol: p.Protocol, Endpoint: p.Endpoint, Model: p.Model, Auth: p.Auth,
@@ -600,30 +616,28 @@ func (p ProviderProfile) Validate() error {
 		Providers: map[string]ProviderConfig{name: provider},
 	}
 	config.ApplyDefaults()
-	want, err := config.Profile()
-	if err != nil {
-		return err
+	return config.Profile()
+}
+
+func policyJSONForProviderProfile(profile ProviderProfile) ([]byte, error) {
+	typeOfProfile := reflect.TypeOf(profile)
+	value := reflect.ValueOf(profile)
+	fields := make([]reflect.StructField, 0, value.NumField()-2)
+	values := make([]reflect.Value, 0, value.NumField()-2)
+	for index := 0; index < value.NumField(); index++ {
+		field := typeOfProfile.Field(index)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "fingerprint" || name == "" || name == "-" {
+			continue
+		}
+		fields = append(fields, field)
+		values = append(values, value.Field(index))
 	}
-	if p.Fingerprint != want.Fingerprint {
-		return errors.New("people inference provider profile fingerprint does not match policy")
+	policy := reflect.New(reflect.StructOf(fields)).Elem()
+	for index, fieldValue := range values {
+		policy.Field(index).Set(fieldValue)
 	}
-	if !bytes.Equal(p.PolicyJSON, want.PolicyJSON) {
-		return errors.New("people inference provider profile policy is not canonical")
-	}
-	if p.Protocol != want.Protocol || p.Endpoint != want.Endpoint || p.Model != want.Model ||
-		p.Auth != want.Auth || p.Credential != want.Credential || p.CredentialRef != want.CredentialRef ||
-		p.OutputMode != want.OutputMode || p.TokenLimitParameter != want.TokenLimitParameter ||
-		p.ReasoningEffort != want.ReasoningEffort || p.ReasoningMode != want.ReasoningMode ||
-		p.DriverVersion != want.DriverVersion || p.RetentionPosture != want.RetentionPosture ||
-		p.TrainingPosture != want.TrainingPosture || !slices.Equal(p.AllowedSources, want.AllowedSources) ||
-		p.SourceSince != want.SourceSince || p.SourceUntil != want.SourceUntil ||
-		p.AllowSensitive != want.AllowSensitive || p.ExecutionBoundary != want.ExecutionBoundary ||
-		p.PacketRendererPolicy != want.PacketRendererPolicy ||
-		p.ProgramFingerprint != want.ProgramFingerprint ||
-		!slices.Equal(p.DisclosedPacketFields, want.DisclosedPacketFields) {
-		return errors.New("people inference provider profile fields are not canonical")
-	}
-	return nil
+	return json.Marshal(policy.Interface())
 }
 
 func setDefaultString(target *string, value string) {

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -158,7 +158,7 @@ func ProviderTOMLValues(provider ProviderConfig) map[string]any {
 	values := make(map[string]any)
 	value := reflect.ValueOf(provider)
 	typeOfProvider := value.Type()
-	for index := 0; index < value.NumField(); index++ {
+	for index := range value.NumField() {
 		field := typeOfProvider.Field(index)
 		tag := field.Tag.Get("toml")
 		name, options, _ := strings.Cut(tag, ",")
@@ -624,7 +624,7 @@ func policyJSONForProviderProfile(profile ProviderProfile) ([]byte, error) {
 	value := reflect.ValueOf(profile)
 	fields := make([]reflect.StructField, 0, value.NumField()-2)
 	values := make([]reflect.Value, 0, value.NumField()-2)
-	for index := 0; index < value.NumField(); index++ {
+	for index := range value.NumField() {
 		field := typeOfProfile.Field(index)
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "fingerprint" || name == "" || name == "-" {

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -398,21 +398,24 @@ func TestProviderProfileHasStableCanonicalPolicy(t *testing.T) {
 }
 
 func TestProviderProfileProjectionRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	t.Setenv("TEST_KEY", "credential-value-must-not-persist")
 	profile, err := validConfig().Profile()
-	require.NoError(t, err)
+	require.NoError(err)
 
 	var decoded peoplesweep.ProviderProfile
-	require.NoError(t, json.Unmarshal(profile.PolicyJSON, &decoded))
+	require.NoError(json.Unmarshal(profile.PolicyJSON, &decoded))
 	decoded.Fingerprint = profile.Fingerprint
 	decoded.PolicyJSON = append(json.RawMessage(nil), profile.PolicyJSON...)
-	assert.Equal(t, profile, decoded)
-	assert.NotContains(t, string(profile.PolicyJSON), "credential-value-must-not-persist")
-	assert.NotContains(t, string(profile.PolicyJSON), "request_timeout")
-	assert.NoError(t, profile.Validate())
+	assert.Equal(profile, decoded)
+	assert.NotContains(string(profile.PolicyJSON), "credential-value-must-not-persist")
+	assert.NotContains(string(profile.PolicyJSON), "request_timeout")
+	assert.NoError(profile.Validate())
 }
 
 func TestProviderConfigTOMLValuesUseTaggedOptionalFields(t *testing.T) {
+	assert := assert.New(t)
 	provider := validConfig().Providers["default"]
 	provider.AllowedSources = []peoplesweep.SourceClass{
 		peoplesweep.SourceMeetingText,
@@ -420,9 +423,9 @@ func TestProviderConfigTOMLValuesUseTaggedOptionalFields(t *testing.T) {
 	}
 	values := peoplesweep.ProviderTOMLValues(provider)
 
-	assert.Equal(t, []string{"conversation_text", "meeting_text"}, values["allowed_sources"])
-	assert.Equal(t, provider.RequestTimeout, values["request_timeout"])
-	assert.Equal(t, provider.Endpoint, values["endpoint"])
+	assert.Equal([]string{"conversation_text", "meeting_text"}, values["allowed_sources"])
+	assert.Equal(provider.RequestTimeout, values["request_timeout"])
+	assert.Equal(provider.Endpoint, values["endpoint"])
 
 	provider.Endpoint = ""
 	provider.CredentialEnv = ""
@@ -437,7 +440,7 @@ func TestProviderConfigTOMLValuesUseTaggedOptionalFields(t *testing.T) {
 		"endpoint", "credential_env", "token_limit_parameter", "reasoning_effort",
 		"reasoning_mode", "executable", "execution_boundary", "source_until",
 	} {
-		assert.NotContains(t, values, key)
+		assert.NotContains(values, key)
 	}
 }
 

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -398,6 +398,7 @@ func TestProviderProfileHasStableCanonicalPolicy(t *testing.T) {
 }
 
 func TestProviderProfileProjectionRoundTrip(t *testing.T) {
+	t.Setenv("TEST_KEY", "credential-value-must-not-persist")
 	profile, err := validConfig().Profile()
 	require.NoError(t, err)
 

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -2,6 +2,7 @@ package peoplesweep_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"maps"
 	"slices"
 	"strings"
@@ -394,6 +395,49 @@ func TestProviderProfileHasStableCanonicalPolicy(t *testing.T) {
 	}`, "PROGRAM_FINGERPRINT", peoplesweep.ProgramFingerprint()), string(profile.PolicyJSON))
 	assert.Contains(string(profile.PolicyJSON), peoplesweep.ProgramFingerprint())
 	assert.NoError(profile.Validate())
+}
+
+func TestProviderProfileProjectionRoundTrip(t *testing.T) {
+	profile, err := validConfig().Profile()
+	require.NoError(t, err)
+
+	var decoded peoplesweep.ProviderProfile
+	require.NoError(t, json.Unmarshal(profile.PolicyJSON, &decoded))
+	decoded.Fingerprint = profile.Fingerprint
+	decoded.PolicyJSON = append(json.RawMessage(nil), profile.PolicyJSON...)
+	assert.Equal(t, profile, decoded)
+	assert.NotContains(t, string(profile.PolicyJSON), "credential-value-must-not-persist")
+	assert.NotContains(t, string(profile.PolicyJSON), "request_timeout")
+	assert.NoError(t, profile.Validate())
+}
+
+func TestProviderConfigTOMLValuesUseTaggedOptionalFields(t *testing.T) {
+	provider := validConfig().Providers["default"]
+	provider.AllowedSources = []peoplesweep.SourceClass{
+		peoplesweep.SourceMeetingText,
+		peoplesweep.SourceConversationText,
+	}
+	values := peoplesweep.ProviderTOMLValues(provider)
+
+	assert.Equal(t, []string{"conversation_text", "meeting_text"}, values["allowed_sources"])
+	assert.Equal(t, provider.RequestTimeout, values["request_timeout"])
+	assert.Equal(t, provider.Endpoint, values["endpoint"])
+
+	provider.Endpoint = ""
+	provider.CredentialEnv = ""
+	provider.TokenLimitParameter = ""
+	provider.ReasoningEffort = ""
+	provider.ReasoningMode = ""
+	provider.Executable = ""
+	provider.ExecutionBoundary = ""
+	provider.SourceUntil = ""
+	values = peoplesweep.ProviderTOMLValues(provider)
+	for _, key := range []string{
+		"endpoint", "credential_env", "token_limit_parameter", "reasoning_effort",
+		"reasoning_mode", "executable", "execution_boundary", "source_until",
+	} {
+		assert.NotContains(t, values, key)
+	}
 }
 
 func TestProviderProfileFingerprintCoversConsentPolicy(t *testing.T) {

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -191,7 +191,7 @@ func (p *personInferenceProfileProjection) insertValues() []any {
 	for valueIndex, fieldIndex := range indexes {
 		field := value.Field(fieldIndex)
 		if field.Type() == reflect.TypeFor[sql.NullString]() {
-			sourceUntil, ok := field.Interface().(sql.NullString)
+			sourceUntil, ok := reflect.TypeAssert[sql.NullString](field)
 			if !ok {
 				values[valueIndex] = field.Interface()
 				continue

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -90,14 +90,26 @@ func personInferenceProfileInsertValues(jsonBindExpr string) string {
 
 func personInferenceProfileColumnsFor(render func(name string, isJSON bool) string) string {
 	typeOfProjection := reflect.TypeOf(personInferenceProfileProjection{})
-	columns := make([]string, typeOfProjection.NumField())
-	for index := range columns {
-		field := typeOfProjection.Field(index)
+	indexes := personInferenceProfileDBFieldIndexes(typeOfProjection)
+	columns := make([]string, len(indexes))
+	for columnIndex, fieldIndex := range indexes {
+		field := typeOfProjection.Field(fieldIndex)
 		tag := field.Tag.Get("db")
 		name, options, _ := strings.Cut(tag, ",")
-		columns[index] = render(name, options == "json")
+		columns[columnIndex] = render(name, options == "json")
 	}
 	return strings.Join(columns, ", ")
+}
+
+func personInferenceProfileDBFieldIndexes(typeOfProjection reflect.Type) []int {
+	indexes := make([]int, 0, typeOfProjection.NumField())
+	for index := 0; index < typeOfProjection.NumField(); index++ {
+		name, _, _ := strings.Cut(typeOfProjection.Field(index).Tag.Get("db"), ",")
+		if name != "" && name != "-" {
+			indexes = append(indexes, index)
+		}
+	}
+	return indexes
 }
 
 func newPersonInferenceProfileProjection(
@@ -131,44 +143,52 @@ func newPersonInferenceProfileProjection(
 
 func (p *personInferenceProfileProjection) scanDestinations() []any {
 	value := reflect.ValueOf(p).Elem()
-	destinations := make([]any, value.NumField())
-	for index := range destinations {
-		destinations[index] = value.Field(index).Addr().Interface()
+	indexes := personInferenceProfileDBFieldIndexes(value.Type())
+	destinations := make([]any, len(indexes))
+	for destinationIndex, fieldIndex := range indexes {
+		destinations[destinationIndex] = value.Field(fieldIndex).Addr().Interface()
 	}
 	return destinations
 }
 
 func (p personInferenceProfileProjection) insertValues() []any {
 	value := reflect.ValueOf(p)
-	values := make([]any, value.NumField())
-	for index := range values {
-		field := value.Field(index)
+	indexes := personInferenceProfileDBFieldIndexes(value.Type())
+	values := make([]any, len(indexes))
+	for valueIndex, fieldIndex := range indexes {
+		field := value.Field(fieldIndex)
 		if field.Type() == reflect.TypeOf(sql.NullString{}) {
 			sourceUntil := field.Interface().(sql.NullString)
 			if !sourceUntil.Valid {
-				values[index] = nil
+				values[valueIndex] = nil
 				continue
 			}
-			values[index] = sourceUntil.String
+			values[valueIndex] = sourceUntil.String
 			continue
 		}
-		values[index] = field.Interface()
+		values[valueIndex] = field.Interface()
 	}
 	return values
 }
 
 func (p personInferenceProfileProjection) equal(expected personInferenceProfileProjection) bool {
-	actualAllowedSources, expectedAllowedSources := p.AllowedSources, expected.AllowedSources
-	actualDisclosedFields, expectedDisclosedFields := p.DisclosedPacketFields, expected.DisclosedPacketFields
-	actualPolicyJSON, expectedPolicyJSON := p.PolicyJSON, expected.PolicyJSON
-	actual := p
-	actual.AllowedSources, expected.AllowedSources = "", ""
-	actual.DisclosedPacketFields, expected.DisclosedPacketFields = "", ""
-	actual.PolicyJSON, expected.PolicyJSON = "", ""
-	return reflect.DeepEqual(actual, expected) &&
-		equalJSON([]byte(actualAllowedSources), []byte(expectedAllowedSources)) &&
-		equalJSON([]byte(actualDisclosedFields), []byte(expectedDisclosedFields)) &&
-		equalJSON([]byte(actualPolicyJSON), []byte(expectedPolicyJSON))
+	value, expectedValue := reflect.ValueOf(p), reflect.ValueOf(expected)
+	indexes := personInferenceProfileDBFieldIndexes(value.Type())
+	for _, fieldIndex := range indexes {
+		field := value.Type().Field(fieldIndex)
+		actual, want := value.Field(fieldIndex).Interface(), expectedValue.Field(fieldIndex).Interface()
+		_, options, _ := strings.Cut(field.Tag.Get("db"), ",")
+		if options == "json" {
+			if !equalJSON([]byte(actual.(string)), []byte(want.(string))) {
+				return false
+			}
+			continue
+		}
+		if !reflect.DeepEqual(actual, want) {
+			return false
+		}
+	}
+	return true
 }
 
 func (p personInferenceProfileProjection) profile() (peoplesweep.ProviderProfile, error) {

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -37,31 +37,31 @@ const personInferenceConsentColumns = `
 	id, profile_fingerprint, granted_by, granted_at, revoked_by, revoked_at`
 
 type personInferenceProfileProjection struct {
-	Fingerprint           string         `db:"fingerprint"`
-	Protocol              string         `db:"provider_kind"`
-	Endpoint              string         `db:"endpoint"`
-	Model                 string         `db:"model"`
-	APIKeyEnv             string         `db:"api_key_env"`
-	AllowAnonymous        bool           `db:"allow_anonymous"`
-	Auth                  string         `db:"auth_scheme"`
-	Credential            string         `db:"credential_source"`
-	CredentialRef         string         `db:"credential_ref"`
-	OutputMode            string         `db:"output_mode"`
-	TokenLimit            string         `db:"token_limit_parameter"`
-	ReasoningEffort       string         `db:"reasoning_effort"`
-	ReasoningMode         string         `db:"reasoning_mode"`
-	DriverVersion         string         `db:"driver_version"`
-	Retention             string         `db:"retention_posture"`
-	Training              string         `db:"training_posture"`
-	AllowedSources        string         `db:"allowed_sources,json"`
-	SourceSince           string         `db:"source_since"`
-	SourceUntil           sql.NullString `db:"source_until"`
-	AllowSensitive        bool           `db:"allow_sensitive"`
-	ExecutionBoundary     string         `db:"execution_boundary"`
-	PacketRendererPolicy  string         `db:"packet_renderer_policy"`
-	ProgramFingerprint    string         `db:"program_fingerprint"`
-	DisclosedPacketFields string         `db:"disclosed_packet_fields,json"`
-	PolicyJSON            string         `db:"policy_json,json"`
+	Fingerprint           string         `db:"fingerprint" profile:"fingerprint"`
+	Protocol              string         `db:"provider_kind" profile:"protocol"`
+	Endpoint              string         `db:"endpoint" profile:"endpoint"`
+	Model                 string         `db:"model" profile:"model"`
+	APIKeyEnv             string         `db:"api_key_env" profile:"credential_ref"`
+	AllowAnonymous        bool           `db:"allow_anonymous" profile:"auth,anonymous"`
+	Auth                  string         `db:"auth_scheme" profile:"auth"`
+	Credential            string         `db:"credential_source" profile:"credential"`
+	CredentialRef         string         `db:"credential_ref" profile:"credential_ref"`
+	OutputMode            string         `db:"output_mode" profile:"output_mode"`
+	TokenLimit            string         `db:"token_limit_parameter" profile:"token_limit_parameter"`
+	ReasoningEffort       string         `db:"reasoning_effort" profile:"reasoning_effort"`
+	ReasoningMode         string         `db:"reasoning_mode" profile:"reasoning_mode"`
+	DriverVersion         string         `db:"driver_version" profile:"driver_version"`
+	Retention             string         `db:"retention_posture" profile:"retention_posture"`
+	Training              string         `db:"training_posture" profile:"training_posture"`
+	AllowedSources        string         `db:"allowed_sources,json" profile:"allowed_sources,json"`
+	SourceSince           string         `db:"source_since" profile:"source_since"`
+	SourceUntil           sql.NullString `db:"source_until" profile:"source_until,null"`
+	AllowSensitive        bool           `db:"allow_sensitive" profile:"allow_sensitive"`
+	ExecutionBoundary     string         `db:"execution_boundary" profile:"execution_boundary"`
+	PacketRendererPolicy  string         `db:"packet_renderer_policy" profile:"packet_renderer_policy"`
+	ProgramFingerprint    string         `db:"program_fingerprint" profile:"program_fingerprint"`
+	DisclosedPacketFields string         `db:"disclosed_packet_fields,json" profile:"disclosed_packet_fields,json"`
+	PolicyJSON            string         `db:"policy_json,json" profile:"policy_json,raw"`
 }
 
 var personInferenceProfileColumns = personInferenceProfileSelectColumns()
@@ -115,30 +115,63 @@ func personInferenceProfileDBFieldIndexes(typeOfProjection reflect.Type) []int {
 func newPersonInferenceProfileProjection(
 	profile peoplesweep.ProviderProfile,
 ) (personInferenceProfileProjection, error) {
-	allowedSources, err := json.Marshal(profile.AllowedSources)
-	if err != nil {
-		return personInferenceProfileProjection{}, fmt.Errorf("encode people inference allowed sources: %w", err)
+	profileValue := reflect.ValueOf(profile)
+	profileFields := make(map[string]reflect.Value, profileValue.NumField())
+	for index := 0; index < profileValue.NumField(); index++ {
+		field := reflect.TypeOf(profile).Field(index)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if field.Name == "PolicyJSON" {
+			profileFields["policy_json"] = profileValue.Field(index)
+		} else if name != "" && name != "-" {
+			profileFields[name] = profileValue.Field(index)
+		}
 	}
-	disclosedPacketFields, err := json.Marshal(profile.DisclosedPacketFields)
-	if err != nil {
-		return personInferenceProfileProjection{}, fmt.Errorf("encode people inference disclosed packet fields: %w", err)
+
+	projection := personInferenceProfileProjection{}
+	projectionValue := reflect.ValueOf(&projection).Elem()
+	projectionType := projectionValue.Type()
+	for index := 0; index < projectionValue.NumField(); index++ {
+		field := projectionType.Field(index)
+		name, option, _ := strings.Cut(field.Tag.Get("profile"), ",")
+		if name == "" || name == "-" {
+			return personInferenceProfileProjection{}, fmt.Errorf(
+				"people inference profile projection field %q has no profile tag", field.Name)
+		}
+		source, ok := profileFields[name]
+		if !ok {
+			return personInferenceProfileProjection{}, fmt.Errorf(
+				"people inference profile projection field %q maps to unknown profile field %q", field.Name, name)
+		}
+		target := projectionValue.Field(index)
+		switch option {
+		case "anonymous":
+			target.SetBool(source.String() == string(peoplesweep.AuthNone))
+		case "json":
+			encoded, err := json.Marshal(source.Interface())
+			if err != nil {
+				return personInferenceProfileProjection{}, fmt.Errorf(
+					"encode people inference %s: %w", name, err)
+			}
+			target.SetString(string(encoded))
+		case "null":
+			target.Set(reflect.ValueOf(sql.NullString{
+				String: source.String(), Valid: source.String() != "",
+			}))
+		case "raw":
+			target.SetString(string(source.Bytes()))
+		default:
+			if target.Kind() == reflect.Bool && source.Kind() == reflect.Bool {
+				target.SetBool(source.Bool())
+				continue
+			}
+			if target.Kind() != reflect.String || source.Kind() != reflect.String {
+				return personInferenceProfileProjection{}, fmt.Errorf(
+					"people inference profile projection field %q has incompatible profile field %q", field.Name, name)
+			}
+			target.SetString(source.String())
+		}
 	}
-	return personInferenceProfileProjection{
-		Fingerprint: profile.Fingerprint, Protocol: string(profile.Protocol),
-		Endpoint: profile.Endpoint, Model: profile.Model, APIKeyEnv: profile.CredentialRef,
-		AllowAnonymous: profile.Auth == peoplesweep.AuthNone, Auth: string(profile.Auth),
-		Credential: string(profile.Credential), CredentialRef: profile.CredentialRef,
-		OutputMode: string(profile.OutputMode), TokenLimit: profile.TokenLimitParameter,
-		ReasoningEffort: profile.ReasoningEffort, ReasoningMode: profile.ReasoningMode,
-		DriverVersion: profile.DriverVersion, Retention: profile.RetentionPosture,
-		Training: profile.TrainingPosture, AllowedSources: string(allowedSources),
-		SourceSince:    profile.SourceSince,
-		SourceUntil:    sql.NullString{String: profile.SourceUntil, Valid: profile.SourceUntil != ""},
-		AllowSensitive: profile.AllowSensitive, ExecutionBoundary: profile.ExecutionBoundary,
-		PacketRendererPolicy:  profile.PacketRendererPolicy,
-		ProgramFingerprint:    profile.ProgramFingerprint,
-		DisclosedPacketFields: string(disclosedPacketFields), PolicyJSON: string(profile.PolicyJSON),
-	}, nil
+	return projection, nil
 }
 
 func (p *personInferenceProfileProjection) scanDestinations() []any {
@@ -177,6 +210,13 @@ func (p personInferenceProfileProjection) equal(expected personInferenceProfileP
 	for _, fieldIndex := range indexes {
 		field := value.Type().Field(fieldIndex)
 		actual, want := value.Field(fieldIndex).Interface(), expectedValue.Field(fieldIndex).Interface()
+		if field.Type == reflect.TypeOf(sql.NullString{}) {
+			actualUntil, expectedUntil := actual.(sql.NullString), want.(sql.NullString)
+			if actualUntil.String != expectedUntil.String {
+				return false
+			}
+			continue
+		}
 		_, options, _ := strings.Cut(field.Tag.Get("db"), ",")
 		if options == "json" {
 			if !equalJSON([]byte(actual.(string)), []byte(want.(string))) {

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -89,7 +89,7 @@ func personInferenceProfileInsertValues(jsonBindExpr string) string {
 }
 
 func personInferenceProfileColumnsFor(render func(name string, isJSON bool) string) string {
-	typeOfProjection := reflect.TypeOf(personInferenceProfileProjection{})
+	typeOfProjection := reflect.TypeFor[personInferenceProfileProjection]()
 	indexes := personInferenceProfileDBFieldIndexes(typeOfProjection)
 	columns := make([]string, len(indexes))
 	for columnIndex, fieldIndex := range indexes {
@@ -103,7 +103,7 @@ func personInferenceProfileColumnsFor(render func(name string, isJSON bool) stri
 
 func personInferenceProfileDBFieldIndexes(typeOfProjection reflect.Type) []int {
 	indexes := make([]int, 0, typeOfProjection.NumField())
-	for index := 0; index < typeOfProjection.NumField(); index++ {
+	for index := range typeOfProjection.NumField() {
 		name, _, _ := strings.Cut(typeOfProjection.Field(index).Tag.Get("db"), ",")
 		if name != "" && name != "-" {
 			indexes = append(indexes, index)
@@ -117,7 +117,7 @@ func newPersonInferenceProfileProjection(
 ) (personInferenceProfileProjection, error) {
 	profileValue := reflect.ValueOf(profile)
 	profileFields := make(map[string]reflect.Value, profileValue.NumField())
-	for index := 0; index < profileValue.NumField(); index++ {
+	for index := range profileValue.NumField() {
 		field := reflect.TypeOf(profile).Field(index)
 		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if field.Name == "PolicyJSON" {
@@ -130,7 +130,7 @@ func newPersonInferenceProfileProjection(
 	projection := personInferenceProfileProjection{}
 	projectionValue := reflect.ValueOf(&projection).Elem()
 	projectionType := projectionValue.Type()
-	for index := 0; index < projectionValue.NumField(); index++ {
+	for index := range projectionValue.NumField() {
 		field := projectionType.Field(index)
 		name, option, _ := strings.Cut(field.Tag.Get("profile"), ",")
 		if name == "" || name == "-" {
@@ -184,14 +184,18 @@ func (p *personInferenceProfileProjection) scanDestinations() []any {
 	return destinations
 }
 
-func (p personInferenceProfileProjection) insertValues() []any {
-	value := reflect.ValueOf(p)
+func (p *personInferenceProfileProjection) insertValues() []any {
+	value := reflect.ValueOf(p).Elem()
 	indexes := personInferenceProfileDBFieldIndexes(value.Type())
 	values := make([]any, len(indexes))
 	for valueIndex, fieldIndex := range indexes {
 		field := value.Field(fieldIndex)
-		if field.Type() == reflect.TypeOf(sql.NullString{}) {
-			sourceUntil := field.Interface().(sql.NullString)
+		if field.Type() == reflect.TypeFor[sql.NullString]() {
+			sourceUntil, ok := field.Interface().(sql.NullString)
+			if !ok {
+				values[valueIndex] = field.Interface()
+				continue
+			}
 			if !sourceUntil.Valid {
 				values[valueIndex] = nil
 				continue
@@ -204,14 +208,18 @@ func (p personInferenceProfileProjection) insertValues() []any {
 	return values
 }
 
-func (p personInferenceProfileProjection) equal(expected personInferenceProfileProjection) bool {
-	value, expectedValue := reflect.ValueOf(p), reflect.ValueOf(expected)
+func (p *personInferenceProfileProjection) equal(expected personInferenceProfileProjection) bool {
+	value, expectedValue := reflect.ValueOf(p).Elem(), reflect.ValueOf(expected)
 	indexes := personInferenceProfileDBFieldIndexes(value.Type())
 	for _, fieldIndex := range indexes {
 		field := value.Type().Field(fieldIndex)
 		actual, want := value.Field(fieldIndex).Interface(), expectedValue.Field(fieldIndex).Interface()
-		if field.Type == reflect.TypeOf(sql.NullString{}) {
-			actualUntil, expectedUntil := actual.(sql.NullString), want.(sql.NullString)
+		if field.Type == reflect.TypeFor[sql.NullString]() {
+			actualUntil, actualOK := actual.(sql.NullString)
+			expectedUntil, expectedOK := want.(sql.NullString)
+			if !actualOK || !expectedOK {
+				return false
+			}
 			if actualUntil.String != expectedUntil.String {
 				return false
 			}
@@ -219,7 +227,9 @@ func (p personInferenceProfileProjection) equal(expected personInferenceProfileP
 		}
 		_, options, _ := strings.Cut(field.Tag.Get("db"), ",")
 		if options == "json" {
-			if !equalJSON([]byte(actual.(string)), []byte(want.(string))) {
+			actualString, actualOK := actual.(string)
+			wantString, wantOK := want.(string)
+			if !actualOK || !wantOK || !equalJSON([]byte(actualString), []byte(wantString)) {
 				return false
 			}
 			continue
@@ -231,7 +241,7 @@ func (p personInferenceProfileProjection) equal(expected personInferenceProfileP
 	return true
 }
 
-func (p personInferenceProfileProjection) profile() (peoplesweep.ProviderProfile, error) {
+func (p *personInferenceProfileProjection) profile() (peoplesweep.ProviderProfile, error) {
 	var storedSources []peoplesweep.SourceClass
 	if err := json.Unmarshal([]byte(p.AllowedSources), &storedSources); err != nil {
 		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode allowed sources: %w", err)

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"slices"
+	"reflect"
 	"strings"
 	"time"
 
@@ -36,14 +36,179 @@ type PersonInferenceConsentStatus struct {
 const personInferenceConsentColumns = `
 	id, profile_fingerprint, granted_by, granted_at, revoked_by, revoked_at`
 
-const personInferenceProfileColumns = `
-	fingerprint, provider_kind, endpoint, model, api_key_env, allow_anonymous,
-	auth_scheme, credential_source, credential_ref, output_mode,
-	token_limit_parameter, reasoning_effort, reasoning_mode, driver_version,
-	retention_posture, training_posture, CAST(allowed_sources AS TEXT),
-	source_since, source_until, allow_sensitive, execution_boundary,
-	packet_renderer_policy, program_fingerprint,
-	CAST(disclosed_packet_fields AS TEXT), CAST(policy_json AS TEXT)`
+type personInferenceProfileProjection struct {
+	Fingerprint           string         `db:"fingerprint"`
+	Protocol              string         `db:"provider_kind"`
+	Endpoint              string         `db:"endpoint"`
+	Model                 string         `db:"model"`
+	APIKeyEnv             string         `db:"api_key_env"`
+	AllowAnonymous        bool           `db:"allow_anonymous"`
+	Auth                  string         `db:"auth_scheme"`
+	Credential            string         `db:"credential_source"`
+	CredentialRef         string         `db:"credential_ref"`
+	OutputMode            string         `db:"output_mode"`
+	TokenLimit            string         `db:"token_limit_parameter"`
+	ReasoningEffort       string         `db:"reasoning_effort"`
+	ReasoningMode         string         `db:"reasoning_mode"`
+	DriverVersion         string         `db:"driver_version"`
+	Retention             string         `db:"retention_posture"`
+	Training              string         `db:"training_posture"`
+	AllowedSources        string         `db:"allowed_sources,json"`
+	SourceSince           string         `db:"source_since"`
+	SourceUntil           sql.NullString `db:"source_until"`
+	AllowSensitive        bool           `db:"allow_sensitive"`
+	ExecutionBoundary     string         `db:"execution_boundary"`
+	PacketRendererPolicy  string         `db:"packet_renderer_policy"`
+	ProgramFingerprint    string         `db:"program_fingerprint"`
+	DisclosedPacketFields string         `db:"disclosed_packet_fields,json"`
+	PolicyJSON            string         `db:"policy_json,json"`
+}
+
+var personInferenceProfileColumns = personInferenceProfileSelectColumns()
+
+func personInferenceProfileSelectColumns() string {
+	return personInferenceProfileColumnsFor(func(name string, isJSON bool) string {
+		if isJSON {
+			return "CAST(" + name + " AS TEXT)"
+		}
+		return name
+	})
+}
+
+func personInferenceProfileInsertColumns() string {
+	return personInferenceProfileColumnsFor(func(name string, _ bool) string { return name })
+}
+
+func personInferenceProfileInsertValues(jsonBindExpr string) string {
+	return personInferenceProfileColumnsFor(func(_ string, isJSON bool) string {
+		if isJSON {
+			return jsonBindExpr
+		}
+		return "?"
+	})
+}
+
+func personInferenceProfileColumnsFor(render func(name string, isJSON bool) string) string {
+	typeOfProjection := reflect.TypeOf(personInferenceProfileProjection{})
+	columns := make([]string, typeOfProjection.NumField())
+	for index := range columns {
+		field := typeOfProjection.Field(index)
+		tag := field.Tag.Get("db")
+		name, options, _ := strings.Cut(tag, ",")
+		columns[index] = render(name, options == "json")
+	}
+	return strings.Join(columns, ", ")
+}
+
+func newPersonInferenceProfileProjection(
+	profile peoplesweep.ProviderProfile,
+) (personInferenceProfileProjection, error) {
+	allowedSources, err := json.Marshal(profile.AllowedSources)
+	if err != nil {
+		return personInferenceProfileProjection{}, fmt.Errorf("encode people inference allowed sources: %w", err)
+	}
+	disclosedPacketFields, err := json.Marshal(profile.DisclosedPacketFields)
+	if err != nil {
+		return personInferenceProfileProjection{}, fmt.Errorf("encode people inference disclosed packet fields: %w", err)
+	}
+	return personInferenceProfileProjection{
+		Fingerprint: profile.Fingerprint, Protocol: string(profile.Protocol),
+		Endpoint: profile.Endpoint, Model: profile.Model, APIKeyEnv: profile.CredentialRef,
+		AllowAnonymous: profile.Auth == peoplesweep.AuthNone, Auth: string(profile.Auth),
+		Credential: string(profile.Credential), CredentialRef: profile.CredentialRef,
+		OutputMode: string(profile.OutputMode), TokenLimit: profile.TokenLimitParameter,
+		ReasoningEffort: profile.ReasoningEffort, ReasoningMode: profile.ReasoningMode,
+		DriverVersion: profile.DriverVersion, Retention: profile.RetentionPosture,
+		Training: profile.TrainingPosture, AllowedSources: string(allowedSources),
+		SourceSince:    profile.SourceSince,
+		SourceUntil:    sql.NullString{String: profile.SourceUntil, Valid: profile.SourceUntil != ""},
+		AllowSensitive: profile.AllowSensitive, ExecutionBoundary: profile.ExecutionBoundary,
+		PacketRendererPolicy:  profile.PacketRendererPolicy,
+		ProgramFingerprint:    profile.ProgramFingerprint,
+		DisclosedPacketFields: string(disclosedPacketFields), PolicyJSON: string(profile.PolicyJSON),
+	}, nil
+}
+
+func (p *personInferenceProfileProjection) scanDestinations() []any {
+	value := reflect.ValueOf(p).Elem()
+	destinations := make([]any, value.NumField())
+	for index := range destinations {
+		destinations[index] = value.Field(index).Addr().Interface()
+	}
+	return destinations
+}
+
+func (p personInferenceProfileProjection) insertValues() []any {
+	value := reflect.ValueOf(p)
+	values := make([]any, value.NumField())
+	for index := range values {
+		field := value.Field(index)
+		if field.Type() == reflect.TypeOf(sql.NullString{}) {
+			sourceUntil := field.Interface().(sql.NullString)
+			if !sourceUntil.Valid {
+				values[index] = nil
+				continue
+			}
+			values[index] = sourceUntil.String
+			continue
+		}
+		values[index] = field.Interface()
+	}
+	return values
+}
+
+func (p personInferenceProfileProjection) equal(expected personInferenceProfileProjection) bool {
+	actualAllowedSources, expectedAllowedSources := p.AllowedSources, expected.AllowedSources
+	actualDisclosedFields, expectedDisclosedFields := p.DisclosedPacketFields, expected.DisclosedPacketFields
+	actualPolicyJSON, expectedPolicyJSON := p.PolicyJSON, expected.PolicyJSON
+	actual := p
+	actual.AllowedSources, expected.AllowedSources = "", ""
+	actual.DisclosedPacketFields, expected.DisclosedPacketFields = "", ""
+	actual.PolicyJSON, expected.PolicyJSON = "", ""
+	return reflect.DeepEqual(actual, expected) &&
+		equalJSON([]byte(actualAllowedSources), []byte(expectedAllowedSources)) &&
+		equalJSON([]byte(actualDisclosedFields), []byte(expectedDisclosedFields)) &&
+		equalJSON([]byte(actualPolicyJSON), []byte(expectedPolicyJSON))
+}
+
+func (p personInferenceProfileProjection) profile() (peoplesweep.ProviderProfile, error) {
+	var storedSources []peoplesweep.SourceClass
+	if err := json.Unmarshal([]byte(p.AllowedSources), &storedSources); err != nil {
+		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode allowed sources: %w", err)
+	}
+	var storedDisclosedFields []string
+	if err := json.Unmarshal([]byte(p.DisclosedPacketFields), &storedDisclosedFields); err != nil {
+		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode disclosed packet fields: %w", err)
+	}
+	var profile peoplesweep.ProviderProfile
+	if err := json.Unmarshal([]byte(p.PolicyJSON), &profile); err != nil {
+		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode people inference policy: %w", err)
+	}
+	if profile.Protocol == "" {
+		return peoplesweep.ProviderProfile{}, errors.New(
+			"stored people inference profile policy has no protocol")
+	}
+	profile.Fingerprint = p.Fingerprint
+	profile.PolicyJSON = json.RawMessage(p.PolicyJSON)
+	expected, err := newPersonInferenceProfileProjection(profile)
+	if err != nil {
+		return peoplesweep.ProviderProfile{}, err
+	}
+	if !p.equal(expected) {
+		return peoplesweep.ProviderProfile{}, errors.New(
+			"stored people inference profile does not match its immutable policy")
+	}
+	canonical, err := peoplesweep.CanonicalProviderProfile(profile)
+	if err != nil {
+		return peoplesweep.ProviderProfile{}, err
+	}
+	if profile.Fingerprint != canonical.Fingerprint ||
+		!equalJSON(profile.PolicyJSON, canonical.PolicyJSON) {
+		return peoplesweep.ProviderProfile{}, errors.New(
+			"stored people inference profile does not match its immutable policy")
+	}
+	return canonical, nil
+}
 
 // EnsurePersonInferenceProfile persists one immutable canonical policy or
 // verifies the already-stored row has the same content.
@@ -54,39 +219,15 @@ func (s *Store) EnsurePersonInferenceProfile(
 	if err := profile.Validate(); err != nil {
 		return false, err
 	}
-	allowedSources, err := json.Marshal(profile.AllowedSources)
+	projection, err := newPersonInferenceProfileProjection(profile)
 	if err != nil {
-		return false, fmt.Errorf("encode people inference allowed sources: %w", err)
-	}
-	disclosedPacketFields, err := json.Marshal(profile.DisclosedPacketFields)
-	if err != nil {
-		return false, fmt.Errorf("encode people inference disclosed packet fields: %w", err)
-	}
-	var sourceUntil any
-	if profile.SourceUntil != "" {
-		sourceUntil = profile.SourceUntil
+		return false, err
 	}
 	result, err := s.db.ExecContext(ctx, `
 		INSERT INTO person_inference_profiles
-			(fingerprint, provider_kind, endpoint, model, api_key_env,
-			 allow_anonymous, auth_scheme, credential_source, credential_ref,
-			 output_mode, token_limit_parameter, reasoning_effort, reasoning_mode,
-			 driver_version, retention_posture, training_posture, allowed_sources,
-			 source_since, source_until, allow_sensitive, execution_boundary,
-			 packet_renderer_policy, program_fingerprint, disclosed_packet_fields,
-			 policy_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+s.dialect.JSONBindExpr()+`,
-		        ?, ?, ?, ?, ?, ?, `+s.dialect.JSONBindExpr()+`, `+s.dialect.JSONBindExpr()+`)
-		ON CONFLICT (fingerprint) DO NOTHING`,
-		profile.Fingerprint, profile.Protocol, profile.Endpoint, profile.Model,
-		profile.CredentialRef, profile.Auth == peoplesweep.AuthNone, profile.Auth,
-		profile.Credential, profile.CredentialRef, profile.OutputMode,
-		profile.TokenLimitParameter, profile.ReasoningEffort, profile.ReasoningMode,
-		profile.DriverVersion, profile.RetentionPosture, profile.TrainingPosture,
-		string(allowedSources), profile.SourceSince, sourceUntil, profile.AllowSensitive,
-		profile.ExecutionBoundary, profile.PacketRendererPolicy, profile.ProgramFingerprint,
-		string(disclosedPacketFields), string(profile.PolicyJSON),
-	)
+			(`+personInferenceProfileInsertColumns()+`)
+		VALUES (`+personInferenceProfileInsertValues(s.dialect.JSONBindExpr())+`)
+		ON CONFLICT (fingerprint) DO NOTHING`, projection.insertValues()...)
 	if err != nil {
 		return false, fmt.Errorf("insert people inference profile: %w", err)
 	}
@@ -94,9 +235,7 @@ func (s *Store) EnsurePersonInferenceProfile(
 	if err != nil {
 		return false, fmt.Errorf("read people inference profile insert result: %w", err)
 	}
-	if err := s.verifyPersonInferenceProfile(
-		ctx, profile, allowedSources, disclosedPacketFields,
-	); err != nil {
+	if err := s.verifyPersonInferenceProfile(ctx, profile, projection); err != nil {
 		return false, err
 	}
 	return rows == 1, nil
@@ -105,52 +244,16 @@ func (s *Store) EnsurePersonInferenceProfile(
 func (s *Store) verifyPersonInferenceProfile(
 	ctx context.Context,
 	profile peoplesweep.ProviderProfile,
-	allowedSources []byte,
-	disclosedPacketFields []byte,
+	expected personInferenceProfileProjection,
 ) error {
-	var (
-		fingerprint, protocol, endpoint, model, apiKeyEnv string
-		auth, credential, credentialRef                   string
-		outputMode, tokenLimit, reasoningEffort           string
-		reasoningMode, driverVersion                      string
-		retention, training, storedSources, since         string
-		executionBoundary, packetRendererPolicy           string
-		programFingerprint, storedDisclosed, storedPolicy string
-		anonymous, sensitive                              bool
-		until                                             sql.NullString
-	)
+	var stored personInferenceProfileProjection
 	err := s.db.QueryRowContext(ctx, `
 		SELECT `+personInferenceProfileColumns+`
-		FROM person_inference_profiles WHERE fingerprint = ?`, profile.Fingerprint).Scan(
-		&fingerprint, &protocol, &endpoint, &model, &apiKeyEnv, &anonymous,
-		&auth, &credential, &credentialRef, &outputMode, &tokenLimit,
-		&reasoningEffort, &reasoningMode, &driverVersion,
-		&retention, &training, &storedSources, &since, &until, &sensitive,
-		&executionBoundary, &packetRendererPolicy, &programFingerprint,
-		&storedDisclosed, &storedPolicy,
-	)
+		FROM person_inference_profiles WHERE fingerprint = ?`, profile.Fingerprint).Scan(stored.scanDestinations()...)
 	if err != nil {
 		return fmt.Errorf("read people inference profile: %w", err)
 	}
-	storedUntil := ""
-	if until.Valid {
-		storedUntil = until.String
-	}
-	if fingerprint != profile.Fingerprint || protocol != string(profile.Protocol) ||
-		endpoint != profile.Endpoint || model != profile.Model ||
-		apiKeyEnv != profile.CredentialRef || anonymous != (profile.Auth == peoplesweep.AuthNone) ||
-		auth != string(profile.Auth) || credential != string(profile.Credential) ||
-		credentialRef != profile.CredentialRef || outputMode != string(profile.OutputMode) ||
-		tokenLimit != profile.TokenLimitParameter || reasoningEffort != profile.ReasoningEffort ||
-		reasoningMode != profile.ReasoningMode || driverVersion != profile.DriverVersion ||
-		retention != profile.RetentionPosture || training != profile.TrainingPosture ||
-		since != profile.SourceSince || storedUntil != profile.SourceUntil ||
-		sensitive != profile.AllowSensitive || executionBoundary != profile.ExecutionBoundary ||
-		packetRendererPolicy != profile.PacketRendererPolicy ||
-		programFingerprint != profile.ProgramFingerprint ||
-		!equalJSON([]byte(storedSources), allowedSources) ||
-		!equalJSON([]byte(storedDisclosed), disclosedPacketFields) ||
-		!equalJSON([]byte(storedPolicy), profile.PolicyJSON) {
+	if !stored.equal(expected) {
 		return errors.New("people inference profile fingerprint already has different immutable policy")
 	}
 	return nil
@@ -395,105 +498,11 @@ func scanPersonInferenceConsent(row scanner) (*PersonInferenceConsent, error) {
 }
 
 func scanPersonInferenceProfile(row scanner) (peoplesweep.ProviderProfile, error) {
-	var (
-		fingerprint, protocol                 string
-		endpoint, model                       string
-		apiKeyEnv, auth, credential           string
-		credentialRef, outputMode, tokenLimit string
-		reasoningEffort, reasoningMode        string
-		driverVersion, retention, training    string
-		sourceSince, executionBoundary        string
-		packetRendererPolicy                  string
-		programFingerprint                    string
-		allowAnonymous, sensitive             bool
-		allowedSources, disclosedFields       string
-		policyJSON                            string
-		sourceUntil                           sql.NullString
-	)
-	if err := row.Scan(
-		&fingerprint, &protocol, &endpoint, &model, &apiKeyEnv, &allowAnonymous,
-		&auth, &credential, &credentialRef, &outputMode, &tokenLimit,
-		&reasoningEffort, &reasoningMode, &driverVersion,
-		&retention, &training, &allowedSources, &sourceSince, &sourceUntil, &sensitive,
-		&executionBoundary, &packetRendererPolicy, &programFingerprint,
-		&disclosedFields, &policyJSON,
-	); err != nil {
+	var projection personInferenceProfileProjection
+	if err := row.Scan(projection.scanDestinations()...); err != nil {
 		return peoplesweep.ProviderProfile{}, err
 	}
-	var storedSources []peoplesweep.SourceClass
-	if err := json.Unmarshal([]byte(allowedSources), &storedSources); err != nil {
-		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode allowed sources: %w", err)
-	}
-	storedUntil := ""
-	if sourceUntil.Valid {
-		storedUntil = sourceUntil.String
-	}
-	var profile peoplesweep.ProviderProfile
-	if err := json.Unmarshal([]byte(policyJSON), &profile); err != nil {
-		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode people inference policy: %w", err)
-	}
-	if profile.Protocol == "" {
-		return peoplesweep.ProviderProfile{}, errors.New(
-			"stored people inference profile policy has no protocol")
-	}
-	profile.Fingerprint = fingerprint
-	profile.PolicyJSON = json.RawMessage(policyJSON)
-	storedDisclosedFields := []string(nil)
-	if err := json.Unmarshal([]byte(disclosedFields), &storedDisclosedFields); err != nil {
-		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode disclosed packet fields: %w", err)
-	}
-	if string(profile.Protocol) != protocol || profile.Endpoint != endpoint || profile.Model != model ||
-		profile.CredentialRef != apiKeyEnv || (profile.Auth == peoplesweep.AuthNone) != allowAnonymous ||
-		string(profile.Auth) != auth || string(profile.Credential) != credential ||
-		profile.CredentialRef != credentialRef || string(profile.OutputMode) != outputMode ||
-		profile.TokenLimitParameter != tokenLimit || profile.ReasoningEffort != reasoningEffort ||
-		profile.ReasoningMode != reasoningMode || profile.DriverVersion != driverVersion ||
-		profile.RetentionPosture != retention || profile.TrainingPosture != training ||
-		!slices.Equal(profile.AllowedSources, storedSources) || profile.SourceSince != sourceSince ||
-		profile.SourceUntil != storedUntil || profile.AllowSensitive != sensitive ||
-		profile.ExecutionBoundary != executionBoundary ||
-		profile.PacketRendererPolicy != packetRendererPolicy ||
-		profile.ProgramFingerprint != programFingerprint ||
-		!slices.Equal(profile.DisclosedPacketFields, storedDisclosedFields) {
-		return peoplesweep.ProviderProfile{}, errors.New(
-			"stored people inference profile does not match its immutable policy")
-	}
-	profileName := "stored"
-	provider := peoplesweep.ProviderConfig{
-		Protocol: profile.Protocol, Endpoint: profile.Endpoint, Model: profile.Model,
-		Auth: profile.Auth, Credential: profile.Credential, OutputMode: profile.OutputMode,
-		TokenLimitParameter: profile.TokenLimitParameter, ReasoningEffort: profile.ReasoningEffort,
-		ReasoningMode: profile.ReasoningMode, DriverVersion: profile.DriverVersion,
-		RetentionPosture: profile.RetentionPosture, TrainingPosture: profile.TrainingPosture,
-		AllowedSources: slices.Clone(profile.AllowedSources), SourceSince: profile.SourceSince,
-		SourceUntil: profile.SourceUntil, AllowSensitive: profile.AllowSensitive,
-		ExecutionBoundary: profile.ExecutionBoundary, RequestTimeout: time.Second,
-	}
-	switch profile.Credential {
-	case peoplesweep.CredentialEnv:
-		provider.CredentialEnv = profile.CredentialRef
-	case peoplesweep.CredentialStored:
-		profileName = profile.CredentialRef
-	case peoplesweep.CredentialNone:
-		provider.CredentialEnv = ""
-	}
-	profileConfig := peoplesweep.Config{
-		Enabled: true, Provider: peoplesweep.ProviderSelection{Name: profileName},
-		Providers: map[string]peoplesweep.ProviderConfig{profileName: provider},
-	}
-	profileConfig.ApplyDefaults()
-	canonical, err := profileConfig.Profile()
-	if err != nil {
-		return peoplesweep.ProviderProfile{}, err
-	}
-	if fingerprint != canonical.Fingerprint || !equalJSON([]byte(policyJSON), canonical.PolicyJSON) {
-		return peoplesweep.ProviderProfile{}, errors.New(
-			"stored people inference profile does not match its immutable policy")
-	}
-	if err := canonical.Validate(); err != nil {
-		return peoplesweep.ProviderProfile{}, err
-	}
-	return canonical, nil
+	return projection.profile()
 }
 
 func validatePersonInferenceConsentInput(fingerprint, actor string) (string, error) {

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -189,21 +189,7 @@ func (p *personInferenceProfileProjection) insertValues() []any {
 	indexes := personInferenceProfileDBFieldIndexes(value.Type())
 	values := make([]any, len(indexes))
 	for valueIndex, fieldIndex := range indexes {
-		field := value.Field(fieldIndex)
-		if field.Type() == reflect.TypeFor[sql.NullString]() {
-			sourceUntil, ok := reflect.TypeAssert[sql.NullString](field)
-			if !ok {
-				values[valueIndex] = field.Interface()
-				continue
-			}
-			if !sourceUntil.Valid {
-				values[valueIndex] = nil
-				continue
-			}
-			values[valueIndex] = sourceUntil.String
-			continue
-		}
-		values[valueIndex] = field.Interface()
+		values[valueIndex] = value.Field(fieldIndex).Interface()
 	}
 	return values
 }
@@ -242,6 +228,8 @@ func (p *personInferenceProfileProjection) equal(expected personInferenceProfile
 }
 
 func (p *personInferenceProfileProjection) profile() (peoplesweep.ProviderProfile, error) {
+	// Validate each entire JSON array before comparing it. equalJSON reads
+	// only the first JSON value and would accept trailing garbage in SQLite.
 	var storedSources []peoplesweep.SourceClass
 	if err := json.Unmarshal([]byte(p.AllowedSources), &storedSources); err != nil {
 		return peoplesweep.ProviderProfile{}, fmt.Errorf("decode allowed sources: %w", err)

--- a/internal/store/person_inference_consent_test.go
+++ b/internal/store/person_inference_consent_test.go
@@ -183,6 +183,21 @@ func TestPersonInferenceProfilesCanBeListedAndRevokedWithoutRuntimeConfig(t *tes
 	assert.False(active)
 }
 
+func TestPersonInferenceProfilesRejectChangedIndexedProjection(t *testing.T) {
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_profiles SET model = ? WHERE fingerprint = ?`),
+		"changed-model", profile.Fingerprint)
+	require.NoError(err)
+
+	_, err = st.ListPersonInferenceProfiles(t.Context())
+	require.ErrorContains(err, "does not match its immutable policy")
+}
+
 func TestPersonInferenceProfilesRestoreCodexPolicyFields(t *testing.T) {
 	requirements := require.New(t)
 	checks := assert.New(t)

--- a/internal/store/person_inference_consent_test.go
+++ b/internal/store/person_inference_consent_test.go
@@ -44,6 +44,23 @@ func inferenceTestProfile(t *testing.T) peoplesweep.ProviderProfile {
 	return profile
 }
 
+func TestPersonInferenceProfileNormalizesNullAndEmptySourceUntil(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	profile := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(t, err)
+
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_profiles SET source_until = '' WHERE fingerprint = ?`),
+		profile.Fingerprint)
+	require.NoError(t, err)
+
+	profiles, err := st.ListPersonInferenceProfiles(t.Context())
+	require.NoError(t, err)
+	require.Len(t, profiles, 1)
+	assert.Equal(t, profile.Fingerprint, profiles[0].Fingerprint)
+}
+
 func TestPersonInferenceConsentLifecycle(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/store/person_inference_consent_test.go
+++ b/internal/store/person_inference_consent_test.go
@@ -45,20 +45,22 @@ func inferenceTestProfile(t *testing.T) peoplesweep.ProviderProfile {
 }
 
 func TestPersonInferenceProfileNormalizesNullAndEmptySourceUntil(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	st := testutil.NewTestStore(t)
 	profile := inferenceTestProfile(t)
 	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	_, err = st.DB().Exec(st.Rebind(`
 		UPDATE person_inference_profiles SET source_until = '' WHERE fingerprint = ?`),
 		profile.Fingerprint)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	profiles, err := st.ListPersonInferenceProfiles(t.Context())
-	require.NoError(t, err)
-	require.Len(t, profiles, 1)
-	assert.Equal(t, profile.Fingerprint, profiles[0].Fingerprint)
+	require.NoError(err)
+	require.Len(profiles, 1)
+	assert.Equal(profile.Fingerprint, profiles[0].Fingerprint)
 }
 
 func TestPersonInferenceConsentLifecycle(t *testing.T) {

--- a/internal/store/person_sweep_budget_pg_test.go
+++ b/internal/store/person_sweep_budget_pg_test.go
@@ -94,6 +94,11 @@ func TestPersonSweepPostgreSQLMarkStartedSurvivesReclaimLockCycle(t *testing.T) 
 		_, err = f.store.DB().ExecContext(t.Context(), fmt.Sprintf(`
 			CREATE FUNCTION park_reclaimed_batch_update() RETURNS trigger AS $$
 			BEGIN
+				-- Keep the reclaim from choosing itself as the victim, including
+				-- if the mark retries and forms another cycle. This transaction's
+				-- detector is deferred beyond the test's bounded wait; the mark's
+				-- detector still breaks each cycle normally.
+				PERFORM set_config('deadlock_timeout', '1h', true);
 				PERFORM pg_advisory_xact_lock(%d);
 				RETURN NEW;
 			END;
@@ -133,10 +138,6 @@ func TestPersonSweepPostgreSQLMarkStartedSurvivesReclaimLockCycle(t *testing.T) 
 			return postgreSQLWaitingLockCount(t, f.store) >= waitingBefore+2
 		}, 5*time.Second, 10*time.Millisecond,
 			"the mark did not park behind the reclaim's batch row lock")
-		// Let the mark's deadlock timer run well ahead of the reclaim's before
-		// the reclaim closes the cycle, so the mark is the victim and its
-		// bounded contention retry is what the test observes.
-		time.Sleep(250 * time.Millisecond)
 		_, err = holder.ExecContext(t.Context(), `SELECT pg_advisory_unlock($1)`, advisoryKey)
 		requirements.NoError(err)
 

--- a/internal/store/person_sweep_budget_pg_test.go
+++ b/internal/store/person_sweep_budget_pg_test.go
@@ -181,8 +181,7 @@ func TestPersonSweepPostgreSQLMarkStartedSurvivesReclaimLockCycle(t *testing.T) 
 // person_sweep_work row first, exactly like the claim's fenced lease transfer;
 // once the mark parks behind that row while holding the attempt row, the
 // blocker asks for the attempt row, so PostgreSQL's deadlock detector has to
-// abort one side. The mark is parked well before the blocker closes the cycle,
-// so its deadlock timer expires first and it, not the blocker, is the victim.
+// abort one side. The blocker defers its detector, so the mark is the victim.
 // The blocker releases cleanly; the mark's own outcome is returned for the
 // caller to judge.
 func forcePersonSweepReclaimLockCycle(

--- a/internal/store/person_sweep_budget_pg_test.go
+++ b/internal/store/person_sweep_budget_pg_test.go
@@ -193,6 +193,8 @@ func forcePersonSweepReclaimLockCycle(
 	blocker, err := f.store.DB().BeginTx(ctx, nil)
 	requirements.NoError(err)
 	t.Cleanup(func() { _ = blocker.Rollback() })
+	_, err = blocker.ExecContext(ctx, `SET LOCAL deadlock_timeout = '1h'`)
+	requirements.NoError(err)
 	var lockedPerson int64
 	requirements.NoError(blocker.QueryRowContext(ctx,
 		`SELECT person_id FROM person_sweep_work WHERE person_id = $1 FOR UPDATE`,
@@ -204,7 +206,6 @@ func forcePersonSweepReclaimLockCycle(
 	requirements.Eventually(func() bool {
 		return postgreSQLWaitingLockCount(t, f.store) >= 1
 	}, 5*time.Second, 10*time.Millisecond, "the mark did not park behind the work row lock")
-	time.Sleep(250 * time.Millisecond)
 
 	blockerDone := make(chan error, 1)
 	go func() {

--- a/internal/store/pg_deadlock_test.go
+++ b/internal/store/pg_deadlock_test.go
@@ -18,9 +18,8 @@ type postgreSQLRowLock struct {
 // forcePostgreSQLDeadlock closes a lock cycle around write. A blocker
 // transaction holds the held row; write is started and parked behind it; then
 // the blocker asks for the cycle row, which write is expected to hold by then,
-// so PostgreSQL's detector has to abort one side. The write is parked well
-// before the blocker closes the cycle so that its deadlock_timeout expires
-// first and it, not the blocker, is the victim. The blocker must release
+// so PostgreSQL's detector has to abort one side. The blocker defers its
+// deadlock detector so the write is the victim. The blocker must release
 // cleanly; the write's own outcome is returned for the caller to judge.
 func forcePostgreSQLDeadlock(
 	ctx context.Context, t *testing.T, st *store.Store,
@@ -31,6 +30,8 @@ func forcePostgreSQLDeadlock(
 	blocker, err := st.DB().BeginTx(ctx, nil)
 	require.NoError(err)
 	t.Cleanup(func() { _ = blocker.Rollback() })
+	_, err = blocker.ExecContext(ctx, `SET LOCAL deadlock_timeout = '1h'`)
+	require.NoError(err)
 	var lockedID int64
 	require.NoError(blocker.QueryRowContext(ctx,
 		`SELECT id FROM `+held.table+` WHERE id = $1 FOR UPDATE`, held.id).Scan(&lockedID))
@@ -41,7 +42,6 @@ func forcePostgreSQLDeadlock(
 	require.Eventually(func() bool {
 		return postgreSQLWaitingLockCount(t, st) >= 1
 	}, 5*time.Second, 10*time.Millisecond, "write did not reach the held row lock")
-	time.Sleep(250 * time.Millisecond)
 
 	blockerDone := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
People-sweep provider profiles now derive their TOML values, consent policy JSON, and database projections from tagged field definitions. This reduces duplicated field lists that could drift apart. Stored policy JSON remains the source of truth, and database columns are checked against it.

- Existing profile fingerprints remain compatible.
- Provider setup writes `allowed_sources` in sorted order. Whole-config saves now omit empty optional provider keys.
- PostgreSQL deadlock tests defer the blocker transaction's detector so the write under test is the victim. The test setup documentation includes the `deadlock_timeout` parameter grant for non-superuser roles.

Closes #740
