### PR TITLE
feat(beeper): retain transcript metadata and repair classifications

### DIFF
--- a/cmd/msgvault/cmd/build_cache_test.go
+++ b/cmd/msgvault/cmd/build_cache_test.go
@@ -2377,6 +2377,8 @@ func TestBuildCacheExportsAttachmentMetadataForRawQuery(t *testing.T) {
 			require.NoError(err, "add attachment metadata column")
 			_, err = db.Exec(`UPDATE attachments SET attachment_metadata = '{"shared_url":"https://example.com/post"}' WHERE id = 1`)
 			require.NoError(err, "set link-preview metadata")
+			_, err = db.Exec(`UPDATE attachments SET attachment_metadata = '{"source_transcript":{"provider":"beeper","text":"voice note"}}' WHERE id = 2`)
+			require.NoError(err, "set transcript metadata")
 			_, err = db.Exec(`UPDATE messages SET message_type = 'beeper' WHERE id = 2`)
 			require.NoError(err, "mark fixture message as Beeper")
 			require.NoError(db.Close(), "close SQLite fixture")
@@ -2388,14 +2390,14 @@ func TestBuildCacheExportsAttachmentMetadataForRawQuery(t *testing.T) {
 			defer func() { _ = engine.Close() }()
 
 			result, err := engine.QuerySQL(context.Background(), `
-				SELECT COALESCE(a.attachment_metadata IS NOT NULL, 0) AS is_share,
+				SELECT CASE WHEN COALESCE(json_extract_string(a.attachment_metadata, '$.shared_url'), '') <> '' THEN 1 ELSE 0 END AS is_share,
 				       COUNT(*), SUM(a.size)
 				FROM attachments a
 				JOIN messages m ON m.id = a.message_id
 				WHERE m.message_type = 'beeper'
 				GROUP BY is_share
 				ORDER BY is_share`)
-			require.NoError(err, "run documented link-preview query")
+			require.NoError(err, "run documented shared URL query")
 			assert.Equal([]string{"is_share", "count_star()", "sum(a.size)"}, result.Columns)
 			require.Len(result.Rows, 2)
 			assert.Equal("0", fmt.Sprint(result.Rows[0][0]))

--- a/cmd/msgvault/cmd/cache_refresh_test.go
+++ b/cmd/msgvault/cmd/cache_refresh_test.go
@@ -412,7 +412,7 @@ func TestRebuildCacheAfterDerivedRepairRefreshesCurrentCache(t *testing.T) {
 	initialState, err := query.ReadCacheSyncState(analyticsDir)
 	require.NoError(err)
 	assert.Equal(query.CacheSchemaVersion, initialState.SchemaVersion)
-	assert.Zero(initialState.DerivedDataRevision)
+	assert.Equal(int64(1), initialState.DerivedDataRevision)
 
 	readCached := func() (string, any) {
 		t.Helper()
@@ -452,11 +452,86 @@ func TestRebuildCacheAfterDerivedRepairRefreshesCurrentCache(t *testing.T) {
 	require.NoError(rebuildCacheAfterWrite(dbPath))
 	repairedState, err := query.ReadCacheSyncState(analyticsDir)
 	require.NoError(err)
-	assert.Equal(int64(1), repairedState.DerivedDataRevision)
+	assert.Equal(int64(3), repairedState.DerivedDataRevision,
+		"initial attachment, classification commit, and completed rederive ledger each advance the existing revision")
 	afterSnippet, afterMetadata := readCached()
 	assert.Equal("https://example.com/post", afterSnippet)
 	require.NotNil(afterMetadata)
 	assert.JSONEq(`{"shared_url":"https://example.com/post"}`, fmt.Sprint(afterMetadata))
+}
+
+func TestRebuildCacheAfterMixedBeeperMetadataRefreshRebuildsExistingRows(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "msgvault.db")
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = &config.Config{HomeDir: tmpDir, Data: config.DataConfig{DataDir: tmpDir}}
+	analyticsDir := cfg.AnalyticsDir()
+
+	st, err := store.Open(dbPath)
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	source, err := st.GetOrCreateSource("beeper", "signal")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversationWithType(source.ID, "!mixed:example.org", "direct_chat", "Mixed")
+	require.NoError(err)
+	insertMessage := func(id string, sentAt time.Time) int64 {
+		messageID, insertErr := st.UpsertMessage(&store.Message{
+			ConversationID: conversationID, SourceID: source.ID, SourceMessageID: id,
+			MessageType: "beeper", SentAt: sql.NullTime{Time: sentAt, Valid: true},
+			ReceivedAt: sql.NullTime{Time: sentAt, Valid: true}, HasAttachments: true, AttachmentCount: 1,
+		})
+		require.NoError(insertErr)
+		return messageID
+	}
+	oldMessageID := insertMessage("mixed-old", time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC))
+	require.NoError(st.ReplaceMessageBeeperAttachments(oldMessageID, []store.AttachmentRef{{
+		StoragePath: "aa/" + strings.Repeat("a", 64), SourceAttachmentID: "beeper:old",
+		Metadata:  `{"source_transcript":{"provider":"beeper","text":"old"}}`,
+		MediaType: "voice_note", Role: store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}}))
+	require.NoError(st.Close())
+	require.NoError(func() error { _, buildErr := buildCache(dbPath, analyticsDir, true); return buildErr }())
+
+	st, err = store.Open(dbPath)
+	require.NoError(err)
+	newMessageID := insertMessage("mixed-new", time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC))
+	require.NoError(st.ReplaceMessageBeeperAttachments(newMessageID, []store.AttachmentRef{{
+		StoragePath: "bb/" + strings.Repeat("b", 64), SourceAttachmentID: "beeper:new",
+		Metadata:  `{"source_transcript":{"provider":"beeper","text":"new"}}`,
+		MediaType: "voice_note", Role: store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}}))
+	require.NoError(st.ReplaceMessageBeeperAttachments(oldMessageID, []store.AttachmentRef{{
+		StoragePath: "aa/" + strings.Repeat("a", 64), SourceAttachmentID: "beeper:old",
+		Metadata:  `{"source_transcript":{"provider":"beeper","text":"refreshed"}}`,
+		MediaType: "voice_note", Role: store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}}))
+	require.NoError(st.Close())
+
+	staleness := cacheNeedsBuild(dbPath, analyticsDir)
+	require.True(staleness.NeedsBuild)
+	assert.True(staleness.HasDerivedDataDrift)
+	assert.True(staleness.FullRebuild)
+	require.NoError(rebuildCacheAfterWrite(dbPath))
+	engine, err := query.NewDuckDBEngine(analyticsDir, "", nil)
+	require.NoError(err)
+	result, err := engine.QuerySQL(context.Background(), `
+		SELECT m.source_message_id, a.attachment_metadata
+		FROM messages m JOIN attachments a ON a.message_id = m.id
+		WHERE m.source_message_id IN ('mixed-old', 'mixed-new')
+		ORDER BY m.source_message_id`)
+	require.NoError(err)
+	require.NoError(engine.Close())
+	require.Len(result.Rows, 2)
+	assert.Equal("mixed-new", fmt.Sprint(result.Rows[0][0]))
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"new"}}`, fmt.Sprint(result.Rows[0][1]))
+	assert.Equal("mixed-old", fmt.Sprint(result.Rows[1][0]))
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"refreshed"}}`, fmt.Sprint(result.Rows[1][1]))
 }
 
 func TestScheduledCacheRefreshSkipsWhenAutoBuildCacheDisabled(t *testing.T) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,9 @@ All notable changes to msgvault, grouped by release.
   view. Multi-source collections offer Fast search only, and deletion staging
   requires the selected messages to belong to one source.
 
