### PR TITLE
refactor(people): centralize provider driver capabilities

### DIFF
--- a/cmd/msgvault/cmd/person_provider_setup.go
+++ b/cmd/msgvault/cmd/person_provider_setup.go
@@ -362,12 +362,12 @@ func personProviderCandidate(options personProviderAddOptions) (peoplesweep.Prov
 	} else {
 		candidate.Credential = peoplesweep.CredentialStored
 	}
-	if candidate.Protocol == peoplesweep.ProtocolOpenAIChat {
-		candidate.OutputMode = peoplesweep.OutputModeNativeJSONSchema
-		candidate.TokenLimitParameter = "max_completion_tokens"
-	} else {
-		candidate.OutputMode = peoplesweep.OutputModeNativeJSONSchema
+	capability, ok := peoplesweep.ProtocolCapabilityFor(candidate.Protocol)
+	if !ok || len(capability.OutputModes) == 0 || len(capability.TokenParameters) == 0 {
+		return peoplesweep.ProviderConfig{}, fmt.Errorf("unsupported people inference protocol %q", candidate.Protocol)
 	}
+	candidate.OutputMode = capability.OutputModes[0]
+	candidate.TokenLimitParameter = capability.TokenParameters[0]
 	return candidate, nil
 }
 

--- a/cmd/msgvault/cmd/person_provider_setup.go
+++ b/cmd/msgvault/cmd/person_provider_setup.go
@@ -499,25 +499,17 @@ func personProviderCatalogAuth(
 	protocol peoplesweep.Protocol,
 	explicit peoplesweep.AuthScheme,
 ) (peoplesweep.AuthScheme, error) {
-	var defaultAuth peoplesweep.AuthScheme
-	switch protocol {
-	case peoplesweep.ProtocolOpenAIChat, peoplesweep.ProtocolOpenAIResponses:
-		defaultAuth = peoplesweep.AuthBearer
-		if explicit == "" || explicit == peoplesweep.AuthBearer || explicit == peoplesweep.AuthXAPIKey {
-			if explicit != "" {
-				return explicit, nil
-			}
-			return defaultAuth, nil
-		}
-	case peoplesweep.ProtocolAnthropicMessages:
-		defaultAuth = peoplesweep.AuthXAPIKey
-	case peoplesweep.ProtocolGoogleGenerateContent:
-		defaultAuth = peoplesweep.AuthGoogleAPIKey
-	default:
+	capability, ok := peoplesweep.ProtocolCapabilityFor(protocol)
+	if !ok || capability.CatalogDefaultAuth == "" {
 		return "", fmt.Errorf("models.dev catalog selected unsupported protocol %q", protocol)
 	}
-	if explicit == "" || explicit == defaultAuth {
-		return defaultAuth, nil
+	if explicit == "" {
+		return capability.CatalogDefaultAuth, nil
+	}
+	for _, supported := range capability.CatalogAuthSchemes {
+		if explicit == supported {
+			return explicit, nil
+		}
 	}
 	return "", fmt.Errorf("models.dev catalog protocol %q does not support auth %q", protocol, explicit)
 }

--- a/cmd/msgvault/cmd/person_provider_setup.go
+++ b/cmd/msgvault/cmd/person_provider_setup.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -506,10 +507,8 @@ func personProviderCatalogAuth(
 	if explicit == "" {
 		return capability.CatalogDefaultAuth, nil
 	}
-	for _, supported := range capability.CatalogAuthSchemes {
-		if explicit == supported {
-			return explicit, nil
-		}
+	if slices.Contains(capability.CatalogAuthSchemes, explicit) {
+		return explicit, nil
 	}
 	return "", fmt.Errorf("models.dev catalog protocol %q does not support auth %q", protocol, explicit)
 }

--- a/cmd/msgvault/cmd/person_provider_setup_test.go
+++ b/cmd/msgvault/cmd/person_provider_setup_test.go
@@ -458,14 +458,16 @@ func TestPersonProviderCatalogAuthUsesProtocolCapabilities(t *testing.T) {
 		{name: "codex rejected", protocol: peoplesweep.ProtocolCodexAppServer, wantErr: "unsupported protocol"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 			got, err := personProviderCatalogAuth(test.protocol, test.explicit)
 			if test.wantErr != "" {
-				require.ErrorContains(t, err, test.wantErr)
-				assert.Empty(t, got)
+				require.ErrorContains(err, test.wantErr)
+				assert.Empty(got)
 				return
 			}
-			require.NoError(t, err)
-			assert.Equal(t, test.want, got)
+			require.NoError(err)
+			assert.Equal(test.want, got)
 		})
 	}
 }

--- a/cmd/msgvault/cmd/person_provider_setup_test.go
+++ b/cmd/msgvault/cmd/person_provider_setup_test.go
@@ -470,6 +470,36 @@ func TestPersonProviderCatalogAuthUsesProtocolCapabilities(t *testing.T) {
 	}
 }
 
+func TestPersonProviderCandidateUsesProtocolCapabilityDefaults(t *testing.T) {
+	for _, test := range []struct {
+		protocol peoplesweep.Protocol
+		auth     peoplesweep.AuthScheme
+		output   peoplesweep.OutputMode
+		token    string
+	}{
+		{protocol: peoplesweep.ProtocolOpenAIChat, auth: peoplesweep.AuthBearer,
+			output: peoplesweep.OutputModeNativeJSONSchema, token: "max_completion_tokens"},
+		{protocol: peoplesweep.ProtocolOpenAIResponses, auth: peoplesweep.AuthBearer,
+			output: peoplesweep.OutputModeNativeJSONSchema},
+		{protocol: peoplesweep.ProtocolAnthropicMessages, auth: peoplesweep.AuthXAPIKey,
+			output: peoplesweep.OutputModeNativeJSONSchema},
+		{protocol: peoplesweep.ProtocolGoogleGenerateContent, auth: peoplesweep.AuthGoogleAPIKey,
+			output: peoplesweep.OutputModeNativeJSONSchema},
+	} {
+		t.Run(string(test.protocol), func(t *testing.T) {
+			candidate, err := personProviderCandidate(personProviderAddOptions{
+				protocol: string(test.protocol), endpoint: "https://example.test",
+				model: "test-model", auth: string(test.auth), retentionPosture: "zero",
+				trainingPosture: "none", allowedSources: []string{"conversation_text"},
+				sourceSince: "2025-01-01",
+			})
+			require.NoError(t, err)
+			assert.Equal(t, test.output, candidate.OutputMode)
+			assert.Equal(t, test.token, candidate.TokenLimitParameter)
+		})
+	}
+}
+
 // TestPersonProviderAddNeverSendsCredentialToCatalogEndpoint catches
 // onboarding reading a credential or negotiating capabilities against an
 // endpoint chosen by the models.dev catalog: a compromised catalog must not

--- a/cmd/msgvault/cmd/person_provider_setup_test.go
+++ b/cmd/msgvault/cmd/person_provider_setup_test.go
@@ -439,6 +439,37 @@ func TestPersonProviderAddCatalogResolvesUnambiguousTransportBeforeCredentialOrS
 	assert.Contains(string(content), `[people.sweep.providers.catalog-provider]`)
 }
 
