### PR TITLE
fix(whatsapp): handle missing group participants table

### DIFF
--- a/internal/whatsapp/importer_group_participants_test.go
+++ b/internal/whatsapp/importer_group_participants_test.go
@@ -1,0 +1,163 @@
+package whatsapp
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type importProgressRecorder struct {
+	NullProgress
+	errors []string
+}
+
+func (p *importProgressRecorder) OnError(err error) {
+	p.errors = append(p.errors, err.Error())
+}
+
+func createGroupParticipantsImportFixture(t *testing.T, setup func(*sql.DB)) string {
+	t.Helper()
+	require := require.New(t)
+
+	path := filepath.Join(t.TempDir(), "msgstore.db")
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(err)
+
+	_, err = db.Exec(`
+		CREATE TABLE jid (
+			_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT
+		);
+		CREATE TABLE chat (
+			_id INTEGER PRIMARY KEY, jid_row_id INTEGER UNIQUE, hidden INTEGER,
+			subject TEXT, sort_timestamp INTEGER
+		);
+		CREATE TABLE message (
+			_id INTEGER PRIMARY KEY, chat_row_id INTEGER, from_me INTEGER,
+			key_id TEXT, sender_jid_row_id INTEGER, timestamp INTEGER,
+			message_type INTEGER, text_data TEXT, status INTEGER, starred INTEGER
+		);
+		CREATE TABLE message_media (
+			message_row_id INTEGER PRIMARY KEY, mime_type TEXT, media_caption TEXT,
+			file_size INTEGER, file_path TEXT, width INTEGER, height INTEGER,
+			media_duration INTEGER
+		);
+		INSERT INTO jid VALUES
+			(1, '120255501234567-987654321', 'g.us', '120255501234567-987654321@g.us'),
+			(2, '120255501234567-123456789', 'g.us', '120255501234567-123456789@g.us'),
+			(3, '12025550124', 's.whatsapp.net', '12025550124@s.whatsapp.net'),
+			(4, '12025550125', 's.whatsapp.net', '12025550125@s.whatsapp.net');
+		INSERT INTO chat VALUES
+			(10, 1, 0, 'Example Group One', 2000),
+			(20, 2, 0, 'Example Group Two', 1000);
+		INSERT INTO message VALUES
+			(100, 10, 0, 'message-incoming', 3, 1700000000000, 1, 'incoming group message', 0, 0),
+			(200, 20, 0, 'message-second-group', 3, 1700000001000, 1, 'second group message', 0, 0);
+	`)
+	require.NoError(err)
+	if setup != nil {
+		setup(db)
+	}
+	require.NoError(db.Close())
+	return path
+}
+
+func TestImportGroupChatWithoutGroupParticipantsTable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	waDBPath := createGroupParticipantsImportFixture(t, nil)
+	progress := &importProgressRecorder{}
+	st := testutil.NewTestStore(t)
+	opts := DefaultOptions()
+	opts.Phone = "+12025550123"
+	opts.DisplayName = "Example User"
+
+	summary, err := NewImporter(st, progress).Import(context.Background(), waDBPath, opts)
+	require.NoError(err)
+	t.Logf("recorded import errors: %v", progress.errors)
+	assert.Equal(int64(0), summary.Errors)
+	assert.NotContains(strings.Join(progress.errors, "\n"), "fetch group participants for")
+	assert.NotContains(strings.Join(progress.errors, "\n"), "no such table: group_participants")
+	assert.Equal(int64(2), summary.MessagesAdded)
+
+	var messageCount int
+	err = st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE source_id = ?`, summary.SourceID).Scan(&messageCount)
+	require.NoError(err)
+	assert.Equal(2, messageCount)
+
+	for _, message := range []struct {
+		keyID string
+		body  string
+	}{
+		{keyID: "message-incoming", body: "incoming group message"},
+		{keyID: "message-second-group", body: "second group message"},
+	} {
+		var messageID int64
+		err = st.DB().QueryRow(
+			`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`,
+			summary.SourceID, message.keyID,
+		).Scan(&messageID)
+		require.NoError(err)
+
+		var body string
+		err = st.DB().QueryRow(
+			`SELECT body_text FROM message_bodies WHERE message_id = ?`, messageID,
+		).Scan(&body)
+		require.NoError(err)
+		assert.Equal(message.body, body)
+	}
+
+	var participantCount int
+	err = st.DB().QueryRow(`
+		SELECT COUNT(*)
+		FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE c.source_id = ?
+		  AND c.source_conversation_id = ?
+		  AND p.phone_number IN (?, ?)
+	`, summary.SourceID, "120255501234567-987654321@g.us", "+12025550124", "+12025550123").Scan(&participantCount)
+	require.NoError(err)
+	assert.Equal(2, participantCount)
+}
+
+func TestImportGroupChatWithPopulatedGroupParticipants(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	waDBPath := createGroupParticipantsImportFixture(t, func(db *sql.DB) {
+		_, err := db.Exec(`
+			CREATE TABLE group_participants (gjid TEXT, jid TEXT, admin INTEGER);
+			INSERT INTO group_participants VALUES
+				('120255501234567-987654321@g.us', '12025550124@s.whatsapp.net', NULL),
+				('120255501234567-987654321@g.us', '12025550125@s.whatsapp.net', 2);
+		`)
+		require.NoError(err)
+	})
+	st := testutil.NewTestStore(t)
+	opts := DefaultOptions()
+	opts.Phone = "+12025550123"
+	opts.DisplayName = "Example User"
+
+	summary, err := NewImporter(st, nil).Import(context.Background(), waDBPath, opts)
+	require.NoError(err)
+	assert.Equal(int64(0), summary.Errors)
+
+	var adminRole string
+	err = st.DB().QueryRow(`
+		SELECT cp.role
+		FROM conversation_participants cp
+		JOIN conversations c ON c.id = cp.conversation_id
+		JOIN participants p ON p.id = cp.participant_id
+		WHERE c.source_id = ?
+		  AND c.source_conversation_id = ?
+		  AND p.phone_number = ?
+	`, summary.SourceID, "120255501234567-987654321@g.us", "+12025550125").Scan(&adminRole)
+	require.NoError(err)
+	assert.Equal("admin", adminRole)
+}

--- a/internal/whatsapp/importer_group_participants_test.go
+++ b/internal/whatsapp/importer_group_participants_test.go
@@ -15,6 +15,7 @@ import (
 
 type importProgressRecorder struct {
 	NullProgress
+
 	errors []string
 }
 
@@ -88,7 +89,7 @@ func TestImportGroupChatWithoutGroupParticipantsTable(t *testing.T) {
 	assert.Equal(int64(2), summary.MessagesAdded)
 
 	var messageCount int
-	err = st.DB().QueryRow(`SELECT COUNT(*) FROM messages WHERE source_id = ?`, summary.SourceID).Scan(&messageCount)
+	err = st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ?`), summary.SourceID).Scan(&messageCount)
 	require.NoError(err)
 	assert.Equal(2, messageCount)
 