+- Preserve bounded provider transcript details in Beeper attachment metadata and
+  repair stale attachment classifications from archived payloads.
+
 - Web Directory workspace: browse and search promoted durable people, filter
   by contact state, category, organization, and last contact, and maintain a
   person's profile, custom fields, employment, typed relationships, tracking,

--- a/docs/usage/beeper.md
+++ b/docs/usage/beeper.md
@@ -137,14 +137,19 @@ cursors are untouched, so it is idempotent.
 
 Media that arrives as a forwarded link preview — an Instagram reel, an x.com
 post — is recorded with the URL it previews in `attachments.attachment_metadata`
-(`{"shared_url": "..."}`), while media a sender composed has none. This tells a
+(`{"shared_url": "..."}`). Voice note transcripts can also appear there under
+`source_transcript`, so the shared URL field identifies previews. This tells a
 photo a friend took apart from a public post they forwarded, which matters
 because forwarded previews can dominate an Instagram archive's bytes while
 remaining recoverable from the URL. Downloads are unaffected: everything is
-still archived. To see the split:
+still archived. The metadata copy of `source_transcript.text` is capped at 32
+KiB on a UTF-8 boundary. A clipped value includes `"truncated": true`; the
+field is omitted when the complete transcript fits. The full transcript stays
+in the searchable message body. To see the split:
 
 ```sql
-SELECT COALESCE(a.attachment_metadata IS NOT NULL, 0) AS is_share,
+SELECT CASE WHEN COALESCE(json_extract_string(a.attachment_metadata, '$.shared_url'), '') <> ''
+            THEN 1 ELSE 0 END AS is_share,
        COUNT(*), SUM(a.size)
 FROM attachments a
 JOIN messages m ON m.id = a.message_id

--- a/internal/beeper/mapping.go
+++ b/internal/beeper/mapping.go
@@ -98,6 +98,13 @@ func placeholderBody(m *Message) string {
 	}
 }
 
+func sourceTranscript(att *Attachment) string {
+	if att == nil || att.Transcription == nil {
+		return ""
+	}
+	return strings.TrimSpace(att.Transcription.Transcription)
+}
+
 // bodyText renders the plain-text body: the message text (or a placeholder
 // for text-less media), plus any voice-note transcriptions so they are
 // visible to FTS and embeddings.
@@ -109,8 +116,8 @@ func bodyText(m *Message) string {
 		parts = append(parts, ph)
 	}
 	for _, att := range m.Attachments {
-		if att.Transcription != nil && strings.TrimSpace(att.Transcription.Transcription) != "" {
-			parts = append(parts, "🎤 transcript: "+strings.TrimSpace(att.Transcription.Transcription))
+		if transcript := sourceTranscript(&att); transcript != "" {
+			parts = append(parts, "🎤 transcript: "+transcript)
 		}
 	}
 	return strings.Join(parts, "\n")

--- a/internal/beeper/mapping_test.go
+++ b/internal/beeper/mapping_test.go
@@ -139,13 +139,13 @@ func TestSharedLink(t *testing.T) {
 func TestShareMetadata(t *testing.T) {
 	assert := assert.New(t)
 	att := []Attachment{{FileName: "image.jpg"}}
-	assert.Empty(shareMetadata(&Message{Type: typeImage, Attachments: att}))
+	assert.Empty(attachmentMetadataJSON(&Message{Type: typeImage, Attachments: att}, &att[0]))
 	assert.JSONEq(
 		`{"shared_url":"https://www.instagram.com/p/ABC/"}`,
-		shareMetadata(&Message{Type: typeImage, Text: "https://www.instagram.com/p/ABC/", Attachments: att}),
+		attachmentMetadataJSON(&Message{Type: typeImage, Text: "https://www.instagram.com/p/ABC/", Attachments: att}, &att[0]),
 	)
 	// A URL carrying a quote must not be able to break out of the JSON value.
-	meta := shareMetadata(&Message{Type: typeImage, Text: `https://x.example/"+evil`, Attachments: att})
+	meta := attachmentMetadataJSON(&Message{Type: typeImage, Text: `https://x.example/"+evil`, Attachments: att}, &att[0])
 	assert.NotEmpty(meta)
 	assert.JSONEq(`{"shared_url":"https://x.example/\"+evil"}`, meta)
 }

--- a/internal/beeper/media.go
+++ b/internal/beeper/media.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/export"
@@ -86,19 +88,50 @@ func recordOverCap(sum *ImportSummary, size int64, lowerBound bool) {
 	}
 }
 