+func TestPersonProviderCatalogAuthUsesProtocolCapabilities(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		protocol peoplesweep.Protocol
+		explicit peoplesweep.AuthScheme
+		want     peoplesweep.AuthScheme
+		wantErr  string
+	}{
+		{name: "openai chat default", protocol: peoplesweep.ProtocolOpenAIChat, want: peoplesweep.AuthBearer},
+		{name: "openai chat x api key", protocol: peoplesweep.ProtocolOpenAIChat, explicit: peoplesweep.AuthXAPIKey, want: peoplesweep.AuthXAPIKey},
+		{name: "openai responses default", protocol: peoplesweep.ProtocolOpenAIResponses, want: peoplesweep.AuthBearer},
+		{name: "openai responses x api key", protocol: peoplesweep.ProtocolOpenAIResponses, explicit: peoplesweep.AuthXAPIKey, want: peoplesweep.AuthXAPIKey},
+		{name: "anthropic default", protocol: peoplesweep.ProtocolAnthropicMessages, want: peoplesweep.AuthXAPIKey},
+		{name: "google default", protocol: peoplesweep.ProtocolGoogleGenerateContent, want: peoplesweep.AuthGoogleAPIKey},
+		{name: "anthropic bearer rejected", protocol: peoplesweep.ProtocolAnthropicMessages, explicit: peoplesweep.AuthBearer, wantErr: "does not support auth"},
+		{name: "google x api key rejected", protocol: peoplesweep.ProtocolGoogleGenerateContent, explicit: peoplesweep.AuthXAPIKey, wantErr: "does not support auth"},
+		{name: "codex rejected", protocol: peoplesweep.ProtocolCodexAppServer, wantErr: "unsupported protocol"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := personProviderCatalogAuth(test.protocol, test.explicit)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				assert.Empty(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 // TestPersonProviderAddNeverSendsCredentialToCatalogEndpoint catches
 // onboarding reading a credential or negotiating capabilities against an
 // endpoint chosen by the models.dev catalog: a compromised catalog must not

--- a/internal/peoplesweep/anthropic_messages.go
+++ b/internal/peoplesweep/anthropic_messages.go
@@ -57,13 +57,6 @@ func (d *AnthropicMessagesDriver) Prepare(
 	if profile.Protocol != ProtocolAnthropicMessages {
 		return PreparedStructuredRequest{}, errors.New("anthropic messages driver requires anthropic_messages profile")
 	}
-	if profile.Auth != AuthXAPIKey {
-		return PreparedStructuredRequest{}, errors.New("anthropic messages profile requires x_api_key authentication")
-	}
-	if profile.ReasoningEffort != "" ||
-		(profile.ReasoningMode != "" && profile.ReasoningMode != reasoningModeProviderDefault) {
-		return PreparedStructuredRequest{}, errors.New("anthropic messages profile has unsupported reasoning settings")
-	}
 	body := anthropicRequest{
 		Model: profile.Model, System: structuredSystemInstruction,
 		Messages:  []anthropicMessage{{Role: "user", Content: request.InputText}},

--- a/internal/peoplesweep/capability_check.go
+++ b/internal/peoplesweep/capability_check.go
@@ -107,41 +107,36 @@ func (c *CapabilityChecker) Negotiate(
 }
 
 func capabilityOutputModes(protocol Protocol) []OutputMode {
-	switch protocol {
-	case ProtocolOpenAIChat, ProtocolOpenAIResponses:
-		return []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON}
-	case ProtocolAnthropicMessages, ProtocolGoogleGenerateContent:
-		return []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON}
-	default:
+	capability, ok := ProtocolCapabilityFor(protocol)
+	if !ok {
 		return nil
 	}
+	return capability.OutputModes
 }
 
 func capabilityTokenParameters(protocol Protocol) []string {
-	if protocol == ProtocolOpenAIChat {
-		return []string{"max_completion_tokens", "max_tokens"}
+	capability, ok := ProtocolCapabilityFor(protocol)
+	if !ok {
+		return nil
 	}
-	return []string{""}
+	return capability.TokenParameters
 }
 
 func validateCapabilityReasoning(candidate ProviderConfig) error {
 	if err := validateReasoning(candidate); err != nil {
 		return err
 	}
-	switch candidate.Protocol {
-	case ProtocolOpenAIChat:
+	capability, ok := ProtocolCapabilityFor(candidate.Protocol)
+	if !ok {
+		if candidate.Protocol == ProtocolCodexAppServer {
+			return errors.New("reasoning capability negotiation is unavailable for codex app server")
+		}
+		return errors.New("reasoning settings are not represented by the selected protocol")
+	}
+	customReasoningMode := candidate.ReasoningMode != "" && candidate.ReasoningMode != reasoningModeProviderDefault
+	if (candidate.ReasoningEffort == "" || capability.SupportsReasoningEffort) &&
+		(!customReasoningMode || capability.SupportsCustomReasoningMode) {
 		return nil
-	case ProtocolOpenAIResponses:
-		if candidate.ReasoningMode == "" || candidate.ReasoningMode == reasoningModeProviderDefault {
-			return nil
-		}
-	case ProtocolAnthropicMessages, ProtocolGoogleGenerateContent:
-		if candidate.ReasoningEffort == "" &&
-			(candidate.ReasoningMode == "" || candidate.ReasoningMode == reasoningModeProviderDefault) {
-			return nil
-		}
-	case ProtocolCodexAppServer:
-		return errors.New("reasoning capability negotiation is unavailable for codex app server")
 	}
 	return errors.New("reasoning settings are not represented by the selected protocol")
 }

--- a/internal/peoplesweep/capability_check.go
+++ b/internal/peoplesweep/capability_check.go
@@ -133,12 +133,7 @@ func validateCapabilityReasoning(candidate ProviderConfig) error {
 		}
 		return errors.New("reasoning settings are not represented by the selected protocol")
 	}
-	customReasoningMode := candidate.ReasoningMode != "" && candidate.ReasoningMode != reasoningModeProviderDefault
-	if (candidate.ReasoningEffort == "" || capability.SupportsReasoningEffort) &&
-		(!customReasoningMode || capability.SupportsCustomReasoningMode) {
-		return nil
-	}
-	return errors.New("reasoning settings are not represented by the selected protocol")
+	return capability.validateReasoning(candidate)
 }
 
 func capabilityReasoningRequested(candidate ProviderConfig) bool {

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -260,20 +260,13 @@ func applyProviderDefaults(provider *ProviderConfig) {
 }
 
 func defaultDriverVersion(protocol Protocol) string {
-	switch protocol {
-	case ProtocolOpenAIChat:
-		return OpenAIChatProviderVersion
-	case ProtocolOpenAIResponses:
-		return "openai-responses-v1"
-	case ProtocolAnthropicMessages:
-		return "anthropic-messages-v1"
-	case ProtocolGoogleGenerateContent:
-		return "google-generate-content-v1"
-	case ProtocolCodexAppServer:
-		return CodexAppServerProviderVersion
-	default:
-		return ""
+	if capability, ok := ProtocolCapabilityFor(protocol); ok {
+		return capability.DriverVersion
 	}
+	if protocol == ProtocolCodexAppServer {
+		return CodexAppServerProviderVersion
+	}
+	return ""
 }
 
 // ActiveProviderConfig resolves the active profile by value so callers cannot
@@ -374,21 +367,24 @@ func (c Config) validateOperationalConfig() error {
 }
 
 func (c Config) validateProvider(provider ProviderConfig) error {
-	switch provider.Protocol {
-	case ProtocolOpenAIChat:
-		if err := requireOneOf(provider.TokenLimitParameter, "max_completion_tokens", "max_tokens"); err != nil {
-			return err
-		}
-	case ProtocolOpenAIResponses, ProtocolAnthropicMessages, ProtocolGoogleGenerateContent:
-		if err := requireEmpty(provider.TokenLimitParameter); err != nil {
-			return err
-		}
-	case ProtocolCodexAppServer:
+	if provider.Protocol == ProtocolCodexAppServer {
 		if err := requireCodexIsolationFields(provider); err != nil {
 			return err
 		}
-	default:
-		return fmt.Errorf("unsupported people inference protocol %q", provider.Protocol)
+	} else {
+		capability, ok := ProtocolCapabilityFor(provider.Protocol)
+		if !ok {
+			return fmt.Errorf("unsupported people inference protocol %q", provider.Protocol)
+		}
+		var err error
+		if len(capability.TokenParameters) == 1 && capability.TokenParameters[0] == "" {
+			err = requireEmpty(provider.TokenLimitParameter)
+		} else {
+			err = requireOneOf(provider.TokenLimitParameter, capability.TokenParameters...)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	if err := validateReasoning(provider); err != nil {
 		return err
@@ -656,41 +652,31 @@ func setDefaultDuration(target *time.Duration, value time.Duration) {
 // profile (for example bearer auth for anthropic_messages) passes startup
 // validation and then fails every scheduled sweep during preparation.
 func validateProtocolHTTPCapabilities(provider ProviderConfig) error {
-	switch provider.Protocol {
-	case ProtocolOpenAIChat:
-		// Every configured auth scheme, output mode, and reasoning setting is
-		// representable on the OpenAI Chat wire format.
-		return nil
-	case ProtocolOpenAIResponses:
-		if provider.ReasoningMode != "" && provider.ReasoningMode != reasoningModeProviderDefault {
-			return fmt.Errorf(
-				"[people.sweep.provider] reasoning_mode %q is not supported by openai_responses",
-				provider.ReasoningMode)
-		}
-		return nil
-	case ProtocolAnthropicMessages:
-		if provider.Auth != AuthXAPIKey {
-			return fmt.Errorf("[people.sweep.provider] anthropic_messages requires auth %q", AuthXAPIKey)
-		}
-		if provider.OutputMode == OutputModeJSONObject {
-			return fmt.Errorf(
-				"[people.sweep.provider] output_mode %q is not supported by anthropic_messages",
-				OutputModeJSONObject)
-		}
-		return validateProviderDefaultReasoning(provider, "anthropic_messages")
-	case ProtocolGoogleGenerateContent:
-		if provider.Auth != AuthGoogleAPIKey {
-			return fmt.Errorf("[people.sweep.provider] google_generate_content requires auth %q", AuthGoogleAPIKey)
-		}
-		if provider.OutputMode == OutputModeJSONObject {
-			return fmt.Errorf(
-				"[people.sweep.provider] output_mode %q is not supported by google_generate_content",
-				OutputModeJSONObject)
-		}
-		return validateProviderDefaultReasoning(provider, "google_generate_content")
-	default:
+	capability, ok := ProtocolCapabilityFor(provider.Protocol)
+	if !ok {
 		return nil
 	}
+	if capability.RequiredAuth != "" && !slices.Contains(capability.AuthSchemes, provider.Auth) {
+		return fmt.Errorf(
+			"[people.sweep.provider] %s requires auth %q",
+			capability.Protocol, capability.RequiredAuth)
+	}
+	if provider.OutputMode == OutputModeJSONObject && !slices.Contains(capability.OutputModes, provider.OutputMode) {
+		return fmt.Errorf(
+			"[people.sweep.provider] output_mode %q is not supported by %s",
+			provider.OutputMode, capability.Protocol)
+	}
+	customReasoningMode := provider.ReasoningMode != "" && provider.ReasoningMode != reasoningModeProviderDefault
+	if !capability.SupportsReasoningEffort && !capability.SupportsCustomReasoningMode &&
+		(provider.ReasoningEffort != "" || customReasoningMode) {
+		return validateProviderDefaultReasoning(provider, string(capability.Protocol))
+	}
+	if customReasoningMode && !capability.SupportsCustomReasoningMode {
+		return fmt.Errorf(
+			"[people.sweep.provider] reasoning_mode %q is not supported by %s",
+			provider.ReasoningMode, capability.Protocol)
+	}
+	return nil
 }
 
 // validateProviderDefaultReasoning rejects reasoning settings the protocol's

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -656,12 +656,19 @@ func validateProtocolHTTPCapabilities(provider ProviderConfig) error {
 	if !ok {
 		return nil
 	}
-	if capability.RequiredAuth != "" && !slices.Contains(capability.AuthSchemes, provider.Auth) {
+	if slices.Contains([]AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone}, provider.Auth) &&
+		!slices.Contains(capability.AuthSchemes, provider.Auth) {
+		if capability.RequiredAuth != "" {
+			return fmt.Errorf(
+				"[people.sweep.provider] %s requires auth %q",
+				capability.Protocol, capability.RequiredAuth)
+		}
 		return fmt.Errorf(
-			"[people.sweep.provider] %s requires auth %q",
-			capability.Protocol, capability.RequiredAuth)
+			"[people.sweep.provider] auth %q is not supported by %s",
+			provider.Auth, capability.Protocol)
 	}
-	if provider.OutputMode == OutputModeJSONObject && !slices.Contains(capability.OutputModes, provider.OutputMode) {
+	if slices.Contains([]OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON}, provider.OutputMode) &&
+		!slices.Contains(capability.OutputModes, provider.OutputMode) {
 		return fmt.Errorf(
 			"[people.sweep.provider] output_mode %q is not supported by %s",
 			provider.OutputMode, capability.Protocol)

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -656,13 +656,14 @@ func validateProtocolHTTPCapabilities(provider ProviderConfig) error {
 	if !ok {
 		return nil
 	}
-	if slices.Contains([]AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone}, provider.Auth) &&
+	if capability.RequiredAuth != "" && !slices.Contains(capability.AuthSchemes, provider.Auth) {
+		return fmt.Errorf(
+			"[people.sweep.provider] %s requires auth %q",
+			capability.Protocol, capability.RequiredAuth)
+	}
+	if capability.RequiredAuth == "" &&
+		slices.Contains([]AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone}, provider.Auth) &&
 		!slices.Contains(capability.AuthSchemes, provider.Auth) {
-		if capability.RequiredAuth != "" {
-			return fmt.Errorf(
-				"[people.sweep.provider] %s requires auth %q",
-				capability.Protocol, capability.RequiredAuth)
-		}
 		return fmt.Errorf(
 			"[people.sweep.provider] auth %q is not supported by %s",
 			provider.Auth, capability.Protocol)

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -367,22 +367,18 @@ func (c Config) validateOperationalConfig() error {
 }
 
 func (c Config) validateProvider(provider ProviderConfig) error {
+	var capability ProtocolCapability
 	if provider.Protocol == ProtocolCodexAppServer {
 		if err := requireCodexIsolationFields(provider); err != nil {
 			return err
 		}
 	} else {
-		capability, ok := ProtocolCapabilityFor(provider.Protocol)
+		var ok bool
+		capability, ok = ProtocolCapabilityFor(provider.Protocol)
 		if !ok {
 			return fmt.Errorf("unsupported people inference protocol %q", provider.Protocol)
 		}
-		var err error
-		if len(capability.TokenParameters) == 1 && capability.TokenParameters[0] == "" {
-			err = requireEmpty(provider.TokenLimitParameter)
-		} else {
-			err = requireOneOf(provider.TokenLimitParameter, capability.TokenParameters...)
-		}
-		if err != nil {
+		if err := requireOneOf(provider.TokenLimitParameter, capability.TokenParameters...); err != nil {
 			return err
 		}
 	}
@@ -398,19 +394,12 @@ func (c Config) validateProvider(provider ProviderConfig) error {
 		}
 		return validateCommonEnabledPolicy(provider)
 	}
-	return c.validateHTTPProvider(provider)
+	return c.validateHTTPProvider(provider, capability)
 }
 
 func requireOneOf(value string, allowed ...string) error {
 	if !slices.Contains(allowed, value) {
 		return fmt.Errorf("[people.sweep.provider] token_limit_parameter %q is not supported", value)
-	}
-	return nil
-}
-
-func requireEmpty(value string) error {
-	if value != "" {
-		return errors.New("[people.sweep.provider] token_limit_parameter is only valid for openai_chat")
 	}
 	return nil
 }
@@ -438,19 +427,13 @@ func validateReasoning(provider ProviderConfig) error {
 	return nil
 }
 
-func (c Config) validateHTTPProvider(provider ProviderConfig) error {
+func (c Config) validateHTTPProvider(provider ProviderConfig, capability ProtocolCapability) error {
 	endpoint, loopback, err := validateEndpoint(provider.Endpoint)
 	if err != nil {
 		return err
 	}
-	if err := validateProtocolHTTPCapabilities(provider); err != nil {
+	if err := capability.validateHTTP(provider); err != nil {
 		return err
-	}
-	if !slices.Contains([]OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON}, provider.OutputMode) {
-		return fmt.Errorf("invalid [people.sweep.provider] output_mode %q", provider.OutputMode)
-	}
-	if !slices.Contains([]AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone}, provider.Auth) {
-		return fmt.Errorf("invalid [people.sweep.provider] auth %q", provider.Auth)
 	}
 	if !slices.Contains([]CredentialSource{CredentialStored, CredentialEnv, CredentialNone}, provider.Credential) {
 		return fmt.Errorf("invalid [people.sweep.provider] credential %q", provider.Credential)
@@ -646,55 +629,35 @@ func setDefaultDuration(target *time.Duration, value time.Duration) {
 	}
 }
 
-// validateProtocolHTTPCapabilities mirrors, at config-validation time, the
-// per-protocol contracts each HTTP driver enforces again at Prepare as
-// defense in depth. Without this centralization, a protocol-incompatible
-// profile (for example bearer auth for anthropic_messages) passes startup
-// validation and then fails every scheduled sweep during preparation.
-func validateProtocolHTTPCapabilities(provider ProviderConfig) error {
-	capability, ok := ProtocolCapabilityFor(provider.Protocol)
-	if !ok {
-		return nil
-	}
-	if capability.RequiredAuth != "" && !slices.Contains(capability.AuthSchemes, provider.Auth) {
-		return fmt.Errorf(
-			"[people.sweep.provider] %s requires auth %q",
-			capability.Protocol, capability.RequiredAuth)
-	}
-	if capability.RequiredAuth == "" &&
-		slices.Contains([]AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone}, provider.Auth) &&
-		!slices.Contains(capability.AuthSchemes, provider.Auth) {
-		return fmt.Errorf(
-			"[people.sweep.provider] auth %q is not supported by %s",
+// validateHTTP applies the same declaration to config validation and driver
+// preparation, which calls ProviderProfile.Validate before encoding a request.
+func (capability ProtocolCapability) validateHTTP(provider ProviderConfig) error {
+	if !slices.Contains(capability.AuthSchemes, provider.Auth) {
+		if len(capability.AuthSchemes) == 1 {
+			return fmt.Errorf("[people.sweep.provider] %s requires auth %q",
+				capability.Protocol, capability.AuthSchemes[0])
+		}
+		return fmt.Errorf("[people.sweep.provider] auth %q is not supported by %s",
 			provider.Auth, capability.Protocol)
 	}
-	if slices.Contains([]OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON}, provider.OutputMode) &&
-		!slices.Contains(capability.OutputModes, provider.OutputMode) {
-		return fmt.Errorf(
-			"[people.sweep.provider] output_mode %q is not supported by %s",
+	if !slices.Contains(capability.OutputModes, provider.OutputMode) {
+		return fmt.Errorf("[people.sweep.provider] output_mode %q is not supported by %s",
 			provider.OutputMode, capability.Protocol)
 	}
-	customReasoningMode := provider.ReasoningMode != "" && provider.ReasoningMode != reasoningModeProviderDefault
-	if !capability.SupportsReasoningEffort && !capability.SupportsCustomReasoningMode &&
-		(provider.ReasoningEffort != "" || customReasoningMode) {
-		return validateProviderDefaultReasoning(provider, string(capability.Protocol))
-	}
-	if customReasoningMode && !capability.SupportsCustomReasoningMode {
-		return fmt.Errorf(
-			"[people.sweep.provider] reasoning_mode %q is not supported by %s",
-			provider.ReasoningMode, capability.Protocol)
-	}
-	return nil
+	return capability.validateReasoning(provider)
 }
 
-// validateProviderDefaultReasoning rejects reasoning settings the protocol's
-// driver cannot represent on its wire format.
-func validateProviderDefaultReasoning(provider ProviderConfig, protocol string) error {
-	if provider.ReasoningEffort != "" ||
-		(provider.ReasoningMode != "" && provider.ReasoningMode != reasoningModeProviderDefault) {
-		return fmt.Errorf("[people.sweep.provider] reasoning settings are not supported by %s", protocol)
+func (capability ProtocolCapability) validateReasoning(provider ProviderConfig) error {
+	customReasoningMode := provider.ReasoningMode != "" && provider.ReasoningMode != reasoningModeProviderDefault
+	if (provider.ReasoningEffort == "" || capability.SupportsReasoningEffort) &&
+		(!customReasoningMode || capability.SupportsCustomReasoningMode) {
+		return nil
 	}
-	return nil
+	if !capability.SupportsReasoningEffort {
+		return fmt.Errorf("[people.sweep.provider] reasoning settings are not supported by %s", capability.Protocol)
+	}
+	return fmt.Errorf("[people.sweep.provider] reasoning_mode %q is not supported by %s",
+		provider.ReasoningMode, capability.Protocol)
 }
 
 func validateEndpoint(raw string) (*url.URL, bool, error) {

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -643,6 +643,18 @@ func TestConfigValidationRejectsProtocolIncompatibleHTTPProfiles(t *testing.T) {
 			want:     `anthropic_messages requires auth "x_api_key"`,
 		},
 		{
+			name:     "anthropic empty auth",
+			protocol: peoplesweep.ProtocolAnthropicMessages,
+			mutate:   func(p *peoplesweep.ProviderConfig) { p.Auth = "" },
+			want:     `anthropic_messages requires auth "x_api_key"`,
+		},
+		{
+			name:     "anthropic unknown auth",
+			protocol: peoplesweep.ProtocolAnthropicMessages,
+			mutate:   func(p *peoplesweep.ProviderConfig) { p.Auth = "unknown" },
+			want:     `anthropic_messages requires auth "x_api_key"`,
+		},
+		{
 			name:     "anthropic json object output",
 			protocol: peoplesweep.ProtocolAnthropicMessages,
 			mutate:   func(p *peoplesweep.ProviderConfig) { p.OutputMode = peoplesweep.OutputModeJSONObject },
@@ -670,6 +682,12 @@ func TestConfigValidationRejectsProtocolIncompatibleHTTPProfiles(t *testing.T) {
 			name:     "google x api key auth",
 			protocol: peoplesweep.ProtocolGoogleGenerateContent,
 			mutate:   func(p *peoplesweep.ProviderConfig) { p.Auth = peoplesweep.AuthXAPIKey },
+			want:     `google_generate_content requires auth "google_api_key"`,
+		},
+		{
+			name:     "google unknown auth",
+			protocol: peoplesweep.ProtocolGoogleGenerateContent,
+			mutate:   func(p *peoplesweep.ProviderConfig) { p.Auth = "unknown" },
 			want:     `google_generate_content requires auth "google_api_key"`,
 		},
 		{

--- a/internal/peoplesweep/driver_registry.go
+++ b/internal/peoplesweep/driver_registry.go
@@ -24,9 +24,15 @@ var ErrCodexIsolationUnreleased = errors.New("codex app-server isolation is not 
 // configured at selection time because its executable is operational config,
 // not part of the immutable provider profile.
 type DriverRegistry struct {
-	drivers   map[Protocol]StructuredDriver
-	commands  CommandStarter
-	isolation CodexIsolationGate
+	drivers       map[Protocol]StructuredDriver
+	registrations map[Protocol]driverRegistration
+	commands      CommandStarter
+	isolation     CodexIsolationGate
+}
+
+type driverRegistration struct {
+	capability ProtocolCapability
+	driver     StructuredDriver
 }
 
 func NewDriverRegistry(
@@ -34,13 +40,22 @@ func NewDriverRegistry(
 	commands CommandStarter,
 	isolation CodexIsolationGate,
 ) (*DriverRegistry, error) {
+	drivers := map[Protocol]StructuredDriver{
+		ProtocolOpenAIChat:            NewOpenAIChatDriver(httpClient),
+		ProtocolOpenAIResponses:       NewOpenAIResponsesDriver(httpClient),
+		ProtocolAnthropicMessages:     NewAnthropicMessagesDriver(httpClient),
+		ProtocolGoogleGenerateContent: NewGoogleGenerateContentDriver(httpClient),
+	}
+	registrations := make(map[Protocol]driverRegistration, len(drivers))
+	for protocol, driver := range drivers {
+		capability, ok := ProtocolCapabilityFor(protocol)
+		if !ok {
+			return nil, fmt.Errorf("missing people sweep capability declaration for %q", protocol)
+		}
+		registrations[protocol] = driverRegistration{capability: capability, driver: driver}
+	}
 	return &DriverRegistry{
-		drivers: map[Protocol]StructuredDriver{
-			ProtocolOpenAIChat:            NewOpenAIChatDriver(httpClient),
-			ProtocolOpenAIResponses:       NewOpenAIResponsesDriver(httpClient),
-			ProtocolAnthropicMessages:     NewAnthropicMessagesDriver(httpClient),
-			ProtocolGoogleGenerateContent: NewGoogleGenerateContentDriver(httpClient),
-		},
+		drivers: drivers, registrations: registrations,
 		commands: commands, isolation: isolation,
 	}, nil
 }
@@ -52,17 +67,20 @@ func (r *DriverRegistry) capabilityDriver(protocol Protocol) (StructuredDriver, 
 	if r == nil {
 		return nil, errors.New("people inference driver registry is required")
 	}
-	switch protocol {
-	case ProtocolOpenAIChat, ProtocolOpenAIResponses,
-		ProtocolAnthropicMessages, ProtocolGoogleGenerateContent:
-		driver, ok := r.drivers[protocol]
-		if !ok || driver == nil {
+	if registration, ok := r.registrations[protocol]; ok {
+		if registration.driver == nil || registration.capability.Protocol != protocol {
 			return nil, fmt.Errorf("unsupported people sweep protocol %q", protocol)
 		}
-		return driver, nil
-	default:
-		return nil, fmt.Errorf("unsupported people sweep capability protocol %q", protocol)
+		return registration.driver, nil
 	}
+	// Internal test registries intentionally provide controlled drivers without
+	// built-in registration records, so retain their source-compatible path.
+	if _, declared := ProtocolCapabilityFor(protocol); declared {
+		if driver, ok := r.drivers[protocol]; ok && driver != nil {
+			return driver, nil
+		}
+	}
+	return nil, fmt.Errorf("unsupported people sweep capability protocol %q", protocol)
 }
 
 func (r *DriverRegistry) Driver(

--- a/internal/peoplesweep/driver_registry.go
+++ b/internal/peoplesweep/driver_registry.go
@@ -24,15 +24,9 @@ var ErrCodexIsolationUnreleased = errors.New("codex app-server isolation is not 
 // configured at selection time because its executable is operational config,
 // not part of the immutable provider profile.
 type DriverRegistry struct {
-	drivers       map[Protocol]StructuredDriver
-	registrations map[Protocol]driverRegistration
-	commands      CommandStarter
-	isolation     CodexIsolationGate
-}
-
-type driverRegistration struct {
-	capability ProtocolCapability
-	driver     StructuredDriver
+	drivers   map[Protocol]StructuredDriver
+	commands  CommandStarter
+	isolation CodexIsolationGate
 }
 
 func NewDriverRegistry(
@@ -46,16 +40,8 @@ func NewDriverRegistry(
 		ProtocolAnthropicMessages:     NewAnthropicMessagesDriver(httpClient),
 		ProtocolGoogleGenerateContent: NewGoogleGenerateContentDriver(httpClient),
 	}
-	registrations := make(map[Protocol]driverRegistration, len(drivers))
-	for protocol, driver := range drivers {
-		capability, ok := ProtocolCapabilityFor(protocol)
-		if !ok {
-			return nil, fmt.Errorf("missing people sweep capability declaration for %q", protocol)
-		}
-		registrations[protocol] = driverRegistration{capability: capability, driver: driver}
-	}
 	return &DriverRegistry{
-		drivers: drivers, registrations: registrations,
+		drivers:  drivers,
 		commands: commands, isolation: isolation,
 	}, nil
 }
@@ -67,14 +53,6 @@ func (r *DriverRegistry) capabilityDriver(protocol Protocol) (StructuredDriver, 
 	if r == nil {
 		return nil, errors.New("people inference driver registry is required")
 	}
-	if registration, ok := r.registrations[protocol]; ok {
-		if registration.driver == nil || registration.capability.Protocol != protocol {
-			return nil, fmt.Errorf("unsupported people sweep protocol %q", protocol)
-		}
-		return registration.driver, nil
-	}
-	// Internal test registries intentionally provide controlled drivers without
-	// built-in registration records, so retain their source-compatible path.
 	if _, declared := ProtocolCapabilityFor(protocol); declared {
 		if driver, ok := r.drivers[protocol]; ok && driver != nil {
 			return driver, nil

--- a/internal/peoplesweep/google_generate_content.go
+++ b/internal/peoplesweep/google_generate_content.go
@@ -55,13 +55,6 @@ func (d *GoogleGenerateContentDriver) Prepare(
 	if profile.Protocol != ProtocolGoogleGenerateContent {
 		return PreparedStructuredRequest{}, errors.New("google generateContent driver requires google_generate_content profile")
 	}
-	if profile.Auth != AuthGoogleAPIKey {
-		return PreparedStructuredRequest{}, errors.New("google generateContent profile requires google_api_key authentication")
-	}
-	if profile.ReasoningEffort != "" ||
-		(profile.ReasoningMode != "" && profile.ReasoningMode != reasoningModeProviderDefault) {
-		return PreparedStructuredRequest{}, errors.New("google generateContent profile has unsupported reasoning settings")
-	}
 	if _, err := googleGenerateContentTarget(profile.Endpoint, profile.Model); err != nil {
 		return PreparedStructuredRequest{}, err
 	}

--- a/internal/peoplesweep/modelsdev.go
+++ b/internal/peoplesweep/modelsdev.go
@@ -331,21 +331,6 @@ func modelsDevEnvironment(raw json.RawMessage) ([]string, error) {
 	return slices.Compact(values), nil
 }
 
-func protocolsForModelsDevShape(shape string) []Protocol {
-	switch shape {
-	case "@ai-sdk/openai-compatible":
-		return []Protocol{ProtocolOpenAIChat}
-	case "@ai-sdk/openai":
-		return []Protocol{ProtocolOpenAIChat, ProtocolOpenAIResponses}
-	case "@ai-sdk/anthropic":
-		return []Protocol{ProtocolAnthropicMessages}
-	case "@ai-sdk/google":
-		return []Protocol{ProtocolGoogleGenerateContent}
-	default:
-		return nil
-	}
-}
-
 func decodeModelsDevObject(ctx context.Context, raw []byte) (map[string]json.RawMessage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/peoplesweep/modelsdev.go
+++ b/internal/peoplesweep/modelsdev.go
@@ -464,26 +464,14 @@ func validModelsDevEndpoint(value string) bool {
 	return err == nil
 }
 
-// independentlyTrustedEndpointHosts maps each HTTP protocol to the
-// first-party API host this binary ships independently of any catalog.
-// Catalog suggestions may pair a credential only with these hosts; every
-// other catalog-supplied endpoint requires an explicitly supplied endpoint
-// so a compromised catalog can never redirect a credential to itself.
-var independentlyTrustedEndpointHosts = map[Protocol]string{
-	ProtocolOpenAIChat:            "api.openai.com",
-	ProtocolOpenAIResponses:       "api.openai.com",
-	ProtocolAnthropicMessages:     "api.anthropic.com",
-	ProtocolGoogleGenerateContent: "generativelanguage.googleapis.com",
-}
-
 // IndependentlyTrustedEndpoint reports whether endpoint is an HTTPS endpoint
 // on the first-party API host compiled into this binary for protocol. Trust
 // never depends on catalog input: paths and the default port may vary because
 // a credential is only ever presented to the first-party TLS endpoint. It
 // returns false for every other host, scheme, port, or protocol.
 func IndependentlyTrustedEndpoint(protocol Protocol, endpoint string) bool {
-	host, trusted := independentlyTrustedEndpointHosts[protocol]
-	if !trusted || endpoint == "" {
+	capability, ok := ProtocolCapabilityFor(protocol)
+	if !ok || capability.CatalogTrustedHost == "" || endpoint == "" {
 		return false
 	}
 	parsed, err := url.Parse(endpoint)
@@ -491,7 +479,7 @@ func IndependentlyTrustedEndpoint(protocol Protocol, endpoint string) bool {
 		parsed.RawQuery != "" || parsed.Fragment != "" || parsed.ForceQuery {
 		return false
 	}
-	if !strings.EqualFold(parsed.Hostname(), host) {
+	if !strings.EqualFold(parsed.Hostname(), capability.CatalogTrustedHost) {
 		return false
 	}
 	port := parsed.Port()

--- a/internal/peoplesweep/openai_responses.go
+++ b/internal/peoplesweep/openai_responses.go
@@ -59,10 +59,6 @@ func (d *OpenAIResponsesDriver) Prepare(
 	if profile.Protocol != ProtocolOpenAIResponses {
 		return PreparedStructuredRequest{}, errors.New("OpenAI Responses driver requires openai_responses profile")
 	}
-	if profile.ReasoningMode != "" && profile.ReasoningMode != reasoningModeProviderDefault {
-		return PreparedStructuredRequest{}, errors.New("OpenAI Responses profile has unsupported reasoning mode")
-	}
-
 	instruction := structuredSystemInstruction
 	body := responsesRequest{
 		Model: profile.Model,

--- a/internal/peoplesweep/protocol_capabilities.go
+++ b/internal/peoplesweep/protocol_capabilities.go
@@ -1,0 +1,99 @@
+package peoplesweep
+
+import "slices"
+
+// ProtocolCapability is the immutable protocol metadata shared by provider
+// validation, capability negotiation, driver registration, and catalog setup.
+// Slice fields are copied by ProtocolCapabilityFor before they leave this
+// package so callers cannot mutate the declarations.
+type ProtocolCapability struct {
+	Protocol                    Protocol
+	DriverVersion               string
+	AuthSchemes                 []AuthScheme
+	RequiredAuth                AuthScheme
+	OutputModes                 []OutputMode
+	TokenParameters             []string
+	SupportsReasoningEffort     bool
+	SupportsCustomReasoningMode bool
+	CatalogAuthSchemes          []AuthScheme
+	CatalogDefaultAuth          AuthScheme
+	ModelsDevShapes             []string
+}
+
+var httpProtocolCapabilities = []ProtocolCapability{
+	{
+		Protocol:                    ProtocolOpenAIChat,
+		DriverVersion:               OpenAIChatProviderVersion,
+		AuthSchemes:                 []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
+		OutputModes:                 []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
+		TokenParameters:             []string{"max_completion_tokens", "max_tokens"},
+		SupportsReasoningEffort:     true,
+		SupportsCustomReasoningMode: true,
+		CatalogAuthSchemes:          []AuthScheme{AuthBearer, AuthXAPIKey},
+		CatalogDefaultAuth:          AuthBearer,
+		ModelsDevShapes:             []string{"@ai-sdk/openai-compatible", "@ai-sdk/openai"},
+	},
+	{
+		Protocol:                ProtocolOpenAIResponses,
+		DriverVersion:           "openai-responses-v1",
+		AuthSchemes:             []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
+		OutputModes:             []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
+		TokenParameters:         []string{""},
+		SupportsReasoningEffort: true,
+		CatalogAuthSchemes:      []AuthScheme{AuthBearer, AuthXAPIKey},
+		CatalogDefaultAuth:      AuthBearer,
+		ModelsDevShapes:         []string{"@ai-sdk/openai"},
+	},
+	{
+		Protocol:           ProtocolAnthropicMessages,
+		DriverVersion:      "anthropic-messages-v1",
+		AuthSchemes:        []AuthScheme{AuthXAPIKey},
+		RequiredAuth:       AuthXAPIKey,
+		OutputModes:        []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
+		TokenParameters:    []string{""},
+		CatalogAuthSchemes: []AuthScheme{AuthXAPIKey},
+		CatalogDefaultAuth: AuthXAPIKey,
+		ModelsDevShapes:    []string{"@ai-sdk/anthropic"},
+	},
+	{
+		Protocol:           ProtocolGoogleGenerateContent,
+		DriverVersion:      "google-generate-content-v1",
+		AuthSchemes:        []AuthScheme{AuthGoogleAPIKey},
+		RequiredAuth:       AuthGoogleAPIKey,
+		OutputModes:        []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
+		TokenParameters:    []string{""},
+		CatalogAuthSchemes: []AuthScheme{AuthGoogleAPIKey},
+		CatalogDefaultAuth: AuthGoogleAPIKey,
+		ModelsDevShapes:    []string{"@ai-sdk/google"},
+	},
+}
+
+// ProtocolCapabilityFor returns a copy of the HTTP capability declaration for
+// protocol. Codex is intentionally absent because it uses process transport.
+func ProtocolCapabilityFor(protocol Protocol) (ProtocolCapability, bool) {
+	for _, capability := range httpProtocolCapabilities {
+		if capability.Protocol == protocol {
+			return cloneProtocolCapability(capability), true
+		}
+	}
+	return ProtocolCapability{}, false
+}
+
+func cloneProtocolCapability(capability ProtocolCapability) ProtocolCapability {
+	capability.AuthSchemes = slices.Clone(capability.AuthSchemes)
+	capability.OutputModes = slices.Clone(capability.OutputModes)
+	capability.TokenParameters = slices.Clone(capability.TokenParameters)
+	capability.CatalogAuthSchemes = slices.Clone(capability.CatalogAuthSchemes)
+	capability.ModelsDevShapes = slices.Clone(capability.ModelsDevShapes)
+	return capability
+}
+
+func protocolsForModelsDevShape(shape string) []Protocol {
+	var protocols []Protocol
+	for _, capability := range httpProtocolCapabilities {
+		if slices.Contains(capability.ModelsDevShapes, shape) {
+			protocols = append(protocols, capability.Protocol)
+		}
+	}
+	return protocols
+}

--- a/internal/peoplesweep/protocol_capabilities.go
+++ b/internal/peoplesweep/protocol_capabilities.go
@@ -7,22 +7,26 @@ import "slices"
 // Slice fields are copied by ProtocolCapabilityFor before they leave this
 // package so callers cannot mutate the declarations.
 type ProtocolCapability struct {
-	Protocol                    Protocol
-	DriverVersion               string
-	AuthSchemes                 []AuthScheme
-	RequiredAuth                AuthScheme
-	OutputModes                 []OutputMode
+	Protocol      Protocol
+	DriverVersion string
+	AuthSchemes   []AuthScheme
+	OutputModes   []OutputMode
+	// TokenParameters lists negotiation attempts in preference order. An empty
+	// string means use the driver's fixed token field; an empty slice offers no attempts.
 	TokenParameters             []string
 	SupportsReasoningEffort     bool
 	SupportsCustomReasoningMode bool
 	CatalogAuthSchemes          []AuthScheme
 	CatalogDefaultAuth          AuthScheme
-	ModelsDevShapes             []string
+	// CatalogTrustedHost is compiled into the binary, independent of catalog input.
+	CatalogTrustedHost string
+	ModelsDevShapes    []string
 }
 
 var httpProtocolCapabilities = []ProtocolCapability{
 	{
 		Protocol:                    ProtocolOpenAIChat,
+		CatalogTrustedHost:          "api.openai.com",
 		DriverVersion:               OpenAIChatProviderVersion,
 		AuthSchemes:                 []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
 		OutputModes:                 []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
@@ -35,6 +39,7 @@ var httpProtocolCapabilities = []ProtocolCapability{
 	},
 	{
 		Protocol:                ProtocolOpenAIResponses,
+		CatalogTrustedHost:      "api.openai.com",
 		DriverVersion:           "openai-responses-v1",
 		AuthSchemes:             []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
 		OutputModes:             []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
@@ -46,9 +51,9 @@ var httpProtocolCapabilities = []ProtocolCapability{
 	},
 	{
 		Protocol:           ProtocolAnthropicMessages,
+		CatalogTrustedHost: "api.anthropic.com",
 		DriverVersion:      "anthropic-messages-v1",
 		AuthSchemes:        []AuthScheme{AuthXAPIKey},
-		RequiredAuth:       AuthXAPIKey,
 		OutputModes:        []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
 		TokenParameters:    []string{""},
 		CatalogAuthSchemes: []AuthScheme{AuthXAPIKey},
@@ -57,9 +62,9 @@ var httpProtocolCapabilities = []ProtocolCapability{
 	},
 	{
 		Protocol:           ProtocolGoogleGenerateContent,
+		CatalogTrustedHost: "generativelanguage.googleapis.com",
 		DriverVersion:      "google-generate-content-v1",
 		AuthSchemes:        []AuthScheme{AuthGoogleAPIKey},
-		RequiredAuth:       AuthGoogleAPIKey,
 		OutputModes:        []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
 		TokenParameters:    []string{""},
 		CatalogAuthSchemes: []AuthScheme{AuthGoogleAPIKey},

--- a/internal/peoplesweep/protocol_capabilities_test.go
+++ b/internal/peoplesweep/protocol_capabilities_test.go
@@ -57,19 +57,21 @@ func TestProtocolCapabilities(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(string(test.protocol), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 			capability, ok := ProtocolCapabilityFor(test.protocol)
-			require.True(t, ok)
-			assert.Equal(t, test.protocol, capability.Protocol)
-			assert.Equal(t, test.driverVersion, capability.DriverVersion)
-			assert.Equal(t, test.authSchemes, capability.AuthSchemes)
-			assert.Equal(t, test.requiredAuth, capability.RequiredAuth)
-			assert.Equal(t, test.outputModes, capability.OutputModes)
-			assert.Equal(t, test.tokenParameters, capability.TokenParameters)
-			assert.Equal(t, test.supportsReasoningEffort, capability.SupportsReasoningEffort)
-			assert.Equal(t, test.supportsCustomReasoningMode, capability.SupportsCustomReasoningMode)
-			assert.Equal(t, test.catalogAuthSchemes, capability.CatalogAuthSchemes)
-			assert.Equal(t, test.catalogDefaultAuth, capability.CatalogDefaultAuth)
-			assert.Equal(t, test.modelsDevShapes, capability.ModelsDevShapes)
+			require.True(ok)
+			assert.Equal(test.protocol, capability.Protocol)
+			assert.Equal(test.driverVersion, capability.DriverVersion)
+			assert.Equal(test.authSchemes, capability.AuthSchemes)
+			assert.Equal(test.requiredAuth, capability.RequiredAuth)
+			assert.Equal(test.outputModes, capability.OutputModes)
+			assert.Equal(test.tokenParameters, capability.TokenParameters)
+			assert.Equal(test.supportsReasoningEffort, capability.SupportsReasoningEffort)
+			assert.Equal(test.supportsCustomReasoningMode, capability.SupportsCustomReasoningMode)
+			assert.Equal(test.catalogAuthSchemes, capability.CatalogAuthSchemes)
+			assert.Equal(test.catalogDefaultAuth, capability.CatalogDefaultAuth)
+			assert.Equal(test.modelsDevShapes, capability.ModelsDevShapes)
 		})
 	}
 
@@ -80,8 +82,10 @@ func TestProtocolCapabilities(t *testing.T) {
 }
 
 func TestProtocolCapabilityLookupCopiesSlices(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	capability, ok := ProtocolCapabilityFor(ProtocolOpenAIChat)
-	require.True(t, ok)
+	require.True(ok)
 	capability.AuthSchemes[0] = AuthNone
 	capability.OutputModes[0] = OutputModePromptJSON
 	capability.TokenParameters[0] = "changed"
@@ -89,29 +93,31 @@ func TestProtocolCapabilityLookupCopiesSlices(t *testing.T) {
 	capability.ModelsDevShapes[0] = "changed"
 
 	unchanged, ok := ProtocolCapabilityFor(ProtocolOpenAIChat)
-	require.True(t, ok)
-	assert.Equal(t, AuthBearer, unchanged.AuthSchemes[0])
-	assert.Equal(t, OutputModeNativeJSONSchema, unchanged.OutputModes[0])
-	assert.Equal(t, "max_completion_tokens", unchanged.TokenParameters[0])
-	assert.Equal(t, AuthBearer, unchanged.CatalogAuthSchemes[0])
-	assert.Equal(t, "@ai-sdk/openai-compatible", unchanged.ModelsDevShapes[0])
+	require.True(ok)
+	assert.Equal(AuthBearer, unchanged.AuthSchemes[0])
+	assert.Equal(OutputModeNativeJSONSchema, unchanged.OutputModes[0])
+	assert.Equal("max_completion_tokens", unchanged.TokenParameters[0])
+	assert.Equal(AuthBearer, unchanged.CatalogAuthSchemes[0])
+	assert.Equal("@ai-sdk/openai-compatible", unchanged.ModelsDevShapes[0])
 }
 
 func TestProtocolCapabilityRegistrationPairsHTTPDriversAndExcludesCodex(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	registry, err := NewDriverRegistry(http.DefaultClient, nil, nil)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	for _, protocol := range []Protocol{
 		ProtocolOpenAIChat, ProtocolOpenAIResponses,
 		ProtocolAnthropicMessages, ProtocolGoogleGenerateContent,
 	} {
 		registration, ok := registry.registrations[protocol]
-		require.True(t, ok)
-		assert.Equal(t, protocol, registration.capability.Protocol)
-		assert.NotNil(t, registration.driver)
+		require.True(ok)
+		assert.Equal(protocol, registration.capability.Protocol)
+		assert.NotNil(registration.driver)
 		_, err := registry.capabilityDriver(protocol)
-		assert.NoError(t, err)
+		assert.NoError(err)
 	}
 	_, err = registry.capabilityDriver(ProtocolCodexAppServer)
-	assert.Error(t, err)
+	assert.Error(err)
 }

--- a/internal/peoplesweep/protocol_capabilities_test.go
+++ b/internal/peoplesweep/protocol_capabilities_test.go
@@ -1,0 +1,117 @@
+package peoplesweep
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolCapabilities(t *testing.T) {
+	tests := []struct {
+		protocol                    Protocol
+		driverVersion               string
+		authSchemes                 []AuthScheme
+		requiredAuth                AuthScheme
+		outputModes                 []OutputMode
+		tokenParameters             []string
+		supportsReasoningEffort     bool
+		supportsCustomReasoningMode bool
+		catalogAuthSchemes          []AuthScheme
+		catalogDefaultAuth          AuthScheme
+		modelsDevShapes             []string
+	}{
+		{
+			protocol: ProtocolOpenAIChat, driverVersion: OpenAIChatProviderVersion,
+			authSchemes:             []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
+			outputModes:             []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
+			tokenParameters:         []string{"max_completion_tokens", "max_tokens"},
+			supportsReasoningEffort: true, supportsCustomReasoningMode: true,
+			catalogAuthSchemes: []AuthScheme{AuthBearer, AuthXAPIKey}, catalogDefaultAuth: AuthBearer,
+			modelsDevShapes: []string{"@ai-sdk/openai-compatible", "@ai-sdk/openai"},
+		},
+		{
+			protocol: ProtocolOpenAIResponses, driverVersion: "openai-responses-v1",
+			authSchemes:     []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
+			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
+			tokenParameters: []string{""}, supportsReasoningEffort: true,
+			catalogAuthSchemes: []AuthScheme{AuthBearer, AuthXAPIKey}, catalogDefaultAuth: AuthBearer,
+			modelsDevShapes: []string{"@ai-sdk/openai"},
+		},
+		{
+			protocol: ProtocolAnthropicMessages, driverVersion: "anthropic-messages-v1",
+			authSchemes: []AuthScheme{AuthXAPIKey}, requiredAuth: AuthXAPIKey,
+			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
+			tokenParameters: []string{""}, catalogAuthSchemes: []AuthScheme{AuthXAPIKey},
+			catalogDefaultAuth: AuthXAPIKey, modelsDevShapes: []string{"@ai-sdk/anthropic"},
+		},
+		{
+			protocol: ProtocolGoogleGenerateContent, driverVersion: "google-generate-content-v1",
+			authSchemes: []AuthScheme{AuthGoogleAPIKey}, requiredAuth: AuthGoogleAPIKey,
+			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
+			tokenParameters: []string{""}, catalogAuthSchemes: []AuthScheme{AuthGoogleAPIKey},
+			catalogDefaultAuth: AuthGoogleAPIKey, modelsDevShapes: []string{"@ai-sdk/google"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.protocol), func(t *testing.T) {
+			capability, ok := ProtocolCapabilityFor(test.protocol)
+			require.True(t, ok)
+			assert.Equal(t, test.protocol, capability.Protocol)
+			assert.Equal(t, test.driverVersion, capability.DriverVersion)
+			assert.Equal(t, test.authSchemes, capability.AuthSchemes)
+			assert.Equal(t, test.requiredAuth, capability.RequiredAuth)
+			assert.Equal(t, test.outputModes, capability.OutputModes)
+			assert.Equal(t, test.tokenParameters, capability.TokenParameters)
+			assert.Equal(t, test.supportsReasoningEffort, capability.SupportsReasoningEffort)
+			assert.Equal(t, test.supportsCustomReasoningMode, capability.SupportsCustomReasoningMode)
+			assert.Equal(t, test.catalogAuthSchemes, capability.CatalogAuthSchemes)
+			assert.Equal(t, test.catalogDefaultAuth, capability.CatalogDefaultAuth)
+			assert.Equal(t, test.modelsDevShapes, capability.ModelsDevShapes)
+		})
+	}
+
+	assert.False(t, func() bool {
+		_, ok := ProtocolCapabilityFor(ProtocolCodexAppServer)
+		return ok
+	}())
+}
+
+func TestProtocolCapabilityLookupCopiesSlices(t *testing.T) {
+	capability, ok := ProtocolCapabilityFor(ProtocolOpenAIChat)
+	require.True(t, ok)
+	capability.AuthSchemes[0] = AuthNone
+	capability.OutputModes[0] = OutputModePromptJSON
+	capability.TokenParameters[0] = "changed"
+	capability.CatalogAuthSchemes[0] = AuthGoogleAPIKey
+	capability.ModelsDevShapes[0] = "changed"
+
+	unchanged, ok := ProtocolCapabilityFor(ProtocolOpenAIChat)
+	require.True(t, ok)
+	assert.Equal(t, AuthBearer, unchanged.AuthSchemes[0])
+	assert.Equal(t, OutputModeNativeJSONSchema, unchanged.OutputModes[0])
+	assert.Equal(t, "max_completion_tokens", unchanged.TokenParameters[0])
+	assert.Equal(t, AuthBearer, unchanged.CatalogAuthSchemes[0])
+	assert.Equal(t, "@ai-sdk/openai-compatible", unchanged.ModelsDevShapes[0])
+}
+
+func TestProtocolCapabilityRegistrationPairsHTTPDriversAndExcludesCodex(t *testing.T) {
+	registry, err := NewDriverRegistry(http.DefaultClient, nil, nil)
+	require.NoError(t, err)
+
+	for _, protocol := range []Protocol{
+		ProtocolOpenAIChat, ProtocolOpenAIResponses,
+		ProtocolAnthropicMessages, ProtocolGoogleGenerateContent,
+	} {
+		registration, ok := registry.registrations[protocol]
+		require.True(t, ok)
+		assert.Equal(t, protocol, registration.capability.Protocol)
+		assert.NotNil(t, registration.driver)
+		_, err := registry.capabilityDriver(protocol)
+		assert.NoError(t, err)
+	}
+	_, err = registry.capabilityDriver(ProtocolCodexAppServer)
+	assert.Error(t, err)
+}

--- a/internal/peoplesweep/protocol_capabilities_test.go
+++ b/internal/peoplesweep/protocol_capabilities_test.go
@@ -116,7 +116,7 @@ func TestProtocolCapabilityRegistrationPairsHTTPDriversAndExcludesCodex(t *testi
 		assert.Equal(protocol, registration.capability.Protocol)
 		assert.NotNil(registration.driver)
 		_, err := registry.capabilityDriver(protocol)
-		assert.NoError(err)
+		require.NoError(err)
 	}
 	_, err = registry.capabilityDriver(ProtocolCodexAppServer)
 	assert.Error(err)

--- a/internal/peoplesweep/protocol_capabilities_test.go
+++ b/internal/peoplesweep/protocol_capabilities_test.go
@@ -8,79 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProtocolCapabilities(t *testing.T) {
-	tests := []struct {
-		protocol                    Protocol
-		driverVersion               string
-		authSchemes                 []AuthScheme
-		requiredAuth                AuthScheme
-		outputModes                 []OutputMode
-		tokenParameters             []string
-		supportsReasoningEffort     bool
-		supportsCustomReasoningMode bool
-		catalogAuthSchemes          []AuthScheme
-		catalogDefaultAuth          AuthScheme
-		modelsDevShapes             []string
-	}{
-		{
-			protocol: ProtocolOpenAIChat, driverVersion: OpenAIChatProviderVersion,
-			authSchemes:             []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
-			outputModes:             []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
-			tokenParameters:         []string{"max_completion_tokens", "max_tokens"},
-			supportsReasoningEffort: true, supportsCustomReasoningMode: true,
-			catalogAuthSchemes: []AuthScheme{AuthBearer, AuthXAPIKey}, catalogDefaultAuth: AuthBearer,
-			modelsDevShapes: []string{"@ai-sdk/openai-compatible", "@ai-sdk/openai"},
-		},
-		{
-			protocol: ProtocolOpenAIResponses, driverVersion: "openai-responses-v1",
-			authSchemes:     []AuthScheme{AuthBearer, AuthXAPIKey, AuthGoogleAPIKey, AuthNone},
-			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModeJSONObject, OutputModePromptJSON},
-			tokenParameters: []string{""}, supportsReasoningEffort: true,
-			catalogAuthSchemes: []AuthScheme{AuthBearer, AuthXAPIKey}, catalogDefaultAuth: AuthBearer,
-			modelsDevShapes: []string{"@ai-sdk/openai"},
-		},
-		{
-			protocol: ProtocolAnthropicMessages, driverVersion: "anthropic-messages-v1",
-			authSchemes: []AuthScheme{AuthXAPIKey}, requiredAuth: AuthXAPIKey,
-			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
-			tokenParameters: []string{""}, catalogAuthSchemes: []AuthScheme{AuthXAPIKey},
-			catalogDefaultAuth: AuthXAPIKey, modelsDevShapes: []string{"@ai-sdk/anthropic"},
-		},
-		{
-			protocol: ProtocolGoogleGenerateContent, driverVersion: "google-generate-content-v1",
-			authSchemes: []AuthScheme{AuthGoogleAPIKey}, requiredAuth: AuthGoogleAPIKey,
-			outputModes:     []OutputMode{OutputModeNativeJSONSchema, OutputModePromptJSON},
-			tokenParameters: []string{""}, catalogAuthSchemes: []AuthScheme{AuthGoogleAPIKey},
-			catalogDefaultAuth: AuthGoogleAPIKey, modelsDevShapes: []string{"@ai-sdk/google"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(string(test.protocol), func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-			capability, ok := ProtocolCapabilityFor(test.protocol)
-			require.True(ok)
-			assert.Equal(test.protocol, capability.Protocol)
-			assert.Equal(test.driverVersion, capability.DriverVersion)
-			assert.Equal(test.authSchemes, capability.AuthSchemes)
-			assert.Equal(test.requiredAuth, capability.RequiredAuth)
-			assert.Equal(test.outputModes, capability.OutputModes)
-			assert.Equal(test.tokenParameters, capability.TokenParameters)
-			assert.Equal(test.supportsReasoningEffort, capability.SupportsReasoningEffort)
-			assert.Equal(test.supportsCustomReasoningMode, capability.SupportsCustomReasoningMode)
-			assert.Equal(test.catalogAuthSchemes, capability.CatalogAuthSchemes)
-			assert.Equal(test.catalogDefaultAuth, capability.CatalogDefaultAuth)
-			assert.Equal(test.modelsDevShapes, capability.ModelsDevShapes)
-		})
-	}
-
-	assert.False(t, func() bool {
-		_, ok := ProtocolCapabilityFor(ProtocolCodexAppServer)
-		return ok
-	}())
-}
-
 func TestProtocolCapabilityLookupCopiesSlices(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -101,7 +28,7 @@ func TestProtocolCapabilityLookupCopiesSlices(t *testing.T) {
 	assert.Equal("@ai-sdk/openai-compatible", unchanged.ModelsDevShapes[0])
 }
 
-func TestProtocolCapabilityRegistrationPairsHTTPDriversAndExcludesCodex(t *testing.T) {
+func TestCapabilityDriverSelectsHTTPDriversAndExcludesCodex(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	registry, err := NewDriverRegistry(http.DefaultClient, nil, nil)
@@ -111,11 +38,16 @@ func TestProtocolCapabilityRegistrationPairsHTTPDriversAndExcludesCodex(t *testi
 		ProtocolOpenAIChat, ProtocolOpenAIResponses,
 		ProtocolAnthropicMessages, ProtocolGoogleGenerateContent,
 	} {
-		registration, ok := registry.registrations[protocol]
+		capability, ok := ProtocolCapabilityFor(protocol)
 		require.True(ok)
-		assert.Equal(protocol, registration.capability.Protocol)
-		assert.NotNil(registration.driver)
-		_, err := registry.capabilityDriver(protocol)
+		driver, err := registry.capabilityDriver(protocol)
+		require.NoError(err)
+		profile, err := capabilityProfile(ProviderConfig{
+			Protocol: protocol, Endpoint: "https://api.example.com", Model: "test-model",
+			Auth: capability.AuthSchemes[0],
+		}, capabilityOutputModes(protocol)[0], capabilityTokenParameters(protocol)[0], false)
+		require.NoError(err)
+		_, err = driver.Prepare(profile, capabilitySyntheticRequest())
 		require.NoError(err)
 	}
 	_, err = registry.capabilityDriver(ProtocolCodexAppServer)


### PR DESCRIPTION
People-sweep HTTP drivers now expose one capability declaration to configuration validation, synthetic negotiation, registry selection, models.dev protocol selection, and provider catalog auth.

The existing protocol order, auth rules, output modes, token parameters, reasoning behavior, driver versions, Codex isolation, and the repository's provider wire implementations remain unchanged. A new capability fact no longer needs matching edits across independent switches.

Closes #741
