### PR TITLE
fix(store): pass version for account identity index migration

### DIFF
--- a/internal/store/migrate_account_identity_key.go
+++ b/internal/store/migrate_account_identity_key.go
@@ -54,7 +54,7 @@ func (s *Store) ensureAccountIdentityAddressKeys(ctx context.Context) error {
 	// writer cannot trip the pool-wide PostgreSQL statement timeout and
 	// fail the open; IF NOT EXISTS covers a cancellation between the
 	// create and the ledger write.
-	return s.runOnceMigration(ctx, migrationAccountIdentityAddressKeyIndex, false,
+	return s.runOnceMigration(ctx, migrationAccountIdentityAddressKeyIndex, 1, false,
 		func(ctx context.Context) error {
 			return s.runMaintenance(ctx, func(ctx context.Context, tx *loggedTx) error {
 				if _, err := tx.ExecContext(ctx, `


### PR DESCRIPTION
Restore the build by passing version 1 to the account-identity index migration. The versioned ledger change in #758 added a required argument that this caller was missing.

The migration SQL and identity remain unchanged; existing ledger entries already default to version 1.