-// shareMetadata renders the attachment_metadata JSON marking media that came
-// in as a link preview rather than as something the sender composed, recording
-// the URL it previews. Returns "" for ordinary media, which stores NULL.
-func shareMetadata(m *Message) string {
-	link := sharedLink(m)
-	if link == "" {
+const maxSourceTranscriptMetadataBytes = 32 * 1024
+
+type sourceTranscriptMetadata struct {
+	Provider  string `json:"provider"`
+	Text      string `json:"text"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+type attachmentMetadata struct {
+	SharedURL        string                    `json:"shared_url,omitempty"`
+	SourceTranscript *sourceTranscriptMetadata `json:"source_transcript,omitempty"`
+}
+
+func truncateUTF8(s string, maxBytes int) (string, bool) {
+	if maxBytes <= 0 {
+		return "", len(s) > 0
+	}
+	s = strings.ToValidUTF8(s, "\uFFFD")
+	if len(s) <= maxBytes {
+		return s, false
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut], true
+}
+
+func attachmentMetadataJSON(m *Message, att *Attachment) string {
+	metadata := attachmentMetadata{SharedURL: sharedLink(m)}
+	if transcript := sourceTranscript(att); transcript != "" {
+		text, truncated := truncateUTF8(transcript, maxSourceTranscriptMetadataBytes)
+		metadata.SourceTranscript = &sourceTranscriptMetadata{
+			Provider:  sourceTypeBeeper,
+			Text:      text,
+			Truncated: truncated,
+		}
+	}
+	if metadata.SharedURL == "" && metadata.SourceTranscript == nil {
 		return ""
 	}
-	// Marshal rather than concatenate: the URL is untrusted remote input and
-	// must not be able to break out of the JSON value.
-	b, err := json.Marshal(struct {
-		SharedURL string `json:"shared_url"`
-	}{SharedURL: link})
+	// Marshal rather than concatenate: provider values are untrusted input and
+	// must not be able to break out of a JSON value.
+	b, err := json.Marshal(metadata)
 	if err != nil {
 		return ""
 	}
@@ -133,8 +166,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 	}
 	policy := opts.MediaPolicy
 	policy.MaxBytes = maxBytes
-	shareMeta := shareMetadata(m)
-	isPreview := shareMeta != ""
+	isPreview := sharedLink(m) != ""
 	refs := make([]store.AttachmentRef, 0, len(m.Attachments))
 	for i := range m.Attachments {
 		att := &m.Attachments[i]
@@ -146,9 +178,9 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 		previous, hadPrevious := existing[sourceAttID]
 		if hadPrevious && previous.ContentHash != "" {
 			// Re-persisting already-downloaded media: keep the blob as-is but
-			// refresh the share marker, so re-running over an existing archive
-			// classifies rows stored before this was recorded.
-			previous.Metadata = shareMeta
+			// refresh current provider metadata, so re-running over an existing
+			// archive classifies rows stored before this was recorded.
+			previous.Metadata = attachmentMetadataJSON(m, att)
 			setBeeperAttachmentRole(&previous, att, isPreview)
 			refs = append(refs, previous)
 			continue
@@ -159,7 +191,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			StoragePath:        ref,
 			Size:               declaredSize(att),
 			SourceAttachmentID: sourceAttID,
-			Metadata:           shareMeta,
+			Metadata:           attachmentMetadataJSON(m, att),
 			State:              attachmentpolicy.StatePending,
 		}
 		if hadPrevious && previous.Size > marker.Size {
@@ -254,7 +286,7 @@ func (imp *Importer) persistAttachments(ctx context.Context, syncID, messageID i
 			SourceAttachmentID: sourceAttID,
 			MediaType:          mediaTypeOf(att),
 			DurationMS:         int64(att.Duration * 1000),
-			Metadata:           shareMeta,
+			Metadata:           attachmentMetadataJSON(m, att),
 			State:              attachmentpolicy.StateStored,
 		}
 		setBeeperAttachmentRole(&stored, att, isPreview)

--- a/internal/beeper/media_test.go
+++ b/internal/beeper/media_test.go
@@ -3,6 +3,7 @@ package beeper
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
@@ -10,12 +11,124 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/attachmentpolicy"
 	"go.kenn.io/msgvault/internal/store"
 )
+
+func TestAttachmentMetadataPreservesSharedURLAndBoundsSourceTranscript(t *testing.T) {
+	assert := assert.New(t)
+	longTranscript := strings.Repeat("あ", 11_000) + "x"
+	m := &Message{
+		Type: typeImage, Text: "https://example.com/shared", Attachments: []Attachment{{
+			IsVoiceNote: true, Transcription: &Transcription{Transcription: longTranscript},
+		}},
+	}
+	var metadata struct {
+		SharedURL        string `json:"shared_url"`
+		SourceTranscript struct {
+			Provider  string `json:"provider"`
+			Text      string `json:"text"`
+			Truncated bool   `json:"truncated"`
+		} `json:"source_transcript"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(attachmentMetadataJSON(m, &m.Attachments[0])), &metadata))
+	assert.Equal("https://example.com/shared", metadata.SharedURL)
+	assert.Equal(sourceTypeBeeper, metadata.SourceTranscript.Provider)
+	assert.True(metadata.SourceTranscript.Truncated)
+	assert.LessOrEqual(len(metadata.SourceTranscript.Text), maxSourceTranscriptMetadataBytes)
+	assert.True(utf8.ValidString(metadata.SourceTranscript.Text))
+	assert.Equal(0, len([]byte(metadata.SourceTranscript.Text))%3)
+	assert.Contains(bodyText(m), longTranscript)
+
+	exact := &Attachment{Transcription: &Transcription{Transcription: strings.Repeat("é", 16_384)}}
+	var exactMetadata struct {
+		SourceTranscript struct {
+			Text      string `json:"text"`
+			Truncated bool   `json:"truncated"`
+		} `json:"source_transcript"`
+	}
+	exactMetadataJSON := attachmentMetadataJSON(&Message{Attachments: []Attachment{{}}}, exact)
+	require.NoError(t, json.Unmarshal([]byte(exactMetadataJSON), &exactMetadata))
+	assert.Len([]byte(exactMetadata.SourceTranscript.Text), maxSourceTranscriptMetadataBytes)
+	assert.False(exactMetadata.SourceTranscript.Truncated)
+	assert.NotContains(exactMetadataJSON, `"truncated":false`)
+	t.Logf("metadata boundary bytes: %d", len([]byte(exactMetadata.SourceTranscript.Text)))
+}
+
+func TestAttachmentMetadataEmptyAndTranscriptAbsentStayNull(t *testing.T) {
+	assert.Empty(t, attachmentMetadataJSON(&Message{Type: typeImage, Attachments: []Attachment{{}}}, &Attachment{}))
+	assert.JSONEq(t, `{"shared_url":"https://example.com"}`, attachmentMetadataJSON(
+		&Message{Text: "https://example.com", Attachments: []Attachment{{}}}, &Attachment{}))
+}
+
+func TestImportAndRepairPreserveAttachmentTranscriptMetadata(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	f := newFakeBeeper(t)
+	ch := mediaTranscriptChat()
+	f.addChat(ch)
+	f.setAsset("mxc://beeper.local/voice1", []byte("voice bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+
+	var body, metadata string
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT m.id, b.body_text, COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM messages m
+		JOIN message_bodies b ON b.message_id = m.id
+		JOIN attachments a ON a.message_id = m.id
+		WHERE m.source_message_id = ? AND a.source_attachment_id = ?`),
+		"voice1", "beeper:mxc://beeper.local/voice1").Scan(&messageID, &body, &metadata))
+	assert.Equal("https://example.com\n🎤 transcript: source words", body)
+	assert.JSONEq(`{"shared_url":"https://example.com","source_transcript":{"provider":"beeper","text":"source words"}}`, metadata)
+
+	require.NoError(st.UpsertAttachmentRecord(t.Context(), messageID, store.AttachmentWrite{
+		Filename: "stale.ogg", MIMEType: "audio/ogg", StoragePath: "stale/path",
+		ContentHash: strings.Repeat("b", 64), Size: 12, SourceAttachmentID: "beeper:stale",
+		MediaType: "audio", State: attachmentpolicy.StateStored,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}))
+	_, err = st.DB().Exec(st.Rebind(`UPDATE attachments SET attachment_metadata = ? WHERE source_attachment_id = ?`),
+		`{"source_transcript":{"provider":"beeper","text":"stale"}}`, "beeper:stale")
+	require.NoError(err)
+
+	_, err = st.DB().Exec(st.Rebind(`UPDATE attachments SET attachment_metadata = NULL WHERE source_attachment_id = ?`), "beeper:mxc://beeper.local/voice1")
+	require.NoError(err)
+	_, err = imp.RepairSource(context.Background(), beeperSourceID(t, st), nil)
+	require.NoError(err)
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM attachments a WHERE a.source_attachment_id = ?`), "beeper:mxc://beeper.local/voice1").Scan(&metadata))
+	assert.JSONEq(`{"shared_url":"https://example.com","source_transcript":{"provider":"beeper","text":"source words"}}`, metadata)
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM attachments a WHERE a.source_attachment_id = ?`), "beeper:stale").Scan(&metadata))
+	assert.Empty(metadata)
+}
+
+func mediaTranscriptChat() *fakeChat {
+	ch := mediaChat()
+	ch.ID = "!transcript:beeper.local"
+	ch.Msgs[0].ID = "voice1"
+	ch.Msgs[0].Type = "VOICE"
+	ch.Msgs[0].Text = "https://example.com"
+	ch.Msgs[0].Attachments = []map[string]any{{
+		"id": "mxc://beeper.local/voice1", "type": "audio", "isVoiceNote": true,
+		"mimeType": "audio/ogg", "fileName": "voice.ogg", "fileSize": 11,
+		"transcription": map[string]any{"transcription": "source words"},
+	}}
+	return ch
+}
 
 // mediaChat builds a chat with one image message whose asset may or may not
 // be present on the fake server.
@@ -64,7 +177,9 @@ func TestImportDownloadsAttachment(t *testing.T) {
 	assert := assert.New(t)
 
 	f := newFakeBeeper(t)
-	f.addChat(mediaChat())
+	ch := mediaChat()
+	ch.Msgs[0].Attachments[0]["transcription"] = map[string]any{"transcription": "stored words"}
+	f.addChat(ch)
 	f.setAsset("mxc://beeper.local/photo1", []byte("hello bytes"))
 	imp, st, done := newTestImporter(t, f)
 	defer done()
@@ -112,11 +227,13 @@ func TestImportDownloadsAttachment(t *testing.T) {
 	}
 
 	// Metadata folded into the attachment row survives the re-persist.
-	var keptMediaType string
+	var keptMediaType, keptMetadata string
 	require.NoError(st.DB().QueryRow(st.Rebind(`
