### PR TITLE
fix(sync): replay failed Gmail fetches from the last completed incremental run

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,10 @@ All notable changes to msgvault, grouped by release.
 
 **Bug fixes**
 
+- Incremental Gmail sync retries raw-message fetch failures from the previous
+  completed incremental run, carries repeated fetch failures forward, and treats
+  messages gone before replay as handled skips. Replay requires a recorded
+  incremental run type; older untyped runs and full-sync failures are excluded.
 - Deduplication now derives missing RFC822 Message-ID metadata only after the
   user confirms the reviewed plan, applies the exact derivation plan atomically,
   rescans, and refuses duplicate hiding when the actionable plan changes. Its

--- a/internal/store/sync.go
+++ b/internal/store/sync.go
@@ -1437,18 +1437,38 @@ func (s *Store) HasAnyActiveSync() (bool, error) {
 
 // GetLastSuccessfulSync returns the most recent successful sync for a source.
 func (s *Store) GetLastSuccessfulSync(sourceID int64) (*SyncRun, error) {
+	return s.getLastSuccessfulSync(sourceID, "", false)
+}
+
+// GetLastSuccessfulSyncByType returns the most recent successful sync whose
+// sync_type exactly equals syncType, the legacy empty value included; only
+// GetLastSuccessfulSync queries without a type filter.
+func (s *Store) GetLastSuccessfulSyncByType(sourceID int64, syncType string) (*SyncRun, error) {
+	return s.getLastSuccessfulSync(sourceID, syncType, true)
+}
+
+func (s *Store) getLastSuccessfulSync(sourceID int64, syncType string, filterByType bool) (*SyncRun, error) {
+	whereType := ""
+	args := []any{sourceID}
+	if filterByType {
+		whereType = " AND sync_type = ?"
+		args = append(args, syncType)
+	}
 	row := s.db.QueryRow(`
 		SELECT id, source_id, started_at, completed_at, status,
 		       messages_processed, messages_added, messages_updated, errors_count,
 		       error_message, cursor_before, cursor_after, request_fingerprint
 		FROM sync_runs
-		WHERE source_id = ? AND status = 'completed'
+		WHERE source_id = ? AND status = 'completed'`+whereType+`
 		ORDER BY completed_at DESC, id DESC
 		LIMIT 1
-	`, sourceID)
+	`, args...)
 
 	run, err := scanSyncRun(row)
 	if errors.Is(err, sql.ErrNoRows) {
+		if filterByType {
+			return nil, fmt.Errorf("last successful %s sync for source %d: %w", syncType, sourceID, ErrSyncRunNotFound)
+		}
 		return nil, fmt.Errorf("last successful sync for source %d: %w", sourceID, ErrSyncRunNotFound)
 	}
 	return run, err

--- a/internal/sync/incremental.go
+++ b/internal/sync/incremental.go
@@ -44,6 +44,13 @@ func (s *Syncer) incremental(
 		return nil, fmt.Errorf("invalid history ID %q: %w", source.SyncCursor.String, err)
 	}
 
+	// Read the prior run's fetch debt before a new run exists, so a ledger error
+	// cannot fail a run and the completed run stays visible for the next attempt.
+	pendingReplayIDs, err := s.pendingFetchReplayIDs(source.ID)
+	if err != nil {
+		return nil, fmt.Errorf("find pending fetch replays: %w", err)
+	}
+
 	// Start sync
 	syncID, err := s.startSync(ctx, execution, "incremental", "")
 	if err != nil {
@@ -87,7 +94,7 @@ func (s *Syncer) incremental(
 	// change while a mailbox is idle, so the post-completion hook still runs,
 	// flagged as a no-op so it only reaches for the provider when a refresh is
 	// owed (never succeeded, previously failed, or stale).
-	if startHistoryID >= profile.HistoryID {
+	if startHistoryID >= profile.HistoryID && len(pendingReplayIDs) == 0 {
 		s.logger.Info("already up to date")
 		if err := s.completeSyncWithoutHook(
 			ctx, syncID, source.ID, strconv.FormatUint(profile.HistoryID, 10), true,
@@ -108,160 +115,189 @@ func (s *Syncer) incremental(
 		return nil, fmt.Errorf("sync labels: %w", err)
 	}
 
-	// Process history
 	checkpoint := &store.Checkpoint{}
-	pageToken := ""
 	var discoveryHealth pageDiscoveryHealth
 
-	for {
-		historyResp, err := s.client.ListHistory(ctx, startHistoryID, pageToken)
+	// Retry the prior run's absent fetches inside this scoped run, before history
+	// selection, so an idle mailbox still works off its durable debt.
+	if len(pendingReplayIDs) > 0 {
+		replayedIDs, err := s.replayFetchFailures(
+			ctx, syncID, source.ID, pendingReplayIDs, labelMap, checkpoint, summary,
+		)
 		if err != nil {
-			// Check for 404 - history too old
-			if _, ok := errors.AsType[*gmail.NotFoundError](err); ok {
-				s.logger.Info("gmail history expired; full sync required")
-				_ = s.store.FailSync(syncID, "history too old")
-				// Callers fall back to a full sync on ErrHistoryExpired.
-				return nil, ErrHistoryExpired
+			if checkpointErr := s.store.UpdateSyncCheckpoint(syncID, checkpoint); checkpointErr != nil {
+				s.logger.Warn("failed to save checkpoint before failing sync", "error", checkpointErr)
 			}
-			_ = s.store.FailSync(syncID, err.Error())
-			return nil, fmt.Errorf("list history: %w", err)
-		}
-
-		// Collect all message IDs referenced in this page for a single batch existence check
-		allIDs := make(map[string]bool)
-		for _, record := range historyResp.History {
-			for _, msg := range record.MessagesAdded {
-				allIDs[msg.Message.ID] = true
-			}
-			for _, item := range record.LabelsAdded {
-				allIDs[item.Message.ID] = true
-			}
-			for _, item := range record.LabelsRemoved {
-				allIDs[item.Message.ID] = true
-			}
-		}
-		idList := make([]string, 0, len(allIDs))
-		for id := range allIDs {
-			idList = append(idList, id)
-		}
-		existingMap, err := s.store.MessageExistsBatch(source.ID, idList)
-		if err != nil {
-			_ = s.store.FailSync(syncID, err.Error())
-			return nil, fmt.Errorf("check existing messages: %w", err)
-		}
-
-		// Collect new message IDs to batch-fetch and deleted IDs to batch-mark
-		newMsgThreads := make(map[string]string) // deduplicates by ID
-		deletedSet := make(map[string]bool)
-		updatedExisting := make(map[string]struct{})
-		identityDiscoverySet := make(map[string]struct{})
-
-		for _, record := range historyResp.History {
-			for _, msg := range record.MessagesAdded {
-				if _, exists := existingMap[msg.Message.ID]; !exists {
-					newMsgThreads[msg.Message.ID] = msg.Message.ThreadID
-				} else {
-					identityDiscoverySet[msg.Message.ID] = struct{}{}
-				}
-			}
-			for _, msg := range record.MessagesDeleted {
-				deletedSet[msg.Message.ID] = true
-			}
-		}
-		for _, record := range historyResp.History {
-			s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, newMsgThreads, updatedExisting, identityDiscoverySet, checkpoint, summary)
-		}
-		checkpoint.MessagesUpdated += int64(len(updatedExisting))
-		checkpoint.MessagesProcessed += int64(len(newMsgThreads) + len(deletedSet) + len(updatedExisting))
-		newMsgIDs := make([]string, 0, len(newMsgThreads))
-		for id := range newMsgThreads {
-			newMsgIDs = append(newMsgIDs, id)
-		}
-		deletedIDs := make([]string, 0, len(deletedSet))
-		for id := range deletedSet {
-			deletedIDs = append(deletedIDs, id)
-		}
-
-		// Batch-fetch and ingest new messages
-		if len(newMsgIDs) > 0 {
-			rawMessages, fetchErr := s.getMessagesRawBatchWithDiagnostics(ctx, newMsgIDs)
-			if fetchErr != nil {
-				s.logger.Warn("failed to batch fetch messages", "error", fetchErr)
-				for _, id := range newMsgIDs {
-					s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, fetchErr)
-				}
-				checkpoint.ErrorsCount += int64(len(newMsgIDs))
-			} else {
-				for i, fetch := range rawMessages {
-					raw := fetch.Message
-					if raw == nil {
-						if isGmailNotFound(fetch.Err) {
-							s.logger.Debug("skipping message deleted before fetch", "id", newMsgIDs[i])
-							s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
-							continue
-						}
-						errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
-						s.logger.Warn("failed to fetch message", "id", newMsgIDs[i], "error", errMsg)
-						s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
-						checkpoint.ErrorsCount++
-						continue
-					}
-					threadID := newMsgThreads[newMsgIDs[i]]
-					if _, err := s.ingestMessage(
-						ctx, source.ID, raw, threadID, labelMap,
-					); err != nil {
-						s.logger.Warn("failed to ingest added message", "id", newMsgIDs[i], "error", err)
-						s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
-						checkpoint.ErrorsCount++
-						continue
-					}
-					checkpoint.MessagesAdded++
-					summary.BytesDownloaded += int64(len(raw.Raw))
-					identityDiscoverySet[newMsgIDs[i]] = struct{}{}
-				}
-
-				// Newly-persisted messages get embed_gen = NULL by column
-				// default, so the scan-and-fill embed worker picks them up
-				// automatically — no sync-time enqueue step is needed.
-			}
-		}
-
-		// Batch-mark deleted messages
-		if len(deletedIDs) > 0 {
-			if err := s.store.MarkMessagesDeletedBatch(source.ID, deletedIDs); err != nil {
-				s.logger.Warn("failed to batch mark messages deleted", "error", err)
-				for _, id := range deletedIDs {
-					s.recordSyncItem(syncID, id, syncItemPhaseDelete, store.SyncRunItemStatusError, syncItemKindDeleteError, err)
-				}
-				checkpoint.ErrorsCount += int64(len(deletedIDs))
-			}
-		}
-
-		identityDiscoveryIDs := make([]string, 0, len(identityDiscoverySet))
-		for id := range identityDiscoverySet {
-			identityDiscoveryIDs = append(identityDiscoveryIDs, id)
-		}
-		sort.Strings(identityDiscoveryIDs)
-		discoveryHealth.observe(s.runPageIdentityDiscovery(ctx, source.ID, identityDiscoveryIDs))
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			err := fmt.Errorf("sync canceled during identity discovery: %w", ctxErr)
 			s.failStoppedSync(syncID, err)
 			return nil, err
 		}
-
-		// Report progress
-		s.progress.OnProgress(checkpoint.MessagesProcessed, checkpoint.MessagesAdded, 0)
-
-		// Save checkpoint
-		pageToken = historyResp.NextPageToken
-		checkpoint.PageToken = pageToken
-		if err := s.store.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
-			s.logger.Warn("failed to save checkpoint", "error", err)
+		if len(replayedIDs) > 0 {
+			discoveryHealth.observe(s.runPageIdentityDiscovery(ctx, source.ID, replayedIDs))
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err := fmt.Errorf("sync canceled during replay identity discovery: %w", ctxErr)
+				s.failStoppedSync(syncID, err)
+				return nil, err
+			}
 		}
+		if err := s.store.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
+			s.logger.Warn("failed to save replay checkpoint", "error", err)
+		}
+	}
 
-		// No more pages
-		if pageToken == "" {
-			break
+	if startHistoryID < profile.HistoryID {
+		// Process history
+		pageToken := ""
+
+		for {
+			historyResp, err := s.client.ListHistory(ctx, startHistoryID, pageToken)
+			if err != nil {
+				// Check for 404 - history too old
+				if _, ok := errors.AsType[*gmail.NotFoundError](err); ok {
+					s.logger.Info("gmail history expired; full sync required")
+					_ = s.store.FailSync(syncID, "history too old")
+					// Callers fall back to a full sync on ErrHistoryExpired.
+					return nil, ErrHistoryExpired
+				}
+				_ = s.store.FailSync(syncID, err.Error())
+				return nil, fmt.Errorf("list history: %w", err)
+			}
+
+			// Collect all message IDs referenced in this page for a single batch existence check
+			allIDs := make(map[string]bool)
+			for _, record := range historyResp.History {
+				for _, msg := range record.MessagesAdded {
+					allIDs[msg.Message.ID] = true
+				}
+				for _, item := range record.LabelsAdded {
+					allIDs[item.Message.ID] = true
+				}
+				for _, item := range record.LabelsRemoved {
+					allIDs[item.Message.ID] = true
+				}
+			}
+			idList := make([]string, 0, len(allIDs))
+			for id := range allIDs {
+				idList = append(idList, id)
+			}
+			existingMap, err := s.store.MessageExistsBatch(source.ID, idList)
+			if err != nil {
+				_ = s.store.FailSync(syncID, err.Error())
+				return nil, fmt.Errorf("check existing messages: %w", err)
+			}
+
+			// Collect new message IDs to batch-fetch and deleted IDs to batch-mark
+			newMsgThreads := make(map[string]string) // deduplicates by ID
+			deletedSet := make(map[string]bool)
+			updatedExisting := make(map[string]struct{})
+			identityDiscoverySet := make(map[string]struct{})
+
+			for _, record := range historyResp.History {
+				for _, msg := range record.MessagesAdded {
+					if _, exists := existingMap[msg.Message.ID]; !exists {
+						newMsgThreads[msg.Message.ID] = msg.Message.ThreadID
+					} else {
+						identityDiscoverySet[msg.Message.ID] = struct{}{}
+					}
+				}
+				for _, msg := range record.MessagesDeleted {
+					deletedSet[msg.Message.ID] = true
+				}
+			}
+			for _, record := range historyResp.History {
+				s.processLabelChanges(ctx, syncID, source.ID, record, labelMap, existingMap, newMsgThreads, updatedExisting, identityDiscoverySet, checkpoint, summary)
+			}
+			checkpoint.MessagesUpdated += int64(len(updatedExisting))
+			checkpoint.MessagesProcessed += int64(len(newMsgThreads) + len(deletedSet) + len(updatedExisting))
+			newMsgIDs := make([]string, 0, len(newMsgThreads))
+			for id := range newMsgThreads {
+				newMsgIDs = append(newMsgIDs, id)
+			}
+			deletedIDs := make([]string, 0, len(deletedSet))
+			for id := range deletedSet {
+				deletedIDs = append(deletedIDs, id)
+			}
+
+			// Batch-fetch and ingest new messages
+			if len(newMsgIDs) > 0 {
+				rawMessages, fetchErr := s.getMessagesRawBatchWithDiagnostics(ctx, newMsgIDs)
+				if fetchErr != nil {
+					s.logger.Warn("failed to batch fetch messages", "error", fetchErr)
+					for _, id := range newMsgIDs {
+						s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, fetchErr)
+					}
+					checkpoint.ErrorsCount += int64(len(newMsgIDs))
+				} else {
+					for i, fetch := range rawMessages {
+						raw := fetch.Message
+						if raw == nil {
+							if isGmailNotFound(fetch.Err) {
+								s.logger.Debug("skipping message deleted before fetch", "id", newMsgIDs[i])
+								s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusSkipped, syncItemKindGmailNotFound, fetch.Err)
+								continue
+							}
+							errMsg := syncItemErrorMessage(fetch.Err, errRawBatchMissing.Error())
+							s.logger.Warn("failed to fetch message", "id", newMsgIDs[i], "error", errMsg)
+							s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, fetch.Err)
+							checkpoint.ErrorsCount++
+							continue
+						}
+						threadID := newMsgThreads[newMsgIDs[i]]
+						if _, err := s.ingestMessage(
+							ctx, source.ID, raw, threadID, labelMap,
+						); err != nil {
+							s.logger.Warn("failed to ingest added message", "id", newMsgIDs[i], "error", err)
+							s.recordSyncItem(syncID, newMsgIDs[i], syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+							checkpoint.ErrorsCount++
+							continue
+						}
+						checkpoint.MessagesAdded++
+						summary.BytesDownloaded += int64(len(raw.Raw))
+						identityDiscoverySet[newMsgIDs[i]] = struct{}{}
+					}
+
+					// Newly-persisted messages get embed_gen = NULL by column
+					// default, so the scan-and-fill embed worker picks them up
+					// automatically — no sync-time enqueue step is needed.
+				}
+			}
+
+			// Batch-mark deleted messages
+			if len(deletedIDs) > 0 {
+				if err := s.store.MarkMessagesDeletedBatch(source.ID, deletedIDs); err != nil {
+					s.logger.Warn("failed to batch mark messages deleted", "error", err)
+					for _, id := range deletedIDs {
+						s.recordSyncItem(syncID, id, syncItemPhaseDelete, store.SyncRunItemStatusError, syncItemKindDeleteError, err)
+					}
+					checkpoint.ErrorsCount += int64(len(deletedIDs))
+				}
+			}
+
+			identityDiscoveryIDs := make([]string, 0, len(identityDiscoverySet))
+			for id := range identityDiscoverySet {
+				identityDiscoveryIDs = append(identityDiscoveryIDs, id)
+			}
+			sort.Strings(identityDiscoveryIDs)
+			discoveryHealth.observe(s.runPageIdentityDiscovery(ctx, source.ID, identityDiscoveryIDs))
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err := fmt.Errorf("sync canceled during identity discovery: %w", ctxErr)
+				s.failStoppedSync(syncID, err)
+				return nil, err
+			}
+
+			// Report progress
+			s.progress.OnProgress(checkpoint.MessagesProcessed, checkpoint.MessagesAdded, summary.MessagesSkipped)
+
+			// Save checkpoint
+			pageToken = historyResp.NextPageToken
+			checkpoint.PageToken = pageToken
+			if err := s.store.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
+				s.logger.Warn("failed to save checkpoint", "error", err)
+			}
+
+			// No more pages
+			if pageToken == "" {
+				break
+			}
 		}
 	}
 
@@ -273,7 +309,7 @@ func (s *Syncer) incremental(
 
 	// Always advance the cursor so a single permanently-failing
 	// message doesn't block all future incremental syncs.
-	// Failed messages can be recovered via full sync.
+	// Failed fetches carry forward to the next incremental run.
 	historyIDStr := strconv.FormatUint(profile.HistoryID, 10)
 	if checkpoint.ErrorsCount > 0 {
 		s.logger.Warn("incremental sync completed with errors",
@@ -281,7 +317,8 @@ func (s *Syncer) incremental(
 			"history_id", historyIDStr)
 	}
 	// Mark sync complete before running best-effort provider maintenance.
-	if err := s.completeSyncAndRunHook(ctx, syncID, historyIDStr, source); err != nil {
+	mailboxChanged := startHistoryID < profile.HistoryID || checkpoint.MessagesAdded > 0
+	if err := s.completeSyncAndRunHook(ctx, syncID, historyIDStr, source, mailboxChanged); err != nil {
 		return nil, err
 	}
 
@@ -294,8 +331,104 @@ func (s *Syncer) incremental(
 	summary.Errors = checkpoint.ErrorsCount
 	summary.FinalHistoryID = profile.HistoryID
 
+	s.progress.OnProgress(checkpoint.MessagesProcessed, checkpoint.MessagesAdded, summary.MessagesSkipped)
 	s.progress.OnComplete(summary)
 	return summary, nil
+}
+
+// replayFetchFailures re-fetches the IDs a prior completed incremental run
+// failed to read, skipping any that already reached the archive. Reads and
+// local ingest only; a repeated failure becomes this run's fetch error and
+// carries the ID to the next run.
+func (s *Syncer) replayFetchFailures(
+	ctx context.Context,
+	syncID, sourceID int64,
+	messageIDs []string,
+	labelMap map[string]int64,
+	checkpoint *store.Checkpoint,
+	summary *gmail.SyncSummary,
+) ([]string, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+
+	existing, err := s.store.MessageExistsBatch(sourceID, messageIDs)
+	if err != nil {
+		return nil, fmt.Errorf("check replay messages: %w", err)
+	}
+	fetchIDs := make([]string, 0, len(messageIDs))
+	for _, messageID := range messageIDs {
+		if _, ok := existing[messageID]; !ok {
+			fetchIDs = append(fetchIDs, messageID)
+		}
+	}
+	if len(fetchIDs) == 0 {
+		return nil, nil
+	}
+
+	batchSize := 10
+	if s.opts.BatchSize > 0 {
+		batchSize = s.opts.BatchSize
+	}
+	successfulIDs := make([]string, 0, len(fetchIDs))
+	for batchStart := 0; batchStart < len(fetchIDs); batchStart += batchSize {
+		batchEnd := min(batchStart+batchSize, len(fetchIDs))
+		batchIDs := fetchIDs[batchStart:batchEnd]
+		checkpoint.MessagesProcessed += int64(len(batchIDs))
+		results, fetchErr := s.getMessagesRawBatchWithDiagnostics(ctx, batchIDs)
+		if fetchErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			if errors.Is(fetchErr, context.Canceled) || errors.Is(fetchErr, context.DeadlineExceeded) {
+				return nil, fetchErr
+			}
+			s.logger.Warn("failed to batch fetch replay messages", "error", fetchErr)
+			for _, messageID := range batchIDs {
+				s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, fetchErr)
+			}
+			checkpoint.ErrorsCount += int64(len(batchIDs))
+			if err := s.store.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
+				return nil, fmt.Errorf("checkpoint replay batch: %w", err)
+			}
+			continue
+		}
+		for i, messageID := range batchIDs {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			result := results[i]
+			if result.Message == nil {
+				if kind, gone := messageGoneKind(result.Err); gone {
+					s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusSkipped, kind, result.Err)
+					summary.MessagesSkipped++
+					continue
+				}
+				errMsg := syncItemErrorMessage(result.Err, errRawBatchMissing.Error())
+				err := errors.New(errMsg)
+				s.recordSyncItem(syncID, messageID, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindFetchError, err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+
+			if _, err := s.ingestMessage(ctx, sourceID, result.Message, result.Message.ThreadID, labelMap); err != nil {
+				if errors.Is(err, store.ErrSyncRunSuperseded) || ctx.Err() != nil {
+					return nil, err
+				}
+				s.recordSyncItem(syncID, messageID, syncItemPhaseIngest, store.SyncRunItemStatusError, syncItemKindIngestError, err)
+				checkpoint.ErrorsCount++
+				continue
+			}
+			checkpoint.MessagesAdded++
+			summary.BytesDownloaded += int64(len(result.Message.Raw))
+			successfulIDs = append(successfulIDs, messageID)
+		}
+		if err := s.store.UpdateSyncCheckpoint(syncID, checkpoint); err != nil {
+			return nil, fmt.Errorf("checkpoint replay batch: %w", err)
+		}
+	}
+
+	return successfulIDs, nil
 }
 
 // processLabelChanges handles label additions and removals for messages.

--- a/internal/sync/item_errors.go
+++ b/internal/sync/item_errors.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
 
 	"go.kenn.io/msgvault/internal/gmail"
 	"go.kenn.io/msgvault/internal/store"
@@ -20,6 +22,15 @@ const (
 	syncItemKindIngestError     = "ingest_error"
 	syncItemKindDeleteError     = "delete_error"
 )
+
+// isFetchReplayCandidate reports whether a durable run item names a raw fetch
+// that never reached the archive and still carries a usable Gmail ID.
+func isFetchReplayCandidate(item store.SyncRunItem) bool {
+	return item.Status == store.SyncRunItemStatusError &&
+		item.Phase == syncItemPhaseFetch &&
+		(item.ErrorKind == syncItemKindFetchError || item.ErrorKind == syncItemKindBatchFetchError) &&
+		item.SourceMessageID != "" && item.SourceMessageID != "(unknown)"
+}
 
 var errRawBatchMissing = errors.New("missing raw message in batch result")
 
@@ -52,6 +63,53 @@ func (s *Syncer) getMessagesRawBatchWithDiagnostics(ctx context.Context, message
 		}
 	}
 	return results, nil
+}
+
+// pendingFetchReplayIDs returns the raw-fetch failures the latest completed
+// incremental run left behind. Only that one run is eligible: a filtered or
+// limited full run never establishes complete Gmail coverage, and a failed or
+// interrupted run stays with normal checkpoint and history recovery. Reading it
+// before a new run starts keeps a ledger error outside the new run and leaves
+// the prior completed run visible.
+//
+// Older versions did not persist the run type. Completed legacy Gmail runs
+// cannot reliably be distinguished from full syncs, so untyped runs are excluded
+// rather than classified as incremental from their cursors or message counts.
+func (s *Syncer) pendingFetchReplayIDs(sourceID int64) ([]string, error) {
+	run, err := s.store.GetLastSuccessfulSyncByType(sourceID, "incremental")
+	if errors.Is(err, store.ErrSyncRunNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get latest completed incremental sync: %w", err)
+	}
+
+	count, err := s.store.CountSyncRunItems(run.ID, store.SyncRunItemStatusError)
+	if err != nil {
+		return nil, fmt.Errorf("count sync %d errors: %w", run.ID, err)
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	items, err := s.store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, int(count))
+	if err != nil {
+		return nil, fmt.Errorf("list sync %d errors: %w", run.ID, err)
+	}
+
+	seen := make(map[string]struct{}, len(items))
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		if !isFetchReplayCandidate(item) {
+			continue
+		}
+		if _, ok := seen[item.SourceMessageID]; ok {
+			continue
+		}
+		seen[item.SourceMessageID] = struct{}{}
+		ids = append(ids, item.SourceMessageID)
+	}
+	sort.Strings(ids)
+	return ids, nil
 }
 
 func isGmailNotFound(err error) bool {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -258,6 +258,7 @@ func (s *Syncer) completeSyncAndRunHook(
 	syncID int64,
 	historyID string,
 	source *store.Source,
+	mailboxChanged bool,
 ) error {
 	publishSourceCursor := source.SourceType != sourceTypeGmail ||
 		(s.opts.Query == "" && s.opts.Limit == 0)
@@ -266,7 +267,7 @@ func (s *Syncer) completeSyncAndRunHook(
 	); err != nil {
 		return err
 	}
-	s.runSuccessfulSyncHook(ctx, source, true)
+	s.runSuccessfulSyncHook(ctx, source, mailboxChanged)
 	return nil
 }
 
@@ -1322,7 +1323,7 @@ func (s *Syncer) full(
 			"history_id", historyIDStr)
 	}
 	// Mark sync complete before running best-effort provider maintenance.
-	if err := s.completeSyncAndRunHook(ctx, state.syncID, historyIDStr, source); err != nil {
+	if err := s.completeSyncAndRunHook(ctx, state.syncID, historyIDStr, source, true); err != nil {
 		return nil, err
 	}
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -52,6 +52,31 @@ func (b *batchErrorAPI) GetMessagesRawBatchWithErrors(_ context.Context, _ []str
 	return nil, errors.New("batch fetch unavailable")
 }
 
+type replayControlAPI struct {
+	*gmail.MockAPI
+
+	beforeBatch   func(batchIndex int, messageIDs []string)
+	beforeResults func()
+	batchErrors   map[int]error
+	batchSizes    []int
+}
+
+func (a *replayControlAPI) GetMessagesRawBatchWithErrors(ctx context.Context, messageIDs []string) ([]gmail.RawMessageBatchResult, error) {
+	batchIndex := len(a.batchSizes)
+	a.batchSizes = append(a.batchSizes, len(messageIDs))
+	if a.beforeBatch != nil {
+		a.beforeBatch(batchIndex, messageIDs)
+	}
+	if err, ok := a.batchErrors[batchIndex]; ok {
+		return nil, err
+	}
+	results, err := a.MockAPI.GetMessagesRawBatchWithErrors(ctx, messageIDs)
+	if a.beforeResults != nil {
+		a.beforeResults()
+	}
+	return results, err
+}
+
 type acknowledgingAPI struct {
 	*gmail.MockAPI
 
@@ -150,6 +175,91 @@ func (a *supersedingProfileAPI) GetProfile(ctx context.Context) (*gmail.Profile,
 
 func (a *staticLabelsAPI) ListLabels(_ context.Context) ([]*gmail.Label, error) {
 	return a.labels, nil
+}
+
+func recordSyncRunItems(t *testing.T, env *TestEnv, sourceID int64, status string, items ...store.SyncRunItem) {
+	t.Helper()
+	recordSyncRunItemsOfType(t, env, sourceID, "full", status, items...)
+}
+
+func recordIncrementalSyncRunItems(t *testing.T, env *TestEnv, sourceID int64, status string, items ...store.SyncRunItem) {
+	t.Helper()
+	recordSyncRunItemsOfType(t, env, sourceID, "incremental", status, items...)
+}
+
+func recordSyncRunItemsOfType(t *testing.T, env *TestEnv, sourceID int64, syncType, status string, items ...store.SyncRunItem) {
+	t.Helper()
+	syncID, err := env.Store.StartSync(sourceID, syncType)
+	require.NoError(t, err, "StartSync")
+	for _, item := range items {
+		item.SyncRunID = syncID
+		require.NoError(t, env.Store.RecordSyncRunItem(item), "RecordSyncRunItem")
+	}
+	if status == store.SyncStatusCompleted {
+		require.NoError(t, env.Store.CompleteSync(syncID, "1000"), "CompleteSync")
+	} else {
+		require.NoError(t, env.Store.FailSync(syncID, "test failure"), "FailSync")
+	}
+}
+
+func seedReplaySource(t *testing.T, env *TestEnv, messageID string) *store.Source {
+	t.Helper()
+	source := env.CreateSourceWithHistory(t, "1000")
+	env.SetHistory(1001, historyAdded(messageID))
+	env.Mock.GetMessageError[messageID] = errors.New("temporary fetch failure")
+	_, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(t, err, "seed replay failure")
+	delete(env.Mock.GetMessageError, messageID)
+	env.Mock.AddMessage(messageID, testMIME(), []string{"INBOX"})
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(t, err, "refresh replay source")
+	env.SetHistory(1001)
+	return source
+}
+
+// TestIncrementalSyncReplayRecordsEachErrorResultClass keeps fetch and ingest
+// failures in their respective phases when replay cannot archive a message.
+func TestIncrementalSyncReplayRecordsEachErrorResultClass(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "1000")
+
+	ids := []string{"b-nil", "c-ingest"}
+	items := make([]store.SyncRunItem, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, store.SyncRunItem{
+			SourceMessageID: id,
+			Phase:           syncItemPhaseFetch,
+			Status:          store.SyncRunItemStatusError,
+			ErrorKind:       syncItemKindFetchError,
+		})
+	}
+	recordIncrementalSyncRunItems(t, env, source.ID, store.SyncStatusCompleted, items...)
+	env.SetHistory(1000)
+
+	env.Mock.GetMessageError["b-nil"] = errors.New("temporary transport failure")
+	env.Mock.AddMessage("c-ingest", nil, []string{"INBOX"})
+
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "replay run must complete despite per-item errors")
+	assert.Equal(int64(2), summary.Errors, "each result class records one error")
+	assert.Equal(int64(0), summary.MessagesAdded, "failed messages are not archived")
+
+	run, err := env.Store.GetLastSuccessfulSyncByType(source.ID, "incremental")
+	require.NoError(err, "latest completed incremental run")
+	recorded, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	require.NoError(err, "ListSyncRunItems")
+	kinds := map[string][2]string{}
+	for _, item := range recorded {
+		kinds[item.SourceMessageID] = [2]string{item.Phase, item.ErrorKind}
+	}
+	assert.Equal([2]string{syncItemPhaseFetch, syncItemKindFetchError}, kinds["b-nil"], "nil result with transient error")
+	assert.Equal([2]string{syncItemPhaseIngest, syncItemKindIngestError}, kinds["c-ingest"], "ingest failure")
+
+	existing, err := env.Store.MessageExistsBatch(source.ID, ids)
+	require.NoError(err, "MessageExistsBatch")
+	assert.Empty(existing, "failed messages are not archived")
 }
 
 func TestFullSync_PanicReturnsError(t *testing.T) {
@@ -1206,6 +1316,368 @@ func TestFullSyncWithErrors(t *testing.T) {
 	assert.Equal("fetch_error", items[0].ErrorKind, "ErrorKind")
 }
 
+func TestIncrementalSyncReplaysPreviousCompletedFetchError(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	const messageID = "replay-message"
+
+	source := env.CreateSourceWithHistory(t, "1000")
+	env.SetHistory(1001, historyAdded(messageID))
+	env.Mock.GetMessageError[messageID] = errors.New("temporary fetch failure")
+
+	firstSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "first incremental sync")
+	assert.Equal(int64(1), firstSummary.Errors, "first run errors")
+	assert.Equal(uint64(1001), firstSummary.FinalHistoryID, "first run final history")
+	assert.Len(env.Mock.GetMessageCalls, 1, "first run fetches the message")
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "source after first run")
+	assert.Equal("1001", source.SyncCursor.String, "first run advances cursor")
+
+	delete(env.Mock.GetMessageError, messageID)
+	env.Mock.AddMessage(messageID, testMIME(), []string{"INBOX"})
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source")
+	env.SetHistory(1001)
+
+	secondSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "second incremental sync")
+	assert.Equal(int64(1), secondSummary.MessagesAdded, "second run added")
+	assert.Equal(int64(1), secondSummary.MessagesFound, "second run processed")
+	assert.Len(env.Mock.GetMessageCalls, 2, "second run replays the message")
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "source after second run")
+	assert.Equal("1001", source.SyncCursor.String, "replay keeps cursor policy")
+
+	existing, err := env.Store.MessageExistsBatch(source.ID, []string{messageID})
+	require.NoError(err, "check replayed message")
+	assert.Contains(existing, messageID, "replayed message is archived")
+}
+
+func TestIncrementalSyncReplaysAfterInterveningFailedRun(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	const messageID = "replay-after-failed-run"
+
+	source := seedReplaySource(t, env, messageID)
+
+	env.Mock.ProfileError = errors.New("temporary profile failure")
+	_, err := env.Syncer.Incremental(env.Context, source)
+	require.Error(err, "intervening run fails")
+	env.Mock.ProfileError = nil
+
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source after failed run")
+	env.Mock.GetMessageCalls = nil
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "replay after failed run")
+	assert.Equal(int64(1), summary.MessagesAdded, "replay added")
+	assert.Equal(int64(1), summary.MessagesFound, "replay processed")
+	assert.Equal([]string{messageID}, env.Mock.GetMessageCalls, "replay fetches the message")
+	assertMessageCount(t, env.Store, 1)
+}
+
+func TestIncrementalSyncReplayCompletion(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		historyID      uint64
+		fetchErr       error
+		mailboxChanged bool
+		errors         int64
+	}{
+		{name: "idle successful replay", historyID: 1001, mailboxChanged: true},
+		{name: "idle failed replay", historyID: 1001, fetchErr: errors.New("temporary fetch failure"), errors: 1},
+		{name: "idle gone message", historyID: 1001, fetchErr: &gmail.NotFoundError{Path: "/messages/replay-completion"}},
+		{name: "new history with failed replay", historyID: 1002, fetchErr: errors.New("temporary fetch failure"), mailboxChanged: true, errors: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			env := newTestEnv(t)
+			const messageID = "replay-completion"
+			source := seedReplaySource(t, env, messageID)
+			env.Mock.GetMessageError[messageID] = tc.fetchErr
+			env.Mock.HistoryCalls = nil
+			env.SetHistory(tc.historyID)
+			logs := newSyncLogCapture(nil)
+			var changedFlags []bool
+			env.Syncer.WithLogger(logs.logger()).WithSuccessfulSyncHook(
+				"test", func(_ context.Context, _ *store.Source, changed bool) error {
+					changedFlags = append(changedFlags, changed)
+					return nil
+				},
+			)
+
+			summary, err := env.Syncer.Incremental(env.Context, source)
+			require.NoError(err)
+			assert.Equal([]bool{tc.mailboxChanged}, changedFlags)
+			assert.Equal(tc.errors, summary.Errors)
+			if tc.historyID == 1001 {
+				assert.Empty(env.Mock.HistoryCalls, "idle replay must not request history")
+			} else {
+				assert.Equal([]uint64{1001}, env.Mock.HistoryCalls)
+			}
+			if tc.errors > 0 {
+				assert.Contains(logs.String(), "incremental sync completed with errors")
+			}
+		})
+	}
+}
+
+func TestIncrementalSyncReplayUsesBoundedBatches(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	source := env.CreateSourceWithHistory(t, "1000")
+	messageIDs := make([]string, 11)
+	history := make([]gmail.HistoryRecord, 0, len(messageIDs))
+	for i := range messageIDs {
+		messageIDs[i] = fmt.Sprintf("bounded-replay-%02d", i)
+		history = append(history, historyAdded(messageIDs[i]))
+		env.Mock.GetMessageError[messageIDs[i]] = errors.New("temporary fetch failure")
+	}
+	env.SetHistory(1001, history...)
+	_, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "seed replay failures")
+
+	for _, messageID := range messageIDs {
+		delete(env.Mock.GetMessageError, messageID)
+		env.Mock.AddMessage(messageID, testMIME(), []string{"INBOX"})
+	}
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source")
+	env.SetHistory(1001)
+
+	var checkpointAfterFirstBatch *store.SyncRun
+	api := &replayControlAPI{
+		MockAPI:     env.Mock,
+		batchErrors: map[int]error{0: errors.New("temporary batch outage")},
+		beforeBatch: func(batchIndex int, _ []string) {
+			if batchIndex != 1 {
+				return
+			}
+			checkpointAfterFirstBatch, err = env.Store.GetLatestSync(source.ID)
+			require.NoError(err, "checkpoint after first replay batch")
+		},
+	}
+	env.Mock.GetMessageCalls = nil
+	env.Syncer = New(api, env.Store, nil)
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "bounded replay")
+	require.NotNil(checkpointAfterFirstBatch, "first replay batch checkpoint")
+	assert.Equal(int64(10), checkpointAfterFirstBatch.MessagesProcessed, "checkpoint processed")
+	assert.Equal(int64(10), checkpointAfterFirstBatch.ErrorsCount, "checkpoint errors")
+	assert.Equal(int64(1), summary.MessagesAdded, "replay added after whole-batch error")
+	assert.Equal(int64(10), summary.Errors, "whole-batch errors")
+	assert.Equal(int64(len(messageIDs)), summary.MessagesFound, "replay processed")
+	assert.Equal([]int{10, 1}, api.batchSizes, "replay batch sizes")
+	assert.Equal([]string{messageIDs[len(messageIDs)-1]}, env.Mock.GetMessageCalls, "later batch continues after error")
+}
+
+func TestIncrementalSyncCarriesForwardFailedFetchReplay(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	const messageID = "carry-forward-message"
+
+	source := env.CreateSourceWithHistory(t, "1000")
+	env.SetHistory(1001, historyAdded(messageID))
+	env.Mock.GetMessageError[messageID] = errors.New("temporary fetch failure")
+	firstSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "first incremental sync")
+	assert.Equal(int64(1), firstSummary.Errors, "first run errors")
+
+	env.Mock.AddMessage(messageID, testMIME(), []string{"INBOX"})
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source after first run")
+	env.SetHistory(1001)
+	secondSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "second incremental sync")
+	assert.Equal(int64(1), secondSummary.Errors, "replay errors")
+	assert.Equal(int64(1), secondSummary.MessagesFound, "replay processed")
+
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "latest replay run")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusError, 10)
+	require.NoError(err, "replay error items")
+	require.Len(items, 1, "replay error item")
+	assert.Equal(messageID, items[0].SourceMessageID, "replay source ID")
+	assert.Equal(syncItemPhaseFetch, items[0].Phase, "replay phase")
+	assert.Equal(syncItemKindFetchError, items[0].ErrorKind, "replay kind")
+
+	delete(env.Mock.GetMessageError, messageID)
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source before successful replay")
+	thirdSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "third incremental sync")
+	assert.Equal(int64(1), thirdSummary.MessagesAdded, "successful replay added")
+	assert.Equal(int64(0), thirdSummary.Errors, "successful replay errors")
+	assertMessageCount(t, env.Store, 1)
+}
+
+func TestIncrementalSyncSkipsGoneFetchReplay(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	const (
+		notFoundID = "replay-not-found"
+		goneID     = "replay-gone"
+	)
+
+	source := env.CreateSourceWithHistory(t, "1000")
+	env.SetHistory(1001, historyAdded(notFoundID), historyAdded(goneID))
+	env.Mock.GetMessageError[notFoundID] = errors.New("temporary fetch failure")
+	env.Mock.GetMessageError[goneID] = errors.New("temporary fetch failure")
+	_, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "seed gone replay failures")
+
+	env.Mock.GetMessageError[notFoundID] = &gmail.NotFoundError{Path: "/messages/" + notFoundID}
+	env.Mock.GetMessageError[goneID] = gmail.ErrMessageGone
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source")
+	env.SetHistory(1001)
+	secondSummary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "gone replay")
+	assert.Equal(int64(0), secondSummary.Errors, "gone replay errors")
+	assert.Equal(int64(2), secondSummary.MessagesSkipped, "gone replay skipped")
+
+	run, err := env.Store.GetLatestSync(source.ID)
+	require.NoError(err, "gone replay run")
+	items, err := env.Store.ListSyncRunItems(run.ID, store.SyncRunItemStatusSkipped, 10)
+	require.NoError(err, "gone replay items")
+	require.Len(items, 2, "gone replay skipped items")
+	kinds := map[string]string{}
+	for _, item := range items {
+		kinds[item.SourceMessageID] = item.ErrorKind
+	}
+	assert.Equal(syncItemKindGmailNotFound, kinds[notFoundID], "404 replay kind")
+	assert.Equal(syncItemKindMessageGone, kinds[goneID], "gone replay kind")
+
+	callsAfterGone := len(env.Mock.GetMessageCalls)
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh source after gone replay")
+	_, err = env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "following idle sync")
+	assert.Len(env.Mock.GetMessageCalls, callsAfterGone, "gone messages are not replayed again")
+}
+
+func TestIncrementalSyncFiltersFetchReplayCandidates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	env := newTestEnv(t)
+	env.Mock.Profile.HistoryID = 1000
+	const presentID = "replay-present"
+	env.Mock.AddMessage(presentID, testMIME(), []string{"INBOX"})
+	env.Mock.MessagePages = [][]string{{presentID}}
+	_, err := env.Syncer.Full(env.Context, testEmail)
+	require.NoError(err, "seed present archive row")
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err, "source after full sync")
+	require.NoError(env.Store.UpdateSourceSyncCursor(source.ID, "1000"), "set current cursor")
+	source, err = env.Store.GetSourceByID(source.ID)
+	require.NoError(err, "refresh current source")
+	env.Mock.GetMessageCalls = nil
+
+	const (
+		olderID       = "replay-older"
+		failedID      = "replay-failed-run"
+		eligibleID    = "replay-eligible"
+		batchEligible = "replay-batch-eligible"
+	)
+	recordIncrementalSyncRunItems(t, env, source.ID, store.SyncStatusCompleted, store.SyncRunItem{
+		SourceMessageID: olderID,
+		Phase:           syncItemPhaseFetch,
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       syncItemKindFetchError,
+	})
+	recordSyncRunItems(t, env, source.ID, store.SyncStatusFailed, store.SyncRunItem{
+		SourceMessageID: failedID,
+		Phase:           syncItemPhaseFetch,
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       syncItemKindFetchError,
+	})
+	recordIncrementalSyncRunItems(t, env, source.ID, store.SyncStatusCompleted,
+		store.SyncRunItem{SourceMessageID: eligibleID, Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindFetchError},
+		store.SyncRunItem{SourceMessageID: eligibleID, Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindBatchFetchError},
+		store.SyncRunItem{SourceMessageID: batchEligible, Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindBatchFetchError},
+		store.SyncRunItem{SourceMessageID: "replay-ingest", Phase: syncItemPhaseIngest, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindIngestError},
+		store.SyncRunItem{SourceMessageID: "replay-delete", Phase: syncItemPhaseDelete, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindDeleteError},
+		store.SyncRunItem{SourceMessageID: "replay-skipped", Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusSkipped, ErrorKind: syncItemKindGmailNotFound},
+		store.SyncRunItem{SourceMessageID: "", Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindFetchError},
+		store.SyncRunItem{SourceMessageID: "(unknown)", Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindBatchFetchError},
+		store.SyncRunItem{SourceMessageID: presentID, Phase: syncItemPhaseFetch, Status: store.SyncRunItemStatusError, ErrorKind: syncItemKindFetchError},
+	)
+	// A later filtered or limited full run completes without establishing full
+	// Gmail coverage, so it neither contributes debt nor hides the incremental run.
+	recordSyncRunItems(t, env, source.ID, store.SyncStatusCompleted, store.SyncRunItem{
+		SourceMessageID: "replay-full-run",
+		Phase:           syncItemPhaseFetch,
+		Status:          store.SyncRunItemStatusError,
+		ErrorKind:       syncItemKindFetchError,
+	})
+	env.Mock.AddMessage(eligibleID, testMIME(), []string{"INBOX"})
+	env.Mock.AddMessage(batchEligible, testMIME(), []string{"INBOX"})
+	env.SetHistory(1000)
+
+	summary, err := env.Syncer.Incremental(env.Context, source)
+	require.NoError(err, "filtered replay")
+	assert.Equal(int64(2), summary.MessagesFound, "eligible replay processed")
+	assert.Equal(int64(2), summary.MessagesAdded, "eligible replay added")
+	assert.Equal(int64(0), summary.Errors, "eligible replay errors")
+	assert.Equal([]string{batchEligible, eligibleID}, env.Mock.GetMessageCalls, "only latest eligible absent IDs fetched")
+}
+
+func TestIncrementalSyncFetchReplayPreservesCursorAndFence(t *testing.T) {
+	t.Run("cancellation", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		env := newTestEnv(t)
+		source := seedReplaySource(t, env, "replay-cancelled")
+		ctx, cancel := context.WithCancel(env.Context)
+		defer cancel()
+		env.Syncer = New(&replayControlAPI{
+			MockAPI: env.Mock,
+			beforeResults: func() {
+				cancel()
+			},
+		}, env.Store, nil)
+
+		_, err := env.Syncer.Incremental(ctx, source)
+		require.ErrorIs(err, context.Canceled, "cancelled replay")
+		source, err = env.Store.GetSourceByID(source.ID)
+		require.NoError(err, "source after cancellation")
+		assert.Equal("1001", source.SyncCursor.String, "cancelled replay does not publish cursor")
+		assertMessageCount(t, env.Store, 0)
+		run, err := env.Store.GetLatestSync(source.ID)
+		require.NoError(err, "cancelled replay run")
+		assert.Equal(store.SyncStatusFailed, run.Status, "cancelled replay fails its run")
+	})
+
+	t.Run("fence", func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		env := newTestEnv(t)
+		source := seedReplaySource(t, env, "replay-fenced")
+		env.Syncer = New(&replayControlAPI{
+			MockAPI: env.Mock,
+			beforeResults: func() {
+				active, err := env.Store.GetActiveSync(source.ID)
+				require.NoError(err, "active replay run")
+				require.NoError(env.Store.FailSync(active.ID, "superseded in test"), "fence replay run")
+			},
+		}, env.Store, nil)
+
+		_, err := env.Syncer.Incremental(env.Context, source)
+		require.ErrorIs(err, store.ErrSyncRunSuperseded, "fenced replay")
+		source, err = env.Store.GetSourceByID(source.ID)
+		require.NoError(err, "source after fence")
+		assert.Equal("1001", source.SyncCursor.String, "fenced replay does not publish cursor")
+		assertMessageCount(t, env.Store, 0)
+	})
+}
+
 func TestFullSyncSkipsGmailNotFoundBeforeFetch(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1494,6 +1966,10 @@ func TestIncrementalSyncAlreadyUpToDate(t *testing.T) {
 
 	summary := runIncrementalSync(t, env)
 	assertSummary(t, summary, WantSummary{Added: new(int64(0))})
+	assert.Zero(t, env.Mock.LabelsCalls,
+		"the no-replay no-op path must not gain a label request")
+	assert.Empty(t, env.Mock.GetMessageCalls,
+		"the no-replay no-op path must not fetch messages")
 }
 
 func TestIncrementalSyncWithChanges(t *testing.T) {


### PR DESCRIPTION
Incremental Gmail sync now retries failed message fetches from the latest completed run recorded as incremental, before processing new history. Previously, advancing the cursor after a partial failure left those messages missing until a full sync. An idle mailbox with pending failures now retries them too.

Replay uses bounded batches. Messages already archived are skipped, gone messages become handled skips, and repeated fetch failures carry forward. Idle retries that add no messages keep automatic identity refresh on its normal schedule.

Full-sync failures, failures while saving messages, and older untyped runs are outside this change. Older releases did not store the run type, so their completed full and incremental runs cannot be reliably distinguished from the saved data. Automatic replay therefore requires an explicitly recorded incremental run type.

Closes #260
