### PR TITLE
feat(tui): scope views by named collections

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -176,6 +176,11 @@ components:
     AggregateResponse:
       additionalProperties: true
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         rows:
           items:
             $ref: "#/components/schemas/AggregateRowJSON"
@@ -4440,6 +4445,11 @@ components:
     FilteredMessagesResponse:
       additionalProperties: true
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         count:
           format: int64
           type: integer
@@ -4555,6 +4565,11 @@ components:
     GmailIDsResponse:
       additionalProperties: true
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         gmail_ids:
           items:
             type: string
@@ -11832,7 +11847,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.16.0
+  version: 2.17.0
 openapi: 3.1.0
 paths:
   /api/ping:
@@ -12007,6 +12022,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -12087,6 +12110,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -17380,6 +17411,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -17511,6 +17550,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -23007,6 +23054,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values; not supported by deep search
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -23199,6 +23254,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -23246,14 +23309,6 @@ paths:
           name: direction
           schema:
             type: string
-        - description: Source IDs; repeat the parameter for multiple sources
-          in: query
-          name: source_ids
-          schema:
-            items:
-              format: int64
-              type: integer
-            type: array
       responses:
         "200":
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11443,6 +11443,9 @@ components:
     TextSearchResponse:
       additionalProperties: true
       properties:
+        applied_source_id:
+          format: int64
+          type: integer
         count:
           format: int64
           type: integer
@@ -24233,6 +24236,12 @@ paths:
     get:
       operationId: searchTextMessages
       parameters:
+        - description: Source ID
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: Search query
           in: query
           name: q

--- a/cmd/msgvault/cmd/tui.go
+++ b/cmd/msgvault/cmd/tui.go
@@ -51,7 +51,7 @@ Navigation:
   ,           Open Settings
   g           Cycle aggregate view (Email and Texts)
   /           Search; Tab adds active-message-only Semantic mode when enabled
-  A           Filter by account, or meeting source in Meetings mode
+  A           Filter by account or named Email collection
   s           Cycle sort field
   r           Reverse sort direction
   t           Toggle time granularity (Time view only)
@@ -96,17 +96,19 @@ HTTP Mode:
 
 		// Create and run TUI
 		semanticSearch := tuiSemanticSearcher(cmd.Context(), backend.client, backend.engine)
+		collectionScopes := tuiCollectionScopes(cmd.Context(), backend.client, backend.engine)
 		model := tui.New(backend.engine, tui.Options{
-			DataDir:          cfg.Data.DataDir,
-			ExportDir:        cfg.ExportDir(),
-			Version:          Version,
-			TextEngine:       textEngine,
-			PeopleBackend:    peopleBackend,
-			ManifestSaver:    backend.client,
-			AttachmentReader: tuiAttachmentOpener{client: backend.client},
-			SemanticSearch:   semanticSearch,
-			AnalyticsNotice:  notice,
-			SettingsBackend:  backend.settings,
+			DataDir:               cfg.Data.DataDir,
+			ExportDir:             cfg.ExportDir(),
+			Version:               Version,
+			TextEngine:            textEngine,
+			PeopleBackend:         peopleBackend,
+			ManifestSaver:         backend.client,
+			AttachmentReader:      tuiAttachmentOpener{client: backend.client},
+			SemanticSearch:        semanticSearch,
+			AnalyticsNotice:       notice,
+			SettingsBackend:       backend.settings,
+			CollectionScopeLister: collectionScopes,
 		})
 		p := tea.NewProgram(model)
 		noticeCtx, stopNoticeRefresh := context.WithCancel(cmd.Context())
@@ -176,10 +178,27 @@ func tuiPeopleBackend(
 }
 
 const (
-	semanticSearchMinAPISchemaVersion = "2.7.0"
-	peopleMinAPISchemaVersion         = "2.10.0"
-	tuiSemanticMessageType            = "email"
+	semanticSearchMinAPISchemaVersion   = "2.7.0"
+	peopleMinAPISchemaVersion           = "2.10.0"
+	collectionScopesMinAPISchemaVersion = "2.17.0"
+	tuiSemanticMessageType              = "email"
 )