-		SELECT a.media_type FROM attachments a JOIN messages m ON m.id = a.message_id
-		WHERE m.source_message_id = ?`), "p0").Scan(&keptMediaType))
+		SELECT a.media_type, COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM attachments a JOIN messages m ON m.id = a.message_id
+		WHERE m.source_message_id = ?`), "p0").Scan(&keptMediaType, &keptMetadata))
 	assert.Equal("image", keptMediaType)
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"stored words"}}`, keptMetadata)
 }
 
 func TestSetBeeperAttachmentRoleUsesSourceSemantics(t *testing.T) {
@@ -154,6 +271,57 @@ func TestSetBeeperAttachmentRoleUsesSourceSemantics(t *testing.T) {
 	}
 }
 
+func TestPersistAttachmentsPreservesReusedMediaFields(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newFakeBeeper(t)
+	f.addChat(mediaChat())
+	f.setAsset("mxc://beeper.local/photo1", []byte("photo bytes"))
+	imp, st, done := newTestImporter(t, f)
+	defer done()
+
+	opts := mediaImportOptions(t)
+	_, err := imp.Import(context.Background(), opts)
+	require.NoError(err)
+	var messageID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		`SELECT id FROM messages WHERE source_message_id = ?`), "p0").Scan(&messageID))
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE attachments
+		SET filename = 'old.jpg', mime_type = 'image/jpeg', width = 32, height = 24,
+			duration_ms = 400, media_type = 'sticker', attachment_metadata = ?,
+			attachment_role = 'sticker', role_source = 'provider_explicit'
+		WHERE source_attachment_id = ?`),
+		`{"source_transcript":{"provider":"beeper","text":"old words"}}`, "beeper:mxc://beeper.local/photo1")
+	// The projection refreshes metadata while preserving optional fields that
+	// the current payload does not authoritatively replace.
+	require.NoError(err)
+
+	imp.persistAttachments(context.Background(), 0, messageID, &Message{
+		Attachments: []Attachment{{
+			ID: "mxc://beeper.local/photo1", Type: "audio", MimeType: "audio/ogg",
+			FileName: "voice.ogg", FileSize: 11,
+			Transcription: &Transcription{Transcription: "new words"},
+		}},
+	}, opts, &ImportSummary{})
+	var filename, mimeType, mediaType, role, roleSource, metadata string
+	var width, height, durationMS int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT filename, mime_type, width, height, duration_ms, media_type, attachment_role, role_source,
+			COALESCE(CAST(attachment_metadata AS TEXT), '')
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:mxc://beeper.local/photo1").Scan(
+		&filename, &mimeType, &width, &height, &durationMS, &mediaType, &role, &roleSource, &metadata))
+	assert.Equal("old.jpg", filename)
+	assert.Equal("image/jpeg", mimeType)
+	assert.EqualValues(32, width)
+	assert.EqualValues(24, height)
+	assert.EqualValues(400, durationMS)
+	assert.Equal("sticker", mediaType)
+	assert.Equal("standalone", role)
+	assert.Equal("importer_semantics", roleSource)
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"new words"}}`, metadata)
+}
+
 func TestImportMediaPolicySkipsWithoutFetching(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -188,7 +356,9 @@ func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
 	assert := assert.New(t)
 
 	f := newFakeBeeper(t)
-	f.addChat(mediaChat())
+	ch := mediaChat()
+	ch.Msgs[0].Attachments[0]["transcription"] = map[string]any{"transcription": "pending words"}
+	f.addChat(ch)
 	// Asset intentionally missing: download fails, message still archives.
 	imp, st, done := newTestImporter(t, f)
 	defer done()
@@ -213,6 +383,16 @@ func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
 		WHERE m.source_message_id = ?`), "p0").Scan(&storagePath, &sourceAttID))
 	assert.Equal("mxc://beeper.local/photo1", storagePath)
 	assert.Equal("beeper:mxc://beeper.local/photo1", sourceAttID)
+	var markerMetadata string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM attachments a WHERE a.source_attachment_id = ?`), sourceAttID).Scan(&markerMetadata))
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"pending words"}}`, markerMetadata)
+	beforeRevision, err := st.DerivedDataRevision()
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`UPDATE attachments SET attachment_metadata = ? WHERE source_attachment_id = ?`),
+		`{"source_transcript":{"provider":"beeper","text":"stale"}}`, sourceAttID)
+	require.NoError(err)
 
 	// Error recorded per item.
 	var itemCount int
