### PR TITLE
fix(cache): resolve recipient addresses in the analytics cache

### DIFF
--- a/cmd/msgvault/cmd/build_cache.go
+++ b/cmd/msgvault/cmd/build_cache.go
@@ -1113,15 +1113,21 @@ func buildCacheLocked(
 	// Junction rows are searchable exactly when their parent message is
 	// exportable. This includes calendar invitees and meeting attendees while
 	// excluding hidden rows and messages without a timestamp.
-	exportableJunctionWhere := fmt.Sprintf(
-		"TRY_CAST(message_id AS BIGINT) IN (SELECT CAST(m.id AS BIGINT) FROM sqlite_db.messages m WHERE %s AND TRY_CAST(m.id AS BIGINT) <= %d)",
-		exportableMessageWhere("m"), maxID,
-	)
-	junctionFilter := func(incremental string) string {
+	exportableJunctionWhereFor := func(messageIDColumn string) string {
+		return fmt.Sprintf(
+			"TRY_CAST(%s AS BIGINT) IN (SELECT CAST(m.id AS BIGINT) FROM sqlite_db.messages m WHERE %s AND TRY_CAST(m.id AS BIGINT) <= %d)",
+			messageIDColumn, exportableMessageWhere("m"), maxID,
+		)
+	}
+	junctionFilterFor := func(messageIDColumn, incremental string) string {
+		where := exportableJunctionWhereFor(messageIDColumn)
 		if incremental != "" {
-			return incremental + " AND " + exportableJunctionWhere
+			return incremental + " AND " + where
 		}
-		return " WHERE " + exportableJunctionWhere
+		return " WHERE " + where
+	}
+	junctionFilter := func(incremental string) string {
+		return junctionFilterFor("message_id", incremental)
 	}
 
 	junctionFile := "data.parquet"
@@ -1144,28 +1150,39 @@ func buildCacheLocked(
 	// 1. Export message_recipients (large junction table)
 	recipientsDir := filepath.Join(staging.root, "message_recipients")
 	escapedRecipientsDir := strings.ReplaceAll(recipientsDir, "'", "''")
+	// This export joins participants, so every column reference is alias
+	// qualified and the incremental predicate names mr.message_id rather
+	// than the bare column the shared junctionFilter helper produces.
 	recipientsFilter := ""
 	if !replaceAll && lastMessageID > 0 {
-		recipientsFilter = fmt.Sprintf(" WHERE message_id > %d", lastMessageID)
+		recipientsFilter = fmt.Sprintf(" WHERE mr.message_id > %d", lastMessageID)
 	}
-	recipientsFilter = junctionFilter(recipientsFilter)
-	// Databases from before the envelope snapshot column export '' so the
-	// dataset always carries email_address and identity filters degrade to
-	// participant matching for every legacy row.
-	recipientEnvelopeExpression := "'' as email_address"
+	recipientsFilter = junctionFilterFor("mr.message_id", recipientsFilter)
+	// Two address columns leave here. envelope_address is the header address
+	// exactly as the store recorded it (NULL when none was — chat, calendar,
+	// and mail ingested before the column existed); identity filters key on
+	// its presence. email_address is the resolved recipient address: the
+	// envelope when present, otherwise the participant's current address, so
+	// an address filter over this dataset finds pre-upgrade mail too. Only a
+	// participant with no email address at all (phone or handle only) leaves
+	// email_address NULL. Databases from before the envelope column export
+	// NULL envelopes for every row.
+	recipientEnvelopeExpression := "NULL::VARCHAR"
 	if sourceSnapshot.hasRecipientEnvelope {
-		recipientEnvelopeExpression = "COALESCE(TRY_CAST(email_address AS VARCHAR), '') as email_address"
+		recipientEnvelopeExpression = "NULLIF(TRY_CAST(mr.email_address AS VARCHAR), '')"
 	}
 	if err := runExport("message_recipients", fmt.Sprintf(`
 	COPY (
 		SELECT
-			message_id,
-			participant_id,
-			recipient_type,
-			COALESCE(TRY_CAST(display_name AS VARCHAR), '') as display_name,
-			%s
-		FROM sqlite_db.message_recipients%s
-	) TO '%s/%s' (
+			mr.message_id,
+			mr.participant_id,
+			mr.recipient_type,
+			COALESCE(TRY_CAST(mr.display_name AS VARCHAR), '') as display_name,
+			COALESCE(%[1]s, NULLIF(TRY_CAST(p.email_address AS VARCHAR), '')) as email_address,
+			%[1]s as envelope_address
+		FROM sqlite_db.message_recipients mr
+		LEFT JOIN sqlite_db.participants p ON p.id = mr.participant_id%[2]s
+	) TO '%[3]s/%[4]s' (
 		FORMAT PARQUET,
 		COMPRESSION 'zstd'
 	)
@@ -1914,7 +1931,11 @@ func (s *cacheSourceSnapshot) tables() []cacheSnapshotTable {
 	}
 	attachmentQuery := "SELECT id, message_id, size, filename, " + attachmentMIMEColumn +
 		", " + attachmentMetadataColumn + " FROM attachments"
-	recipientEnvelopeColumn := "'' AS email_address"
+	// This is the store's raw envelope column, which the export reads as
+	// mr.email_address to derive both cache columns. NULL travels through
+	// the CSV fallback as the \N sentinel, so a row with no recorded header
+	// address stays distinguishable from one carrying an empty value.
+	recipientEnvelopeColumn := "NULL AS email_address"
 	if s.hasRecipientEnvelope {
 		recipientEnvelopeColumn = "email_address"
 	}

--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -1006,41 +1006,94 @@ func TestBuildCache_PublishesConversationParticipants(t *testing.T) {
 	assert.Equal(t, int64(9), count)
 }
 
-// TestBuildCache_ExportsRecipientEnvelopeAddress verifies the envelope
-// address snapshot reaches the message_recipients Parquet dataset (cache
-// schema v17): identity filters compare against it, so an export that drops
-// the column would silently degrade every filter to participant matching.
+// TestBuildCache_ExportsRecipientEnvelopeAddress verifies both address
+// columns of the message_recipients Parquet dataset (cache schema v26).
+// envelope_address is the header address exactly as the store recorded it and
+// stays NULL for rows that never recorded one: identity filters compare
+// against it, so an export that drops the column would silently degrade every
+// filter to participant matching, and one that coerces absence to an empty
+// string would make "no address recorded" indistinguishable from a recorded
+// but empty value. email_address is the resolved address, so a row without a
+// header address still carries its participant's current address and ad-hoc
+// address filters find pre-upgrade mail.
+// Both snapshot readers are covered because they build the address columns
+// from separate SQL: the sqlite_scanner path resolves them inside the Parquet
+// COPY and the CSV fallback carries the raw column through the \N null
+// sentinel first.
 func TestBuildCache_ExportsRecipientEnvelopeAddress(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	tmpDir := setupTestSQLite(t)
-	dbPath := filepath.Join(tmpDir, "test.db")
-	analyticsDir := filepath.Join(tmpDir, "analytics")
+	for _, tc := range []struct {
+		name     string
+		forceCSV bool
+	}{
+		{name: "sqlite scanner"},
+		{name: "CSV snapshot", forceCSV: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			if tc.forceCSV {
+				t.Setenv("MSGVAULT_FORCE_CSV_SNAPSHOT", "1")
+			}
+			tmpDir := setupTestSQLite(t)
+			dbPath := filepath.Join(tmpDir, "test.db")
+			analyticsDir := filepath.Join(tmpDir, "analytics")
 
-	_, err := buildCache(dbPath, analyticsDir, false)
-	require.NoError(err)
+			_, err := buildCache(dbPath, analyticsDir, false)
+			require.NoError(err)
 
-	duckdb, err := sql.Open("duckdb", "")
-	require.NoError(err)
-	defer func() { _ = duckdb.Close() }()
-	glob := filepath.Join(analyticsDir, "message_recipients", "*.parquet")
+			duckdb, err := sql.Open("duckdb", "")
+			require.NoError(err)
+			defer func() { _ = duckdb.Close() }()
+			glob := filepath.Join(analyticsDir, "message_recipients", "*.parquet")
 
-	var envelope string
-	err = duckdb.QueryRow(
-		`SELECT email_address FROM read_parquet(?)
-		 WHERE message_id = 1 AND recipient_type = 'from'`, glob,
-	).Scan(&envelope)
-	require.NoError(err, "exported message_recipients must carry email_address")
-	assert.Equal("alice-envelope@example.com", envelope)
+			var envelope, resolved string
+			err = duckdb.QueryRow(
+				`SELECT envelope_address, email_address FROM read_parquet(?)
+				 WHERE message_id = 1 AND recipient_type = 'from'`, glob,
+			).Scan(&envelope, &resolved)
+			require.NoError(err, "exported message_recipients must carry both address columns")
+			assert.Equal("alice-envelope@example.com", envelope)
+			assert.Equal("alice-envelope@example.com", resolved,
+				"a recorded header address is also the resolved address")
 
-	var withoutSnapshot int64
-	err = duckdb.QueryRow(
-		`SELECT COUNT(*) FROM read_parquet(?)
-		 WHERE COALESCE(email_address, '') = ''`, glob,
-	).Scan(&withoutSnapshot)
-	require.NoError(err)
-	assert.Equal(int64(11), withoutSnapshot,
-		"rows without a snapshot export as empty, keeping the participant fallback")
+			var withoutSnapshot int64
+			err = duckdb.QueryRow(
+				`SELECT COUNT(*) FROM read_parquet(?)
+				 WHERE envelope_address IS NULL`, glob,
+			).Scan(&withoutSnapshot)
+			require.NoError(err)
+			assert.Equal(int64(11), withoutSnapshot,
+				"rows without a snapshot export a NULL envelope so readers can tell absence from an empty value")
+
+			// Message 4's from row recorded no header address, so it resolves
+			// to the sending participant's current address.
+			var resolvedFallback string
+			err = duckdb.QueryRow(
+				`SELECT email_address FROM read_parquet(?)
+				 WHERE message_id = 4 AND recipient_type = 'from'`, glob,
+			).Scan(&resolvedFallback)
+			require.NoError(err)
+			assert.Equal("bob@company.org", resolvedFallback,
+				"a row without a header address resolves to its participant's address")
+
+			var unresolved int64
+			err = duckdb.QueryRow(
+				`SELECT COUNT(*) FROM read_parquet(?)
+				 WHERE email_address IS NULL`, glob,
+			).Scan(&unresolved)
+			require.NoError(err)
+			assert.Equal(int64(0), unresolved,
+				"every fixture participant carries an email address, so every row resolves")
+
+			var emptyString int64
+			err = duckdb.QueryRow(
+				`SELECT COUNT(*) FROM read_parquet(?)
+				 WHERE envelope_address = '' OR email_address = ''`, glob,
+			).Scan(&emptyString)
+			require.NoError(err)
+			assert.Equal(int64(0), emptyString, "no row exports an empty-string address")
+		})
+	}
 }
 
 // TestBuildCache_ExportsListID proves the cache retains the scalar List-Id
@@ -3595,7 +3648,7 @@ func TestCacheNeedsBuild_IgnoresAlreadyProcessedUpdatedSyncRun(t *testing.T) {
 // schema version other than the current one now forces a full rebuild.
 func TestCacheNeedsBuild_SchemaVersionMismatch(t *testing.T) {
 	require := require.New(t)
-	require.Equal(25, cacheSchemaVersion, "List-ID requires cache v25")
+	require.Equal(26, cacheSchemaVersion, "the recipient address columns require cache v26")
 	tmpDir := setupTestSQLiteEmpty(t)
 
 	dbPath := filepath.Join(tmpDir, "test.db")

--- a/docs/usage/querying.md
+++ b/docs/usage/querying.md
@@ -44,12 +44,19 @@ These map directly to the Parquet files in `~/.msgvault/analytics/`.
 |---|---|
 | `messages` | id, source_id, source_message_id, conversation_id, subject, snippet, sent_at, size_estimate, has_attachments, attachment_count, sender_id, message_type, year, month, deleted_from_source_at |
 | `participants` | id, email_address, domain, display_name, phone_number |
-| `message_recipients` | message_id, participant_id, recipient_type (from/to/cc/bcc), display_name |
+| `message_recipients` | message_id, participant_id, recipient_type (from/to/cc/bcc), display_name, email_address, envelope_address |
 | `labels` | id, name |
 | `message_labels` | message_id, label_id |
 | `attachments` | message_id, filename, size |
 | `conversations` | id, source_conversation_id, title, conversation_type |
 | `sources` | id, source_type |
+
+`message_recipients.email_address` is the recipient's address: the address
+written in the message header when one was recorded, otherwise the
+participant's current address. It is NULL only for participants without an
+email address, such as phone-number contacts. `envelope_address` is the header
+address exactly as written and is NULL when none was recorded, which covers
+chat and calendar rows and mail imported before v0.19.0.
 
 ### Convenience views
 

--- a/internal/api/explore.go
+++ b/internal/api/explore.go
@@ -835,9 +835,9 @@ func (s *Server) resolveExploreIdentityContext(
 	// An email-shaped identity carries its stored address into the predicate
 	// for envelope-first matching, and stays matchable even with zero
 	// resolved participants: the address may survive only in
-	// message_recipients.email_address snapshots after a participant merge.
-	// Identifier types without an envelope surface keep the match-none
-	// short-circuit when no participant carries them.
+	// message_recipients.envelope_address, the raw header snapshot, after a
+	// participant merge. Identifier types without an envelope surface keep
+	// the match-none short-circuit when no participant carries them.
 	emailIdentifier := ""
 	if resolved.IdentifierIsEmail {
 		emailIdentifier = resolved.Identifier

--- a/internal/api/explore_review_test.go
+++ b/internal/api/explore_review_test.go
@@ -179,8 +179,8 @@ func TestExploreIdentityFilterResolvesConfirmedEmailCaseInsensitively(t *testing
 // TestExploreIdentityFilterConfirmedUnseenEmailIdentityKeepsEnvelopePredicate
 // covers the merge edge where a confirmed email address no longer resolves to
 // any participant: the filter must still carry the envelope predicate (the
-// address may survive in message_recipients.email_address snapshots) instead
-// of short-circuiting to match-none.
+// address may survive in message_recipients.envelope_address, the raw header
+// snapshot) instead of short-circuiting to match-none.
 func TestExploreIdentityFilterConfirmedUnseenEmailIdentityKeepsEnvelopePredicate(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/query/cache_state.go
+++ b/internal/query/cache_state.go
@@ -29,9 +29,13 @@ import (
 // explainable contact completion without reopening archive tables; version 24
 // adds graph-relative current and annual relationship temperature summaries to
 // the compact relationship people dataset; version 25 adds the scalar list_id
-// message dimension.
-// Schema bumps force a full rebuild before readers use an older publication.
-const CacheSchemaVersion = 25
+// message dimension; version 26 adds envelope_address (the header address as
+// recorded, NULL when absent) to message_recipients and makes email_address
+// the resolved recipient address (envelope, else participant), never an empty
+// string.
+// Schema bumps force a full rebuild before readers use an older publication,
+// so committed caches never mix shards of different shapes.
+const CacheSchemaVersion = 26
 
 // CacheSyncState is the commit marker written after a complete analytics
 // cache publication. SQLite remains authoritative; these watermarks only

--- a/internal/query/cache_state_test.go
+++ b/internal/query/cache_state_test.go
@@ -152,8 +152,8 @@ func TestInspectCacheReadiness(t *testing.T) {
 	}
 }
 
-func TestCacheSchemaVersionIncludesListID(t *testing.T) {
-	assert.Equal(t, 25, CacheSchemaVersion)
+func TestCacheSchemaVersionIncludesRecipientAddressColumns(t *testing.T) {
+	assert.Equal(t, 26, CacheSchemaVersion)
 }
 
 func TestInspectCacheReadinessNamesStaleSchemaAndDrift(t *testing.T) {

--- a/internal/query/explore.go
+++ b/internal/query/explore.go
@@ -459,10 +459,14 @@ func buildIdentityPredicateCondition(identity *IdentityPredicate, prefix string)
 	}
 	// recipientRowMatch renders the identity comparison for one
 	// message_recipients row. For an email-shaped identity the envelope
-	// snapshot (message_recipients.email_address, written at email ingest)
-	// is authoritative: it is immutable under participant merges, so
-	// comparing it keeps one alias's filter from selecting mail sent
-	// through another alias that the merge survivor now also carries.
+	// snapshot (message_recipients.envelope_address, the header address
+	// written at email ingest) is authoritative: it is immutable under
+	// participant merges, so comparing it keeps one alias's filter from
+	// selecting mail sent through another alias that the merge survivor now
+	// also carries. The sibling email_address column must not be used here:
+	// it is the resolved address, falling back to the participant's current
+	// address, so it moves under merges and would defeat alias-precise
+	// matching.
 	// Rows without a snapshot (legacy ingests, non-email writers) fall
 	// back to the resolved participant IDs, and non-email identifier
 	// types (phone, matrix, handles) have no envelope column at all, so
@@ -482,11 +486,11 @@ func buildIdentityPredicateCondition(identity *IdentityPredicate, prefix string)
 			return participantMatch(alias + ".participant_id")
 		}
 		args = append(args, identity.EmailIdentifier)
-		envelope := "(COALESCE(" + alias + ".email_address, '') <> '' AND LOWER(" + alias + ".email_address) = LOWER(?))"
+		envelope := "(COALESCE(" + alias + ".envelope_address, '') <> '' AND LOWER(" + alias + ".envelope_address) = LOWER(?))"
 		if len(identity.ParticipantIDs) == 0 {
 			return envelope
 		}
-		return "(" + envelope + " OR (COALESCE(" + alias + ".email_address, '') = '' AND " +
+		return "(" + envelope + " OR (COALESCE(" + alias + ".envelope_address, '') = '' AND " +
 			participantMatch(alias+".participant_id") + fallbackGuard + "))"
 	}
 	senderCondition := func() string {
@@ -494,7 +498,7 @@ func buildIdentityPredicateCondition(identity *IdentityPredicate, prefix string)
 			SELECT 1 FROM message_recipients identity_mr_sender_envelope
 			WHERE identity_mr_sender_envelope.message_id = ` + outerPrefix + `message_id
 			  AND identity_mr_sender_envelope.recipient_type = 'from'
-			  AND COALESCE(identity_mr_sender_envelope.email_address, '') <> ''
+			  AND COALESCE(identity_mr_sender_envelope.envelope_address, '') <> ''
 		)`
 		explicitFrom := `EXISTS (
 			SELECT 1 FROM message_recipients identity_mr_sender

--- a/internal/query/explore_models.go
+++ b/internal/query/explore_models.go
@@ -29,7 +29,7 @@ type IdentityPredicate struct {
 	ParticipantIDs []int64
 	// EmailIdentifier carries the confirmed address when it is email-shaped.
 	// Non-empty, it switches recipient-row matching to the immutable
-	// envelope snapshot (message_recipients.email_address, compared
+	// envelope snapshot (message_recipients.envelope_address, compared
 	// case-insensitively like every email rule): participant merges repoint
 	// recipient rows onto a survivor that may carry several aliases, so a
 	// participant-only match would let one alias's filter select another

--- a/internal/query/testfixtures_test.go
+++ b/internal/query/testfixtures_test.go
@@ -92,9 +92,11 @@ type RecipientFixture struct {
 	ParticipantID int64
 	Type          string // "from", "to", "cc", "bcc"
 	DisplayName   string
-	// EmailAddress is the envelope address snapshot written at email
-	// ingest. Empty models rows without a snapshot (legacy ingests,
-	// non-email writers).
+	// EmailAddress is the header address recorded at email ingest. Empty
+	// models rows where none was recorded (legacy ingests, non-email
+	// writers): the shard then carries NULL in envelope_address and the
+	// participant's current address in email_address, matching what the
+	// exporter writes for cache schema v26.
 	EmailAddress string
 }
 
@@ -177,7 +179,7 @@ type TestDataBuilder struct {
 
 	emptyAttachments bool // if true, write empty attachments file
 	// legacyRecipientSchema writes message_recipients without the
-	// email_address envelope column, modeling a pre-v17 cache.
+	// email_address and envelope_address columns, modeling a pre-v17 cache.
 	legacyRecipientSchema bool
 }
 
@@ -593,9 +595,32 @@ func (b *TestDataBuilder) recipientsSQL() string {
 		})
 	}
 	return joinRows(b.recipients, func(r RecipientFixture) string {
-		return fmt.Sprintf("(%d::BIGINT, %d::BIGINT, %s, %s, %s)",
-			r.MessageID, r.ParticipantID, sqlStr(r.Type), sqlStr(r.DisplayName), sqlStr(r.EmailAddress))
+		// Mirror the exporter: envelope_address is the recorded header
+		// address or NULL, and email_address resolves to the envelope when
+		// present, else the participant's current address, else NULL.
+		envelope := "NULL::VARCHAR"
+		resolved := "NULL::VARCHAR"
+		if r.EmailAddress != "" {
+			envelope = sqlStr(r.EmailAddress)
+			resolved = envelope
+		} else if email := b.participantEmail(r.ParticipantID); email != "" {
+			resolved = sqlStr(email)
+		}
+		return fmt.Sprintf("(%d::BIGINT, %d::BIGINT, %s, %s, %s, %s)",
+			r.MessageID, r.ParticipantID, sqlStr(r.Type), sqlStr(r.DisplayName),
+			resolved, envelope)
 	})
+}
+
+// participantEmail returns the fixture participant's current email address,
+// or an empty string when the participant is absent or carries none.
+func (b *TestDataBuilder) participantEmail(participantID int64) string {
+	for _, p := range b.participants {
+		if p.ID == participantID {
+			return p.Email
+		}
+	}
+	return ""
 }
 
 func (b *TestDataBuilder) labelsSQL() string {
@@ -654,10 +679,10 @@ const (
 	participantsCols           = "id, email_address, domain, display_name, phone_number"
 	participantIdentifiersCols = "participant_id, identifier_type, identifier_value, display_value, is_primary"
 	messageRecipientsCols      = "message_id, participant_id, recipient_type, display_name"
-	// messageRecipientsColsWithEnvelope adds the envelope address snapshot
-	// (cache schema v17). messageRecipientsCols stays for fixtures that
-	// model pre-v17 caches without the column.
-	messageRecipientsColsWithEnvelope = "message_id, participant_id, recipient_type, display_name, email_address"
+	// messageRecipientsColsWithEnvelope adds the resolved recipient address
+	// and the raw header address (cache schema v26). messageRecipientsCols
+	// stays for fixtures that model pre-v17 caches without either column.
+	messageRecipientsColsWithEnvelope = "message_id, participant_id, recipient_type, display_name, email_address, envelope_address"
 	labelsCols                        = "id, name"
 	messageLabelsCols                 = "message_id, label_id"
 	attachmentsCols                   = "attachment_id, message_id, size, filename, mime_type"
@@ -738,7 +763,7 @@ func (b *TestDataBuilder) recipientDummyRow() string {
 	if b.legacyRecipientSchema {
 		return "(0::BIGINT, 0::BIGINT, '', '')"
 	}
-	return "(0::BIGINT, 0::BIGINT, '', '', '')"
+	return "(0::BIGINT, 0::BIGINT, '', '', '', '')"
 }
 
 // addAuxiliaryTables adds sources, participants, recipients, labels, message_labels, and conversations.

--- a/internal/query/views.go
+++ b/internal/query/views.go
@@ -255,16 +255,29 @@ func createBaseViews(db *sql.DB, analyticsDir string, optCols map[string]map[str
 					"CAST(recipient_type AS VARCHAR) AS recipient_type",
 					"CAST(display_name AS VARCHAR) AS display_name",
 				},
-				optionalCols: []optionalCol{{
-					// Envelope address snapshot (cache schema v17). The ''
-					// default keeps pre-v17 caches readable: an empty
-					// envelope makes identity filters fall back to
-					// participant matching (see
-					// buildIdentityPredicateCondition).
-					name:        "email_address",
-					replaceExpr: "COALESCE(CAST(email_address AS VARCHAR), '') AS email_address",
-					defaultExpr: "'' AS email_address",
-				}},
+				optionalCols: []optionalCol{
+					{
+						// Resolved recipient address (cache schema v26): the
+						// header address when one was recorded, otherwise the
+						// participant's current address. NULL only for
+						// participants without an email address.
+						name:        "email_address",
+						replaceExpr: "CAST(email_address AS VARCHAR) AS email_address",
+						defaultExpr: "NULL::VARCHAR AS email_address",
+					},
+					{
+						// Header address exactly as recorded (cache schema
+						// v26); NULL when none was — chat, calendar, and mail
+						// ingested before the store column existed. Identity
+						// filters key on its presence (see
+						// buildIdentityPredicateCondition); a cache without
+						// the column reads as NULL and falls back to
+						// participant matching.
+						name:        "envelope_address",
+						replaceExpr: "CAST(envelope_address AS VARCHAR) AS envelope_address",
+						defaultExpr: "NULL::VARCHAR AS envelope_address",
+					},
+				},
 			},
 			probe: colsFor("message_recipients"),
 		},

--- a/internal/query/views_test.go
+++ b/internal/query/views_test.go
@@ -301,3 +301,69 @@ func TestRegisterViews_ConvenienceViews(t *testing.T) {
 		assert.Equal("email", convType)
 	})
 }
+
+// TestRegisterViews_RecipientAddressColumns proves the message_recipients
+// view exposes both address columns of cache schema v26: envelope_address
+// keeps NULL for rows where no header address was recorded instead of
+// coercing them to the empty string, while email_address resolves those rows
+// to the participant's current address. A legacy cache lacking both columns
+// reads as NULL for each.
+func TestRegisterViews_RecipientAddressColumns(t *testing.T) {
+	type addresses struct {
+		resolved sql.NullString
+		envelope sql.NullString
+	}
+	scan := func(t *testing.T, builder *TestDataBuilder) (populated, absent addresses) {
+		t.Helper()
+		dir, cleanup := builder.Build()
+		t.Cleanup(cleanup)
+		engine := builder.BuildEngine()
+		t.Cleanup(func() { _ = engine.Close() })
+		require.NoError(t, RegisterViews(engine.db, dir), "RegisterViews")
+
+		err := engine.db.QueryRowContext(context.Background(),
+			`SELECT email_address, envelope_address FROM message_recipients WHERE recipient_type = 'from'`,
+		).Scan(&populated.resolved, &populated.envelope)
+		require.NoError(t, err, "scan populated row")
+		err = engine.db.QueryRowContext(context.Background(),
+			`SELECT email_address, envelope_address FROM message_recipients WHERE recipient_type = 'to'`,
+		).Scan(&absent.resolved, &absent.envelope)
+		require.NoError(t, err, "scan absent row")
+		return populated, absent
+	}
+
+	t.Run("current cache", func(t *testing.T) {
+		builder := NewTestDataBuilder(t)
+		srcID := builder.AddSource("owner@example.com")
+		alice := builder.AddParticipant("alice@example.com", "example.com", "Alice")
+		bob := builder.AddParticipant("bob@example.com", "example.com", "Bob")
+		msgID := builder.AddMessage(MessageOpt{Subject: "Hello", SourceID: srcID})
+		builder.AddRecipientWithEnvelope(msgID, alice, "from", "Alice", "alice-alias@example.com")
+		builder.AddRecipient(msgID, bob, "to", "Bob")
+
+		populated, absent := scan(t, builder)
+		alias := sql.NullString{String: "alice-alias@example.com", Valid: true}
+		assert.Equal(t, alias, populated.envelope)
+		assert.Equal(t, alias, populated.resolved,
+			"a recorded header address is also the resolved address")
+		assert.Equal(t, sql.NullString{}, absent.envelope,
+			"row without a recorded address reads as NULL, not ''")
+		assert.Equal(t, sql.NullString{String: "bob@example.com", Valid: true}, absent.resolved,
+			"row without a recorded address resolves to the participant's address")
+	})
+
+	t.Run("legacy cache without the columns", func(t *testing.T) {
+		builder := NewTestDataBuilder(t)
+		builder.legacyRecipientSchema = true
+		srcID := builder.AddSource("owner@example.com")
+		alice := builder.AddParticipant("alice@example.com", "example.com", "Alice")
+		bob := builder.AddParticipant("bob@example.com", "example.com", "Bob")
+		msgID := builder.AddMessage(MessageOpt{Subject: "Hello", SourceID: srcID})
+		builder.AddFrom(msgID, alice, "Alice")
+		builder.AddTo(msgID, bob, "Bob")
+
+		populated, absent := scan(t, builder)
+		assert.Equal(t, addresses{}, populated, "legacy cache carries neither column")
+		assert.Equal(t, addresses{}, absent)
+	})
+}

--- a/internal/query/views_test.go
+++ b/internal/query/views_test.go
@@ -333,6 +333,7 @@ func TestRegisterViews_RecipientAddressColumns(t *testing.T) {
 	}
 
 	t.Run("current cache", func(t *testing.T) {
+		assert := assert.New(t)
 		builder := NewTestDataBuilder(t)
 		srcID := builder.AddSource("owner@example.com")
 		alice := builder.AddParticipant("alice@example.com", "example.com", "Alice")
@@ -343,12 +344,12 @@ func TestRegisterViews_RecipientAddressColumns(t *testing.T) {
 
 		populated, absent := scan(t, builder)
 		alias := sql.NullString{String: "alice-alias@example.com", Valid: true}
-		assert.Equal(t, alias, populated.envelope)
-		assert.Equal(t, alias, populated.resolved,
+		assert.Equal(alias, populated.envelope)
+		assert.Equal(alias, populated.resolved,
 			"a recorded header address is also the resolved address")
-		assert.Equal(t, sql.NullString{}, absent.envelope,
+		assert.Equal(sql.NullString{}, absent.envelope,
 			"row without a recorded address reads as NULL, not ''")
-		assert.Equal(t, sql.NullString{String: "bob@example.com", Valid: true}, absent.resolved,
+		assert.Equal(sql.NullString{String: "bob@example.com", Valid: true}, absent.resolved,
 			"row without a recorded address resolves to the participant's address")
 	})
 

--- a/internal/skills/templates/msgvault-analytics.md.tmpl
+++ b/internal/skills/templates/msgvault-analytics.md.tmpl
@@ -56,9 +56,11 @@ Default output is `--format json`:
   `participant_emails` (JSON array as string).
 
 Base views for joins: `messages`, `participants`, `message_recipients`
-(`recipient_type` ∈ from/to/cc/bcc), `labels`, `message_labels`,
-`attachments` (`message_id`, `filename`, `size`), `conversations`,
-`sources`.
+(`recipient_type` ∈ from/to/cc/bcc; `email_address` is the header address when
+one was recorded and otherwise the participant's current address, while
+`envelope_address` is the header address alone and is NULL when none was
+recorded), `labels`, `message_labels`, `attachments` (`message_id`,
+`filename`, `size`), `conversations`, `sources`.
 
 ### Notes
 


### PR DESCRIPTION
## What changed

- The analytics cache's `message_recipients` dataset now carries two address columns. `envelope_address` is the header address exactly as the store recorded it and is NULL when none was recorded. `email_address` is the resolved recipient address: the envelope when present, otherwise the participant's current address, and NULL only for participants that have no email address at all.
- The exporter builds both columns on the Parquet and CSV paths, the `message_recipients` DuckDB view exposes both (NULL for caches that predate them), and the identity filter in Explore now keys on `envelope_address`, so alias-precise matching is unchanged.
- Cache schema version 25 → 26, so existing caches rebuild once through the normal staleness path.
- The store schema, migrations, identity discovery, and attribution are untouched.
- `docs/usage/querying.md` and the bundled analytics skill describe both columns and when each is NULL.

## Why

Every recipient row written before v0.19.0 had an empty envelope address in the analytics cache, because the upgrade added the column without backfilling it and the export turned NULL into `''`. Address filters over `message_recipients` returned 0 rows with no error for mail that is in the archive, which is exactly the check people run before deleting mail from a live mailbox. Sender-side views were unaffected because they resolve through `participants`.

## Usage

No usage change. The cache rebuilds on the next automatic or manual `build-cache`. In queries, filter on `message_recipients.email_address` to find every row for an address, and read `envelope_address` when you need the header address as written.

Closes #780