+
+func tuiCollectionScopes(
+	ctx context.Context,
+	client *daemonclient.Client,
+	engine query.Engine,
+) query.CollectionScopeLister {
+	if client == nil || engine == nil {
+		return nil
+	}
+	compatible, err := client.SupportsAPISchemaVersion(ctx, collectionScopesMinAPISchemaVersion)
+	if err != nil || !compatible {
+		return nil
+	}
+	lister, _ := engine.(query.CollectionScopeLister)
+	return lister
+}
 
 type tuiAttachmentOpener struct {
 	client *daemonclient.Client

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ All notable changes to msgvault, grouped by release.
 
 - The HTTP API separates observed participant analytics from durable curated
   people, crossing the API schema 2.0 compatibility boundary at 2.1.0. The
-  current unreleased API schema is 2.15.0. Version 2.14.0 also replaces the CardDAV
+  current unreleased API schema is 2.17.0. Version 2.14.0 also replaces the CardDAV
   publication and conflict response shapes with bounded projections that
   omit raw vCards and resource hrefs. The
   analytical routes formerly under `/api/v1/people/*` (search, detail,
@@ -33,6 +33,14 @@ All notable changes to msgvault, grouped by release.
   should pass `account` or stage each source separately.
 
 **Features**
+
+- The Email TUI scope selector now exposes named collections. Collection
+  member source IDs flow through aggregate, message, fast-search, statistics,
+  and deletion-target reads, with API schema 2.17.0 gating and fail-closed
+  response echoes. Empty collections match nothing. Email, Texts, and Meetings
+  have independent selectors. Changing the Email scope returns to the top-level
+  view. Multi-source collections offer Fast search only, and deletion staging
+  requires the selected messages to belong to one source.
 
 - Web Directory workspace: browse and search promoted durable people, filter
   by contact state, category, organization, and last contact, and maintain a

--- a/docs/usage/multi-account.md
+++ b/docs/usage/multi-account.md
@@ -160,7 +160,23 @@ Once several accounts hold overlapping copies of the same message, [deduplicatio
 
 ## TUI Filtering
 
-Press `A` (uppercase) inside the TUI to open the account selector modal. Pick a single account to scope every view, or pick "All Accounts" to clear the filter. The currently selected account is shown in the title bar.
+Press `A` (uppercase) inside the TUI to open the Email scope selector. Pick a
+single account, a named collection, or "All Accounts" to clear the filter. The
+title bar shows the selected account or `Collection: <name>`. A collection
+scope carries its exact member source IDs through Email aggregates, message
+lists, fast search, statistics, and deletion-target inspection. An empty
+collection matches nothing.
+
+Named collections require API schema `2.17.0` or newer. Older or unavailable
+daemons hide collection rows while preserving account browsing. Texts and
+Meetings keep independent source selectors. Changing the Email scope returns
+to the top-level view and clears the current search and selection.
+
+Multi-source collections offer Fast search only. Deep search is available for
+single-source collections. Collection scopes do not offer Semantic search.
+Deletion staging accepts selections from one source, including within a larger
+collection; selections spanning sources are rejected. Deduplication remains
+available through the collection-scoped CLI commands, not through the TUI.
 
 Meetings mode uses the same key for a separate source selector. It lists only
 configured Granola and Circleback sources, and changing it does not replace the

--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -52,6 +52,29 @@ msgvault tui --local
 ```
 
 Deletion staging and attachment export use the selected daemon. When connected to a configured remote server, staged deletion manifests are saved on that remote host; attachment export streams bytes from the daemon and writes the zip file on the CLI machine.
+
+### Email Account and Collection Scopes
+
+Press `A` in Email mode to choose `All Accounts`, an individual account, or a
+named collection. A collection is a daemon-owned group of accounts, and the
+title shows `Collection: <name>` while its exact member sources scope
+aggregates, message lists, fast search, statistics, and deletion-target
+inspection. An empty collection shows no results and makes no scoped HTTP read.
+
+Collections require a daemon with API schema `2.17.0` or newer. Older or
+unavailable daemons keep the account selector usable and hide collection rows.
+Changing the Email scope returns to the top-level view and clears the current
+search and selection. Texts and Meetings keep separate account or source
+selectors; changing one mode's selection does not change another mode's scope.
+
+Collections with multiple sources offer Fast search only. Deep search is
+available for single-source collections; Semantic search requires an individual
+account or All Accounts, subject to its other filter limits.
+
+Deletion staging requires the selected messages to belong to one source.
+You can stage messages from one source within a larger collection, but a
+selection spanning sources is rejected. The TUI does not offer deduplication
+operations; use the collection-scoped CLI commands for those.
 <figure class="screenshot" data-lightbox>
   <img src="/docs/assets/generated/tui-senders.svg" alt="msgvault TUI showing the Senders view with message counts and sizes" loading="lazy">
 </figure>
@@ -217,7 +240,7 @@ Press `Esc` to return to the message list.
 | `v` | Reverse sort direction |
 | `t` | Jump to Time view (cycle granularity when already in Time) |
 | `a` | Show all individual messages in current view |
-| `A` | Filter by account, or by source in Meetings mode |
+| `A` | Filter by account or named Email collection; select a source in Meetings mode |
 | `f` | Open filter modal |
 | `Space` | Toggle selection |
 | `d` | Stage selected for deletion |

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -3308,7 +3308,7 @@ func cliCollectionResponseFromStore(
 		Name:               coll.Name,
 		Description:        coll.Description,
 		CreatedAt:          coll.CreatedAt,
-		SourceIDs:          append([]int64(nil), coll.SourceIDs...),
+		SourceIDs:          append([]int64{}, coll.SourceIDs...),
 		MessageCount:       coll.MessageCount,
 		SourceDeletedCount: coll.SourceDeletedCount,
 		Sources:            make([]cliCollectionSourceResponse, 0, len(coll.SourceIDs)),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -226,18 +226,20 @@ type StatusMessageResponse struct {
 }
 
 type FilteredMessagesResponse struct {
-	Count    int              `json:"count"`
-	HasMore  bool             `json:"has_more"`
-	Offset   int              `json:"offset"`
-	Limit    int              `json:"limit"`
-	Messages []MessageSummary `json:"messages"`
+	Count            int              `json:"count"`
+	HasMore          bool             `json:"has_more"`
+	Offset           int              `json:"offset"`
+	Limit            int              `json:"limit"`
+	Messages         []MessageSummary `json:"messages"`
+	AppliedSourceIDs []int64          `json:"applied_source_ids,omitempty"`
 }
 
 type GmailIDsResponse struct {
-	GmailIDs    []string               `json:"gmail_ids"`
-	Targets     []query.DeletionTarget `json:"targets,omitempty"`
-	SearchQuery string                 `json:"search_query,omitempty"`
-	SearchMode  string                 `json:"search_mode,omitempty"`
+	GmailIDs         []string               `json:"gmail_ids"`
+	Targets          []query.DeletionTarget `json:"targets,omitempty"`
+	SearchQuery      string                 `json:"search_query,omitempty"`
+	SearchMode       string                 `json:"search_mode,omitempty"`
+	AppliedSourceIDs []int64                `json:"applied_source_ids,omitempty"`
 }
 
 type DeepSearchResponse struct {
@@ -2003,8 +2005,9 @@ func (s *Server) writeIfAnalyticsInitializing(ctx context.Context, w http.Respon
 
 // AggregateResponse represents aggregate query results.
 type AggregateResponse struct {
-	ViewType string             `json:"view_type"`
-	Rows     []AggregateRowJSON `json:"rows"`
+	ViewType         string             `json:"view_type"`
+	Rows             []AggregateRowJSON `json:"rows"`
+	AppliedSourceIDs []int64            `json:"applied_source_ids,omitempty"`
 }
 
 // AggregateRowJSON represents a single aggregate row in JSON format.
@@ -2286,6 +2289,11 @@ func parseAggregateOptions(r *http.Request) (query.AggregateOptions, error) {
 	} else if ok {
 		opts.SourceID = &sourceID
 	}
+	if sourceIDs, ok, err := queryInt64s(r, "source_ids"); err != nil {
+		return opts, err
+	} else if ok {
+		opts.SourceIDs = normalizeSourceIDs(sourceIDs)
+	}
 	if r.URL.Query().Get("attachments_only") == "true" {
 		opts.WithAttachmentsOnly = true
 	}
@@ -2364,6 +2372,11 @@ func parseMessageFilter(r *http.Request) (query.MessageFilter, error) {
 		return filter, err
 	} else if ok {
 		filter.SourceID = &id
+	}
+	if ids, ok, err := queryInt64s(r, "source_ids"); err != nil {
+		return filter, err
+	} else if ok {
+		filter.SourceIDs = normalizeSourceIDs(ids)
 	}
 	if r.URL.Query().Get("attachments_only") == "true" {
 		filter.WithAttachmentsOnly = true
@@ -2754,8 +2767,9 @@ func (s *Server) handleAggregates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, AggregateResponse{
-		ViewType: viewTypeString(viewType),
-		Rows:     jsonRows,
+		ViewType:         viewTypeString(viewType),
+		Rows:             jsonRows,
+		AppliedSourceIDs: append([]int64(nil), opts.SourceIDs...),
 	})
 }
 
@@ -2816,8 +2830,9 @@ func (s *Server) handleSubAggregates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, AggregateResponse{
-		ViewType: viewTypeString(viewType),
-		Rows:     jsonRows,
+		ViewType:         viewTypeString(viewType),
+		Rows:             jsonRows,
+		AppliedSourceIDs: append([]int64(nil), filter.SourceIDs...),
 	})
 }
 
@@ -2870,11 +2885,12 @@ func (s *Server) handleFilteredMessages(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, http.StatusOK, FilteredMessagesResponse{
-		Count:    len(summaries),
-		HasMore:  hasMore,
-		Offset:   filter.Pagination.Offset,
-		Limit:    requestLimit,
-		Messages: summaries,
+		Count:            len(summaries),
+		HasMore:          hasMore,
+		Offset:           filter.Pagination.Offset,
+		Limit:            requestLimit,
+		Messages:         summaries,
+		AppliedSourceIDs: append([]int64(nil), filter.SourceIDs...),
 	})
 }
 
@@ -3227,8 +3243,11 @@ func (s *Server) handleGmailIDsByFilter(w http.ResponseWriter, r *http.Request) 
 		targets = []query.DeletionTarget{}
 	}
 	writeJSON(w, http.StatusOK, GmailIDsResponse{
-		GmailIDs: deletion.SourceMessageIDs(targets), Targets: targets,
-		SearchQuery: searchQuery, SearchMode: searchMode,
+		GmailIDs:         deletion.SourceMessageIDs(targets),
+		Targets:          targets,
+		SearchQuery:      searchQuery,
+		SearchMode:       searchMode,
+		AppliedSourceIDs: append([]int64(nil), filter.SourceIDs...),
 	})
 }
 
@@ -3641,12 +3660,6 @@ func (s *Server) handleFastSearch(w http.ResponseWriter, r *http.Request) {
 		s.rejectBadParam(w, err)
 		return
 	}
-	if ids, ok, err := queryInt64s(r, "source_ids"); err != nil {
-		s.rejectBadParam(w, err)
-		return
-	} else if ok {
-		filter.SourceIDs = normalizeSourceIDs(ids)
-	}
 	q := search.Parse(queryStr)
 	if err := q.Err(); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_query", err.Error())
@@ -3732,6 +3745,11 @@ func (s *Server) handleDeepSearch(w http.ResponseWriter, r *http.Request) {
 	if scope == "body" && len(q.TextTerms) == 0 {
 		writeError(w, http.StatusBadRequest, "missing_free_text",
 			"Body-scoped search requires at least one free-text term")
+		return
+	}
+	if filter.SourceIDs != nil {
+		writeError(w, http.StatusBadRequest, "unsupported_filter",
+			"Deep search does not support source_ids filters")
 		return
 	}
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2078,11 +2078,12 @@ type TextMessagesResponse struct {
 }
 
 type TextSearchResponse struct {
-	Count    int                    `json:"count"`
-	HasMore  bool                   `json:"has_more"`
-	Offset   int                    `json:"offset"`
-	Limit    int                    `json:"limit"`
-	Messages []query.MessageSummary `json:"messages"`
+	AppliedSourceID *int64                 `json:"applied_source_id,omitempty"`
+	Count           int                    `json:"count"`
+	HasMore         bool                   `json:"has_more"`
+	Offset          int                    `json:"offset"`
+	Limit           int                    `json:"limit"`
+	Messages        []query.MessageSummary `json:"messages"`
 }
 
 // aggregateViewTypes are the accepted view_type values, surfaced in 400 messages.
@@ -4067,7 +4068,15 @@ func (s *Server) handleTextSearch(w http.ResponseWriter, r *http.Request) {
 		limit = maxPageSize
 	}
 
-	messages, err := textEngine.TextSearch(r.Context(), queryStr, limit+1, offset)
+	var sourceID *int64
+	if id, present, err := queryInt64(r, "source_id"); err != nil {
+		s.rejectBadParam(w, err)
+		return
+	} else if present {
+		sourceID = &id
+	}
+
+	messages, err := textEngine.TextSearch(r.Context(), queryStr, sourceID, limit+1, offset)
 	if err != nil {
 		if s.writeIfContextError(w, err) {
 			return
@@ -4086,11 +4095,12 @@ func (s *Server) handleTextSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, TextSearchResponse{
-		Count:    len(messages),
-		HasMore:  hasMore,
-		Offset:   offset,
-		Limit:    limit,
-		Messages: messages,
+		AppliedSourceID: sourceID,
+		Count:           len(messages),
+		HasMore:         hasMore,
+		Offset:          offset,
+		Limit:           limit,
+		Messages:        messages,
 	})
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -8241,3 +8241,70 @@ func TestStatsReportsTextLaneSeparatelyFromMultimodal(t *testing.T) {
 	assert.Equal("ready", resp.VectorVisualStatus,
 		"the visual lane reports its own readiness for MCP capability probes")
 }
+
+func TestHandleAggregatesEchoesNormalizedSourceIDs(t *testing.T) {
+	srv := newTestServerWithEngine(t, &querytest.MockEngine{})
+	w := doGet(srv, "/api/v1/aggregates?view_type=senders&source_id=99&source_ids=8,7&source_ids=8")
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var response map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	assert.Equal(t, []any{float64(7), float64(8)}, response["applied_source_ids"])
+}
+
+func TestHandleFilteredMessagesUsesSourceIDsAndEchoesThem(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var captured query.MessageFilter
+	engine := &querytest.MockEngine{
+		ListMessagesFunc: func(_ context.Context, filter query.MessageFilter) ([]query.MessageSummary, error) {
+			captured = filter
+			return []query.MessageSummary{}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	w := doGet(srv, "/api/v1/messages/filter?source_id=99&source_ids=8,7&source_ids=8")
+
+	requirements.Equal(http.StatusOK, w.Code, w.Body.String())
+	assertions.Equal([]int64{7, 8}, captured.SourceIDs)
+	requirements.NotNil(captured.SourceID)
+	assertions.Equal(int64(99), *captured.SourceID)
+	var response map[string]any
+	requirements.NoError(json.NewDecoder(w.Body).Decode(&response))
+	assertions.Equal([]any{float64(7), float64(8)}, response["applied_source_ids"])
+}
+
+func TestHandleDeepSearchRejectsSourceIDs(t *testing.T) {
+	called := false
+	engine := &querytest.MockEngine{
+		SearchFunc: func(_ context.Context, _ *search.Query, _, _ int) ([]query.MessageSummary, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	w := doGet(srv, "/api/v1/search/deep?q=needle&source_ids=7,8")
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.False(t, called)
+}
+
+func TestHandleGmailIDsEchoesSourceIDs(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var captured query.MessageFilter
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			captured = filter
+			return []query.DeletionTarget{}, nil
+		},
+	}
+	srv := newTestServerWithEngine(t, engine)
+	w := doGet(srv, "/api/v1/messages/gmail-ids?source_ids=8,7")
+
+	requirements.Equal(http.StatusOK, w.Code, w.Body.String())
+	assertions.Equal([]int64{7, 8}, captured.SourceIDs)
+	var response map[string]any
+	requirements.NoError(json.NewDecoder(w.Body).Decode(&response))
+	assertions.Equal([]any{float64(7), float64(8)}, response["applied_source_ids"])
+}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5854,7 +5854,7 @@ func (e *contextErrorTextEngine) ListConversationMessages(context.Context, int64
 	return nil, fmt.Errorf("acquire query slot: %w", e.err)
 }
 
-func (e *contextErrorTextEngine) TextSearch(context.Context, string, int, int) ([]query.MessageSummary, error) {
+func (e *contextErrorTextEngine) TextSearch(context.Context, string, *int64, int, int) ([]query.MessageSummary, error) {
 	return nil, fmt.Errorf("acquire query slot: %w", e.err)
 }
 
@@ -5878,7 +5878,7 @@ func (*textEngineWithoutSnapshot) ListConversationMessages(context.Context, int6
 	return []query.MessageSummary{}, nil
 }
 
-func (*textEngineWithoutSnapshot) TextSearch(context.Context, string, int, int) ([]query.MessageSummary, error) {
+func (*textEngineWithoutSnapshot) TextSearch(context.Context, string, *int64, int, int) ([]query.MessageSummary, error) {
 	return nil, nil
 }
 
@@ -8307,4 +8307,41 @@ func TestHandleGmailIDsEchoesSourceIDs(t *testing.T) {
 	var response map[string]any
 	requirements.NoError(json.NewDecoder(w.Body).Decode(&response))
 	assertions.Equal([]any{float64(7), float64(8)}, response["applied_source_ids"])
+}
+
+func TestDaemonTextSearchScopesBeforePagination(t *testing.T) {
+	require := require.New(t)
+	db := dbtest.NewTestDB(t, "../store/schema.sql")
+	_, err := db.DB.Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES
+			(1, 'imessage', 'first@example.com'), (2, 'imessage', 'second@example.com');
+		INSERT INTO conversations (id, source_id, source_conversation_id, conversation_type) VALUES
+			(1, 1, 'chat-1', 'direct_chat'), (2, 2, 'chat-2', 'direct_chat');
+		INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at, subject) VALUES
+			(1, 1, 1, 'message-1', 'imessage', '2026-01-01 10:00:00', 'hello first'),
+			(2, 2, 2, 'message-2', 'imessage', '2026-01-01 11:00:00', 'hello second');
+		CREATE VIRTUAL TABLE messages_fts USING fts5(subject, body);
+		INSERT INTO messages_fts (rowid, subject, body) VALUES
+			(1, 'hello first', ''), (2, 'hello second', '');
+	`)
+	require.NoError(err)
+
+	srv := newTestServerWithEngine(t, query.NewSQLiteEngine(db.DB))
+	daemon := httptest.NewServer(srv.Router())
+	t.Cleanup(daemon.Close)
+	engine, err := daemonclient.NewEngine(daemonclient.Config{
+		URL: daemon.URL, AllowInsecure: true, HTTPClient: daemon.Client(),
+	})
+	require.NoError(err)
+	t.Cleanup(func() { assert.NoError(t, engine.Close()) })
+
+	messages, err := engine.TextSearch(t.Context(), "hello", new(int64(1)), 1, 0)
+	require.NoError(err)
+	require.Len(messages, 1)
+	assert.Equal(t, int64(1), messages[0].ID)
+
+	messages, err = engine.TextSearch(t.Context(), "hello", nil, 1, 0)
+	require.NoError(err)
+	require.Len(messages, 1)
+	assert.Equal(t, int64(2), messages[0].ID)
 }

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -266,9 +266,12 @@ import (
 // parameters introduced with these TUI contracts are also covered by 2.16.0.
 // It also adds authenticated asynchronous historical import jobs at
 // POST /api/v1/imports and GET /api/v1/imports/{job_id}. Existing synchronous
-// CLI sync routes, source-status responses, unfiltered statistics, search, and
-// deletion requests are unchanged.
-const APISchemaVersion = "2.16.0"
+// CLI sync routes and source-status responses are unchanged.
+// 2.17.0 adds repeated/comma-separated source_ids to aggregate and message
+// filter routes, plus applied_source_ids echoes. Clients can therefore fail
+// closed when an older daemon ignores an additive source scope instead of
+// widening the result to all sources.
+const APISchemaVersion = "2.17.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration
 // used by the daemon. It binds no socket and needs no database.

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -270,7 +270,8 @@ import (
 // 2.17.0 adds repeated/comma-separated source_ids to aggregate and message
 // filter routes, plus applied_source_ids echoes. Clients can therefore fail
 // closed when an older daemon ignores an additive source scope instead of
-// widening the result to all sources.
+// widening the result to all sources. Text search also accepts source_id
+// and confirms it with applied_source_id.
 const APISchemaVersion = "2.17.0"
 
 // OpenAPIDocument builds the API schema from the same Huma route registration

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -35,7 +35,7 @@ func TestOpenAPIDocumentUsesAPISchemaVersion(t *testing.T) {
 }
 
 func TestOpenAPISchemaVersionAsyncImportsIs2160(t *testing.T) {
-	assert.Equal(t, "2.16.0", APISchemaVersion)
+	assert.Equal(t, "2.17.0", APISchemaVersion)
 }
 
 func TestOpenAPIImportJobContract(t *testing.T) {
@@ -192,7 +192,7 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 	assert := assert.New(t)
 	doc := OpenAPIDocument()
 
-	assert.Equal("2.16.0", APISchemaVersion)
+	assert.Equal("2.17.0", APISchemaVersion)
 	for _, path := range []string{
 		"/api/v1/participants/search",
 		"/api/v1/participants/{id}",
@@ -214,11 +214,11 @@ func TestOpenAPISeparatesParticipantAnalyticsFromDurablePeople(t *testing.T) {
 }
 
 func TestAnalyticsCacheReadinessUsesAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.16.0", APISchemaVersion)
+	assert.Equal(t, "2.17.0", APISchemaVersion)
 }
 
 func TestPersonFilesUseAdditiveSchemaVersion(t *testing.T) {
-	assert.Equal(t, "2.16.0", APISchemaVersion)
+	assert.Equal(t, "2.17.0", APISchemaVersion)
 }
 
 func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
@@ -242,7 +242,7 @@ func TestPersonFileRoutesPublishTypedPathIDs(t *testing.T) {
 
 func TestOrganizationCreateOpenAPIDocumentsLocationHeader(t *testing.T) {
 	require := require.New(t)
-	assert.Equal(t, "2.16.0", APISchemaVersion,
+	assert.Equal(t, "2.17.0", APISchemaVersion,
 		"document and person-file search preserve the organization and employment contract")
 	for _, document := range []*huma.OpenAPI{
 		OpenAPIDocument(),
@@ -566,7 +566,7 @@ func TestOpenAPISearchDocumentsConversationID(t *testing.T) {
 func TestOpenAPIPersonAttributeContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
-	assert.Equal("2.16.0", APISchemaVersion,
+	assert.Equal("2.17.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the structured profile contract")
 
 	doc := OpenAPIDocument()
@@ -680,7 +680,7 @@ func TestOpenAPIPersonProfilePatchUsesWritableEnvelopeShape(t *testing.T) {
 func TestOpenAPIOrganizationProfilePutDocumentsLimits(t *testing.T) {
 	assertions := assert.New(t)
 	requirements := require.New(t)
-	assertions.Equal("2.16.0", APISchemaVersion,
+	assertions.Equal("2.17.0", APISchemaVersion,
 		"organization profile write limits advance the published contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/organizations/{id}/profile"]
@@ -700,7 +700,7 @@ func TestOpenAPIPersonProfileMediaContentContract(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	assert.Equal("2.16.0", APISchemaVersion,
+	assert.Equal("2.17.0", APISchemaVersion,
 		"activity, identity match review, document search, and person files preserve the raw profile media contract")
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/people/{id}/profile/media/{media_id}/content"]
@@ -728,7 +728,7 @@ func TestOpenAPIIdentityMatchReviewContract(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 
-	assertions.Equal("2.16.0", APISchemaVersion,
+	assertions.Equal("2.17.0", APISchemaVersion,
 		"document and person-file search preserve the identity match review contract")
 
 	doc := OpenAPIDocument()
@@ -777,9 +777,10 @@ func TestOpenAPIMeetingImportContract(t *testing.T) {
 	// calendars in 2.10.0, person fact diagnostics in 2.11.0, lexical deletion
 	// scope in 2.12.0, Directory people and deduplicate planning in 2.13.0,
 	// CardDAV status and run history plus List-ID filtering in 2.14.0, Gmail
-	// repair in 2.15.0, and complete TUI search and statistics contracts plus
-	// historical import jobs in 2.16.0 did not touch it.
-	assert.Equal("2.16.0", APISchemaVersion, "meeting import is an additive schema release")
+	// repair in 2.15.0, complete TUI search and statistics contracts plus
+	// historical import jobs in 2.16.0, and collection source scopes in 2.17.0
+	// did not touch it.
+	assert.Equal("2.17.0", APISchemaVersion, "meeting import is an additive schema release")
 
 	doc := OpenAPIDocument()
 	path := doc.Paths["/api/v1/import/meeting"]
@@ -1748,4 +1749,35 @@ func generatedGoFiles(dir string) ([]string, error) {
 	}
 	sort.Strings(files)
 	return files, nil
+}
+
+func TestOpenAPICollectionScopeContracts(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	doc := OpenAPIDocument()
+	for _, path := range []string{"/api/v1/aggregates", "/api/v1/aggregates/sub", "/api/v1/messages/filter", "/api/v1/messages/gmail-ids"} {
+		op := doc.Paths[path].Get
+		requirements.NotNil(op, path+" operation")
+		found := false
+		for _, parameter := range op.Parameters {
+			if parameter.Name != "source_ids" {
+				continue
+			}
+			found = true
+			assertions.Equal("query", parameter.In, path+" source_ids location")
+			requirements.NotNil(parameter.Schema, path+" source_ids schema")
+			assertions.Equal("array", parameter.Schema.Type, path+" source_ids type")
+		}
+		assertions.True(found, path+" documents source_ids")
+	}
+
+	deep := doc.Paths["/api/v1/search/deep"].Get
+	requirements.NotNil(deep, "deep search operation")
+	for _, parameter := range deep.Parameters {
+		if parameter.Name == "source_ids" {
+			assertions.Contains(parameter.Description, "not supported by deep search")
+			return
+		}
+	}
+	assertions.Fail("deep search documents source_ids rejection")
 }

--- a/internal/api/relationship_calendar_test.go
+++ b/internal/api/relationship_calendar_test.go
@@ -177,7 +177,7 @@ func TestRelationshipCalendarRequestRejectsTrailingJSON(t *testing.T) {
 func TestRelationshipCalendarOpenAPIContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.Equal("2.16.0", APISchemaVersion)
+	assert.Equal("2.17.0", APISchemaVersion)
 	document := OpenAPIDocument()
 	path := document.Paths["/api/v1/relationships/{id}/calendar"]
 	require.NotNil(path)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -882,13 +882,13 @@ func rawRouteParameters(operationID string) []*huma.Param {
 			queryStringParam("q", "Search query", true),
 			queryStringParam("view_type", "Stats grouping view type", false),
 		}, messageFilterParams()...)
-		return append(params,
-			queryIntegerArrayParam("source_ids", "Source IDs; repeat the parameter for multiple sources"),
-		)
+		return params
 	case "deepSearch":
 		filterParams := messageFilterParams()
 		for _, parameter := range filterParams {
 			switch parameter.Name {
+			case "source_ids":
+				parameter.Description += "; not supported by deep search"
 			case "sender", "sender_name", recipientParam, "recipient_name", "domain", "label",
 				"time_period", "conversation_id",
 				"empty_targets", "message_type", "list_id":
@@ -974,6 +974,7 @@ func aggregateOptionParams() []*huma.Param {
 		queryIntegerParam(limitParam, "Maximum number of rows to return (default 100; values below 1 fall back to the default)"),
 		queryStringParam("time_granularity", "Time bucket granularity", false),
 		queryIntegerParam("source_id", "Source ID"),
+		queryIntegerArrayParam("source_ids", "Source IDs; repeat or comma-separate values"),
 		queryBooleanParam("attachments_only", "Only include messages with attachments"),
 		queryBooleanParam("hide_deleted", "Exclude deleted messages"),
 		queryStringParam("search_query", "Search query", false),
@@ -1005,6 +1006,7 @@ func messageFilterScopeParams() []*huma.Param {
 		queryStringParam("time_granularity", "Time bucket granularity", false),
 		queryIntegerParam("conversation_id", "Conversation ID"),
 		queryIntegerParam("source_id", "Source ID"),
+		queryIntegerArrayParam("source_ids", "Source IDs; repeat or comma-separate values"),
 		queryBooleanParam("attachments_only", "Only include messages with attachments"),
 		queryBooleanParam("hide_deleted", "Exclude deleted messages"),
 		queryStringParam("after", "Lower date/time bound (RFC3339 or YYYY-MM-DD)", false),

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -920,6 +920,7 @@ func rawRouteParameters(operationID string) []*huma.Param {
 		}, textFilterParams()...)
 	case "searchTextMessages":
 		return []*huma.Param{
+			queryIntegerParam("source_id", "Source ID"),
 			queryStringParam("q", "Search query", true),
 			queryIntegerParam("offset", "Zero-based row offset"),
 			queryIntegerParam(limitParam, "Maximum number of rows to return"),

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -63,7 +63,7 @@ func (e *participantFilterTextEngine) ListConversationMessages(_ context.Context
 	return nil, nil
 }
 
-func (*participantFilterTextEngine) TextSearch(context.Context, string, int, int) ([]query.MessageSummary, error) {
+func (*participantFilterTextEngine) TextSearch(context.Context, string, *int64, int, int) ([]query.MessageSummary, error) {
 	return nil, nil
 }
 

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -37,6 +37,7 @@ type Engine struct {
 // Compile-time check that Engine implements query.Engine.
 var _ query.Engine = (*Engine)(nil)
 var _ query.TextEngine = (*Engine)(nil)
+var _ query.CollectionScopeLister = (*Engine)(nil)
 var _ query.MessageBodySearcher = (*Engine)(nil)
 var _ query.SemanticMessageSearcher = (*Engine)(nil)
 var _ query.DeletionTargetSearchResolver = (*Engine)(nil)
@@ -295,6 +296,10 @@ func emptyValueTargetsString(filter query.MessageFilter) *string {
 }
 
 func generatedFilterMessagesQuery(filter query.MessageFilter, paginated bool) generated.FilterMessagesQuery {
+	sourceID := filter.SourceID
+	if filter.SourceIDs != nil {
+		sourceID = nil
+	}
 	out := generated.FilterMessagesQuery{
 		Sender:          optionalString(filter.Sender),
 		SenderName:      optionalString(filter.SenderName),
@@ -307,7 +312,8 @@ func generatedFilterMessagesQuery(filter query.MessageFilter, paginated bool) ge
 		TimePeriod:      optionalString(filter.TimeRange.Period),
 		TimeGranularity: optionalString(timeGranularityToString(filter.TimeRange.Granularity)),
 		ConversationID:  filter.ConversationID,
-		SourceID:        filter.SourceID,
+		SourceID:        sourceID,
+		SourceIds:       copyInt64sPreserveNil(filter.SourceIDs),
 		AttachmentsOnly: optionalBool(filter.WithAttachmentsOnly),
 		HideDeleted:     optionalBool(filter.HideDeletedFromSource),
 		After:           optionalTimeRFC3339(filter.After),
@@ -330,7 +336,7 @@ func gmailIDsFilterQuery(filter query.MessageFilter) *generated.GetGmailIDsByFil
 		Recipient: base.Recipient, RecipientName: base.RecipientName,
 		Domain: base.Domain, Label: base.Label, ListID: base.ListID, MessageType: base.MessageType,
 		TimePeriod: base.TimePeriod, TimeGranularity: base.TimeGranularity,
-		ConversationID: base.ConversationID, SourceID: base.SourceID,
+		ConversationID: base.ConversationID, SourceID: base.SourceID, SourceIds: copyInt64sPreserveNil(base.SourceIds),
 		AttachmentsOnly: base.AttachmentsOnly, HideDeleted: base.HideDeleted,
 		After: base.After, Before: base.Before, EmptyTargets: base.EmptyTargets,
 		Offset: base.Offset, Sort: base.Sort, Direction: base.Direction,
@@ -421,7 +427,7 @@ func fastSearchQuery(queryStr string, filter query.MessageFilter, statsGroupBy q
 		TimeGranularity: fields.TimeGranularity,
 		ConversationID:  fields.ConversationID,
 		SourceID:        fields.SourceID,
-		SourceIds:       append([]int64(nil), filter.SourceIDs...),
+		SourceIds:       copyInt64sPreserveNil(filter.SourceIDs),
 		AttachmentsOnly: fields.AttachmentsOnly,
 		HideDeleted:     fields.HideDeleted,
 		After:           fields.After,
@@ -642,6 +648,9 @@ func queryMessageSummariesFromCLIGenerated(msgs []generated.CLIQueryMessageSumma
 
 // Aggregate performs grouping based on the provided ViewType.
 func (e *Engine) Aggregate(ctx context.Context, groupBy query.ViewType, opts query.AggregateOptions) ([]query.AggregateRow, error) {
+	if opts.SourceIDs != nil && len(opts.SourceIDs) == 0 {
+		return []query.AggregateRow{}, nil
+	}
 	if err := e.requireListIDCapability(ctx, search.Parse(opts.SearchQuery), query.MessageFilter{}, groupBy); err != nil {
 		return nil, err
 	}
@@ -653,7 +662,8 @@ func (e *Engine) Aggregate(ctx context.Context, groupBy query.ViewType, opts que
 				Direction:       optionalString(sortDirectionToString(opts.SortDirection)),
 				Limit:           optionalPositiveInt64(opts.Limit),
 				TimeGranularity: optionalString(timeGranularityToString(opts.TimeGranularity)),
-				SourceID:        opts.SourceID,
+				SourceID:        sourceIDForSourceIDs(opts.SourceID, opts.SourceIDs),
+				SourceIds:       copyInt64sPreserveNil(opts.SourceIDs),
 				AttachmentsOnly: optionalBool(opts.WithAttachmentsOnly),
 				HideDeleted:     optionalBool(opts.HideDeletedFromSource),
 				SearchQuery:     optionalString(opts.SearchQuery),
@@ -665,12 +675,23 @@ func (e *Engine) Aggregate(ctx context.Context, groupBy query.ViewType, opts que
 	if err != nil {
 		return nil, err
 	}
-
+	if err := requireAppliedSourceIDs(opts.SourceIDs, resp.JSON200.AppliedSourceIds, "aggregate"); err != nil {
+		return nil, err
+	}
 	return aggregateRowsFromGenerated(resp.JSON200), nil
 }
 
 // SubAggregate performs aggregation on a filtered subset of messages.
 func (e *Engine) SubAggregate(ctx context.Context, filter query.MessageFilter, groupBy query.ViewType, opts query.AggregateOptions) ([]query.AggregateRow, error) {
+	sourceID, sourceIDs := filter.SourceID, filter.SourceIDs
+	if opts.SourceIDs != nil {
+		sourceID, sourceIDs = opts.SourceID, opts.SourceIDs
+	} else if opts.SourceID != nil {
+		sourceID, sourceIDs = opts.SourceID, nil
+	}
+	if sourceIDs != nil && len(sourceIDs) == 0 {
+		return []query.AggregateRow{}, nil
+	}
 	if err := e.requireListIDCapability(ctx, search.Parse(opts.SearchQuery), filter, groupBy); err != nil {
 		return nil, err
 	}
@@ -693,7 +714,8 @@ func (e *Engine) SubAggregate(ctx context.Context, filter query.MessageFilter, g
 				TimePeriod:      optionalString(filter.TimeRange.Period),
 				TimeGranularity: optionalString(timeGranularityToString(opts.TimeGranularity)),
 				ConversationID:  filter.ConversationID,
-				SourceID:        filter.SourceID,
+				SourceID:        sourceIDForSourceIDs(sourceID, sourceIDs),
+				SourceIds:       copyInt64sPreserveNil(sourceIDs),
 				AttachmentsOnly: optionalBool(filter.WithAttachmentsOnly),
 				HideDeleted:     optionalBool(filter.HideDeletedFromSource),
 				After:           optionalTimeRFC3339(filter.After),
@@ -710,12 +732,17 @@ func (e *Engine) SubAggregate(ctx context.Context, filter query.MessageFilter, g
 	if err != nil {
 		return nil, err
 	}
-
+	if err := requireAppliedSourceIDs(sourceIDs, resp.JSON200.AppliedSourceIds, "sub-aggregate"); err != nil {
+		return nil, err
+	}
 	return aggregateRowsFromGenerated(resp.JSON200), nil
 }
 
 // ListMessages returns messages matching the filter criteria.
 func (e *Engine) ListMessages(ctx context.Context, filter query.MessageFilter) ([]query.MessageSummary, error) {
+	if filter.SourceIDs != nil && len(filter.SourceIDs) == 0 {
+		return []query.MessageSummary{}, nil
+	}
 	if err := e.requireListIDCapability(ctx, nil, filter); err != nil {
 		return nil, err
 	}
@@ -725,6 +752,9 @@ func (e *Engine) ListMessages(ctx context.Context, filter query.MessageFilter) (
 		})
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := requireAppliedSourceIDs(filter.SourceIDs, resp.JSON200.AppliedSourceIds, "message filter"); err != nil {
 		return nil, err
 	}
 	return messageSummariesFromGenerated(resp.JSON200.Messages), nil
@@ -1101,9 +1131,8 @@ func (e *Engine) SearchFastWithStats(ctx context.Context, q *search.Query, query
 	if err != nil {
 		return nil, err
 	}
-	if len(filter.SourceIDs) > 0 &&
-		!slices.Equal(normalizedSourceIDs(filter.SourceIDs), normalizedSourceIDs(resp.JSON200.AppliedSourceIds)) {
-		return nil, errors.New("daemon did not confirm fast-search source IDs; upgrade the daemon to API schema 1.5.0 or newer")
+	if err := requireAppliedSourceIDs(filter.SourceIDs, resp.JSON200.AppliedSourceIds, "fast-search"); err != nil {
+		return nil, err
 	}
 	return &query.SearchFastResult{
 		Messages:   messageSummariesFromGenerated(resp.JSON200.Messages),
@@ -1113,6 +1142,9 @@ func (e *Engine) SearchFastWithStats(ctx context.Context, q *search.Query, query
 }
 
 func (e *Engine) GetDeletionTargetsByFilter(ctx context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+	if filter.SourceIDs != nil && len(filter.SourceIDs) == 0 {
+		return []query.DeletionTarget{}, nil
+	}
 	if err := e.requireListIDCapability(ctx, nil, filter); err != nil {
 		return nil, err
 	}
@@ -1124,6 +1156,9 @@ func (e *Engine) GetDeletionTargetsByFilter(ctx context.Context, filter query.Me
 	if err != nil {
 		return nil, err
 	}
+	if err := requireAppliedSourceIDs(filter.SourceIDs, resp.JSON200.AppliedSourceIds, "deletion-target"); err != nil {
+		return nil, err
+	}
 	return deletionTargetsFromGenerated(resp.JSON200)
 }
 
@@ -1133,6 +1168,9 @@ func (e *Engine) GetDeletionTargetsBySearch(
 	filter query.MessageFilter,
 	mode query.DeletionSearchMode,
 ) ([]query.DeletionTarget, error) {
+	if filter.SourceIDs != nil && len(filter.SourceIDs) == 0 {
+		return []query.DeletionTarget{}, nil
+	}
 	if err := validateParsedSearchQuery(searchQuery); err != nil {
 		return nil, err
 	}
@@ -1160,6 +1198,9 @@ func (e *Engine) GetDeletionTargetsBySearch(
 	if stringValue(resp.JSON200.SearchQuery) != queryString || stringValue(resp.JSON200.SearchMode) != modeString {
 		return nil, errors.New("daemon did not confirm the deletion search scope; upgrade the daemon and retry")
 	}
+	if err := requireAppliedSourceIDs(filter.SourceIDs, resp.JSON200.AppliedSourceIds, "deletion-target"); err != nil {
+		return nil, err
+	}
 	return deletionTargetsFromGenerated(resp.JSON200)
 }
 
@@ -1170,6 +1211,9 @@ func (e *Engine) GetDeletionTargetsByAggregateSearch(
 	groupBy query.ViewType,
 	key string,
 ) ([]query.DeletionTarget, error) {
+	if filter.SourceIDs != nil && len(filter.SourceIDs) == 0 {
+		return []query.DeletionTarget{}, nil
+	}
 	parsed := search.Parse(searchQuery)
 	if err := validateParsedSearchQuery(parsed); err != nil {
 		return nil, err
@@ -1201,6 +1245,9 @@ func (e *Engine) GetDeletionTargetsByAggregateSearch(
 	}
 	if stringValue(resp.JSON200.SearchQuery) != queryString || stringValue(resp.JSON200.SearchMode) != modeString {
 		return nil, errors.New("daemon did not confirm the aggregate deletion search scope; upgrade the daemon and retry")
+	}
+	if err := requireAppliedSourceIDs(filter.SourceIDs, resp.JSON200.AppliedSourceIds, "deletion-target"); err != nil {
+		return nil, err
 	}
 	return deletionTargetsFromGenerated(resp.JSON200)
 }
@@ -1283,6 +1330,26 @@ func (e *Engine) ListAccounts(ctx context.Context) ([]query.AccountInfo, error) 
 	return result, nil
 }
 
+// ListCollectionScopes returns the user-managed collection projections used
+// by the TUI. The daemon-owned All collection is not a selectable scope.
+func (e *Engine) ListCollectionScopes(ctx context.Context) ([]query.CollectionScope, error) {
+	collections, err := e.store.GetCLICollections(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scopes := make([]query.CollectionScope, 0, len(collections))
+	for _, collection := range collections {
+		if collection.Name == store.DefaultCollectionName {
+			continue
+		}
+		scopes = append(scopes, query.CollectionScope{
+			Name:      collection.Name,
+			SourceIDs: append([]int64{}, collection.SourceIDs...),
+		})
+	}
+	return scopes, nil
+}
+
 func (e *Engine) ListConversations(ctx context.Context, filter query.TextFilter) ([]query.ConversationRow, error) {
 	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.ListTextConversationsResp, error) {
 		return client.ListTextConversationsWithResponse(ctx, &generated.ListTextConversationsRequestOptions{
@@ -1353,15 +1420,18 @@ func (e *Engine) GetTextStats(ctx context.Context, opts query.TextStatsOptions) 
 
 // GetTotalStats returns overall database statistics.
 func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*query.TotalStats, error) {
-	if opts.SourceIDs != nil && len(opts.SourceIDs) == 0 {
-		return &query.TotalStats{}, nil
-	}
-	if opts.SourceIDs == nil && opts.Filter != nil && opts.Filter.SourceIDs != nil && len(opts.Filter.SourceIDs) == 0 {
-		return &query.TotalStats{}, nil
-	}
 	var filter query.MessageFilter
 	if opts.Filter != nil {
 		filter = opts.Filter.Clone()
+	}
+	sourceID, sourceIDs := opts.SourceID, opts.SourceIDs
+	if opts.SourceIDs == nil && opts.SourceID == nil && opts.Filter != nil {
+		sourceID, sourceIDs = filter.SourceID, filter.SourceIDs
+	}
+	if sourceIDs != nil && len(sourceIDs) == 0 {
+		return &query.TotalStats{}, nil
+	}
+	if opts.Filter != nil {
 		compatible, err := e.store.SupportsAPISchemaVersion(ctx, tuiSearchContractMinAPISchemaVersion)
 		if err != nil {
 			return nil, fmt.Errorf("check filtered-stats capability: %w", err)
@@ -1374,8 +1444,8 @@ func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*q
 		return nil, err
 	}
 	params := &generated.GetTotalStatsQuery{
-		SourceID:        opts.SourceID,
-		SourceIds:       append([]int64(nil), opts.SourceIDs...),
+		SourceID:        sourceIDForSourceIDs(sourceID, sourceIDs),
+		SourceIds:       copyInt64sPreserveNil(sourceIDs),
 		AttachmentsOnly: optionalBool(opts.WithAttachmentsOnly),
 		HideDeleted:     optionalBool(opts.HideDeletedFromSource),
 		SearchQuery:     optionalString(opts.SearchQuery),
@@ -1398,12 +1468,8 @@ func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*q
 		params.After = fields.After
 		params.Before = fields.Before
 		params.EmptyTargets = fields.EmptyTargets
-		if opts.SourceIDs == nil && opts.SourceID == nil && filter.SourceIDs != nil {
-			params.SourceIds = append([]int64(nil), filter.SourceIDs...)
-		}
-		if opts.SourceIDs == nil && params.SourceID == nil {
-			params.SourceID = fields.SourceID
-		}
+		params.SourceID = sourceIDForSourceIDs(sourceID, sourceIDs)
+		params.SourceIds = copyInt64sPreserveNil(sourceIDs)
 		params.AttachmentsOnly = optionalBool(opts.WithAttachmentsOnly || filter.WithAttachmentsOnly)
 		params.HideDeleted = optionalBool(opts.HideDeletedFromSource || filter.HideDeletedFromSource)
 	}
@@ -1418,9 +1484,8 @@ func (e *Engine) GetTotalStats(ctx context.Context, opts query.StatsOptions) (*q
 	if opts.SearchScope && (resp.JSON200.AppliedSearchScope == nil || !*resp.JSON200.AppliedSearchScope) {
 		return nil, errors.New("daemon did not confirm total-stats search scope; upgrade the daemon to API schema 1.5.0 or newer")
 	}
-	if len(opts.SourceIDs) > 0 &&
-		!slices.Equal(normalizedSourceIDs(opts.SourceIDs), normalizedSourceIDs(resp.JSON200.AppliedSourceIds)) {
-		return nil, errors.New("daemon did not confirm total-stats source IDs; upgrade the daemon to API schema 1.5.0 or newer")
+	if err := requireAppliedSourceIDs(sourceIDs, resp.JSON200.AppliedSourceIds, "total-stats"); err != nil {
+		return nil, err
 	}
 	return totalStatsFromGenerated(resp.JSON200), nil
 }
@@ -1439,9 +1504,36 @@ func normalizedSourceIDs(ids []int64) []int64 {
 	if ids == nil {
 		return nil
 	}
-	normalized := append([]int64(nil), ids...)
+	normalized := append(make([]int64, 0, len(ids)), ids...)
 	slices.Sort(normalized)
 	return slices.Compact(normalized)
+}
+
+func copyInt64sPreserveNil(ids []int64) []int64 {
+	if ids == nil {
+		return nil
+	}
+	return append(make([]int64, 0, len(ids)), ids...)
+}
+
+func sourceIDForSourceIDs(sourceID *int64, sourceIDs []int64) *int64 {
+	if sourceIDs != nil {
+		return nil
+	}
+	return sourceID
+}
+
+func requireAppliedSourceIDs(requested, applied []int64, surface string) error {
+	if requested == nil {
+		return nil
+	}
+	if applied == nil {
+		return fmt.Errorf("daemon did not confirm %s source IDs; upgrade the daemon to API schema 2.17.0 or newer", surface)
+	}
+	if !slices.Equal(normalizedSourceIDs(requested), normalizedSourceIDs(applied)) {
+		return fmt.Errorf("daemon did not confirm %s source IDs; upgrade the daemon to API schema 2.17.0 or newer", surface)
+	}
+	return nil
 }
 
 func hasExplicitEmptyAccountScope(q *search.Query) bool {

--- a/internal/daemonclient/engine_adapter.go
+++ b/internal/daemonclient/engine_adapter.go
@@ -1387,18 +1387,22 @@ func (e *Engine) ListConversationMessages(ctx context.Context, convID int64, fil
 	return queryMessageSummariesFromCLIGenerated(resp.JSON200.Messages), nil
 }
 
-func (e *Engine) TextSearch(ctx context.Context, queryStr string, limit, offset int) ([]query.MessageSummary, error) {
+func (e *Engine) TextSearch(ctx context.Context, queryStr string, sourceID *int64, limit, offset int) ([]query.MessageSummary, error) {
 	resp, err := APIResponse(e.store, func(client *apiclient.Client) (*generated.SearchTextMessagesResp, error) {
 		return client.SearchTextMessagesWithResponse(ctx, &generated.SearchTextMessagesRequestOptions{
 			Query: &generated.SearchTextMessagesQuery{
-				Q:      queryStr,
-				Limit:  optionalPositiveInt64(limit),
-				Offset: optionalPositiveInt64(offset),
+				Q:        queryStr,
+				SourceID: copyInt64(sourceID),
+				Limit:    optionalPositiveInt64(limit),
+				Offset:   optionalPositiveInt64(offset),
 			},
 		})
 	})
 	if err != nil {
 		return nil, err
+	}
+	if sourceID != nil && (resp.JSON200.AppliedSourceID == nil || *resp.JSON200.AppliedSourceID != *sourceID) {
+		return nil, errors.New("daemon did not confirm text-search source ID; upgrade the daemon and retry")
 	}
 	return queryMessageSummariesFromCLIGenerated(resp.JSON200.Messages), nil
 }

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -867,6 +867,27 @@ func TestEngineGetDeletionTargetsByFilterPreservesSource(t *testing.T) {
 	}}, targets)
 }
 
+func TestEngineGetDeletionTargetsByFilterForwardsSourceIDs(t *testing.T) {
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, []string{"7", "8"}, r.URL.Query()["source_ids"])
+		assert.Empty(t, r.URL.Query().Get("source_id"))
+		writeJSONResponse(t, w, map[string]any{
+			"gmail_ids":          []string{"shared-id"},
+			"applied_source_ids": []int64{8, 7},
+			"targets": []map[string]any{{
+				"message_id": 7, "source_id": 8, "source_type": "gmail",
+				"source_identifier": "account@example.invalid", "source_message_id": "shared-id",
+			}},
+		})
+	})
+	targets, err := NewEngineAdapter(store).GetDeletionTargetsByFilter(context.Background(), query.MessageFilter{
+		SourceIDs: []int64{7, 8},
+	})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, int64(8), targets[0].SourceID)
+}
+
 func TestEngineRejectsListIDFilterAgainstOlderDaemonBeforeScopedRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -1100,6 +1121,27 @@ func TestEngineGetDeletionTargetsBySearchTreatsCanonicalEmptyAsFilter(t *testing
 		MessageID: 1, SourceID: 7, SourceType: "gmail",
 		SourceIdentifier: "account@example.invalid", SourceMessageID: "gm-1",
 	}}, targets)
+}
+
+func TestEngineDeletionSearchExplicitEmptySourceIDsSkipsHTTP(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	called := false
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	})
+	engine := NewEngineAdapter(store)
+	filter := query.MessageFilter{SourceIDs: []int64{}}
+
+	searchTargets, err := engine.GetDeletionTargetsBySearch(t.Context(), search.Parse("invoice"), filter, query.DeletionSearchDeep)
+	requirements.NoError(err)
+	assertions.Empty(searchTargets)
+
+	aggregateTargets, err := engine.GetDeletionTargetsByAggregateSearch(t.Context(), "invoice", filter, query.ViewSenders, "alice@example.com")
+	requirements.NoError(err)
+	assertions.Empty(aggregateTargets)
+	assertions.False(called, "explicit empty source scope must skip deletion HTTP requests")
 }
 
 func TestEngineSearchByDomainsUsesGeneratedClientAdapter(t *testing.T) {
@@ -1481,6 +1523,64 @@ func TestEngineGetTotalStatsForwardsSourceIDs(t *testing.T) {
 	assert.Equal(int64(2), stats.MessageCount)
 }
 
+func TestEngineGetTotalStatsUsesFilterSourceIDsAndRequiresEcho(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+			return
+		}
+		assertions.Equal([]string{"7", "8"}, r.URL.Query()["source_ids"])
+		writeJSONResponse(t, w, map[string]any{
+			"message_count":      2,
+			"applied_source_ids": []int64{8, 7},
+		})
+	})
+
+	stats, err := NewEngineAdapter(store).GetTotalStats(t.Context(), query.StatsOptions{
+		Filter: &query.MessageFilter{SourceIDs: []int64{7, 8}},
+	})
+	requirements.NoError(err)
+	assertions.Equal(int64(2), stats.MessageCount)
+
+	store = newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+			return
+		}
+		writeJSONResponse(t, w, map[string]any{"message_count": 2})
+	})
+	stats, err = NewEngineAdapter(store).GetTotalStats(t.Context(), query.StatsOptions{
+		Filter: &query.MessageFilter{SourceIDs: []int64{7, 8}},
+	})
+	requirements.ErrorContains(err, "total-stats source IDs")
+	assertions.Nil(stats)
+}
+
+func TestEngineGetTotalStatsTopLevelSourceIDOverridesFilterSourceIDs(t *testing.T) {
+	sourceID := int64(9)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			writeJSONResponse(t, w, map[string]any{"status": "ok", "api_schema_version": "2.16.0"})
+			return
+		}
+		assert.Equal(t, "9", r.URL.Query().Get("source_id"))
+		assert.Empty(t, r.URL.Query()["source_ids"])
+		writeJSONResponse(t, w, map[string]any{
+			"message_count":      1,
+			"applied_source_ids": []int64{9},
+		})
+	})
+
+	stats, err := NewEngineAdapter(store).GetTotalStats(t.Context(), query.StatsOptions{
+		Filter:   &query.MessageFilter{SourceIDs: []int64{7, 8}},
+		SourceID: &sourceID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.MessageCount)
+}
+
 func TestEngineGetTotalStatsRequiresCapabilityEchoes(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1554,6 +1654,12 @@ func TestEngineGetTotalStatsExplicitEmptySourceIDsSkipsHTTP(t *testing.T) {
 	require.NotNil(stats, "stats")
 	assert.Zero(stats.MessageCount, "explicit empty source scope")
 	assert.False(called, "explicit empty source scope must skip HTTP")
+}
+
+func TestRequireAppliedSourceIDsPreservesExplicitEmptyScope(t *testing.T) {
+	require.NoError(t, requireAppliedSourceIDs([]int64{}, []int64{}, "test"))
+	require.Error(t, requireAppliedSourceIDs([]int64{}, nil, "test"))
+	require.NoError(t, requireAppliedSourceIDs(nil, nil, "test"))
 }
 
 func TestEngineGetMessageCarriesAttachmentContentHash(t *testing.T) {
@@ -2278,6 +2384,100 @@ func TestEngineSearchFastWithStatsForwardsSourceIDs(t *testing.T) {
 	require.NotNil(result.Stats)
 	assert.Equal(int64(2), result.Stats.MessageCount)
 	assert.Equal(int64(2), result.Stats.AccountCount)
+}
+
+func TestEngineListCollectionScopesProjectsUserCollections(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assertions.Equal("/api/v1/cli/collections", r.URL.Path)
+		writeJSONResponse(t, w, map[string]any{
+			"collections": []map[string]any{
+				{"name": "All", "created_at": "2026-01-01T00:00:00Z", "source_ids": []int64{1, 2}},
+				{"name": "Work", "created_at": "2026-01-02T00:00:00Z", "source_ids": []int64{2, 1}},
+				{"name": "Empty", "created_at": "2026-01-03T00:00:00Z", "source_ids": nil},
+			},
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	got, err := engine.ListCollectionScopes(context.Background())
+	requirements.NoError(err)
+	requirements.Len(got, 2)
+	assertions.Equal("Work", got[0].Name)
+	assertions.Equal([]int64{2, 1}, got[0].SourceIDs)
+	assertions.Equal("Empty", got[1].Name)
+	assertions.NotNil(got[1].SourceIDs)
+	assertions.Empty(got[1].SourceIDs)
+}
+
+func TestEngineAggregateForwardsAndConfirmsCollectionSourceIDs(t *testing.T) {
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, []string{"7", "8"}, r.URL.Query()["source_ids"])
+		assert.Empty(t, r.URL.Query()["source_id"])
+		writeJSONResponse(t, w, map[string]any{
+			"view_type": "senders", "rows": []map[string]any{}, "applied_source_ids": []int64{8, 7},
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	rows, err := engine.Aggregate(context.Background(), query.ViewSenders, query.AggregateOptions{SourceIDs: []int64{7, 8}})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestEngineSubAggregateForwardsOptionSourceIDs(t *testing.T) {
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, []string{"7", "8"}, r.URL.Query()["source_ids"])
+		assert.Empty(t, r.URL.Query().Get("source_id"))
+		writeJSONResponse(t, w, map[string]any{
+			"view_type": "senders", "rows": []map[string]any{}, "applied_source_ids": []int64{8, 7},
+		})
+	})
+
+	rows, err := NewEngineAdapter(store).SubAggregate(context.Background(), query.MessageFilter{}, query.ViewSenders,
+		query.AggregateOptions{SourceIDs: []int64{7, 8}})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestEngineCollectionReadsFailClosedWithoutAppliedSourceEcho(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSONResponse(t, w, map[string]any{"view_type": "senders", "rows": []map[string]any{}})
+	})
+	engine := NewEngineAdapter(store)
+
+	rows, err := engine.Aggregate(context.Background(), query.ViewSenders, query.AggregateOptions{SourceIDs: []int64{7, 8}})
+	requirements.Error(err)
+	assertions.Nil(rows)
+	assertions.Contains(err.Error(), "source IDs")
+	assertions.Contains(err.Error(), "upgrade")
+}
+
+func TestEngineCollectionMessageReadsForwardSourceIDsAndEmptySkipsHTTP(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	calls := 0
+	store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		assertions.Equal("/api/v1/messages/filter", r.URL.Path)
+		assertions.Equal([]string{"7", "8"}, r.URL.Query()["source_ids"])
+		writeJSONResponse(t, w, map[string]any{
+			"count": 0, "has_more": false, "offset": 0, "limit": 500,
+			"messages": []map[string]any{}, "applied_source_ids": []int64{7, 8},
+		})
+	})
+	engine := NewEngineAdapter(store)
+
+	messages, err := engine.ListMessages(context.Background(), query.MessageFilter{SourceIDs: []int64{7, 8}})
+	requirements.NoError(err)
+	assertions.Empty(messages)
+	empty, err := engine.ListMessages(context.Background(), query.MessageFilter{SourceIDs: []int64{}})
+	requirements.NoError(err)
+	assertions.Empty(empty)
+	assertions.Equal(1, calls)
 }
 
 func TestEngineSearchFastWithStatsRequiresSourceIDEcho(t *testing.T) {

--- a/internal/daemonclient/engine_adapter_full_test.go
+++ b/internal/daemonclient/engine_adapter_full_test.go
@@ -465,7 +465,7 @@ func TestEngineTextMethodsUseGeneratedClientAdapter(t *testing.T) {
 	assert.Equal("Family", timeline[0].ConversationTitle)
 	assert.Equal("+15555550123", timeline[0].FromPhone)
 
-	searchResults, err := textEngine.TextSearch(context.Background(), "dinner", 10, 5)
+	searchResults, err := textEngine.TextSearch(context.Background(), "dinner", nil, 10, 5)
 	require.NoError(err, "TextSearch")
 	require.Len(searchResults, 1, "searchResults")
 	assert.Equal("search body", searchResults[0].BodyText)
@@ -2675,4 +2675,27 @@ func TestEngineSearchFastWithStatsMessageTypeConflictReturnsNoMatches(t *testing
 	require.NotNil(result.Stats, "Stats")
 	assert.Equal(int64(0), result.Stats.MessageCount, "Stats.MessageCount")
 	assert.Equal([]string{"email"}, parsedQuery.MessageTypes, "base query MessageTypes must not be mutated")
+}
+
+func TestEngineTextSearchRejectsUnconfirmedAccount(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		applied *int64
+	}{
+		{name: "missing confirmation"},
+		{name: "different account", applied: new(int64(2))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newGeneratedClientAdapterStore(t, func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "1", r.URL.Query().Get("source_id"))
+				writeJSONResponse(t, w, map[string]any{
+					"applied_source_id": tc.applied,
+					"messages":          []map[string]any{{"id": 2}},
+				})
+			})
+			messages, err := NewEngineAdapter(store).TextSearch(t.Context(), "hello", new(int64(1)), 10, 0)
+			require.ErrorContains(t, err, "did not confirm text-search source ID")
+			assert.Empty(t, messages)
+		})
+	}
 }

--- a/internal/query/collection_scope.go
+++ b/internal/query/collection_scope.go
@@ -1,0 +1,18 @@
+package query
+
+import "context"
+
+// CollectionScope is the read-only projection used by clients that can
+// present named source collections. SourceIDs is non-nil and empty for an
+// explicitly empty collection, which means match nothing.
+type CollectionScope struct {
+	Name      string
+	SourceIDs []int64
+}
+
+// CollectionScopeLister is an optional query capability. It projects the
+// existing store collection catalog without widening the query.Engine
+// contract. The catalog excludes the built-in All collection.
+type CollectionScopeLister interface {
+	ListCollectionScopes(ctx context.Context) ([]CollectionScope, error)
+}

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -1556,6 +1556,10 @@ func (e *DuckDBEngine) SubAggregate(ctx context.Context, filter MessageFilter, g
 	if strings.TrimSpace(opts.SearchQuery) != "" && e.sqliteEngine != nil {
 		return e.sqliteEngine.SubAggregate(ctx, filter, groupBy, opts)
 	}
+	if opts.SourceIDs != nil || opts.SourceID != nil {
+		filter.SourceID = nil
+		filter.SourceIDs = nil
+	}
 
 	release, err := e.acquireQuerySlot(ctx)
 	if err != nil {
@@ -1578,10 +1582,10 @@ func (e *DuckDBEngine) SubAggregate(ctx context.Context, filter MessageFilter, g
 		where += " AND " + emailOnlyFilterMsg
 	}
 
-	// Add opts-based conditions (source_id, date range, attachment filter)
-	if opts.SourceID != nil {
-		where += " AND msg.source_id = ?"
-		args = append(args, *opts.SourceID)
+	// Add opts-based conditions (source IDs, date range, attachment filter).
+	whereParts, args := appendSourceFilter(nil, args, "msg.", opts.SourceID, opts.SourceIDs)
+	if len(whereParts) > 0 {
+		where += " AND " + strings.Join(whereParts, " AND ")
 	}
 	if opts.After != nil {
 		where += " AND msg.sent_at >= CAST(? AS TIMESTAMP)"

--- a/internal/query/duckdb_test.go
+++ b/internal/query/duckdb_test.go
@@ -763,6 +763,99 @@ func TestDuckDBEngine_SubAggregateBySenderName(t *testing.T) {
 	}
 }
 
+func TestDuckDBEngine_SubAggregateSourceIDsTakePrecedence(t *testing.T) {
+	b := NewTestDataBuilder(t)
+	sourceOne := b.AddSource("one@example.com")
+	sourceTwo := b.AddSource("two@example.com")
+	aliceID := b.AddParticipant("alice@example.com", "example.com", "Alice")
+	bobID := b.AddParticipant("bob@example.com", "example.com", "Bob")
+
+	messageOne := b.AddMessage(MessageOpt{SourceID: sourceOne, SenderID: &aliceID})
+	b.AddFrom(messageOne, aliceID, "Alice")
+	messageTwo := b.AddMessage(MessageOpt{SourceID: sourceTwo, SenderID: &bobID})
+	b.AddFrom(messageTwo, bobID, "Bob")
+	b.SetEmptyAttachments()
+	engine := b.BuildEngine()
+
+	selectedSource := sourceOne
+	opts := DefaultAggregateOptions()
+	opts.SourceID = &selectedSource
+	opts.SourceIDs = []int64{sourceTwo}
+	results, err := engine.SubAggregate(context.Background(), MessageFilter{}, ViewSenders, opts)
+	require.NoError(t, err, "SubAggregate")
+
+	assertAggregateCounts(t, results, map[string]int64{"bob@example.com": 1})
+}
+
+func TestDuckDBEngine_SubAggregateSourceScopePrecedence(t *testing.T) {
+	b := NewTestDataBuilder(t)
+	sourceOne := b.AddSource("one@example.com")
+	sourceTwo := b.AddSource("two@example.com")
+	senderID := b.AddParticipant("scope-sender@example.com", "example.com", "Scope Sender")
+	messageID := b.AddMessage(MessageOpt{SourceID: sourceTwo, SenderID: &senderID})
+	b.AddFrom(messageID, senderID, "Scope Sender")
+	b.SetEmptyAttachments()
+	engine := b.BuildEngine()
+
+	sourceTwoID := sourceTwo
+	cases := []struct {
+		name   string
+		filter MessageFilter
+		opts   AggregateOptions
+		want   map[string]int64
+	}{
+		{
+			name:   "option multi overrides filter single",
+			filter: MessageFilter{SourceID: &sourceOne, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceIDs: []int64{sourceTwo}},
+			want:   map[string]int64{"scope-sender@example.com": 1},
+		},
+		{
+			name:   "option single overrides filter multi",
+			filter: MessageFilter{SourceIDs: []int64{sourceOne}, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceID: &sourceTwoID},
+			want:   map[string]int64{"scope-sender@example.com": 1},
+		},
+		{
+			name:   "option single overrides empty filter",
+			filter: MessageFilter{SourceIDs: []int64{}, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceID: &sourceTwoID},
+			want:   map[string]int64{"scope-sender@example.com": 1},
+		},
+		{
+			name:   "explicit empty option overrides filter",
+			filter: MessageFilter{SourceID: &sourceTwo, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceIDs: []int64{}},
+			want:   map[string]int64{},
+		},
+		{
+			name:   "filter remains when options are nil",
+			filter: MessageFilter{SourceID: &sourceTwo, Sender: "scope-sender@example.com"},
+			opts:   DefaultAggregateOptions(),
+			want:   map[string]int64{"scope-sender@example.com": 1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			filter := tc.filter
+			opts := DefaultAggregateOptions()
+			opts.SourceID = tc.opts.SourceID
+			opts.SourceIDs = tc.opts.SourceIDs
+			rows, err := engine.SubAggregate(context.Background(), filter, ViewSenders, opts)
+			require.NoError(err, "SubAggregate")
+			assertAggregateCounts(t, rows, tc.want)
+			if tc.filter.SourceID != nil {
+				require.NotNil(filter.SourceID)
+				assert.Equal(*tc.filter.SourceID, *filter.SourceID)
+			}
+			assert.Equal(tc.filter.SourceIDs, filter.SourceIDs)
+		})
+	}
+}
+
 func TestDuckDBEngine_ListMessages_SenderNameFilter(t *testing.T) {
 	engine := newParquetEngine(t)
 	ctx := context.Background()

--- a/internal/query/duckdb_text.go
+++ b/internal/query/duckdb_text.go
@@ -542,7 +542,7 @@ func (e *DuckDBEngine) listConversationMessages(
 // chat timeline will show truncated previews for search results rather than
 // the complete message body.
 func (e *DuckDBEngine) TextSearch(
-	ctx context.Context, query string, limit, offset int,
+	ctx context.Context, query string, sourceID *int64, limit, offset int,
 ) ([]MessageSummary, error) {
 	if e.sqliteDB == nil {
 		return nil, nil
@@ -556,6 +556,11 @@ func (e *DuckDBEngine) TextSearch(
 	}
 
 	// Use FTS5 MATCH on messages_fts, filtered to text message types.
+	conditions, args := appendSourceFilter(
+		[]string{"messages_fts MATCH ?", textMsgTypeFilter(), store.LiveMessagesWhere("m", true)},
+		[]any{match}, "m.", sourceID, nil,
+	)
+
 	sqlQuery := fmt.Sprintf(`
 		SELECT
 			m.id,
@@ -578,15 +583,12 @@ func (e *DuckDBEngine) TextSearch(
 		JOIN messages m ON m.id = fts.rowid
 		LEFT JOIN participants p ON p.id = m.sender_id
 		LEFT JOIN conversations c ON c.id = m.conversation_id
-		WHERE messages_fts MATCH ?
-		  AND %s
-		  AND %s
+		WHERE %s
 		ORDER BY m.sent_at DESC
 		LIMIT ? OFFSET ?
-	`, textMsgTypeFilter(), store.LiveMessagesWhere("m", true))
+	`, strings.Join(conditions, " AND "))
 
-	rows, err := e.sqliteDB.QueryContext(ctx, sqlQuery,
-		match, limit, offset)
+	rows, err := e.sqliteDB.QueryContext(ctx, sqlQuery, append(args, limit, offset)...)
 	if err != nil {
 		return nil, fmt.Errorf("text search: %w", err)
 	}

--- a/internal/query/sqlite.go
+++ b/internal/query/sqlite.go
@@ -592,6 +592,10 @@ func appendExactListIDCondition(
 // SubAggregate performs aggregation on a filtered subset of messages.
 // This is used for sub-grouping after drill-down.
 func (e *SQLiteEngine) SubAggregate(ctx context.Context, filter MessageFilter, groupBy ViewType, opts AggregateOptions) ([]AggregateRow, error) {
+	if opts.SourceIDs != nil || opts.SourceID != nil {
+		filter.SourceID = nil
+		filter.SourceIDs = nil
+	}
 	// Reconcile opts.HideDeletedFromSource into filter so the helper
 	// inside buildFilterJoinsAndConditions / optsToFilterConditions
 	// sees the OR of both fields. Mirrors the DuckDB SubAggregate

--- a/internal/query/sqlite_aggregate_test.go
+++ b/internal/query/sqlite_aggregate_test.go
@@ -516,6 +516,78 @@ func TestSubAggregates(t *testing.T) {
 	}
 }
 
+func TestSQLiteEngine_SubAggregateSourceScopePrecedence(t *testing.T) {
+	env := newTestEnv(t)
+	sourceOne := int64(1)
+	sourceTwo := env.AddSource(dbtest.SourceOpts{Identifier: "scope@example.com"})
+	senderID := env.AddParticipant(dbtest.ParticipantOpts{
+		Email: new("scope-sender@example.com"), DisplayName: new("Scope Sender"), Domain: "example.com",
+	})
+	conversationID := env.AddConversation(dbtest.ConversationOpts{SourceID: sourceTwo, Title: "Scoped"})
+	env.AddMessage(dbtest.MessageOpts{
+		SourceID: sourceTwo, ConversationID: conversationID, FromID: senderID,
+		Subject: "Scoped message", SentAt: "2024-06-01 10:00:00",
+	})
+
+	sourceTwoID := sourceTwo
+	cases := []struct {
+		name   string
+		filter MessageFilter
+		opts   AggregateOptions
+		want   []aggExpectation
+	}{
+		{
+			name:   "option multi overrides filter single",
+			filter: MessageFilter{SourceID: &sourceOne, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceIDs: []int64{sourceTwo}},
+			want:   []aggExpectation{{"scope-sender@example.com", 1}},
+		},
+		{
+			name:   "option single overrides filter multi",
+			filter: MessageFilter{SourceIDs: []int64{sourceOne}, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceID: &sourceTwoID},
+			want:   []aggExpectation{{"scope-sender@example.com", 1}},
+		},
+		{
+			name:   "option single overrides empty filter",
+			filter: MessageFilter{SourceIDs: []int64{}, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceID: &sourceTwoID},
+			want:   []aggExpectation{{"scope-sender@example.com", 1}},
+		},
+		{
+			name:   "explicit empty option overrides filter",
+			filter: MessageFilter{SourceID: &sourceTwo, Sender: "scope-sender@example.com"},
+			opts:   AggregateOptions{SourceIDs: []int64{}},
+			want:   nil,
+		},
+		{
+			name:   "filter remains when options are nil",
+			filter: MessageFilter{SourceID: &sourceTwo, Sender: "scope-sender@example.com"},
+			opts:   DefaultAggregateOptions(),
+			want:   []aggExpectation{{"scope-sender@example.com", 1}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			filter := tc.filter
+			opts := DefaultAggregateOptions()
+			opts.SourceID = tc.opts.SourceID
+			opts.SourceIDs = tc.opts.SourceIDs
+			rows, err := env.Engine.SubAggregate(env.Ctx, filter, ViewSenders, opts)
+			require.NoError(err, "SubAggregate")
+			assertAggRows(t, rows, tc.want)
+			if tc.filter.SourceID != nil {
+				require.NotNil(filter.SourceID)
+				assert.Equal(*tc.filter.SourceID, *filter.SourceID)
+			}
+			assert.Equal(tc.filter.SourceIDs, filter.SourceIDs)
+		})
+	}
+}
+
 func TestSubAggregate_MatchEmptySenderName(t *testing.T) {
 	env := newTestEnvWithEmptyBuckets(t)
 

--- a/internal/query/sqlite_text.go
+++ b/internal/query/sqlite_text.go
@@ -778,7 +778,7 @@ func sanitizeTextSearchMatch(query string) string {
 // TextSearch performs plain full-text search over text messages.
 // Uses FTS5 if available; otherwise returns empty results.
 func (e *SQLiteEngine) TextSearch(
-	ctx context.Context, query string, limit, offset int,
+	ctx context.Context, query string, sourceID *int64, limit, offset int,
 ) ([]MessageSummary, error) {
 	match := sanitizeTextSearchMatch(query)
 	if match == "" {
@@ -790,6 +790,11 @@ func (e *SQLiteEngine) TextSearch(
 	if limit == 0 {
 		limit = 50
 	}
+
+	conditions, args := appendSourceFilter(
+		[]string{"fts.messages_fts MATCH ?", textMsgTypeFilter(), store.LiveMessagesWhere("m", true)},
+		[]any{match}, "m.", sourceID, nil,
+	)
 
 	sqlQuery := fmt.Sprintf(`
 		SELECT
@@ -813,14 +818,12 @@ func (e *SQLiteEngine) TextSearch(
 		JOIN messages m ON m.id = fts.rowid
 		LEFT JOIN participants p ON p.id = m.sender_id
 		LEFT JOIN conversations c ON c.id = m.conversation_id
-		WHERE fts.messages_fts MATCH ?
-		  AND %s
-		  AND %s
+		WHERE %s
 		ORDER BY m.sent_at DESC
 		LIMIT ? OFFSET ?
-	`, textMsgTypeFilter(), store.LiveMessagesWhere("m", true))
+	`, strings.Join(conditions, " AND "))
 
-	rows, err := e.db.QueryContext(ctx, sqlQuery, match, limit, offset)
+	rows, err := e.db.QueryContext(ctx, sqlQuery, append(args, limit, offset)...)
 	if err != nil {
 		return nil, fmt.Errorf("text search: %w", err)
 	}

--- a/internal/query/text_engine.go
+++ b/internal/query/text_engine.go
@@ -20,7 +20,8 @@ type TextEngine interface {
 		filter TextFilter) ([]MessageSummary, error)
 
 	// TextSearch performs plain full-text search over text messages.
-	TextSearch(ctx context.Context, query string,
+	// A nil sourceID searches all Text accounts.
+	TextSearch(ctx context.Context, query string, sourceID *int64,
 		limit, offset int) ([]MessageSummary, error)
 
 	// GetTextStats returns aggregate stats for text messages.

--- a/internal/query/text_search_live_test.go
+++ b/internal/query/text_search_live_test.go
@@ -79,7 +79,7 @@ func TestSQLiteEngine_TextSearch_ExcludesDedupHidden(t *testing.T) {
 	ctx := context.Background()
 
 	// Confirm the message appears before deletion.
-	results, err := engine.TextSearch(ctx, "hello", 10, 0)
+	results, err := engine.TextSearch(ctx, "hello", nil, 10, 0)
 	require.NoError(err, "TextSearch before delete")
 	require.Len(results, 1, "want 1 result before delete")
 
@@ -87,7 +87,7 @@ func TestSQLiteEngine_TextSearch_ExcludesDedupHidden(t *testing.T) {
 	_, err = db.Exec(`UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`, msgID)
 	require.NoError(err, "set deleted_at")
 
-	results, err = engine.TextSearch(ctx, "hello", 10, 0)
+	results, err = engine.TextSearch(ctx, "hello", nil, 10, 0)
 	require.NoError(err, "TextSearch after dedup delete")
 	assert.Empty(t, results, "want 0 results after dedup delete")
 }
@@ -101,7 +101,7 @@ func TestSQLiteEngine_TextSearch_ExcludesSourceDeleted(t *testing.T) {
 	_, err := db.Exec(`UPDATE messages SET deleted_from_source_at = CURRENT_TIMESTAMP WHERE id = ?`, msgID)
 	require.NoError(t, err, "set deleted_from_source_at")
 
-	results, err := engine.TextSearch(ctx, "hello", 10, 0)
+	results, err := engine.TextSearch(ctx, "hello", nil, 10, 0)
 	require.NoError(t, err, "TextSearch after source delete")
 	assert.Empty(t, results, "want 0 results after source delete")
 }
@@ -150,7 +150,7 @@ func TestTextSearch_SanitizesFTSInput(t *testing.T) {
 
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
-					results, err := engine.TextSearch(ctx, tc.query, 10, 0)
+					results, err := engine.TextSearch(ctx, tc.query, nil, 10, 0)
 					require.NoError(t, err,
 						"TextSearch(%q) must not error", tc.query)
 					if tc.wantMatch {
@@ -177,7 +177,7 @@ func TestTextModeIncludesTeamsAndMMSAndExcludesSynctechCalls(t *testing.T) {
 	insertTextSearchMessage(t, db, 4, "teams", "teams body")
 	insertTextSearchMessage(t, db, 5, "synctech_sms_call", "missed call body")
 
-	results, err := engine.TextSearch(ctx, "body", 10, 0)
+	results, err := engine.TextSearch(ctx, "body", nil, 10, 0)
 	require.NoError(t, err, "TextSearch")
 	var types []string
 	for _, r := range results {
@@ -201,4 +201,46 @@ func insertTextSearchMessage(t *testing.T, db *sql.DB, id int64, messageType, bo
 	require.NoError(t, err, "insert %s message", messageType)
 	_, err = db.Exec(`INSERT INTO messages_fts (rowid, subject, body) VALUES (?, ?, ?)`, id, body, body)
 	require.NoError(t, err, "insert %s fts", messageType)
+}
+
+func TestTextSearchScopesBeforePagination(t *testing.T) {
+	db, _ := openTextSearchDB(t)
+	insertTextSearchMessage(t, db, 2, "imessage", "hello second")
+	_, err := db.Exec(`
+		INSERT INTO sources (id, identifier) VALUES (2, 'second@example.com');
+		UPDATE messages SET sent_at = '2026-01-01 10:00:00' WHERE id = 1;
+		UPDATE messages SET source_id = 2, sent_at = '2026-01-01 11:00:00' WHERE id = 2;
+	`)
+	require.NoError(t, err)
+
+	for name, engine := range map[string]TextEngine{
+		"sqlite": NewSQLiteEngine(db),
+		"duckdb": &DuckDBEngine{sqliteDB: db},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, tc := range []struct {
+				name     string
+				sourceID *int64
+				offset   int
+				wantIDs  []int64
+			}{
+				{name: "first account", sourceID: new(int64(1)), wantIDs: []int64{1}},
+				{name: "second account", sourceID: new(int64(2)), wantIDs: []int64{2}},
+				{name: "all accounts", wantIDs: []int64{2}},
+				{name: "account offset", sourceID: new(int64(1)), offset: 1},
+				{name: "all accounts offset", offset: 1, wantIDs: []int64{1}},
+				{name: "missing account", sourceID: new(int64(3))},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					messages, err := engine.TextSearch(t.Context(), "hello", tc.sourceID, 1, tc.offset)
+					require.NoError(t, err)
+					var ids []int64
+					for _, message := range messages {
+						ids = append(ids, message.ID)
+					}
+					assert.Equal(t, tc.wantIDs, ids)
+				})
+			}
+		})
+	}
 }

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -35,6 +36,7 @@ type DeletionContext struct {
 	MessageSelection   map[int64]bool
 	AggregateViewType  query.ViewType
 	AccountFilter      *int64
+	SourceIDs          []int64
 	Accounts           []query.AccountInfo
 	TimeGranularity    query.TimeGranularity
 	Messages           []query.MessageSummary
@@ -245,10 +247,12 @@ func manifestMatchFilter(filter query.MessageFilter) allMatchesManifestFilter {
 
 // resolveGmailIDs converts selections (aggregate keys and message IDs) into Gmail IDs.
 func (c *ActionController) resolveDeletionTargets(ctx context.Context, dctx DeletionContext) ([]query.DeletionTarget, error) {
+	if dctx.SourceIDs != nil && len(dctx.SourceIDs) == 0 {
+		return []query.DeletionTarget{}, nil
+	}
 	if dctx.AllMatches {
 		return c.resolveAllMatchingDeletionTargets(ctx, dctx)
 	}
-
 	targetsByMessageID := make(map[int64]query.DeletionTarget)
 
 	// From selected aggregates - resolve to Gmail IDs via query engine
@@ -285,7 +289,7 @@ func (c *ActionController) resolveDeletionTargets(ctx context.Context, dctx Dele
 			accounts[account.ID] = account
 		}
 		for _, msg := range dctx.Messages {
-			if dctx.MessageSelection[msg.ID] {
+			if dctx.MessageSelection[msg.ID] && deletionSourceAllowed(msg.SourceID, dctx) {
 				account, ok := accounts[msg.SourceID]
 				if !ok {
 					return nil, fmt.Errorf("selected message %d has no source metadata", msg.ID)
@@ -365,6 +369,13 @@ func deletionSearchModeName(mode searchModeKind) string {
 	}
 }
 
+func deletionSourceAllowed(sourceID int64, dctx DeletionContext) bool {
+	if dctx.SourceIDs != nil {
+		return slices.Contains(dctx.SourceIDs, sourceID)
+	}
+	return dctx.AccountFilter == nil || sourceID == *dctx.AccountFilter
+}
+
 // buildFilterForAggregate constructs a MessageFilter for a single aggregate key.
 func (c *ActionController) buildFilterForAggregate(key string, dctx DeletionContext) query.MessageFilter {
 	var filter query.MessageFilter
@@ -378,7 +389,11 @@ func (c *ActionController) buildFilterForAggregate(key string, dctx DeletionCont
 	}
 	filter.WithAttachmentsOnly = filter.WithAttachmentsOnly || dctx.MatchFilter.WithAttachmentsOnly
 	filter.HideDeletedFromSource = filter.HideDeletedFromSource || dctx.MatchFilter.HideDeletedFromSource
-	if dctx.AccountFilter != nil {
+	filter.SourceID = nil
+	filter.SourceIDs = nil
+	if dctx.SourceIDs != nil {
+		filter.SourceIDs = append(make([]int64, 0, len(dctx.SourceIDs)), dctx.SourceIDs...)
+	} else if dctx.AccountFilter != nil {
 		filter.SourceID = dctx.AccountFilter
 	}
 	// TUI deletion is an email/Gmail workflow. Keep aggregate resolution
@@ -467,6 +482,13 @@ func (c *ActionController) applyManifestFilters(m *deletion.Manifest, ctx Deleti
 		}
 	} else if len(ctx.Accounts) == 1 {
 		m.Filters.Account = ctx.Accounts[0].Identifier
+	} else if len(ctx.SourceIDs) == 1 {
+		for _, acc := range ctx.Accounts {
+			if acc.ID == ctx.SourceIDs[0] {
+				m.Filters.Account = acc.Identifier
+				break
+			}
+		}
 	}
 
 	if ctx.AllMatches {

--- a/internal/tui/actions_test.go
+++ b/internal/tui/actions_test.go
@@ -216,6 +216,27 @@ func TestStageForDeletion_FromMessageSelection(t *testing.T) {
 	assert.ElementsMatch(t, []string{"gid_a", "gid_c"}, manifest.GmailIDs)
 }
 
+func TestStageForDeletion_MessageSelectionRespectsSourceScope(t *testing.T) {
+	env := newTestEnv(t)
+	accounts := []query.AccountInfo{
+		{ID: 1, SourceType: "gmail", Identifier: "one@example.invalid"},
+		{ID: 2, SourceType: "gmail", Identifier: "two@example.invalid"},
+	}
+	messages := []query.MessageSummary{
+		{ID: 10, SourceID: 1, SourceMessageID: "in-scope"},
+		{ID: 20, SourceID: 2, SourceMessageID: "out-of-scope"},
+	}
+
+	manifest, err := env.Ctrl.StageForDeletion(DeletionContext{
+		MessageSelection: map[int64]bool{10: true, 20: true},
+		SourceIDs:        []int64{1},
+		Accounts:         accounts,
+		Messages:         messages,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"in-scope"}, manifest.GmailIDs)
+}
+
 func TestStageForDeletion_NoSelection(t *testing.T) {
 	env := newTestEnv(t)
 

--- a/internal/tui/collection_scope_test.go
+++ b/internal/tui/collection_scope_test.go
@@ -1,0 +1,796 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/daemonclient"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/query/querytest"
+	"go.kenn.io/msgvault/internal/testutil/dbtest"
+)
+
+type reproductionCollectionScopeLister struct {
+	scopes []query.CollectionScope
+}
+
+func (l reproductionCollectionScopeLister) ListCollectionScopes(_ context.Context) ([]query.CollectionScope, error) {
+	return l.scopes, nil
+}
+
+func TestCollectionScopeSelectorReproduction(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	var captured query.MessageFilter
+	engine := newMockEngine(MockConfig{})
+	engine.ListMessagesFunc = func(_ context.Context, filter query.MessageFilter) ([]query.MessageSummary, error) {
+		captured = filter
+		return nil, nil
+	}
+
+	model := New(engine, Options{
+		DataDir: "/tmp/test",
+		Version: "test",
+		CollectionScopeLister: reproductionCollectionScopeLister{
+			scopes: []query.CollectionScope{{Name: "Work", SourceIDs: []int64{1, 2}}},
+		},
+	})
+	model.accounts = []query.AccountInfo{{ID: 1, Identifier: "alice@example.com"}, {ID: 2, Identifier: "bob@example.com"}}
+
+	scopesMsg, ok := model.loadCollectionScopes()().(collectionScopesLoadedMsg)
+	requirements.True(ok)
+	requirements.NoError(scopesMsg.err)
+	model = sendMsg(t, model, scopesMsg)
+	model.openAccountSelector()
+
+	modal := stripANSI(model.renderAccountSelectorModal())
+	assertions.Contains(modal, "Work")
+
+	model, _ = sendKey(t, model, keyDown())
+	model, _ = sendKey(t, model, keyDown())
+	model, _ = sendKey(t, model, keyDown())
+	model, cmd := sendKey(t, model, keyEnter())
+	assertions.NotNil(cmd)
+	assertions.Equal("Collection: Work", model.scopeTitle())
+
+	loaded, ok := model.loadMessages()().(messagesLoadedMsg)
+	requirements.True(ok)
+	requirements.NoError(loaded.err)
+	assertions.Equal([]int64{1, 2}, captured.SourceIDs)
+	assertions.Nil(captured.SourceID)
+}
+
+func TestCollectionScopeSourceFieldsPreserveKindsAndCopies(t *testing.T) {
+	assertions := assert.New(t)
+	accountID := int64(7)
+	collectionIDs := []int64{7, 8}
+	collection := query.CollectionScope{Name: "Work", SourceIDs: collectionIDs}
+
+	accountFilter := query.MessageFilter{SourceID: &accountID, SourceIDs: []int64{99}}
+	accountSourceScope(&accountID).apply(&accountFilter)
+	assertions.Equal(&accountID, accountFilter.SourceID)
+	assertions.Nil(accountFilter.SourceIDs)
+
+	collectionFilter := query.MessageFilter{SourceID: &accountID}
+	collectionSourceScope(collection).apply(&collectionFilter)
+	assertions.Nil(collectionFilter.SourceID)
+	assertions.Equal([]int64{7, 8}, collectionFilter.SourceIDs)
+	collectionIDs[0] = 99
+	assertions.Equal([]int64{7, 8}, collectionFilter.SourceIDs)
+
+	empty := collectionSourceScope(query.CollectionScope{Name: "Empty", SourceIDs: []int64{}})
+	emptyFilter := query.MessageFilter{SourceID: &accountID}
+	empty.apply(&emptyFilter)
+	assertions.NotNil(emptyFilter.SourceIDs)
+	assertions.Empty(emptyFilter.SourceIDs)
+}
+
+func TestEmptyCollectionReadsMatchNothing(t *testing.T) {
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	tdb.SeedStandardDataSet()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "empty collection issued an HTTP request", "%s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+	remote, err := daemonclient.NewEngine(daemonclient.Config{URL: server.URL, AllowInsecure: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, remote.Close()) })
+
+	for name, engine := range map[string]query.Engine{
+		"sqlite": query.NewSQLiteEngine(tdb.DB),
+		"daemon": remote,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			model := New(engine, Options{DataDir: t.TempDir(), Version: "test"})
+			model.sourceScope = collectionSourceScope(query.CollectionScope{Name: "Empty", SourceIDs: []int64{}})
+
+			data, ok := model.loadData()().(dataLoadedMsg)
+			requirements.True(ok)
+			requirements.NoError(data.err)
+			assertions.Empty(data.rows)
+			stats, ok := model.loadStats()().(statsLoadedMsg)
+			requirements.True(ok)
+			requirements.NoError(stats.err)
+			assertions.Equal(&query.TotalStats{}, stats.stats)
+			messages, ok := model.loadMessages()().(messagesLoadedMsg)
+			requirements.True(ok)
+			requirements.NoError(messages.err)
+			assertions.Empty(messages.messages)
+			results, ok := model.loadSearch("needle")().(searchResultsMsg)
+			requirements.True(ok)
+			requirements.NoError(results.err)
+			assertions.Empty(results.messages)
+			thread, ok := model.loadThreadMessages(1)().(threadMessagesLoadedMsg)
+			requirements.True(ok)
+			requirements.NoError(thread.err)
+			assertions.Empty(thread.messages)
+		})
+	}
+}
+
+func TestCollectionScopeStatsRejectStaleResponses(t *testing.T) {
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.stats = &query.TotalStats{MessageCount: 1}
+	model.statsRequestID = 10
+	model.presentationGeneration = 20
+	model.invalidateSourceScope()
+
+	stale := statsLoadedMsg{
+		stats:                  &query.TotalStats{MessageCount: 99},
+		requestID:              10,
+		presentationGeneration: 20,
+	}
+	updated, _ := model.handleStatsLoaded(stale)
+	got := asModel(t, updated)
+	assert.Nil(t, got.stats)
+
+	current := statsLoadedMsg{
+		stats:                  &query.TotalStats{MessageCount: 2},
+		requestID:              got.statsRequestID,
+		presentationGeneration: got.presentationGeneration,
+	}
+	updated, _ = got.handleStatsLoaded(current)
+	assert.Equal(t, int64(2), asModel(t, updated).stats.MessageCount)
+}
+
+func TestStatsResponseSurvivesAggregateOnlyRefresh(t *testing.T) {
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.statsRequestID = 7
+	model.aggregateRequestID = 10
+	model.presentationGeneration = 20
+	updated, _ := model.handleAggregateKeys(key('s'))
+	model = asModel(t, updated)
+
+	updated, _ = model.handleStatsLoaded(statsLoadedMsg{
+		stats:                  &query.TotalStats{MessageCount: 3},
+		requestID:              7,
+		presentationGeneration: 20,
+	})
+	got := asModel(t, updated)
+	require.NotNil(t, got.stats)
+	assert.Equal(t, int64(3), got.stats.MessageCount)
+}
+
+func TestStatsSchedulersReplaceOldTotals(t *testing.T) {
+	tests := []struct {
+		name  string
+		model func(t *testing.T) Model
+		key   tea.KeyPressMsg
+		call  func(Model, tea.KeyPressMsg) (tea.Model, tea.Cmd)
+	}{
+		{
+			name: "mode switch",
+			model: func(t *testing.T) Model {
+				t.Helper()
+				model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+				model.mode = modePeople
+				return model
+			},
+			key: key('m'),
+			call: func(model Model, key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+				updated, cmd, _ := model.handleGlobalKeys(key)
+				return updated, cmd
+			},
+		},
+		{
+			name: "account selector",
+			model: func(t *testing.T) Model {
+				t.Helper()
+				model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+				model.accounts = []query.AccountInfo{{ID: 1, Identifier: "alice@example.invalid"}}
+				model.openAccountSelector()
+				model.modalCursor = 1
+				return model
+			},
+			key: keyEnter(),
+			call: func(model Model, key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+				return model.handleAccountSelectorKeys(key)
+			},
+		},
+		{
+			name: "aggregate filter",
+			model: func(t *testing.T) Model {
+				t.Helper()
+				model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+				model.modal = modalFilterToggle
+				return model
+			},
+			key: keyEnter(),
+			call: func(model Model, key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+				return model.handleFilterToggleKeys(key)
+			},
+		},
+		{
+			name: "message list filter",
+			model: func(t *testing.T) Model {
+				t.Helper()
+				model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+				model.level = levelMessageList
+				model.modal = modalFilterToggle
+				return model
+			},
+			key: keyEnter(),
+			call: func(model Model, key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+				return model.handleFilterToggleKeys(key)
+			},
+		},
+		{
+			name: "message list search filter",
+			model: func(t *testing.T) Model {
+				t.Helper()
+				model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+				model.level = levelMessageList
+				model.modal = modalFilterToggle
+				model.searchQuery = "needle"
+				return model
+			},
+			key: keyEnter(),
+			call: func(model Model, key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+				return model.handleFilterToggleKeys(key)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			requirements := require.New(t)
+			model := tt.model(t)
+			old, ok := model.loadStats()().(statsLoadedMsg)
+			requirements.True(ok)
+			old.stats = &query.TotalStats{MessageCount: 99}
+			updated, cmd := tt.call(model, tt.key)
+			got := asModel(t, updated)
+			currentStats := got.stats
+			got = sendMsg(t, got, old)
+			assertions.Equal(currentStats, got.stats)
+			var delivered bool
+			for _, msg := range runBatchCommand(t, cmd) {
+				if stats, ok := msg.(statsLoadedMsg); ok {
+					requirements.NoError(stats.err)
+					got = sendMsg(t, got, stats)
+					assertions.Equal(stats.stats, got.stats)
+					delivered = true
+				}
+			}
+			assertions.True(delivered, "scheduled fresh totals")
+		})
+	}
+}
+
+func TestFilterToggleSupersedesInFlightStatsResponse(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.level = levelMessageList
+	model.modal = modalFilterToggle
+	model.statsRequestID = 7
+	model.presentationGeneration = 20
+	model.stats = &query.TotalStats{MessageCount: 1}
+
+	updated, cmd := model.handleFilterToggleKeys(keyEnter())
+	got := asModel(t, updated)
+	assertions.NotNil(cmd)
+
+	updated, _ = got.handleStatsLoaded(statsLoadedMsg{
+		stats:                  &query.TotalStats{MessageCount: 99},
+		requestID:              7,
+		presentationGeneration: got.presentationGeneration,
+	})
+	got = asModel(t, updated)
+	requirements.NotNil(got.stats)
+	assertions.Equal(int64(1), got.stats.MessageCount)
+}
+
+func TestCollectionScopeInvalidationClearsNavigationAndReaders(t *testing.T) {
+	assertions := assert.New(t)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.level = levelMessageDetail
+	model.breadcrumbs = []navigationSnapshot{{state: viewState{level: levelAggregates}}}
+	model.messageDetail = &query.MessageDetail{ID: 7}
+	model.threadConversationID = 12
+	model.threadMessages = []query.MessageSummary{{ID: 7}}
+	model.parkedMessageReaders[modeEmail].messageDetail = &query.MessageDetail{ID: 8}
+
+	model.invalidateSourceScope()
+
+	assertions.Equal(levelAggregates, model.level)
+	assertions.Empty(model.breadcrumbs)
+	assertions.Nil(model.messageDetail)
+	assertions.Empty(model.threadMessages)
+	assertions.Zero(model.threadConversationID)
+	assertions.Nil(model.parkedMessageReaders[modeEmail].messageDetail)
+	_, cmd := model.goBack()
+	assertions.Nil(cmd)
+}
+
+func TestTextAccountSelectionPreservesEmailScope(t *testing.T) {
+	accountID := int64(7)
+	for name, scope := range map[string]sourceScope{
+		"all":        allSourceScope(),
+		"account":    accountSourceScope(&accountID),
+		"collection": collectionSourceScope(query.CollectionScope{Name: "Work", SourceIDs: []int64{7, 8}}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+			model.sourceScope = scope
+			model.level = levelMessageList
+			model.drillFilter = query.MessageFilter{Sender: "sender@example.com"}
+			before := model.buildMessageFilter()
+			model.mode = modeTexts
+			model.textState.sourceID = &accountID
+			model.openAccountSelector()
+			model.modalCursor = 0
+
+			model, _ = sendKey(t, model, keyEnter())
+			assert.Nil(t, model.textState.sourceID)
+			model.mode = modeEmail
+			assert.Equal(t, before, model.buildMessageFilter())
+			assert.Equal(t, levelMessageList, model.level)
+		})
+	}
+}
+
+func TestEmailScopeSelectionPreservesTextAccount(t *testing.T) {
+	textID := int64(7)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{{ID: 8, Identifier: "email@example.com"}}
+	model.collectionScopes = []query.CollectionScope{{Name: "Work", SourceIDs: []int64{8, 9}}}
+	model.textState.sourceID = &textID
+	for _, choice := range []int{1, 2, 0} {
+		model.openAccountSelector()
+		model.modalCursor = choice
+		model, _ = sendKey(t, model, keyEnter())
+		assert.Equal(t, &textID, model.textState.sourceID)
+	}
+}
+
+func TestTextDetailAccountSelectionLeavesNoIndefiniteLoading(t *testing.T) {
+	firstID := int64(1)
+	secondID := int64(2)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelDetail
+	model.textState.selectedMessageID = 0
+	model.messageDetail = nil
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, cmd := sendKey(t, model, keyEnter())
+
+	assert.Nil(t, cmd)
+	assert.False(t, got.loading)
+}
+
+func TestTextDetailAccountSelectionReloadsMissingDetail(t *testing.T) {
+	assertions := assert.New(t)
+	firstID := int64(1)
+	secondID := int64(2)
+	engine := newMockEngine(MockConfig{})
+	engine.GetMessageFunc = func(_ context.Context, id int64) (*query.MessageDetail, error) {
+		return &query.MessageDetail{ID: id, ConversationID: 7}, nil
+	}
+	model := New(engine, Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelDetail
+	model.textState.selectedConvID = 7
+	model.textState.selectedMessageID = 42
+	model.messageDetail = nil
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, cmd := sendKey(t, model, keyEnter())
+
+	assertions.NotNil(cmd)
+	assertions.True(got.loading)
+	got = deliverTextCommand(t, got, cmd)
+	assertions.Equal(int64(42), got.messageDetail.ID)
+	assertions.False(got.loading)
+}
+
+func TestTextDetailAccountSelectionPreservesLoadedDetail(t *testing.T) {
+	assertions := assert.New(t)
+	firstID := int64(1)
+	secondID := int64(2)
+	detail := &query.MessageDetail{ID: 42, ConversationID: 7}
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelDetail
+	model.textState.selectedConvID = 7
+	model.textState.selectedMessageID = detail.ID
+	model.messageDetail = detail
+	model.textRequestID = 10
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, cmd := sendKey(t, model, keyEnter())
+
+	assertions.Nil(cmd)
+	assertions.False(got.loading)
+	assertions.Same(detail, got.messageDetail)
+}
+
+func TestStaleTextDetailCompletionRejectedAfterAccountChange(t *testing.T) {
+	assertions := assert.New(t)
+	firstID := int64(1)
+	secondID := int64(2)
+	oldDetail := &query.MessageDetail{ID: 42, ConversationID: 7}
+	oldErr := errors.New("old detail error")
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelDetail
+	model.textState.selectedConvID = 7
+	model.textState.selectedMessageID = oldDetail.ID
+	model.messageDetail = oldDetail
+	model.err = oldErr
+	model.textRequestID = 10
+	model.presentationGeneration = 20
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, _ := sendKey(t, model, keyEnter())
+	updated, _ := got.handleTextMessageLoaded(textMessageLoadedMsg{
+		detail:                 &query.MessageDetail{ID: 42, ConversationID: 7},
+		requestID:              10,
+		conversationID:         7,
+		messageID:              42,
+		presentationGeneration: 20,
+	})
+	got = asModel(t, updated)
+
+	assertions.Same(oldDetail, got.messageDetail)
+	require.ErrorIs(t, got.err, oldErr)
+}
+
+func TestTextAccountSelectionSurvivesBackNavigation(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	_, err := tdb.DB.Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES
+			(7, 'imessage', 'first@example.com'), (8, 'imessage', 'second@example.com');
+		INSERT INTO participants (id, phone_number, display_name) VALUES
+			(11, '+15550000011', 'Alice'), (12, '+15550000012', 'Bob');
+		INSERT INTO conversations (id, source_id, source_conversation_id, conversation_type, title) VALUES
+			(701, 7, 'chat-701', 'direct_chat', 'First'),
+			(702, 8, 'chat-702', 'direct_chat', 'Second');
+		INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at, snippet, sender_id) VALUES
+			(801, 701, 7, 'message-801', 'imessage', '2026-01-01 10:00:00', 'first', 11),
+			(802, 702, 8, 'message-802', 'imessage', '2026-01-01 11:00:00', 'second', 12);
+		INSERT INTO conversation_participants (conversation_id, participant_id) VALUES (701, 11), (702, 12);
+	`)
+	requirements.NoError(err)
+	model := New(query.NewSQLiteEngine(tdb.DB), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: 7, Identifier: "first@example.com"}, {ID: 8, Identifier: "second@example.com"},
+	}
+	model.mode = modeTexts
+	model.textState.sourceID = new(int64(7))
+	model = sendMsg(t, model, model.loadTextConversations()())
+	requirements.Len(model.textState.conversations, 1)
+	assertions.Equal(int64(701), model.textState.conversations[0].ConversationID)
+
+	// Enter a conversation, change account, then return through its breadcrumb.
+	model, _ = sendKey(t, model, keyEnter())
+	model.openAccountSelector()
+	model.modalCursor = 2
+	model, _ = sendKey(t, model, keyEnter())
+	updated, cmd := model.textGoBack()
+	model = asModel(t, updated)
+	requirements.NotNil(cmd)
+	model = sendMsg(t, model, cmd())
+
+	requirements.NoError(model.err)
+	requirements.Len(model.textState.conversations, 1)
+	assertions.Equal(int64(702), model.textState.conversations[0].ConversationID)
+	requirements.NotNil(model.textState.stats)
+	assertions.Equal(int64(1), model.textState.stats.MessageCount)
+	assertions.Equal("second@example.com", model.scopeTitle())
+}
+
+func TestTextGlobalSearchTimelinePreservedOnAccountSelection(t *testing.T) {
+	assertions := assert.New(t)
+	firstID := int64(1)
+	secondID := int64(2)
+	messages := []query.MessageSummary{{ID: 42}}
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelTimeline
+	model.textState.globalSearchTimeline = true
+	model.textState.messages = messages
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, cmd := sendKey(t, model, keyEnter())
+
+	assertions.Nil(cmd)
+	assertions.False(got.loading)
+	assertions.True(got.textState.globalSearchTimeline)
+	assertions.Equal(messages, got.textState.messages)
+}
+
+func TestTextModeSwitchActivationUnchangedByExtraction(t *testing.T) {
+	tests := []struct {
+		name           string
+		level          textViewLevel
+		selectedID     int64
+		detail         *query.MessageDetail
+		globalTimeline bool
+		wantCmd        bool
+		wantLoading    bool
+	}{
+		{name: "loaded detail", level: textLevelDetail, selectedID: 42, detail: &query.MessageDetail{ID: 42}, wantCmd: false, wantLoading: false},
+		{name: "missing detail", level: textLevelDetail, selectedID: 42, wantCmd: true, wantLoading: true},
+		{name: "global timeline", level: textLevelTimeline, globalTimeline: true, wantCmd: false, wantLoading: false},
+		{name: "aggregate", level: textLevelAggregate, wantCmd: true, wantLoading: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := assert.New(t)
+			engine := newMockEngine(MockConfig{})
+			engine.GetMessageFunc = func(_ context.Context, id int64) (*query.MessageDetail, error) {
+				return &query.MessageDetail{ID: id}, nil
+			}
+			model := New(engine, Options{DataDir: t.TempDir(), Version: "test", TextEngine: meetingModeTextEngine{}})
+			model.mode = modeEmail
+			model.textState.level = tt.level
+			model.textState.selectedConvID = 7
+			model.textState.selectedMessageID = tt.selectedID
+			model.textState.globalSearchTimeline = tt.globalTimeline
+			model.parkedMessageReaders[modeTexts].messageDetail = tt.detail
+
+			got, cmd, handled := model.handleGlobalKeys(key('m'))
+
+			assertions.True(handled)
+			assertions.Equal(modeTexts, got.mode)
+			assertions.Equal(tt.wantCmd, cmd != nil)
+			assertions.Equal(tt.wantLoading, got.loading)
+		})
+	}
+}
+
+func TestTextDetailReloadErrorSettlesLoading(t *testing.T) {
+	firstID := int64(1)
+	secondID := int64(2)
+	engine := newMockEngine(MockConfig{})
+	engine.GetMessageFunc = func(_ context.Context, _ int64) (*query.MessageDetail, error) {
+		return nil, errors.New("detail unavailable")
+	}
+	model := New(engine, Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeTexts
+	model.textState.level = textLevelDetail
+	model.textState.selectedConvID = 7
+	model.textState.selectedMessageID = 42
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	got, cmd := sendKey(t, model, keyEnter())
+	got = deliverTextCommand(t, got, cmd)
+
+	assert.False(t, got.loading)
+	assert.Equal(t, modalError, got.modal)
+	assert.NotEmpty(t, got.modalResult)
+}
+
+func TestTextActivationSpinnerIsIdempotent(t *testing.T) {
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.mode = modeTexts
+	model.textState.level = textLevelConversations
+	model.spinnerActive = true
+
+	cmd := model.activateTextPresentation()
+
+	assert.NotNil(t, cmd)
+	assert.True(t, model.spinnerActive)
+}
+
+func deliverTextCommand(t *testing.T, model Model, cmd tea.Cmd) Model {
+	t.Helper()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, child := range batch {
+			childMsg := child()
+			if _, ok := childMsg.(textMessageLoadedMsg); ok {
+				model = sendMsg(t, model, childMsg)
+			}
+		}
+		return model
+	}
+	return sendMsg(t, model, msg)
+}
+
+func TestStageForDeletionUsesEmailScopeAuthority(t *testing.T) {
+	accountID := int64(7)
+	var captured query.MessageFilter
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			captured = filter
+			return []query.DeletionTarget{{
+				MessageID: 1, SourceID: accountID, SourceType: "gmail",
+				SourceIdentifier: "account@example.invalid", SourceMessageID: "gm-1",
+			}}, nil
+		},
+	}
+	model := New(engine, Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{{ID: accountID, SourceType: "gmail", Identifier: "account@example.invalid"}}
+	model.sourceScope = accountSourceScope(&accountID)
+	model.selection.aggregateKeys["sender@example.invalid"] = true
+	model.selection.aggregateViewType = query.ViewSenders
+
+	updated, _ := model.stageForDeletion()
+	got := asModel(t, updated)
+
+	assert.Equal(t, &accountID, captured.SourceID)
+	assert.Nil(t, captured.SourceIDs)
+	assert.Equal(t, modalDeleteConfirm, got.modal)
+}
+
+func TestTextAccountSelectionPreservesParkedEmailReader(t *testing.T) {
+	assertions := assert.New(t)
+	firstID := int64(1)
+	secondID := int64(2)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{
+		{ID: firstID, Identifier: "first@example.invalid"},
+		{ID: secondID, Identifier: "second@example.invalid"},
+	}
+	model.mode = modeEmail
+	model.messageDetail = &query.MessageDetail{ID: 1}
+	model.switchMessageReaderState(modeTexts)
+	model.mode = modeTexts
+	model.messageDetail = &query.MessageDetail{ID: 2}
+	model.textState.sourceID = &firstID
+	model.sourceScope = accountSourceScope(&firstID)
+	model.modal = modalAccountSelector
+	model.modalCursor = 2
+
+	model, _ = sendKey(t, model, keyEnter())
+
+	require.NotNil(t, model.parkedMessageReaders[modeEmail].messageDetail)
+	assertions.Equal(int64(1), model.parkedMessageReaders[modeEmail].messageDetail.ID)
+	assertions.Equal(int64(2), model.messageDetail.ID)
+	assertions.Equal(firstID, *model.sourceScope.accountID)
+}
+
+func TestCollectionRowsStayEmailOnly(t *testing.T) {
+	assertions := assert.New(t)
+	model := New(newMockEngine(MockConfig{}), Options{
+		DataDir: "/tmp/test",
+		Version: "test",
+		CollectionScopeLister: reproductionCollectionScopeLister{
+			scopes: []query.CollectionScope{{Name: "Work", SourceIDs: []int64{1}}},
+		},
+	})
+	model.accounts = []query.AccountInfo{{ID: 1, SourceType: meetingSourceImported, Identifier: "alice@example.com"}}
+	model.collectionScopes = []query.CollectionScope{{Name: "Work", SourceIDs: []int64{1}}}
+
+	model.mode = modeTexts
+	assertions.Len(model.selectorOptions(), 2)
+	model.mode = modeMeetings
+	assertions.Len(model.selectorOptions(), 2)
+	model.mode = modeEmail
+	assertions.Len(model.selectorOptions(), 3)
+	model.sourceScope = collectionSourceScope(query.CollectionScope{Name: "Work", SourceIDs: []int64{1}})
+	model.mode = modeTexts
+	assertions.Equal("All Accounts", model.scopeTitle())
+}
+
+func TestCollectionScopeSelectionFencesPendingResponses(t *testing.T) {
+	assertions := assert.New(t)
+	model := New(newMockEngine(MockConfig{}), Options{DataDir: t.TempDir(), Version: "test"})
+	model.accounts = []query.AccountInfo{{ID: 1, Identifier: "alice@example.com"}}
+	model.collectionScopes = []query.CollectionScope{{Name: "Work", SourceIDs: []int64{1}}}
+	model.openAccountSelector()
+	model.aggregateRequestID = 10
+	model.loadRequestID = 20
+	model.detailRequestID = 30
+	model.searchRequestID = 40
+	model.presentationGeneration = 50
+	oldAggregateRequestID := model.aggregateRequestID
+	oldPresentationGeneration := model.presentationGeneration
+
+	model.modalCursor = 2
+	updated, cmd := sendKey(t, model, keyEnter())
+	assertions.NotNil(cmd)
+
+	stale := dataLoadedMsg{
+		rows:                   []query.AggregateRow{{Key: "old", Count: 1}},
+		requestID:              oldAggregateRequestID,
+		presentationGeneration: oldPresentationGeneration,
+	}
+	updated = sendMsg(t, updated, stale)
+	assertions.Empty(updated.rows)
+}
+
+func TestCollectionDeletionRetainsExactSourcesAndRejectsMultipleSources(t *testing.T) {
+	var captured query.MessageFilter
+	engine := &querytest.MockEngine{
+		GetDeletionTargetsByFilterFunc: func(_ context.Context, filter query.MessageFilter) ([]query.DeletionTarget, error) {
+			captured = filter
+			return []query.DeletionTarget{
+				{MessageID: 1, SourceID: 1, SourceType: "gmail", SourceIdentifier: "one@example.invalid", SourceMessageID: "gm-1"},
+				{MessageID: 2, SourceID: 2, SourceType: "gmail", SourceIdentifier: "two@example.invalid", SourceMessageID: "gm-2"},
+			}, nil
+		},
+	}
+	controller := NewActionController(engine, t.TempDir(), nil)
+	_, err := controller.StageForDeletion(DeletionContext{
+		AggregateSelection: map[string]bool{"example.invalid": true},
+		AggregateViewType:  query.ViewDomains,
+		SourceIDs:          []int64{1, 2},
+		Accounts: []query.AccountInfo{
+			{ID: 1, Identifier: "one@example.invalid"},
+			{ID: 2, Identifier: "two@example.invalid"},
+		},
+	})
+	require.ErrorContains(t, err, "press 'a' to filter by account")
+	assert.Equal(t, []int64{1, 2}, captured.SourceIDs)
+	assert.Nil(t, captured.SourceID)
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -166,7 +166,7 @@ func (m *Model) invalidateInlineSearchRequests() {
 
 func (m Model) currentSearchFilter() query.MessageFilter {
 	filter := m.drillFilter
-	filter.SourceID = m.accountFilter
+	m.sourceScope.apply(&filter)
 	filter.WithAttachmentsOnly = m.filters.attachmentsOnly
 	filter.HideDeletedFromSource = m.filters.hideDeletedFromSource
 	return filter
@@ -178,7 +178,8 @@ func (m Model) semanticSearchAvailable() bool {
 }
 
 func (m Model) deepSearchAvailable() bool {
-	return true
+	filter := m.currentSearchFilter()
+	return filter.SourceIDs == nil || len(filter.SourceIDs) == 1
 }
 
 func (m *Model) syncSearchScope() {
@@ -251,22 +252,7 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		m.searchLoadingMore = false
 		switch m.mode {
 		case modeTexts:
-			m.textState.filter.SourceID = m.accountFilter
-			var loadCmd tea.Cmd
-			if m.textState.level == textLevelDetail {
-				if m.messageDetail == nil && m.textState.selectedMessageID > 0 {
-					loadCmd = m.loadTextMessage(m.textState.selectedMessageID)
-				}
-			} else if m.textState.level != textLevelTimeline || !m.textState.globalSearchTimeline {
-				loadCmd = m.loadTextData()
-			}
-			if loadCmd == nil {
-				m.loading = false
-				return m, nil, true
-			}
-			m.loading = true
-			spinCmd := m.startSpinner()
-			return m, tea.Batch(spinCmd, loadCmd), true
+			return m, m.activateTextPresentation(), true
 		case modeMeetings:
 			m.meetingState.listLoading = false
 			m.meetingState.searchLoading = false
@@ -359,11 +345,22 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		default:
 			m.loading = true
 			m.aggregateRequestID++
+			statsCmd := m.refreshStats()
 			spinCmd := m.startSpinner()
-			return m, tea.Batch(spinCmd, m.loadData(), m.loadStats()), true
+			return m, tea.Batch(spinCmd, m.loadData(), statsCmd), true
 		}
 	}
 	return m, nil, false
+}
+
+func (m *Model) activateTextPresentation() tea.Cmd {
+	loadCmd := m.textPresentationLoadCmd()
+	if loadCmd == nil {
+		m.loading = false
+		return nil
+	}
+	m.loading = true
+	return tea.Batch(m.startSpinner(), loadCmd)
 }
 
 // handleAggregateKeys handles keys in the aggregate and sub-aggregate views.
@@ -1248,8 +1245,8 @@ func (m Model) handleQuitConfirmKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleAccountSelectorKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	accounts := m.selectableAccounts()
-	maxIdx := len(accounts) // 0 = All Accounts/Sources, then selectable sources
+	options := m.selectorOptions()
+	maxIdx := len(options) - 1
 	switch msg.String() {
 	case "up", "k", keyNameCtrlP:
 		if m.modalCursor > 0 {
@@ -1261,15 +1258,30 @@ func (m Model) handleAccountSelectorKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 		}
 	case keyNameEnter:
 		// Apply selection with bounds check
-		var selectedID *int64
-		if m.modalCursor > 0 && m.modalCursor <= len(accounts) {
-			accID := accounts[m.modalCursor-1].ID
-			selectedID = &accID
+		if m.modalCursor < 0 || m.modalCursor > maxIdx {
+			m.modalCursor = 0
 		}
-		if m.mode == modeMeetings {
-			m.meetingState.sourceID = selectedID
-		} else {
-			m.accountFilter = selectedID
+		selected := options[m.modalCursor]
+		switch m.mode {
+		case modeMeetings:
+			m.meetingState.sourceID = selected.accountID
+		case modeTexts:
+			m.textState.sourceID = selected.accountID
+			m.nextTextRequestID()
+		case modeEmail:
+			previous := m.sourceScope
+			switch selected.kind {
+			case scopeOptionAll:
+				m.sourceScope = allSourceScope()
+			case scopeOptionAccount:
+				m.sourceScope = accountSourceScope(selected.accountID)
+			case scopeOptionCollection:
+				m.sourceScope = collectionSourceScope(selected.collection)
+			}
+			if !previous.matches(selected) {
+				m.invalidateSourceScope()
+			}
+		case modePeople, modeCount:
 		}
 		m.modal = modalNone
 		m.loading = true
@@ -1302,12 +1314,11 @@ func (m Model) handleAccountSelectorKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cm
 			return m, m.loadMeetingMessages()
 		}
 		if m.mode == modeTexts {
-			m.textState.filter.SourceID = m.accountFilter
-			cmd := m.loadTextData()
-			return m, cmd
+			return m, m.activateTextPresentation()
 		}
 		m.aggregateRequestID++
-		return m, tea.Batch(m.loadData(), m.loadStats())
+		statsCmd := m.refreshStats()
+		return m, tea.Batch(m.loadData(), statsCmd)
 	case keyNameEsc:
 		m.modal = modalNone
 	}
@@ -1358,13 +1369,16 @@ func (m Model) handleFilterToggleKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 				m.loadRequestID++ // Invalidate normal list loads before replacing ranked results.
 				m.searchRequestID++
 				m.prepareSearchReplacement()
-				return m, tea.Batch(m.loadSearch(m.searchQuery), m.loadStats())
+				statsCmd := m.refreshStats()
+				return m, tea.Batch(m.loadSearch(m.searchQuery), statsCmd)
 			}
 			m.loadRequestID++
-			return m, tea.Batch(m.loadMessages(), m.loadStats())
+			statsCmd := m.refreshStats()
+			return m, tea.Batch(m.loadMessages(), statsCmd)
 		}
 		m.aggregateRequestID++
-		return m, tea.Batch(m.loadData(), m.loadStats())
+		statsCmd := m.refreshStats()
+		return m, tea.Batch(m.loadData(), statsCmd)
 	}
 	return m, nil
 }
@@ -1556,11 +1570,11 @@ func (m Model) enterDrillDown(row query.AggregateRow) (tea.Model, tea.Cmd) {
 		// Top-level: create fresh drill filter
 		m.drillViewType = m.viewType
 		m.drillFilter = query.MessageFilter{
-			SourceID:              m.accountFilter,
 			WithAttachmentsOnly:   m.filters.attachmentsOnly,
 			HideDeletedFromSource: m.filters.hideDeletedFromSource,
 			TimeRange:             query.TimeRange{Granularity: m.timeGranularity},
 		}
+		m.sourceScope.apply(&m.drillFilter)
 	}
 
 	// Set filter field on drillFilter (accumulates for sub-agg)
@@ -1603,23 +1617,66 @@ func (m Model) enterDrillDown(row query.AggregateRow) (tea.Model, tea.Cmd) {
 func (m *Model) openAccountSelector() {
 	m.modal = modalAccountSelector
 	m.modalCursor = 0 // Default to "All Accounts" / "All Sources"
-	selectedID := m.accountFilter
-	if m.mode == modeMeetings {
-		selectedID = m.meetingState.sourceID
-	}
-	accounts := m.selectableAccounts()
-	if selectedID != nil {
-		for i, acc := range accounts {
-			if acc.ID == *selectedID {
-				m.modalCursor = i + 1 // +1 because 0 is "All Accounts"
+	options := m.selectorOptions()
+	for i, option := range options {
+		if m.mode == modeEmail {
+			if m.sourceScope.matches(option) {
+				m.modalCursor = i
+				break
+			}
+		} else if option.kind == scopeOptionAll && m.mode == modeMeetings && m.meetingState.sourceID == nil {
+			m.modalCursor = i
+		} else if option.kind == scopeOptionAll && m.mode == modeTexts && m.textState.sourceID == nil {
+			m.modalCursor = i
+		} else if option.accountID != nil {
+			selectedID := m.textState.sourceID
+			if m.mode == modeMeetings {
+				selectedID = m.meetingState.sourceID
+			}
+			if selectedID != nil && *selectedID == *option.accountID {
+				m.modalCursor = i
 				break
 			}
 		}
 	}
 	// Clamp to valid range in case accounts list changed
-	if m.modalCursor > len(accounts) {
+	if m.modalCursor >= len(options) {
 		m.modalCursor = 0
 	}
+}
+
+func (m *Model) invalidateSourceScope() {
+	m.deletionRequestID++
+	m.finishDeletionResolution()
+	m.aggregateRequestID++
+	m.statsRequestID++
+	m.loadRequestID++
+	m.detailRequestID++
+	m.searchRequestID++
+	m.presentationGeneration++
+	m.invalidatePreSearchSnapshot()
+	m.resetEmailNavigation()
+}
+
+// resetEmailNavigation returns Email to its root while retaining display preferences.
+func (m *Model) resetEmailNavigation() {
+	m.viewState = viewState{
+		viewType:         m.viewType,
+		timeGranularity:  m.timeGranularity,
+		sortField:        m.sortField,
+		sortDirection:    m.sortDirection,
+		msgSortField:     m.msgSortField,
+		msgSortDirection: m.msgSortDirection,
+	}
+	m.breadcrumbs = nil
+	m.selection = selectionState{
+		aggregateKeys:     make(map[string]bool),
+		aggregateViewType: m.viewType,
+		messageIDs:        make(map[int64]bool),
+	}
+	m.stats = nil
+	m.parkedMessageReaders[modeEmail] = messageReaderState{}
+	m.restorePosition = false
 }
 
 func (m *Model) openFilterModal() {

--- a/internal/tui/meeting_mode_test.go
+++ b/internal/tui/meeting_mode_test.go
@@ -155,7 +155,7 @@ func TestMeetingAccountSelectionDoesNotReplaceEmailFilter(t *testing.T) {
 		query.AccountInfo{ID: 2, SourceType: meetingSourceGranola, Identifier: "work-notes"},
 	).Build()
 	model.mode = modeMeetings
-	model.accountFilter = &emailID
+	model.sourceScope = accountSourceScope(&emailID)
 	model.modal = modalAccountSelector
 	model.modalCursor = 1
 
@@ -163,8 +163,8 @@ func TestMeetingAccountSelectionDoesNotReplaceEmailFilter(t *testing.T) {
 
 	require.NotNil(updatedModel.meetingState.sourceID)
 	assert.Equal(int64(2), *updatedModel.meetingState.sourceID)
-	require.NotNil(updatedModel.accountFilter)
-	assert.Equal(emailID, *updatedModel.accountFilter)
+	require.NotNil(updatedModel.sourceScope.accountID)
+	assert.Equal(emailID, *updatedModel.sourceScope.accountID)
 }
 
 func TestMeetingAccountSelectionRerunsActiveSearchForNewSource(t *testing.T) {

--- a/internal/tui/meeting_mode_test.go
+++ b/internal/tui/meeting_mode_test.go
@@ -39,7 +39,7 @@ func (meetingModeTextEngine) ListConversationMessages(
 }
 
 func (meetingModeTextEngine) TextSearch(
-	context.Context, string, int, int,
+	context.Context, string, *int64, int, int,
 ) ([]query.MessageSummary, error) {
 	return []query.MessageSummary{{ID: 99, Subject: "Old search result"}}, nil
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -84,6 +84,141 @@ type Options struct {
 	// SettingsBackend reads and writes the same daemon-owned settings catalog
 	// used by the Web UI. When nil, the Settings surface reports unavailable.
 	SettingsBackend SettingsBackend
+
+	// CollectionScopeLister optionally supplies named Email source scopes. The
+	// command root gates this capability on the daemon API schema version.
+	CollectionScopeLister query.CollectionScopeLister
+}
+
+type sourceScopeKind uint8
+
+const (
+	sourceScopeAll sourceScopeKind = iota
+	sourceScopeAccount
+	sourceScopeCollection
+)
+
+type sourceScope struct {
+	kind           sourceScopeKind
+	accountID      *int64
+	collectionName string
+	sourceIDs      []int64
+}
+
+type scopeOptionKind uint8
+
+const (
+	scopeOptionAll scopeOptionKind = iota
+	scopeOptionAccount
+	scopeOptionCollection
+)
+
+type scopeOption struct {
+	kind       scopeOptionKind
+	label      string
+	accountID  *int64
+	collection query.CollectionScope
+}
+
+func allSourceScope() sourceScope { return sourceScope{} }
+
+func accountSourceScope(id *int64) sourceScope {
+	if id == nil {
+		return allSourceScope()
+	}
+	idCopy := *id
+	return sourceScope{kind: sourceScopeAccount, accountID: &idCopy}
+}
+
+func collectionSourceScope(collection query.CollectionScope) sourceScope {
+	return sourceScope{
+		kind:           sourceScopeCollection,
+		collectionName: collection.Name,
+		sourceIDs:      copySourceIDs(collection.SourceIDs),
+	}
+}
+
+func (s sourceScope) title(accounts []query.AccountInfo) string {
+	if s.kind == sourceScopeCollection {
+		return "Collection: " + s.collectionName
+	}
+	if s.accountID == nil {
+		return "All Accounts"
+	}
+	for _, account := range accounts {
+		if account.ID == *s.accountID {
+			return account.Identifier
+		}
+	}
+	return "All Accounts"
+}
+
+func (s sourceScope) apply(filter *query.MessageFilter) {
+	filter.SourceID = nil
+	filter.SourceIDs = nil
+	switch s.kind {
+	case sourceScopeAll:
+		return
+	case sourceScopeAccount:
+		if s.accountID != nil {
+			id := *s.accountID
+			filter.SourceID = &id
+		}
+	case sourceScopeCollection:
+		filter.SourceIDs = copySourceIDs(s.sourceIDs)
+	}
+}
+
+func copySourceIDs(ids []int64) []int64 {
+	if ids == nil {
+		return nil
+	}
+	return append(make([]int64, 0, len(ids)), ids...)
+}
+
+func (m Model) scopeTitle() string {
+	if m.mode != modeEmail {
+		return accountSourceScope(m.textState.sourceID).title(m.accounts)
+	}
+	return m.sourceScope.title(m.accounts)
+}
+
+func (m Model) scopeOptions() []scopeOption {
+	options := []scopeOption{{kind: scopeOptionAll, label: "All Accounts"}}
+	for _, account := range m.accounts {
+		id := account.ID
+		options = append(options, scopeOption{kind: scopeOptionAccount, label: account.Identifier, accountID: &id})
+	}
+	for _, collection := range m.collectionScopes {
+		options = append(options, scopeOption{kind: scopeOptionCollection, label: collection.Name,
+			collection: query.CollectionScope{Name: collection.Name, SourceIDs: copySourceIDs(collection.SourceIDs)}})
+	}
+	return options
+}
+
+func (m Model) selectorOptions() []scopeOption {
+	if m.mode == modeEmail {
+		return m.scopeOptions()
+	}
+	options := []scopeOption{{kind: scopeOptionAll}}
+	for _, account := range m.selectableAccounts() {
+		id := account.ID
+		options = append(options, scopeOption{kind: scopeOptionAccount, label: account.Identifier, accountID: &id})
+	}
+	return options
+}
+
+func (s sourceScope) matches(option scopeOption) bool {
+	switch option.kind {
+	case scopeOptionAll:
+		return s.kind == sourceScopeAll
+	case scopeOptionAccount:
+		return s.kind == sourceScopeAccount && s.accountID != nil && option.accountID != nil && *s.accountID == *option.accountID
+	case scopeOptionCollection:
+		return s.kind == sourceScopeCollection && s.collectionName == option.collection.Name
+	default:
+		return false
+	}
 }
 
 // modalType represents the type of modal dialog.
@@ -191,11 +326,11 @@ type Model struct {
 	breadcrumbs []navigationSnapshot
 
 	// Global Stats (not view specific)
-	stats    *query.TotalStats // Global stats
-	accounts []query.AccountInfo
-
-	// Account filter (nil = all accounts)
-	accountFilter *int64
+	stats                 *query.TotalStats // Global stats
+	accounts              []query.AccountInfo
+	collectionScopeLister query.CollectionScopeLister
+	collectionScopes      []query.CollectionScope
+	sourceScope           sourceScope
 
 	// Content filters
 	filters struct {
@@ -234,6 +369,7 @@ type Model struct {
 
 	// Request tracking to ignore stale async results
 	aggregateRequestID     uint64 // Current request ID for aggregate data
+	statsRequestID         uint64 // Current request ID for total statistics
 	loadRequestID          uint64 // Current request ID for message list
 	detailRequestID        uint64 // Current request ID for message detail
 	searchRequestID        uint64 // Current request ID for search results
@@ -329,11 +465,13 @@ func New(engine query.Engine, opts Options) Model {
 	}
 
 	return Model{
-		engine:          engine,
-		textEngine:      textEngine,
-		peopleBackend:   opts.PeopleBackend,
-		settingsBackend: opts.SettingsBackend,
-		settings:        newSettingsState(),
+		engine:                engine,
+		textEngine:            textEngine,
+		collectionScopeLister: opts.CollectionScopeLister,
+		sourceScope:           allSourceScope(),
+		peopleBackend:         opts.PeopleBackend,
+		settingsBackend:       opts.SettingsBackend,
+		settings:              newSettingsState(),
 		actions: NewActionControllerWithOptions(engine, ActionControllerOptions{
 			DataDir:             opts.DataDir,
 			AttachmentOutputDir: opts.ExportDir,
@@ -382,6 +520,7 @@ func (m Model) Init() tea.Cmd {
 		m.loadData(),
 		m.loadStats(),
 		m.loadAccounts(),
+		m.loadCollectionScopes(),
 		m.checkForUpdate(),
 		spinnerTick(), // Start spinner for initial load
 	)
@@ -410,8 +549,10 @@ type dataLoadedMsg struct {
 
 // statsLoadedMsg is sent when stats are loaded.
 type statsLoadedMsg struct {
-	stats *query.TotalStats
-	err   error
+	stats                  *query.TotalStats
+	err                    error
+	requestID              uint64
+	presentationGeneration uint64
 }
 
 // accountsLoadedMsg is sent when accounts are loaded.
@@ -420,12 +561,17 @@ type accountsLoadedMsg struct {
 	err      error
 }
 
+type collectionScopesLoadedMsg struct {
+	scopes []query.CollectionScope
+	err    error
+}
+
 // scopeLabelForLog returns a short, stable string describing the
 // current account scope so it can be attached to log records.
 // Uses "filtered" rather than the account identifier to avoid
 // persisting email addresses in the log file.
 func (m Model) scopeLabelForLog() string {
-	if m.accountFilter != nil {
+	if m.sourceScope.kind != sourceScopeAll {
 		return "filtered"
 	}
 	return "all"
@@ -454,7 +600,6 @@ func (m Model) loadData() tea.Cmd {
 	return safeCmdWithPanic(
 		func() tea.Msg {
 			opts := query.AggregateOptions{
-				SourceID:              m.accountFilter,
 				SortField:             m.sortField,
 				SortDirection:         m.sortDirection,
 				Limit:                 m.aggregateLimit,
@@ -463,6 +608,9 @@ func (m Model) loadData() tea.Cmd {
 				HideDeletedFromSource: m.filters.hideDeletedFromSource,
 				SearchQuery:           m.searchQuery,
 			}
+			scope := m.sourceScope
+			opts.SourceID = scope.accountID
+			opts.SourceIDs = copySourceIDs(scope.sourceIDs)
 
 			start := time.Now()
 			ctx := context.Background()
@@ -474,7 +622,7 @@ func (m Model) loadData() tea.Cmd {
 			// generic Aggregate call, lets the TUI's mode constraint intersect
 			// an explicit message_type search instead of being overridden by it.
 			aggregateFilter := emailScopedMessageFilter(m.drillFilter)
-			aggregateFilter.SourceID = m.accountFilter
+			m.sourceScope.apply(&aggregateFilter)
 			aggregateFilter.WithAttachmentsOnly = m.filters.attachmentsOnly
 			aggregateFilter.HideDeletedFromSource = m.filters.hideDeletedFromSource
 			rows, err = m.engine.SubAggregate(ctx, aggregateFilter, m.viewType, opts)
@@ -507,13 +655,14 @@ func (m Model) loadData() tea.Cmd {
 				} else {
 					statsOpts := query.StatsOptions{
 						Filter:                &aggregateFilter,
-						SourceID:              m.accountFilter,
 						WithAttachmentsOnly:   m.filters.attachmentsOnly,
 						HideDeletedFromSource: m.filters.hideDeletedFromSource,
 						SearchQuery:           scopedQuery,
 						SearchScope:           true,
 						GroupBy:               m.viewType,
 					}
+					statsOpts.SourceID = m.sourceScope.accountID
+					statsOpts.SourceIDs = copySourceIDs(m.sourceScope.sourceIDs)
 					filteredStats, _ = m.engine.GetTotalStats(ctx, statsOpts)
 				}
 			}
@@ -532,20 +681,29 @@ func (m Model) loadData() tea.Cmd {
 	)
 }
 
+// refreshStats supersedes previous totals whenever a new statistics read is scheduled.
+func (m *Model) refreshStats() tea.Cmd {
+	m.statsRequestID++
+	return m.loadStats()
+}
+
 // loadStats fetches total statistics.
 func (m Model) loadStats() tea.Cmd {
+	requestID := m.statsRequestID
+	presentationGeneration := m.presentationGeneration
 	return safeCmdWithPanic(
 		func() tea.Msg {
 			opts := query.StatsOptions{
-				SourceID:              m.accountFilter,
 				WithAttachmentsOnly:   m.filters.attachmentsOnly,
 				HideDeletedFromSource: m.filters.hideDeletedFromSource,
 			}
+			opts.SourceID = m.sourceScope.accountID
+			opts.SourceIDs = copySourceIDs(m.sourceScope.sourceIDs)
 			stats, err := m.engine.GetTotalStats(context.Background(), opts)
-			return statsLoadedMsg{stats: stats, err: err}
+			return statsLoadedMsg{stats: stats, err: err, requestID: requestID, presentationGeneration: presentationGeneration}
 		},
 		func(r any) tea.Msg {
-			return statsLoadedMsg{err: fmt.Errorf("stats panic: %v", r)}
+			return statsLoadedMsg{err: fmt.Errorf("stats panic: %v", r), requestID: requestID, presentationGeneration: presentationGeneration}
 		},
 	)
 }
@@ -567,6 +725,30 @@ func (m Model) loadAccounts() tea.Cmd {
 		},
 		func(r any) tea.Msg {
 			return accountsLoadedMsg{err: fmt.Errorf("accounts panic: %v", r)}
+		},
+	)
+}
+
+func (m Model) loadCollectionScopes() tea.Cmd {
+	lister := m.collectionScopeLister
+	return safeCmdWithPanic(
+		func() tea.Msg {
+			if lister == nil {
+				return collectionScopesLoadedMsg{}
+			}
+			scopes, err := lister.ListCollectionScopes(context.Background())
+			if err != nil {
+				slog.Warn("tui loadCollectionScopes failed", "error", err)
+				return collectionScopesLoadedMsg{err: err}
+			}
+			out := make([]query.CollectionScope, len(scopes))
+			for i, scope := range scopes {
+				out[i] = query.CollectionScope{Name: scope.Name, SourceIDs: copySourceIDs(scope.SourceIDs)}
+			}
+			return collectionScopesLoadedMsg{scopes: out}
+		},
+		func(r any) tea.Msg {
+			return collectionScopesLoadedMsg{err: fmt.Errorf("collections panic: %v", r)}
 		},
 	)
 }
@@ -690,6 +872,7 @@ func (m Model) loadSearchWithOffset(queryStr string, offset int, appendResults b
 			ctx := context.Background()
 			q := search.Parse(queryStr)
 			searchFilter := emailScopedMessageFilter(m.searchFilter)
+			m.sourceScope.apply(&searchFilter)
 
 			start := time.Now()
 			var results []query.MessageSummary
@@ -807,7 +990,7 @@ func (m Model) buildMessageFilter() query.MessageFilter {
 	}
 
 	// Override sorting and pagination
-	filter.SourceID = m.accountFilter
+	m.sourceScope.apply(&filter)
 	filter.Sorting.Field = m.msgSortField
 	filter.Sorting.Direction = m.msgSortDirection
 	filter.WithAttachmentsOnly = m.filters.attachmentsOnly
@@ -957,6 +1140,7 @@ func (m Model) loadThreadMessages(conversationID int64) tea.Cmd {
 				Sorting:        query.MessageSorting{Field: query.MessageSortByDate, Direction: query.SortAsc},
 				Pagination:     query.Pagination{Limit: threadLimit + 1}, // Request one extra to detect truncation
 			}
+			m.sourceScope.apply(&filter)
 			messages, err := m.engine.ListMessages(context.Background(), filter)
 
 			// Check if truncated (more messages than limit)
@@ -1061,6 +1245,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleStatsLoaded(msg)
 	case accountsLoadedMsg:
 		return m.handleAccountsLoaded(msg)
+	case collectionScopesLoadedMsg:
+		return m.handleCollectionScopesLoaded(msg)
 	case updateCheckMsg:
 		return m.handleUpdateCheck(msg)
 	case AnalyticsNoticeMsg:
@@ -1367,6 +1553,9 @@ func (m Model) sumRowStats(rows []query.AggregateRow) *query.TotalStats {
 
 // handleStatsLoaded processes stats load completion.
 func (m Model) handleStatsLoaded(msg statsLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.requestID != m.statsRequestID || msg.presentationGeneration != m.presentationGeneration {
+		return m, nil
+	}
 	if msg.err == nil {
 		m.stats = msg.stats
 	}
@@ -1377,6 +1566,13 @@ func (m Model) handleStatsLoaded(msg statsLoadedMsg) (tea.Model, tea.Cmd) {
 func (m Model) handleAccountsLoaded(msg accountsLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.err == nil {
 		m.accounts = msg.accounts
+	}
+	return m, nil
+}
+
+func (m Model) handleCollectionScopesLoaded(msg collectionScopesLoadedMsg) (tea.Model, tea.Cmd) {
+	if msg.err == nil {
+		m.collectionScopes = msg.scopes
 	}
 	return m, nil
 }
@@ -1668,6 +1864,22 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if m.settings.active {
 		return m.handleSettingsKeyPress(msg)
 	}
+
+	// Resolving every deletion match is view-independent. Keep the current
+	// scope stable until it finishes, while still allowing cancellation and
+	// the normal quit flow from every mode.
+	if m.deletionLoading {
+		switch msg.String() {
+		case keyNameEsc:
+			m.cancelDeletionResolution()
+			return m.showFlash("Deletion match resolution canceled")
+		case "q", keyNameCtrlC:
+			m.cancelDeletionResolution()
+		default:
+			return m, nil
+		}
+	}
+
 	if msg.String() == "," && m.settingsShortcutAvailable() {
 		return m.openSettings()
 	}
@@ -1685,21 +1897,6 @@ func (m Model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// Handle modal first (error modals must dismiss even during search)
 	if m.modal != modalNone {
 		return m.handleModalKeys(msg)
-	}
-
-	// Resolving every deletion match is view-independent. Keep the current
-	// scope stable until it finishes, while still allowing cancellation and
-	// the normal quit flow from aggregate and message-list views alike.
-	if m.deletionLoading {
-		switch msg.String() {
-		case keyNameEsc:
-			m.cancelDeletionResolution()
-			return m.showFlash("Deletion match resolution canceled")
-		case "q", keyNameCtrlC:
-			m.cancelDeletionResolution()
-		default:
-			return m, nil
-		}
 	}
 
 	// Handle inline search (takes priority over view)
@@ -1873,6 +2070,7 @@ func (m Model) stageForDeletionContext(allMatches bool) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) deletionContext(allMatches bool) DeletionContext {
+	scope := m.sourceScope
 	var drillFilter *query.MessageFilter
 	if m.hasDrillFilter() {
 		f := m.drillFilter
@@ -1882,7 +2080,8 @@ func (m Model) deletionContext(allMatches bool) DeletionContext {
 		AggregateSelection: m.selection.aggregateKeys,
 		MessageSelection:   m.selection.messageIDs,
 		AggregateViewType:  m.selection.aggregateViewType,
-		AccountFilter:      m.accountFilter,
+		AccountFilter:      scope.accountID,
+		SourceIDs:          copySourceIDs(scope.sourceIDs),
 		Accounts:           m.accounts,
 		TimeGranularity:    m.timeGranularity,
 		Messages:           m.messages,

--- a/internal/tui/nav_modal_test.go
+++ b/internal/tui/nav_modal_test.go
@@ -70,8 +70,8 @@ func TestAccountSelectorModal(t *testing.T) {
 	m, cmd = applyModalKey(t, m, keyEnter())
 
 	assert.Equal(modalNone, m.modal, "after selection")
-	require.NotNil(t, m.accountFilter)
-	assert.Equal(int64(1), *m.accountFilter)
+	require.NotNil(t, m.sourceScope.accountID)
+	assert.Equal(int64(1), *m.sourceScope.accountID)
 	assert.NotNil(cmd, "expected command to reload data")
 }
 
@@ -89,7 +89,7 @@ func TestOpenAccountSelector(t *testing.T) {
 			query.AccountInfo{ID: 10, Identifier: "a@example.com"},
 			query.AccountInfo{ID: 42, Identifier: "b@example.com"},
 		).Build()
-		m.accountFilter = &acctID
+		m.sourceScope = accountSourceScope(&acctID)
 		m.openAccountSelector()
 		assertModal(t, m, modalAccountSelector)
 		assert.Equal(t, 2, m.modalCursor, "index 1 + 1 for All Accounts")

--- a/internal/tui/people_state_isolation_test.go
+++ b/internal/tui/people_state_isolation_test.go
@@ -31,8 +31,8 @@ func TestPeopleInboxKeepsTextWorkspaceIndependentAcrossModeSwitches(t *testing.T
 	model := peopleModel(&fakePeopleBackend{})
 	model.textEngine = meetingModeTextEngine{}
 	model.mode = modeTexts
-	model.accountFilter = &textSourceID
 	model.textState = textState{
+		sourceID: &textSourceID,
 		viewType: query.TextViewContacts,
 		level:    textLevelDetail,
 		conversations: []query.ConversationRow{
@@ -49,7 +49,6 @@ func TestPeopleInboxKeepsTextWorkspaceIndependentAcrossModeSwitches(t *testing.T
 		selectedConvID:    701,
 		selectedMessageID: 713,
 		filter: query.TextFilter{
-			SourceID:     &textSourceID,
 			ContactPhone: "+15550000071",
 			SortField:    query.TextSortByName,
 		},
@@ -99,8 +98,8 @@ func TestPeopleInboxKeepsTextWorkspaceIndependentAcrossModeSwitches(t *testing.T
 	assert.Equal(int64(713), model.textState.selectedMessageID)
 	assert.Equal(2, model.textState.cursor)
 	assert.Equal(1, model.textState.scrollOffset)
-	require.NotNil(t, model.textState.filter.SourceID)
-	assert.Equal(textSourceID, *model.textState.filter.SourceID)
+	require.NotNil(t, model.textState.sourceID)
+	assert.Equal(textSourceID, *model.textState.sourceID)
 	assert.Equal("+15550000071", model.textState.filter.ContactPhone)
 	assert.Empty(model.textState.filter.ParticipantIDs)
 	assert.Equal([]int64{711, 712, 713}, messageSummaryIDs(model.textState.messages))

--- a/internal/tui/search_test.go
+++ b/internal/tui/search_test.go
@@ -299,11 +299,12 @@ func TestInlineSearchOmitsSemanticForUnsupportedScopes(t *testing.T) {
 	tests := []struct {
 		name   string
 		filter query.MessageFilter
+		scope  sourceScope
 	}{
 		{name: "sender display name", filter: query.MessageFilter{SenderName: "Billing Team"}},
 		{name: "recipient display name", filter: query.MessageFilter{RecipientName: "Accounts Payable"}},
 		{name: "empty aggregate bucket", filter: query.MessageFilter{EmptyValueTargets: map[query.ViewType]bool{query.ViewSenderNames: true}}},
-		{name: "multiple sources", filter: query.MessageFilter{SourceIDs: []int64{7, 8}}},
+		{name: "multiple sources", scope: collectionSourceScope(query.CollectionScope{Name: "Work", SourceIDs: []int64{7, 8}})},
 	}
 
 	for _, tt := range tests {
@@ -313,6 +314,7 @@ func TestInlineSearchOmitsSemanticForUnsupportedScopes(t *testing.T) {
 				WithActiveSearch("find the invoice", searchModeDeep).Build()
 			model.semanticSearch = &recordingSemanticSearcher{response: &query.SemanticMessageSearchResult{}}
 			model.drillFilter = tt.filter
+			model.sourceScope = tt.scope
 
 			assertions.Contains(model.searchPlaceholder(), "fast")
 			assertions.NotContains(model.searchPlaceholder(), "semantic")

--- a/internal/tui/selection_test.go
+++ b/internal/tui/selection_test.go
@@ -222,6 +222,42 @@ func TestDeletionKeyScope(t *testing.T) {
 	})
 }
 
+func TestDeletionResolutionCannotCrossScopeChanges(t *testing.T) {
+	model := NewBuilder().Build()
+	model.deletionLoading = true
+	model.deletionRequestID = 7
+	oldRequestID := model.deletionRequestID
+	canceled := false
+	model.deletionCancel = func() { canceled = true }
+
+	model.invalidateSourceScope()
+
+	assert.True(t, canceled)
+	assert.False(t, model.deletionLoading)
+	assert.Greater(t, model.deletionRequestID, oldRequestID)
+	model = sendMsg(t, model, deletionPreparedMsg{
+		manifest:  &deletion.Manifest{},
+		requestID: oldRequestID,
+	})
+	assertModal(t, model, modalNone)
+}
+
+func TestDeletionResolutionBlocksTextScopeInput(t *testing.T) {
+	assertions := assert.New(t)
+	model := NewBuilder().Build()
+	model.mode = modeTexts
+	model.deletionLoading = true
+
+	model, cmd := sendKey(t, model, key('A'))
+	assertions.Nil(cmd)
+	assertions.Equal(modeTexts, model.mode)
+	assertModal(t, model, modalNone)
+
+	model, cmd = sendKey(t, model, key('m'))
+	assertions.Nil(cmd)
+	assertions.Equal(modeTexts, model.mode)
+}
+
 func TestUppercaseDResolvesEveryFilteredMessageInOneBackendCall(t *testing.T) {
 	allMessages := deletionScopeMessages(searchPageSize + 1)
 	var calls int

--- a/internal/tui/setup_test.go
+++ b/internal/tui/setup_test.go
@@ -291,7 +291,7 @@ func (b *TestModelBuilder) configureState(m *Model) {
 	}
 
 	if b.accountFilter != nil {
-		m.accountFilter = b.accountFilter
+		m.sourceScope = accountSourceScope(b.accountFilter)
 	}
 
 	if b.stats != nil {

--- a/internal/tui/text_commands.go
+++ b/internal/tui/text_commands.go
@@ -222,12 +222,13 @@ func (m Model) handleTextMessageLoaded(msg textMessageLoadedMsg) (tea.Model, tea
 // loadTextSearch executes a text message search.
 func (m *Model) loadTextSearch(searchQuery string) tea.Cmd {
 	te := m.textEngine
+	sourceID := m.textState.sourceID
 	requestID := m.nextTextRequestID()
 	presentationGeneration := m.presentationGeneration
 	return safeCmdWithPanic(
 		func() tea.Msg {
 			msgs, err := te.TextSearch(
-				context.Background(), searchQuery, 100, 0,
+				context.Background(), searchQuery, sourceID, 100, 0,
 			)
 			return textSearchResultMsg{
 				messages: msgs, err: err, requestID: requestID,

--- a/internal/tui/text_commands.go
+++ b/internal/tui/text_commands.go
@@ -67,6 +67,7 @@ func (m *Model) nextTextRequestID() uint64 {
 func (m *Model) loadTextConversations() tea.Cmd {
 	te := m.textEngine
 	filter := m.textState.filter
+	filter.SourceID = m.textState.sourceID
 	requestID := m.nextTextRequestID()
 	presentationGeneration := m.presentationGeneration
 	return safeCmdWithPanic(
@@ -101,6 +102,7 @@ func (m *Model) loadTextAggregate() tea.Cmd {
 	te := m.textEngine
 	vt := m.textState.viewType
 	filter := m.textState.filter
+	filter.SourceID = m.textState.sourceID
 	requestID := m.nextTextRequestID()
 	presentationGeneration := m.presentationGeneration
 	return safeCmdWithPanic(
@@ -143,6 +145,7 @@ func (m *Model) loadTextMessages() tea.Cmd {
 	te := m.textEngine
 	convID := m.textState.selectedConvID
 	filter := m.textState.filter
+	filter.SourceID = m.textState.sourceID
 	requestID := m.nextTextRequestID()
 	presentationGeneration := m.presentationGeneration
 	return safeCmdWithPanic(
@@ -255,5 +258,19 @@ func (m *Model) loadTextData() tea.Cmd {
 		return nil
 	default:
 		return m.loadTextAggregate()
+	}
+}
+
+func (m *Model) textPresentationLoadCmd() tea.Cmd {
+	switch {
+	case m.textState.level == textLevelDetail:
+		if m.messageDetail == nil && m.textState.selectedMessageID > 0 {
+			return m.loadTextMessage(m.textState.selectedMessageID)
+		}
+		return nil
+	case m.textState.level == textLevelTimeline && m.textState.globalSearchTimeline:
+		return nil
+	default:
+		return m.loadTextData()
 	}
 }

--- a/internal/tui/text_keys.go
+++ b/internal/tui/text_keys.go
@@ -96,8 +96,9 @@ func (m Model) handleTextListKeys(
 		return m, cmd
 
 	case "a":
-		// Reset to conversations view (clear filters)
+		// Reset navigation and drill filters within the selected account.
 		m.textState = textState{
+			sourceID: m.textState.sourceID,
 			viewType: query.TextViewConversations,
 		}
 		m.loading = true

--- a/internal/tui/text_scope_test.go
+++ b/internal/tui/text_scope_test.go
@@ -1,0 +1,61 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/testutil/dbtest"
+)
+
+func textAccountScopeModel(t *testing.T) Model {
+	t.Helper()
+	tdb := dbtest.NewTestDB(t, "../store/schema.sql")
+	_, err := tdb.DB.Exec(`
+		INSERT INTO sources (id, source_type, identifier) VALUES
+			(7, 'imessage', 'first@example.com'), (8, 'imessage', 'second@example.com');
+		INSERT INTO conversations (id, source_id, source_conversation_id, conversation_type, title) VALUES
+			(701, 7, 'chat-701', 'direct_chat', 'First'),
+			(702, 8, 'chat-702', 'direct_chat', 'Second');
+		INSERT INTO messages (id, conversation_id, source_id, source_message_id, message_type, sent_at, subject) VALUES
+			(801, 701, 7, 'message-801', 'imessage', '2026-01-01 10:00:00', 'hello first'),
+			(802, 702, 8, 'message-802', 'imessage', '2026-01-01 11:00:00', 'hello second');
+		CREATE VIRTUAL TABLE messages_fts USING fts5(subject, body);
+		INSERT INTO messages_fts (rowid, subject, body) VALUES
+			(801, 'hello first', ''), (802, 'hello second', '');
+	`)
+	require.NoError(t, err)
+	model := New(query.NewSQLiteEngine(tdb.DB), Options{DataDir: t.TempDir(), Version: "test"})
+	model.mode = modeTexts
+	model.textState.sourceID = new(int64(7))
+	return model
+}
+
+func TestGlobalTextSearchRespectsSelectedAccount(t *testing.T) {
+	require := require.New(t)
+	model := textAccountScopeModel(t)
+	model, _ = sendKey(t, model, key('/'))
+	model.searchInput.SetValue("hello")
+	model, cmd := sendKey(t, model, keyEnter())
+	require.NotNil(cmd)
+	model = sendMsg(t, model, cmd())
+
+	require.NoError(model.err)
+	require.Len(model.textState.messages, 1)
+	assert.Equal(t, int64(801), model.textState.messages[0].ID)
+}
+
+func TestTextConversationsResetPreservesSelectedAccount(t *testing.T) {
+	require := require.New(t)
+	model := textAccountScopeModel(t)
+	model.textState.viewType = query.TextViewSources
+	model.textState.level = textLevelAggregate
+	model, cmd := sendKey(t, model, key('a'))
+	require.NotNil(cmd)
+	model = sendMsg(t, model, cmd())
+
+	require.NoError(model.err)
+	require.Len(model.textState.conversations, 1)
+	assert.Equal(t, int64(701), model.textState.conversations[0].ConversationID)
+}

--- a/internal/tui/text_state.go
+++ b/internal/tui/text_state.go
@@ -50,6 +50,7 @@ const (
 
 // textState holds all state for the Texts mode TUI.
 type textState struct {
+	sourceID             *int64 // Account selector; independent of Email and navigation snapshots.
 	viewType             query.TextViewType
 	level                textViewLevel
 	conversations        []query.ConversationRow

--- a/internal/tui/text_test.go
+++ b/internal/tui/text_test.go
@@ -143,7 +143,7 @@ type globalSearchRefineTextEngine struct {
 }
 
 func (e *globalSearchRefineTextEngine) TextSearch(
-	_ context.Context, searchQuery string, _, _ int,
+	_ context.Context, searchQuery string, _ *int64, _, _ int,
 ) ([]query.MessageSummary, error) {
 	e.searches = append(e.searches, searchQuery)
 	return []query.MessageSummary{{ID: 77, Subject: "Refined global result"}}, nil

--- a/internal/tui/text_view.go
+++ b/internal/tui/text_view.go
@@ -59,9 +59,9 @@ func (m Model) textTitleBar() string {
 
 	// Mode indicator
 	accountStr := "Texts"
-	if m.accountFilter != nil {
+	if m.textState.sourceID != nil {
 		for _, acc := range m.accounts {
-			if acc.ID == *m.accountFilter {
+			if acc.ID == *m.textState.sourceID {
 				accountStr = "Texts - " + acc.Identifier
 				break
 			}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -178,17 +178,7 @@ func (m Model) buildTitleBar() string {
 	}
 
 	// Account indicator
-	var accountStr string
-	if m.accountFilter == nil {
-		accountStr = "All Accounts"
-	} else {
-		for _, acc := range m.accounts {
-			if acc.ID == *m.accountFilter {
-				accountStr = acc.Identifier
-				break
-			}
-		}
-	}
+	accountStr := m.scopeTitle()
 
 	// Filter indicators
 	if m.filters.attachmentsOnly {
@@ -1371,19 +1361,16 @@ func (m Model) renderAccountSelectorModal() string {
 	}
 	sb.WriteString(m.styles.modalTitle.Render(title))
 	sb.WriteString("\n\n")
-	// All Accounts option
-	indicator := "○"
-	if m.modalCursor == 0 {
-		indicator = "●"
-	}
-	_, _ = fmt.Fprintf(&sb, " %s %s\n", indicator, allLabel)
-	// Individual accounts
-	for i, acc := range m.selectableAccounts() {
-		indicator = "○"
-		if m.modalCursor == i+1 {
+	for i, option := range m.selectorOptions() {
+		label := option.label
+		if i == 0 {
+			label = allLabel
+		}
+		indicator := "○"
+		if m.modalCursor == i {
 			indicator = "●"
 		}
-		_, _ = fmt.Fprintf(&sb, " %s %s\n", indicator, acc.Identifier)
+		_, _ = fmt.Fprintf(&sb, " %s %s\n", indicator, label)
 	}
 	sb.WriteString("\n[↑/↓] Navigate  [Enter] Select  [Esc] Cancel")
 	return sb.String()

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -27,6 +27,9 @@ type GetAggregatesQuery struct {
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
 
+	// SourceIds Source IDs; repeat or comma-separate values
+	SourceIds []int64 `json:"source_ids,omitempty"`
+
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
 
@@ -61,6 +64,9 @@ type GetSubAggregatesQuery struct {
 
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
+
+	// SourceIds Source IDs; repeat or comma-separate values
+	SourceIds []int64 `json:"source_ids,omitempty"`
 
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
@@ -499,6 +505,9 @@ type FilterMessagesQuery struct {
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
 
+	// SourceIds Source IDs; repeat or comma-separate values
+	SourceIds []int64 `json:"source_ids,omitempty"`
+
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
 
@@ -563,6 +572,9 @@ type GetGmailIDsByFilterQuery struct {
 
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
+
+	// SourceIds Source IDs; repeat or comma-separate values
+	SourceIds []int64 `json:"source_ids,omitempty"`
 
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
@@ -1048,6 +1060,9 @@ type DeepSearchQuery struct {
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
 
+	// SourceIds Source IDs; repeat or comma-separate values; not supported by deep search
+	SourceIds []int64 `json:"source_ids,omitempty"`
+
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
 
@@ -1144,6 +1159,9 @@ type FastSearchQuery struct {
 	// SourceID Source ID
 	SourceID *int64 `json:"source_id,omitempty"`
 
+	// SourceIds Source IDs; repeat or comma-separate values
+	SourceIds []int64 `json:"source_ids,omitempty"`
+
 	// AttachmentsOnly Only include messages with attachments
 	AttachmentsOnly *bool `json:"attachments_only,omitempty"`
 
@@ -1170,9 +1188,6 @@ type FastSearchQuery struct {
 
 	// Direction Sort direction: asc or desc
 	Direction *string `json:"direction,omitempty"`
-
-	// SourceIds Source IDs; repeat the parameter for multiple sources
-	SourceIds []int64 `json:"source_ids,omitempty"`
 }
 
 func (f FastSearchQuery) Validate() error {

--- a/pkg/client/generated/queries.go
+++ b/pkg/client/generated/queries.go
@@ -1413,6 +1413,9 @@ type ListTextConversationMessagesQuery struct {
 }
 
 type SearchTextMessagesQuery struct {
+	// SourceID Source ID
+	SourceID *int64 `json:"source_id,omitempty"`
+
 	// Q Search query
 	Q string `json:"q" validate:"required"`
 

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -145,8 +145,9 @@ func (a Address) Validate() error {
 }
 
 type AggregateResponse struct {
-	Rows     []AggregateRowJSON `json:"rows" validate:"required"`
-	ViewType string             `json:"view_type" validate:"required"`
+	AppliedSourceIds []int64            `json:"applied_source_ids,omitempty"`
+	Rows             []AggregateRowJSON `json:"rows" validate:"required"`
+	ViewType         string             `json:"view_type" validate:"required"`
 }
 
 func (a AggregateResponse) Validate() error {
@@ -4041,11 +4042,12 @@ func (f FileSearchSort) Validate() error {
 }
 
 type FilteredMessagesResponse struct {
-	Count    int64            `json:"count"`
-	HasMore  bool             `json:"has_more"`
-	Limit    int64            `json:"limit"`
-	Messages []MessageSummary `json:"messages" validate:"required"`
-	Offset   int64            `json:"offset"`
+	AppliedSourceIds []int64          `json:"applied_source_ids,omitempty"`
+	Count            int64            `json:"count"`
+	HasMore          bool             `json:"has_more"`
+	Limit            int64            `json:"limit"`
+	Messages         []MessageSummary `json:"messages" validate:"required"`
+	Offset           int64            `json:"offset"`
 }
 
 func (f FilteredMessagesResponse) Validate() error {
@@ -4103,10 +4105,11 @@ func (g GenerationSummary) Validate() error {
 }
 
 type GmailIDsResponse struct {
-	GmailIds    []string         `json:"gmail_ids" validate:"required"`
-	SearchMode  *string          `json:"search_mode,omitempty"`
-	SearchQuery *string          `json:"search_query,omitempty"`
-	Targets     []DeletionTarget `json:"targets,omitempty"`
+	AppliedSourceIds []int64          `json:"applied_source_ids,omitempty"`
+	GmailIds         []string         `json:"gmail_ids" validate:"required"`
+	SearchMode       *string          `json:"search_mode,omitempty"`
+	SearchQuery      *string          `json:"search_query,omitempty"`
+	Targets          []DeletionTarget `json:"targets,omitempty"`
 }
 
 func (g GmailIDsResponse) Validate() error {

--- a/pkg/client/generated/types.go
+++ b/pkg/client/generated/types.go
@@ -10811,11 +10811,12 @@ func (t TextMessagesResponse) Validate() error {
 }
 
 type TextSearchResponse struct {
-	Count    int64                    `json:"count"`
-	HasMore  bool                     `json:"has_more"`
-	Limit    int64                    `json:"limit"`
-	Messages []CLIQueryMessageSummary `json:"messages" validate:"required"`
-	Offset   int64                    `json:"offset"`
+	AppliedSourceID *int64                   `json:"applied_source_id,omitempty"`
+	Count           int64                    `json:"count"`
+	HasMore         bool                     `json:"has_more"`
+	Limit           int64                    `json:"limit"`
+	Messages        []CLIQueryMessageSummary `json:"messages" validate:"required"`
+	Offset          int64                    `json:"offset"`
 }
 
 func (t TextSearchResponse) Validate() error {

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -169,6 +169,11 @@ components:
       type: object
     AggregateResponse:
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         rows:
           items:
             $ref: "#/components/schemas/AggregateRowJSON"
@@ -4413,6 +4418,11 @@ components:
       type: object
     FilteredMessagesResponse:
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         count:
           format: int64
           type: integer
@@ -4525,6 +4535,11 @@ components:
       type: object
     GmailIDsResponse:
       properties:
+        applied_source_ids:
+          items:
+            format: int64
+            type: integer
+          type: array
         gmail_ids:
           items:
             type: string
@@ -11496,7 +11511,7 @@ components:
       type: apiKey
 info:
   title: msgvault API
-  version: 2.16.0
+  version: 2.17.0
 openapi: 3.0.3
 paths:
   /api/ping:
@@ -11671,6 +11686,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -11751,6 +11774,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -17044,6 +17075,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -17175,6 +17214,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -22671,6 +22718,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values; not supported by deep search
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -22863,6 +22918,14 @@ paths:
           schema:
             format: int64
             type: integer
+        - description: Source IDs; repeat or comma-separate values
+          in: query
+          name: source_ids
+          schema:
+            items:
+              format: int64
+              type: integer
+            type: array
         - description: Only include messages with attachments
           in: query
           name: attachments_only
@@ -22910,14 +22973,6 @@ paths:
           name: direction
           schema:
             type: string
-        - description: Source IDs; repeat the parameter for multiple sources
-          in: query
-          name: source_ids
-          schema:
-            items:
-              format: int64
-              type: integer
-            type: array
       responses:
         "200":
           content:

--- a/pkg/client/openapi.yaml
+++ b/pkg/client/openapi.yaml
@@ -11114,6 +11114,9 @@ components:
       type: object
     TextSearchResponse:
       properties:
+        applied_source_id:
+          format: int64
+          type: integer
         count:
           format: int64
           type: integer
@@ -23897,6 +23900,12 @@ paths:
     get:
       operationId: searchTextMessages
       parameters:
+        - description: Source ID
+          in: query
+          name: source_id
+          schema:
+            format: int64
+            type: integer
         - description: Search query
           in: query
           name: q

--- a/web/src/lib/api/generated/models/aggregateResponse.ts
+++ b/web/src/lib/api/generated/models/aggregateResponse.ts
@@ -4,6 +4,7 @@
 import type { AggregateRowJSON } from "./aggregateRowJSON";
 
 export interface AggregateResponse {
+  applied_source_ids?: number[];
   rows: AggregateRowJSON[];
   view_type: string;
   [key: string]: unknown;

--- a/web/src/lib/api/generated/models/deepSearchParams.ts
+++ b/web/src/lib/api/generated/models/deepSearchParams.ts
@@ -60,6 +60,10 @@ export type DeepSearchParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values; not supported by deep search
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;

--- a/web/src/lib/api/generated/models/fastSearchParams.ts
+++ b/web/src/lib/api/generated/models/fastSearchParams.ts
@@ -60,6 +60,10 @@ export type FastSearchParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;
@@ -95,8 +99,4 @@ export type FastSearchParams = {
    * Sort direction: asc or desc
    */
   direction?: string;
-  /**
-   * Source IDs; repeat the parameter for multiple sources
-   */
-  source_ids?: number[];
 };

--- a/web/src/lib/api/generated/models/filterMessagesParams.ts
+++ b/web/src/lib/api/generated/models/filterMessagesParams.ts
@@ -52,6 +52,10 @@ export type FilterMessagesParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;

--- a/web/src/lib/api/generated/models/filteredMessagesResponse.ts
+++ b/web/src/lib/api/generated/models/filteredMessagesResponse.ts
@@ -4,6 +4,7 @@
 import type { MessageSummary } from "./messageSummary";
 
 export interface FilteredMessagesResponse {
+  applied_source_ids?: number[];
   count: number;
   has_more: boolean;
   limit: number;

--- a/web/src/lib/api/generated/models/getAggregatesParams.ts
+++ b/web/src/lib/api/generated/models/getAggregatesParams.ts
@@ -28,6 +28,10 @@ export type GetAggregatesParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;

--- a/web/src/lib/api/generated/models/getGmailIDsByFilterParams.ts
+++ b/web/src/lib/api/generated/models/getGmailIDsByFilterParams.ts
@@ -52,6 +52,10 @@ export type GetGmailIDsByFilterParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;

--- a/web/src/lib/api/generated/models/getSubAggregatesParams.ts
+++ b/web/src/lib/api/generated/models/getSubAggregatesParams.ts
@@ -28,6 +28,10 @@ export type GetSubAggregatesParams = {
    */
   source_id?: number;
   /**
+   * Source IDs; repeat or comma-separate values
+   */
+  source_ids?: number[];
+  /**
    * Only include messages with attachments
    */
   attachments_only?: boolean;

--- a/web/src/lib/api/generated/models/gmailIDsResponse.ts
+++ b/web/src/lib/api/generated/models/gmailIDsResponse.ts
@@ -4,6 +4,7 @@
 import type { DeletionTarget } from "./deletionTarget";
 
 export interface GmailIDsResponse {
+  applied_source_ids?: number[];
   gmail_ids: string[];
   search_mode?: string;
   search_query?: string;

--- a/web/src/lib/api/generated/models/searchTextMessagesParams.ts
+++ b/web/src/lib/api/generated/models/searchTextMessagesParams.ts
@@ -4,6 +4,10 @@
 
 export type SearchTextMessagesParams = {
   /**
+   * Source ID
+   */
+  source_id?: number;
+  /**
    * Search query
    */
   q: string;

--- a/web/src/lib/api/generated/models/textSearchResponse.ts
+++ b/web/src/lib/api/generated/models/textSearchResponse.ts
@@ -4,6 +4,7 @@
 import type { CLIQueryMessageSummary } from "./cLIQueryMessageSummary";
 
 export interface TextSearchResponse {
+  applied_source_id?: number;
   count: number;
   has_more: boolean;
   limit: number;


### PR DESCRIPTION
The TUI account selector now offers named collections alongside All Accounts and individual accounts. Press `A` in the Email view to pick one, and the choice scopes Email aggregates, messages, Fast search, and statistics, with the title showing the collection name. Collections already existed in the CLI and API, so this makes them usable where you actually browse the archive.

Email, Texts, and Meetings keep separate scopes, and changing the Email scope returns to the top level and clears the current search. Collections need daemon API schema 2.17.0 or newer and stay session-only; a multi-source collection offers Fast search only, and deletion staging still needs the selected messages to share one source.

Refs #526