@@ -237,6 +417,13 @@ func TestImportMediaFailureLeavesMarkerAndBackfillRepairs(t *testing.T) {
 		WHERE m.source_message_id = ?`), "p0").Scan(&attCount, &contentHash))
 	assert.Equal(1, attCount, "marker replaced, not duplicated")
 	assert.NotEmpty(contentHash)
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(a.attachment_metadata AS TEXT), '')
+		FROM attachments a WHERE a.source_attachment_id = ?`), sourceAttID).Scan(&markerMetadata))
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"pending words"}}`, markerMetadata)
+	afterRevision, err := st.DerivedDataRevision()
+	require.NoError(err)
+	assert.Equal(beforeRevision+1, afterRevision, "backfill metadata refresh invalidates the analytics cache")
 
 	// Nothing pending anymore: a second backfill visits no messages.
 	bsum, err = imp.BackfillMedia(context.Background(), ImportOptions{

--- a/internal/beeper/repair.go
+++ b/internal/beeper/repair.go
@@ -23,7 +23,8 @@ const rawArchiveFormat = "beeper_json"
 //	v2 — refresh snippets and the search index even when body text is current.
 //	v3 — exclude Matrix reply fallbacks from body text, snippets, and search.
 //	v4 — keep link-preview media out of standalone document processing.
-const rederiveVersion = "v4"
+//	v5 — preserve Beeper source transcript provenance on attachment metadata.
+const rederiveVersion = "v5"
 
 // repairBatchSize bounds how many archived messages are held in memory per
 // pass of the walk.
@@ -120,11 +121,31 @@ func (imp *Importer) repairMessage(item *store.ArchivedRawMessage, sourceID int6
 		sum.BodiesRewritten++
 	}
 
-	if len(m.Attachments) == 0 {
-		return
+	classifications := make(map[string]store.BeeperAttachmentClassification, len(m.Attachments))
+	isPreview := sharedLink(&m) != ""
+	for i := range m.Attachments {
+		att := &m.Attachments[i]
+		ref := assetRef(att)
+		if ref == "" {
+			continue
+		}
+		classifications[beeperAttachmentID(ref)] = store.BeeperAttachmentClassification{
+			Metadata:  attachmentMetadataJSON(&m, att),
+			IsPreview: isPreview,
+			IsSticker: att.IsSticker,
+		}
 	}
-	metadata := shareMetadata(&m)
-	changed, err := imp.store.SetBeeperAttachmentClassification(item.MessageID, metadata, metadata != "")
+	if len(classifications) == 0 {
+		stored, err := imp.store.MessageBeeperAttachments(item.MessageID)
+		if err != nil {
+			sum.Errors++
+			return
+		}
+		if len(stored) == 0 {
+			return
+		}
+	}
+	changed, err := imp.store.SetBeeperAttachmentClassifications(item.MessageID, classifications)
 	if err != nil {
 		sum.Errors++
 		return

--- a/internal/beeper/repair_test.go
+++ b/internal/beeper/repair_test.go
@@ -2,11 +2,14 @@ package beeper
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/documentindex"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -24,12 +27,41 @@ func TestRepairArchiveRewritesStaleDerivedRows(t *testing.T) {
 	f.addChat(ch)
 	f.setAsset("mxc://x/share1", []byte("share-preview-bytes"))
 	f.setAsset("mxc://x/photo1", []byte("photo-bytes"))
+	f.setAsset("mxc://x/sticker1", []byte("sticker-bytes"))
+	ch.Msgs[0].Attachments = []map[string]any{{
+		"id": "mxc://x/sticker1", "type": beeperAttachmentTypeImage, "isSticker": true,
+		"mimeType": "image/webp", "fileName": "sticker.webp", "fileSize": 13,
+	}}
 
 	imp, st, done := newTestImporter(t, f)
 	defer done()
 
 	_, err := imp.Import(context.Background(), ImportOptions{AccountID: "signal", AttachmentsDir: t.TempDir()})
 	require.NoError(err)
+	var htmlMessageID int64
+	require.NoError(st.DB().QueryRow(`
+		SELECT id FROM messages WHERE source_message_id = 'html1'`).Scan(&htmlMessageID))
+	require.NoError(st.UpsertAttachmentRecord(t.Context(), htmlMessageID, store.AttachmentWrite{
+		Filename: "stale.ogg", MIMEType: "audio/ogg", StoragePath: "stale/path",
+		ContentHash: strings.Repeat("a", 64), Size: 12, SourceAttachmentID: "beeper:stale",
+		MediaType: "audio", State: attachmentpolicy.StateStored,
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}))
+	_, err = st.DB().Exec(st.Rebind(`UPDATE attachments SET attachment_metadata = ? WHERE source_attachment_id = ?`),
+		`{"source_transcript":{"provider":"beeper","text":"stale"}}`, "beeper:stale")
+	require.NoError(err)
+	reconciler, err := documentindex.NewReconciler(st, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	var staleOccurrenceKey string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT o.occurrence_key
+		FROM document_occurrences o
+		JOIN attachments a ON a.id = o.attachment_id
+		WHERE a.source_attachment_id = ?`), "beeper:stale").Scan(&staleOccurrenceKey))
 
 	// Simulate rows written by an older build: raw HTML in the body and no
 	// share classification on the attachments.
@@ -41,7 +73,8 @@ func TestRepairArchiveRewritesStaleDerivedRows(t *testing.T) {
 		UPDATE attachments
 		SET attachment_metadata = NULL,
 		    attachment_role = 'standalone',
-		    role_source = 'importer_semantics'`)
+		    role_source = 'importer_semantics'
+		WHERE source_attachment_id <> 'beeper:stale'`)
 	require.NoError(err)
 
 	sum, err := imp.RepairSource(context.Background(), beeperSourceID(t, st), nil)