@@ -101,21 +102,21 @@ func TestImportGroupChatWithoutGroupParticipantsTable(t *testing.T) {
 	} {
 		var messageID int64
 		err = st.DB().QueryRow(
-			`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`,
+			st.Rebind(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`),
 			summary.SourceID, message.keyID,
 		).Scan(&messageID)
 		require.NoError(err)
 
 		var body string
 		err = st.DB().QueryRow(
-			`SELECT body_text FROM message_bodies WHERE message_id = ?`, messageID,
+			st.Rebind(`SELECT body_text FROM message_bodies WHERE message_id = ?`), messageID,
 		).Scan(&body)
 		require.NoError(err)
 		assert.Equal(message.body, body)
 	}
 
 	var participantCount int
-	err = st.DB().QueryRow(`
+	err = st.DB().QueryRow(st.Rebind(`
 		SELECT COUNT(*)
 		FROM conversation_participants cp
 		JOIN conversations c ON c.id = cp.conversation_id
@@ -123,7 +124,7 @@ func TestImportGroupChatWithoutGroupParticipantsTable(t *testing.T) {
 		WHERE c.source_id = ?
 		  AND c.source_conversation_id = ?
 		  AND p.phone_number IN (?, ?)
-	`, summary.SourceID, "120255501234567-987654321@g.us", "+12025550124", "+12025550123").Scan(&participantCount)
+	`), summary.SourceID, "120255501234567-987654321@g.us", "+12025550124", "+12025550123").Scan(&participantCount)
 	require.NoError(err)
 	assert.Equal(2, participantCount)
 }
@@ -150,7 +151,7 @@ func TestImportGroupChatWithPopulatedGroupParticipants(t *testing.T) {
 	assert.Equal(int64(0), summary.Errors)
 
 	var adminRole string
-	err = st.DB().QueryRow(`
+	err = st.DB().QueryRow(st.Rebind(`
 		SELECT cp.role
 		FROM conversation_participants cp
 		JOIN conversations c ON c.id = cp.conversation_id
@@ -158,7 +159,7 @@ func TestImportGroupChatWithPopulatedGroupParticipants(t *testing.T) {
 		WHERE c.source_id = ?
 		  AND c.source_conversation_id = ?
 		  AND p.phone_number = ?
-	`, summary.SourceID, "120255501234567-987654321@g.us", "+12025550125").Scan(&adminRole)
+	`), summary.SourceID, "120255501234567-987654321@g.us", "+12025550125").Scan(&adminRole)
 	require.NoError(err)
 	assert.Equal("admin", adminRole)
 }

--- a/internal/whatsapp/importer_group_participants_test.go
+++ b/internal/whatsapp/importer_group_participants_test.go
@@ -52,7 +52,8 @@ func createGroupParticipantsImportFixture(t *testing.T, setup func(*sql.DB)) str
 			(1, '120255501234567-987654321', 'g.us', '120255501234567-987654321@g.us'),
 			(2, '120255501234567-123456789', 'g.us', '120255501234567-123456789@g.us'),
 			(3, '12025550124', 's.whatsapp.net', '12025550124@s.whatsapp.net'),
-			(4, '12025550125', 's.whatsapp.net', '12025550125@s.whatsapp.net');
+			(4, '12025550125', 's.whatsapp.net', '12025550125@s.whatsapp.net'),
+			(5, '12025550123', 's.whatsapp.net', '12025550123@s.whatsapp.net');
 		INSERT INTO chat VALUES
 			(10, 1, 0, 'Example Group One', 2000),
 			(20, 2, 0, 'Example Group Two', 1000);

--- a/internal/whatsapp/queries.go
+++ b/internal/whatsapp/queries.go
@@ -316,6 +316,7 @@ func scanReactionChunk(rows *sql.Rows, result map[int64][]waReaction) error {
 
 // fetchGroupParticipants returns all participants of a group chat.
 // The group_participants table is optional in newer WhatsApp Android schemas.
+// When absent, it returns an empty result without an error.
 // In the WhatsApp schema, group_participants.gjid and .jid are TEXT fields
 // containing raw JID strings (e.g., "447700900000@s.whatsapp.net"),
 // not integer row IDs.

--- a/internal/whatsapp/queries.go
+++ b/internal/whatsapp/queries.go
@@ -315,6 +315,7 @@ func scanReactionChunk(rows *sql.Rows, result map[int64][]waReaction) error {
 }
 
 // fetchGroupParticipants returns all participants of a group chat.
+// The group_participants table is optional in newer WhatsApp Android schemas.
 // In the WhatsApp schema, group_participants.gjid and .jid are TEXT fields
 // containing raw JID strings (e.g., "447700900000@s.whatsapp.net"),
 // not integer row IDs.
@@ -331,6 +332,9 @@ func fetchGroupParticipants(db *sql.DB, groupJIDRawString string) ([]waGroupMemb
 		WHERE gp.gjid = ?
 	`, groupJIDRawString)
 	if err != nil {
+		if isTableNotFound(err) && strings.HasSuffix(err.Error(), "no such table: group_participants") {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("fetch group participants: %w", err)
 	}
 	defer func() { _ = rows.Close() }()

--- a/internal/whatsapp/queries_test.go
+++ b/internal/whatsapp/queries_test.go
@@ -364,8 +364,8 @@ func TestFetchGroupParticipantsOtherErrorPropagates(t *testing.T) {
 			members, err := fetchGroupParticipants(db, "120255501234567-987654321@g.us")
 			assert.Nil(members)
 			require.Error(err)
-			assert.ErrorContains(err, "fetch group participants")
-			assert.ErrorContains(err, tt.wantErrMsg)
+			require.ErrorContains(err, "fetch group participants")
+			require.ErrorContains(err, tt.wantErrMsg)
 		})
 	}
 }

--- a/internal/whatsapp/queries_test.go
+++ b/internal/whatsapp/queries_test.go
@@ -248,3 +248,124 @@ func TestFetchLidMapMissingTable(t *testing.T) {
 	require.NoError(t, err, "expected no error for missing table")
 	assert.Empty(t, lidMap, "expected empty map")
 }
+
+func TestFetchGroupParticipantsMissingTable(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE jid (
+			_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT
+		);
+	`)
+	require.NoError(err)
+
+	members, err := fetchGroupParticipants(db, "120255501234567-987654321@g.us")
+	require.NoError(err)
+	assert.Empty(members)
+}
+
+func TestFetchGroupParticipantsPresent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE jid (
+			_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT
+		);
+		CREATE TABLE group_participants (
+			gjid TEXT, jid TEXT, admin INTEGER
+		);
+		INSERT INTO jid VALUES
+			(1, '12025550124', 's.whatsapp.net', '12025550124@s.whatsapp.net'),
+			(2, '12025550125', 's.whatsapp.net', '12025550125@s.whatsapp.net');
+		INSERT INTO group_participants VALUES
+			('120255501234567-987654321@g.us', '12025550124@s.whatsapp.net', 2),
+			('120255501234567-987654321@g.us', '12025550125@s.whatsapp.net', NULL),
+			('120255501234567-111111111@g.us', '12025550124@s.whatsapp.net', 1);
+	`)
+	require.NoError(err)
+
+	members, err := fetchGroupParticipants(db, "120255501234567-987654321@g.us")
+	require.NoError(err)
+	require.Len(members, 2)
+	assert.Equal(waGroupMember{
+		GroupJID:     "120255501234567-987654321@g.us",
+		MemberJID:    "12025550124@s.whatsapp.net",
+		MemberUser:   "12025550124",
+		MemberServer: "s.whatsapp.net",
+		Admin:        2,
+	}, members[0])
+	assert.Equal(waGroupMember{
+		GroupJID:     "120255501234567-987654321@g.us",
+		MemberJID:    "12025550125@s.whatsapp.net",
+		MemberUser:   "12025550125",
+		MemberServer: "s.whatsapp.net",
+		Admin:        0,
+	}, members[1])
+
+	empty, err := fetchGroupParticipants(db, "120255501234567-222222222@g.us")
+	require.NoError(err)
+	assert.Empty(empty)
+}
+
+func TestFetchGroupParticipantsOtherErrorPropagates(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      string
+		wantErrMsg string
+	}{
+		{
+			name: "missing admin column",
+			setup: `
+				CREATE TABLE jid (
+					_id INTEGER PRIMARY KEY, user TEXT, server TEXT, raw_string TEXT
+				);
+				CREATE TABLE group_participants (gjid TEXT, jid TEXT);
+			`,
+			wantErrMsg: "no such column: gp.admin",
+		},
+		{
+			name: "missing required jid table",
+			setup: `
+				CREATE TABLE group_participants (
+					gjid TEXT, jid TEXT, admin INTEGER
+				);
+			`,
+			wantErrMsg: "no such table: jid",
+		},
+		{
+			name: "missing roster dependency",
+			setup: `
+				CREATE VIEW group_participants AS
+				SELECT gjid, jid, admin FROM group_participants_shadow;
+			`,
+			wantErrMsg: "no such table: main.group_participants_shadow",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			db, err := sql.Open("sqlite3", ":memory:")
+			require.NoError(err)
+			defer func() { _ = db.Close() }()
+
+			_, err = db.Exec(tt.setup)
+			require.NoError(err)
+
+			members, err := fetchGroupParticipants(db, "120255501234567-987654321@g.us")
+			assert.Nil(members)
+			require.Error(err)
+			assert.ErrorContains(err, "fetch group participants")
+			assert.ErrorContains(err, tt.wantErrMsg)
+		})
+	}
+}


### PR DESCRIPTION
WhatsApp imports now accept Android databases that omit the optional group_participants table. Messages continue to import, and resolved message senders remain conversation participants.

The group-participant reader treats the missing table as an empty result, matching the importer's existing sender fallback. Databases with the table keep their participant and admin-role handling, and other query failures still produce warnings and error counts.

The warning text and Android version came from the report in [#327](https://github.com/kenn-io/msgvault/issues/327).

Closes #327