@@ -72,6 +105,26 @@ func TestRepairArchiveRewritesStaleDerivedRows(t *testing.T) {
 	assert.Equal("preview", shareRole)
 	assert.Empty(photoMeta, "media the sender composed is not a share")
 	assert.Equal("standalone", photoRole)
+	var staleMeta, staleRole, staleRoleSource string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:stale").Scan(&staleMeta, &staleRole, &staleRoleSource))
+	assert.Empty(staleMeta, "repair clears classifications for attachments removed from the archived payload")
+	assert.Equal("unknown", staleRole)
+	assert.Equal("unknown", staleRoleSource)
+	var stickerRole, stickerSource string
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT attachment_role, role_source
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:mxc://x/sticker1").Scan(&stickerRole, &stickerSource))
+	assert.Equal("sticker", stickerRole)
+	assert.Equal("provider_explicit", stickerSource)
+	result, err := reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.Positive(result.ChangesConsumed)
+	var occurrenceCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT COUNT(*) FROM document_occurrences WHERE occurrence_key = ?`), staleOccurrenceKey).Scan(&occurrenceCount))
+	assert.Zero(occurrenceCount, "the existing reconciler removes the now-ineligible occurrence")
 
 	// Re-running must be a no-op: nothing left differing from the archive.
 	again, err := imp.RepairSource(context.Background(), beeperSourceID(t, st), nil)

--- a/internal/store/beeper_attachment_classification.go
+++ b/internal/store/beeper_attachment_classification.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BeeperAttachmentClassification contains the derived metadata and role
+// evidence for one attachment in an archived Beeper payload.
+type BeeperAttachmentClassification struct {
+	Metadata  string
+	IsPreview bool
+	IsSticker bool
+}
+
+// SetBeeperAttachmentClassifications refreshes per-attachment Beeper metadata
+// and roles without replacing rows or touching occurrence identity. Attachments
+// absent from the archived payload become unknown so stale rows fail closed.
+func (s *Store) SetBeeperAttachmentClassifications(
+	messageID int64, classifications map[string]BeeperAttachmentClassification,
+) (int64, error) {
+	var changed int64
+	err := s.withTx(func(tx *loggedTx) error {
+		resetQuery := fmt.Sprintf(`
+			UPDATE attachments
+			SET attachment_metadata = %s,
+			    attachment_role = ?,
+			    role_source = ?
+			WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%%'
+			  AND (
+			      %s
+			      OR attachment_role != ?
+			      OR role_source != ?
+			  )
+		`, s.dialect.JSONBindExpr(), s.dialect.JSONIsDistinctExpr("attachment_metadata"))
+		resetArgs := []any{
+			nullIfEmpty(""), string(AttachmentRoleUnknown), string(AttachmentRoleSourceUnknown),
+			messageID, nullIfEmpty(""), string(AttachmentRoleUnknown), string(AttachmentRoleSourceUnknown),
+		}
+		if len(classifications) > 0 {
+			placeholders := strings.TrimSuffix(strings.Repeat("?,", len(classifications)), ",")
+			resetQuery += " AND source_attachment_id NOT IN (" + placeholders + ")"
+			for sourceAttachmentID := range classifications {
+				resetArgs = append(resetArgs, sourceAttachmentID)
+			}
+		}
+		result, err := tx.Exec(resetQuery, resetArgs...)
+		if err != nil {
+			return fmt.Errorf("clear stale Beeper attachment classifications: %w", err)
+		}
+		n, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("count stale Beeper attachment classifications: %w", err)
+		}
+		changed += n
+
+		for sourceAttachmentID, classification := range classifications {
+			role := AttachmentRoleStandalone
+			roleSource := AttachmentRoleSourceImporterSemantics
+			if classification.IsSticker {
+				role = AttachmentRoleSticker
+				roleSource = AttachmentRoleSourceProviderExplicit
+			} else if classification.IsPreview {
+				role = AttachmentRolePreview
+			}
+			result, err := tx.Exec(fmt.Sprintf(`
+				UPDATE attachments
+				SET attachment_metadata = %s,
+				    attachment_role = ?,
+				    role_source = ?
+				WHERE message_id = ? AND source_attachment_id = ?
+				  AND (
+				      %s
+				      OR attachment_role != ?
+				      OR role_source != ?
+				  )
+			`, s.dialect.JSONBindExpr(), s.dialect.JSONIsDistinctExpr("attachment_metadata")),
+				nullIfEmpty(classification.Metadata), string(role), string(roleSource),
+				messageID, sourceAttachmentID, nullIfEmpty(classification.Metadata), string(role), string(roleSource))
+			if err != nil {
+				return fmt.Errorf("classify Beeper attachment %s: %w", sourceAttachmentID, err)
+			}
+			n, err := result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("count Beeper attachment %s: %w", sourceAttachmentID, err)
+			}
+			changed += n
+		}
+		if changed > 0 {
+			if err := s.bumpDerivedDataRevision(tx); err != nil {
+				return fmt.Errorf("advance Beeper attachment cache revision: %w", err)
+			}
+		}
+
+		return nil
+	})
+	return changed, err
+}

--- a/internal/store/beeper_attachment_classification_test.go
+++ b/internal/store/beeper_attachment_classification_test.go
@@ -1,0 +1,221 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentpolicy"
+	"go.kenn.io/msgvault/internal/documentindex"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil/storetest"
+)
+
+func TestSetBeeperAttachmentClassificationsReconcilesStaleRowsAndOccurrences(t *testing.T) {
+	f := storetest.New(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	_, err := f.Store.DB().Exec(f.Store.Rebind(`UPDATE sources SET source_type = 'beeper' WHERE id = ?`), f.Source.ID)
+	require.NoError(err)
+	messageID := f.CreateMessage("beeper-message")
+	firstHash := strings.Repeat("a", 64)
+	secondHash := strings.Repeat("b", 64)
+	thirdHash := strings.Repeat("c", 64)
+	for _, attachment := range []store.AttachmentWrite{
+		{Filename: "voice.ogg", MIMEType: "audio/ogg", StoragePath: "aa/" + firstHash, ContentHash: firstHash,
+			Size: 10, SourceAttachmentID: "beeper:voice", MediaType: "voice_note", State: attachmentpolicy.StateStored,
+			Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceImporterSemantics},
+		{Filename: "old.ogg", MIMEType: "audio/ogg", StoragePath: "bb/" + secondHash, ContentHash: secondHash,
+			Size: 10, SourceAttachmentID: "beeper:removed", MediaType: "audio", State: attachmentpolicy.StateStored,
+			Role: store.AttachmentRoleSticker, RoleSource: store.AttachmentRoleSourceProviderExplicit},
+		{Filename: "other.ogg", MIMEType: "audio/ogg", StoragePath: "cc/" + thirdHash, ContentHash: thirdHash, Metadata: `{"shared_url":"https://other.example"}`,
+			Size: 10, SourceAttachmentID: "slack:other", MediaType: "audio", State: attachmentpolicy.StateStored,
+			Role: store.AttachmentRolePreview, RoleSource: store.AttachmentRoleSourceProviderExplicit},
+	} {
+		require.NoError(f.Store.UpsertAttachmentRecord(t.Context(), messageID, attachment))
+	}
+	reconciler, err := documentindex.NewReconciler(f.Store, documentindex.ReconcilerConfig{
+		AttachmentPageSize: 10, ChangePageSize: 10,
+	})
+	require.NoError(err)
+	_, err = reconciler.Reconcile(t.Context())
+	require.NoError(err)
+
+	var beforeRevision, afterRevision int64
+	require.NoError(f.Store.DB().QueryRow(`SELECT revision FROM document_index_state WHERE singleton = 1`).Scan(&beforeRevision))
+	var beforeDerivedRevision int64
+	require.NoError(f.Store.DB().QueryRow(`
+		SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'), 0)`).Scan(&beforeDerivedRevision))
+	changed, err := f.Store.SetBeeperAttachmentClassifications(messageID, map[string]store.BeeperAttachmentClassification{
+		"beeper:voice": {Metadata: `{"source_transcript":{"provider":"beeper","text":"hello"}}`, IsPreview: true},
+	})
+	require.NoError(err)
+	assert.EqualValues(2, changed)
+	require.NoError(f.Store.DB().QueryRow(`SELECT revision FROM document_index_state WHERE singleton = 1`).Scan(&afterRevision))
+	assert.Equal(beforeRevision, afterRevision, "attachment classification leaves occurrence reconciliation to its journal owner")
+	var afterDerivedRevision int64
+	require.NoError(f.Store.DB().QueryRow(`
+		SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'`).Scan(&afterDerivedRevision))
+	assert.Equal(beforeDerivedRevision+1, afterDerivedRevision)
+
+	var metadata, role, roleSource string
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:voice").Scan(&metadata, &role, &roleSource))
+	assert.JSONEq(`{"source_transcript":{"provider":"beeper","text":"hello"}}`, metadata)
+	assert.Equal("preview", role)
+	assert.Equal("importer_semantics", roleSource)
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:removed").Scan(&metadata, &role, &roleSource))
+	assert.Empty(metadata)
+	assert.Equal("unknown", role)
+	assert.Equal("unknown", roleSource)
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COALESCE(CAST(attachment_metadata AS TEXT), ''), attachment_role, role_source
+		FROM attachments WHERE source_attachment_id = ?`), "slack:other").Scan(&metadata, &role, &roleSource))
+	assert.JSONEq(`{"shared_url":"https://other.example"}`, metadata)
+	assert.Equal("preview", role)
+	assert.Equal("provider_explicit", roleSource)
+	result, err := reconciler.Reconcile(t.Context())
+	require.NoError(err)
+	assert.Positive(result.ChangesConsumed)
+	var occurrenceCount int
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COUNT(*) FROM document_occurrences WHERE message_id = ?`), messageID).Scan(&occurrenceCount))
+	assert.Zero(occurrenceCount, "the existing reconciler removes the now-ineligible preview occurrence")
+	require.NoError(f.Store.DB().QueryRow(`SELECT revision FROM document_index_state WHERE singleton = 1`).Scan(&afterRevision))
+	assert.Greater(afterRevision, beforeRevision)
+	reconciledRevision := afterRevision
+
+	changed, err = f.Store.SetBeeperAttachmentClassifications(messageID, map[string]store.BeeperAttachmentClassification{
+		"beeper:voice": {Metadata: `{"source_transcript":{"provider":"beeper","text":"hello"}}`, IsPreview: true},
+	})
+	require.NoError(err)
+	assert.Zero(changed)
+	require.NoError(f.Store.DB().QueryRow(`SELECT revision FROM document_index_state WHERE singleton = 1`).Scan(&afterRevision))
+	assert.Equal(reconciledRevision, afterRevision)
+	require.NoError(f.Store.DB().QueryRow(`
+		SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'`).Scan(&afterDerivedRevision))
+	assert.Equal(beforeDerivedRevision+1, afterDerivedRevision)
+}
+
+func TestReplaceMessageBeeperAttachmentsAdvancesRevisionForExistingMetadata(t *testing.T) {
+	f := storetest.New(t)
+	require := require.New(t)
+	messageID := f.CreateMessage("beeper-cache-revision")
+	ref := func(metadata string) store.AttachmentRef {
+		return store.AttachmentRef{
+			StoragePath:        "aa/" + strings.Repeat("a", 64),
+			SourceAttachmentID: "beeper:voice",
+			Metadata:           metadata,
+			MediaType:          "voice_note",
+			Role:               store.AttachmentRoleStandalone,
+			RoleSource:         store.AttachmentRoleSourceImporterSemantics,
+		}
+	}
+	readRevision := func() int64 {
+		var revision int64
+		require.NoError(f.Store.DB().QueryRow(
+			`SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'), 0)`).Scan(&revision))
+		return revision
+	}
+	assertRevision := func(want int64) { require.Equal(want, readRevision()) }
+
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{
+		ref(`{"source_transcript":{"provider":"beeper","text":"old"}}`),
+	}))
+	assertRevision(1)
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{
+		ref(`{"source_transcript":{"provider":"beeper","text":"old"}}`),
+	}))
+	assertRevision(1)
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{
+		ref(`{"source_transcript":{"provider":"beeper","text":"new"}}`),
+	}))
+	assertRevision(2)
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, nil))
+	assertRevision(3)
+}
+
+func TestReplaceMessageBeeperAttachmentsAdvancesRevisionForAddedMetadata(t *testing.T) {
+	f := storetest.New(t)
+	require := require.New(t)
+	messageID := f.CreateMessage("beeper-cache-added-attachment")
+	ref := func(sourceAttachmentID, storagePath, metadata string) store.AttachmentRef {
+		return store.AttachmentRef{
+			StoragePath:        storagePath,
+			SourceAttachmentID: sourceAttachmentID,
+			Metadata:           metadata,
+			MediaType:          "voice_note",
+			Role:               store.AttachmentRoleStandalone,
+			RoleSource:         store.AttachmentRoleSourceImporterSemantics,
+		}
+	}
+	readRevision := func() int64 {
+		var revision int64
+		require.NoError(f.Store.DB().QueryRow(
+			`SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'), 0)`).Scan(&revision))
+		return revision
+	}
+	first := ref("beeper:voice", "aa/"+strings.Repeat("a", 64), `{"source_transcript":{"provider":"beeper","text":"old"}}`)
+	second := ref("beeper:photo", "bb/"+strings.Repeat("b", 64), `{"source_transcript":{"provider":"beeper","text":"new"}}`)
+
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{first}))
+	require.Equal(int64(1), readRevision(), "initial Beeper attachment publication must invalidate exported metadata")
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{first, second}))
+	require.Equal(int64(2), readRevision(), "adding a Beeper attachment must invalidate exported metadata")
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{first, second}))
+	require.Equal(int64(2), readRevision(), "replaying the same attachment set must be a no-op")
+}
+
+func TestReplaceMessageBeeperAttachmentsRollsBackRevisionAndMetadata(t *testing.T) {
+	f := storetest.New(t)
+	require := require.New(t)
+	messageID := f.CreateMessage("beeper-cache-rollback")
+	ref := store.AttachmentRef{
+		StoragePath:        "aa/" + strings.Repeat("a", 64),
+		SourceAttachmentID: "beeper:voice",
+		Metadata:           `{"source_transcript":{"provider":"beeper","text":"old"}}`,
+		MediaType:          "voice_note",
+		Role:               store.AttachmentRoleStandalone,
+		RoleSource:         store.AttachmentRoleSourceImporterSemantics,
+	}
+	require.NoError(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{ref}))
+	triggerSQL := `
+		CREATE TRIGGER fail_derived_revision
+		BEFORE UPDATE OF value ON archive_metadata
+		WHEN NEW.key = 'derived_data_revision'
+		BEGIN SELECT RAISE(ABORT, 'injected revision failure'); END`
+	if f.Store.IsPostgreSQL() {
+		triggerSQL = `
+			CREATE FUNCTION fail_derived_revision() RETURNS trigger AS $$
+			BEGIN
+				RAISE EXCEPTION 'injected revision failure';
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER fail_derived_revision
+			BEFORE UPDATE OF value ON archive_metadata
+			FOR EACH ROW WHEN (NEW.key = 'derived_data_revision')
+			EXECUTE FUNCTION fail_derived_revision()`
+	}
+	_, err := f.Store.DB().Exec(triggerSQL)
+	require.NoError(err)
+	ref.Metadata = `{"source_transcript":{"provider":"beeper","text":"new"}}`
+	require.Error(f.Store.ReplaceMessageBeeperAttachments(messageID, []store.AttachmentRef{ref}))
+	require.NoError(f.Store.DB().QueryRow(f.Store.Rebind(`
+		SELECT COALESCE(CAST(attachment_metadata AS TEXT), '')
+		FROM attachments WHERE source_attachment_id = ?`), "beeper:voice").Scan(&ref.Metadata))
+	require.JSONEq(`{"source_transcript":{"provider":"beeper","text":"old"}}`, ref.Metadata)
+	var revision int64
+	require.NoError(f.Store.DB().QueryRow(`
+		SELECT COALESCE((SELECT CAST(value AS INTEGER) FROM archive_metadata WHERE key = 'derived_data_revision'), 0)`).Scan(&revision))
+	require.Equal(int64(1), revision)
+	dropSQL := `DROP TRIGGER fail_derived_revision`
+	if f.Store.IsPostgreSQL() {
+		dropSQL = `DROP TRIGGER fail_derived_revision ON archive_metadata; DROP FUNCTION fail_derived_revision()`
+	}
+	_, err = f.Store.DB().Exec(dropSQL)
+	require.NoError(err)
+}

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -5336,49 +5336,56 @@ func (s *Store) replaceMessageAttachmentsWhere(
 	messageID int64, deleteWhere string, requireHash bool, refs []AttachmentRef, deleteArgs ...any,
 ) error {
 	return s.withTx(func(tx *loggedTx) error {
-		args := append([]any{messageID}, deleteArgs...)
-		if _, err := tx.Exec(`DELETE FROM attachments WHERE message_id = ? AND (`+deleteWhere+`)`, args...); err != nil {
+		return s.replaceMessageAttachmentsWhereTx(tx, messageID, deleteWhere, requireHash, refs, deleteArgs...)
+	})
+}
+
+func (s *Store) replaceMessageAttachmentsWhereTx(
+	tx *loggedTx, messageID int64, deleteWhere string, requireHash bool,
+	refs []AttachmentRef, deleteArgs ...any,
+) error {
+	args := append([]any{messageID}, deleteArgs...)
+	if _, err := tx.Exec(`DELETE FROM attachments WHERE message_id = ? AND (`+deleteWhere+`)`, args...); err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		if ref.StoragePath == "" || (requireHash && ref.ContentHash == "") {
+			continue
+		}
+		write := AttachmentWrite{
+			Filename:           ref.Filename,
+			MIMEType:           ref.MimeType,
+			StoragePath:        ref.StoragePath,
+			ContentHash:        ref.ContentHash,
+			Size:               int64(ref.Size),
+			SourceAttachmentID: ref.SourceAttachmentID,
+			MediaType:          ref.MediaType,
+			Width:              ref.Width,
+			Height:             ref.Height,
+			DurationMS:         ref.DurationMS,
+			Metadata:           ref.Metadata,
+			Role:               ref.Role,
+			RoleSource:         ref.RoleSource,
+			SourcePartKey:      ref.SourcePartKey,
+			ContentID:          ref.ContentID,
+			State:              ref.State,
+			SkipReason:         ref.SkipReason,
+		}.normalized()
+		if write.SourcePartKey == "" && write.SourceAttachmentID != "" {
+			// Provider attachment IDs are already namespaced by every caller of
+			// this replacement path. They are the stable occurrence identity;
+			// unlike a content hash, they preserve two source parts with the
+			// same bytes and keep hashless pending rows distinct.
+			write.SourcePartKey = write.SourceAttachmentID
+		}
+		if err := write.validate(); err != nil {
 			return err
 		}
-		for _, ref := range refs {
-			if ref.StoragePath == "" || (requireHash && ref.ContentHash == "") {
-				continue
-			}
-			write := AttachmentWrite{
-				Filename:           ref.Filename,
-				MIMEType:           ref.MimeType,
-				StoragePath:        ref.StoragePath,
-				ContentHash:        ref.ContentHash,
-				Size:               int64(ref.Size),
-				SourceAttachmentID: ref.SourceAttachmentID,
-				MediaType:          ref.MediaType,
-				Width:              ref.Width,
-				Height:             ref.Height,
-				DurationMS:         ref.DurationMS,
-				Metadata:           ref.Metadata,
-				Role:               ref.Role,
-				RoleSource:         ref.RoleSource,
-				SourcePartKey:      ref.SourcePartKey,
-				ContentID:          ref.ContentID,
-				State:              ref.State,
-				SkipReason:         ref.SkipReason,
-			}.normalized()
-			if write.SourcePartKey == "" && write.SourceAttachmentID != "" {
-				// Provider attachment IDs are already namespaced by every caller of
-				// this replacement path. They are the stable occurrence identity;
-				// unlike a content hash, they preserve two source parts with the
-				// same bytes and keep hashless pending rows distinct.
-				write.SourcePartKey = write.SourceAttachmentID
-			}
-			if err := write.validate(); err != nil {
-				return err
-			}
-			if err := s.upsertAttachmentRecord(tx, messageID, write); err != nil {
-				return err
-			}
+		if err := s.upsertAttachmentRecord(tx, messageID, write); err != nil {
+			return err
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 func nullIfEmpty(s string) sql.NullString {
@@ -5424,7 +5431,77 @@ func (s *Store) MessageTeamsInlineAttachments(messageID int64) (map[string]Attac
 // pending-download markers whose storage_path holds the source asset URL, so
 // a later retry pass can find and repair them.
 func (s *Store) ReplaceMessageBeeperAttachments(messageID int64, refs []AttachmentRef) error {
-	return s.replaceMessageProviderAttachments(messageID, "beeper:", refs)
+	return s.withTx(func(tx *loggedTx) error {
+		metadataChanged, err := s.beeperAttachmentMetadataChangedTx(tx, messageID, refs)
+		if err != nil {
+			return err
+		}
+		if err := s.replaceMessageAttachmentsWhereTx(tx, messageID, `source_attachment_id LIKE ?`, false, refs, "beeper:%"); err != nil {
+			return err
+		}
+		if metadataChanged {
+			if err := s.bumpDerivedDataRevision(tx); err != nil {
+				return fmt.Errorf("advance Beeper attachment cache revision: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+func (s *Store) beeperAttachmentMetadataChangedTx(
+	tx *loggedTx, messageID int64, refs []AttachmentRef,
+) (bool, error) {
+	incoming := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if ref.StoragePath == "" || !strings.HasPrefix(ref.SourceAttachmentID, "beeper:") {
+			continue
+		}
+		incoming[ref.SourceAttachmentID] = ref.Metadata
+	}
+	rows, err := tx.Query(`
+		SELECT source_attachment_id
+		FROM attachments
+		WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%'`, messageID)
+	if err != nil {
+		return false, fmt.Errorf("list existing Beeper attachment metadata: %w", err)
+	}
+	var existingIDs []string
+	for rows.Next() {
+		var sourceAttachmentID string
+		if err := rows.Scan(&sourceAttachmentID); err != nil {
+			_ = rows.Close()
+			return false, fmt.Errorf("scan existing Beeper attachment metadata: %w", err)
+		}
+		existingIDs = append(existingIDs, sourceAttachmentID)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return false, fmt.Errorf("iterate existing Beeper attachment metadata: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return false, fmt.Errorf("close existing Beeper attachment metadata: %w", err)
+	}
+	if len(existingIDs) != len(incoming) {
+		return true, nil
+	}
+	for _, sourceAttachmentID := range existingIDs {
+		metadata, ok := incoming[sourceAttachmentID]
+		if !ok {
+			return true, nil
+		}
+		var same int
+		if err := tx.QueryRow(fmt.Sprintf(`
+			SELECT COUNT(*) FROM attachments
+			WHERE message_id = ? AND source_attachment_id = ?
+			  AND NOT (%s)`, s.dialect.JSONIsDistinctExpr("attachment_metadata")),
+			messageID, sourceAttachmentID, nullIfEmpty(metadata)).Scan(&same); err != nil {
+			return false, fmt.Errorf("compare existing Beeper attachment metadata: %w", err)
+		}
+		if same == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // MessageBeeperAttachments returns the message's existing Beeper-managed
@@ -5486,47 +5563,6 @@ func (s *Store) ScanArchivedRawMessages(sourceID int64, format string, afterID i
 		out = append(out, item)
 	}
 	return out, rows.Err()
-}
-
-// SetBeeperAttachmentClassification refreshes link-preview metadata and role
-// on a message's Beeper-managed attachment rows. Sticker is explicit provider
-// evidence and takes precedence over the message-level preview shape.
-func (s *Store) SetBeeperAttachmentClassification(
-	messageID int64,
-	metadata string,
-	isPreview bool,
-) (int64, error) {
-	role := AttachmentRoleStandalone
-	if isPreview {
-		role = AttachmentRolePreview
-	}
-	res, err := s.db.Exec(s.Rebind(fmt.Sprintf(`
-		UPDATE attachments
-		SET attachment_metadata = %s,
-		    attachment_role = CASE
-		        WHEN attachment_role = 'sticker' THEN attachment_role
-		        ELSE ?
-		    END,
-		    role_source = CASE
-		        WHEN attachment_role = 'sticker' THEN role_source
-		        ELSE 'importer_semantics'
-		    END
-		WHERE message_id = ? AND source_attachment_id LIKE 'beeper:%%'
-		  AND (
-		      %s
-		      OR (attachment_role != 'sticker' AND attachment_role != ?)
-		      OR (attachment_role != 'sticker' AND role_source != 'importer_semantics')
-		  )
-	`, s.dialect.JSONBindExpr(), s.dialect.JSONIsDistinctExpr("attachment_metadata"))),
-		nullIfEmpty(metadata), string(role), messageID, nullIfEmpty(metadata), string(role))
-	if err != nil {
-		return 0, fmt.Errorf("set beeper attachment classification: %w", err)
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("set beeper attachment classification: rows affected: %w", err)
-	}
-	return n, nil
 }
 
 // UpdateMessageDerivedText atomically updates the text fields derived from one


### PR DESCRIPTION
Beeper voice-note attachments now keep the transcript metadata their provider attaches, with a 32 KiB text cap and a truncation flag, while the full transcript stays in searchable message text. This is groundwork for routing Beeper speech to Docbank (#728), which needs that provenance preserved first.

Sync refreshes the metadata on already downloaded attachments, and archive repair rebuilds per-attachment metadata and fixes attachment classifications from the stored raw payloads, which document reconciliation then picks up. The existing metadata JSON and raw-message commands already expose all of this, so there is no new command. Routing the media to Docbank remains separate work.

Refs #728
