### PR TITLE
fix(teams): sync the chat a user holds with themselves

### DIFF
--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -206,6 +206,14 @@ func pageThroughLimit[T any](ctx context.Context, c *Client, startURL string, li
 	}
 }
 
+// SelfChatID is the Teams chat a user holds with themselves. Graph never
+// returns it from /me/chats, and a metadata read of /chats/48:notes fails with
+// "Call made for a thread which is not a ChatThread". Its messages endpoint
+// answers normally, including the incremental lastModifiedDateTime filter, so
+// once the chat is in the list it syncs through the same path as every other
+// chat.
+const SelfChatID = "48:notes"
+
 func (c *Client) ListChats(ctx context.Context) ([]Chat, error) {
 	var out []Chat
 	_, err := pageThrough[Chat](ctx, c, "/me/chats?$top=50", func(p []Chat) { out = append(out, p...) })

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -196,7 +196,8 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
-	chats = append(chats, imp.selfChat(ctx)...)
+	selfChat, selfMembers := imp.selfChat(ctx)
+	chats = append(chats, selfChat...)
 	total := len(chats)
 	for idx, ch := range chats {
 		if ctx.Err() != nil {
@@ -209,7 +210,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		// Resolve chat members once for this chat.
 		// Member fetch failure is non-fatal; we proceed with empty toRecips
 		// rather than aborting the chat import.
-		members, merr := imp.chatMembers(ctx, ch.ID, opts.Email)
+		members, merr := imp.chatMembers(ctx, ch.ID, selfMembers)
 		// Only the roster's size and read outcome matter to media policy; the
 		// members are resolved below, where their display names are kept too.
 		roster := &memberRoster{memberCount: len(members), err: merr}
@@ -319,25 +320,35 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 }
 
 // selfChat reports the chat a user holds with themselves, which Graph does not
-// list under /me/chats. It is read once here because the thread is
-// undocumented: an account that has never used it, and a tenant where it is
-// unavailable, both answer this probe and are then left alone rather than
-// counted as a sync failure.
-func (imp *Importer) selfChat(ctx context.Context) []Chat {
+// list under /me/chats, together with its roster. It is read once here because
+// the thread is undocumented: an account that has never used it, and a tenant
+// where it is unavailable, both answer this probe and are then left alone
+// rather than counted as a sync failure.
+//
+// Graph also rejects a members read on the thread, so the roster is taken from
+// the probed message instead. The chat's only member is the signed-in user,
+// who is the sender of every message in it, and that identity carries the same
+// object ID a members read would have returned. Resolution therefore takes the
+// same path as every other chat member, down to the participant cache key that
+// mention resolution reads.
+func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember) {
 	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
 	if err != nil || len(msgs) == 0 {
-		return nil
+		return nil, nil
 	}
-	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}
+	var members []ChatMember
+	if from := msgs[0].From; from != nil && from.User != nil && from.User.ID != "" {
+		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName}}
+	}
+	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members
 }
 
-// chatMembers reads a chat's roster. Graph rejects a members read on the self
-// chat, whose only member is the signed-in user, so that roster is built here
-// rather than fetched. A roster reported as unreadable would archive the chat
+// chatMembers reads a chat's roster, using the roster selfChat already resolved
+// for the self chat. A roster reported as unreadable would archive the chat
 // with unknown membership and fail media policy closed against it.
-func (imp *Importer) chatMembers(ctx context.Context, chatID, email string) ([]ChatMember, error) {
+func (imp *Importer) chatMembers(ctx context.Context, chatID string, self []ChatMember) ([]ChatMember, error) {
 	if chatID == SelfChatID {
-		return []ChatMember{{Email: email, DisplayName: email}}, nil
+		return self, nil
 	}
 	return imp.client.ListChatMembers(ctx, chatID)
 }

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -196,6 +196,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
+	chats = append(chats, imp.selfChat(ctx)...)
 	total := len(chats)
 	for idx, ch := range chats {
 		if ctx.Err() != nil {
@@ -208,7 +209,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		// Resolve chat members once for this chat.
 		// Member fetch failure is non-fatal; we proceed with empty toRecips
 		// rather than aborting the chat import.
-		members, merr := imp.client.ListChatMembers(ctx, ch.ID)
+		members, merr := imp.chatMembers(ctx, ch.ID, opts.Email)
 		// Only the roster's size and read outcome matter to media policy; the
 		// members are resolved below, where their display names are kept too.
 		roster := &memberRoster{memberCount: len(members), err: merr}
@@ -315,6 +316,30 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		}
 	}
 	return nil
+}
+
+// selfChat reports the chat a user holds with themselves, which Graph does not
+// list under /me/chats. It is read once here because the thread is
+// undocumented: an account that has never used it, and a tenant where it is
+// unavailable, both answer this probe and are then left alone rather than
+// counted as a sync failure.
+func (imp *Importer) selfChat(ctx context.Context) []Chat {
+	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
+	if err != nil || len(msgs) == 0 {
+		return nil
+	}
+	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}
+}
+
+// chatMembers reads a chat's roster. Graph rejects a members read on the self
+// chat, whose only member is the signed-in user, so that roster is built here
+// rather than fetched. A roster reported as unreadable would archive the chat
+// with unknown membership and fail media policy closed against it.
+func (imp *Importer) chatMembers(ctx context.Context, chatID, email string) ([]ChatMember, error) {
+	if chatID == SelfChatID {
+		return []ChatMember{{Email: email, DisplayName: email}}, nil
+	}
+	return imp.client.ListChatMembers(ctx, chatID)
 }
 
 func (imp *Importer) syncChannels(ctx context.Context, sourceID, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) error {

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -2964,7 +2964,9 @@ func TestSyncImportsSelfChat(t *testing.T) {
 			memberCalls.Add(1)
 			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
 		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
-			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me","userIdentityType":"aadUser"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+		case r.URL.Path == "/users/u-me":
+			_, _ = w.Write([]byte(`{"id":"u-me","mail":"me@example.com","displayName":"Me"}`))
 		default:
 			http.Error(w, "404", http.StatusNotFound)
 		}
@@ -2982,7 +2984,22 @@ func TestSyncImportsSelfChat(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("teams", "me@example.com")
 	require.NoError(err)
-	msgs, err := st.MessageExistsBatch(src.ID, []string{chatSourceMessageID(SelfChatID, "n1")})
+	sourceMessageID := chatSourceMessageID(SelfChatID, "n1")
+	msgs, err := st.MessageExistsBatch(src.ID, []string{sourceMessageID})
 	require.NoError(err)
 	assert.Len(msgs, 1)
+
+	// The roster comes from the probed message, so the signed-in user resolves
+	// through the same path a members read would have taken and is archived
+	// against the account email.
+	name, err := st.InspectDisplayName(sourceMessageID, "from", "me@example.com")
+	require.NoError(err)
+	assert.Equal("Me", name)
+
+	// A self chat has no "to" rows: they are every member except the sender,
+	// and here the only member is the sender. Pinned so a future roster change
+	// cannot start addressing these messages to their own author.
+	to, err := st.InspectRecipientCount(sourceMessageID, "to")
+	require.NoError(err)
+	assert.Equal(0, to)
 }

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -43,10 +43,24 @@ func (e *recordingEnqueuer) EnqueueMessages(_ context.Context, ids []int64) erro
 	return nil
 }
 
+// selfChatAbsent answers the self-chat probe the way Graph answers for an
+// account that has never used that chat. These fakes route on a path suffix,
+// so without this they serve the self chat another chat's messages.
+func selfChatAbsent(w http.ResponseWriter, r *http.Request) bool {
+	if strings.Contains(r.URL.Path, SelfChatID) {
+		http.Error(w, "404", http.StatusNotFound)
+		return true
+	}
+	return false
+}
+
 func fakeChatGraph(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -89,6 +103,9 @@ func TestImportChatsPopulatesConversationParticipantsAndStats(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -145,6 +162,9 @@ func fakeChannelGraph(t *testing.T) *httptest.Server {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -169,6 +189,9 @@ func TestInlineImageDownloaded(t *testing.T) {
 	assert := assert.New(t)
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -209,6 +232,9 @@ func TestContentlessGraphAttachmentDoesNotSetMessageAttachmentStats(t *testing.T
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -257,6 +283,9 @@ func TestTeamsReimportRemovesStaleInlineAttachments(t *testing.T) {
 	includeImage := true
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -339,6 +368,9 @@ func TestTeamsInlineMarkerSurvivesLinkAttachmentReplacement(t *testing.T) {
 	hostedFetches := 0
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			hostedFetches++
@@ -414,6 +446,9 @@ func TestBackfillInlineMedia(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		// Regression guard: a doubled version segment ("/v1.0/v1.0") must 404.
 		if strings.Contains(r.URL.Path, "/v1.0/v1.0") {
 			http.Error(w, "404", http.StatusNotFound)
@@ -649,6 +684,9 @@ func TestHostedFetchPath(t *testing.T) {
 func fakeLimitChatGraph(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -722,6 +760,9 @@ func TestLimitedChatImportStopsPaging(t *testing.T) {
 	serverURL := ""
 	var secondPageRequests int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -759,6 +800,9 @@ func TestChatMemberFetchFailureDoesNotAdvanceCursor(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -863,6 +907,9 @@ func TestChatMessageIDsAreNamespacedByConversation(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -954,6 +1001,9 @@ func TestChannelMediaPolicyUsesTeamParticipantCount(t *testing.T) {
 			hostedFetches := 0
 			serverURL := ""
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if selfChatAbsent(w, r) {
+					return
+				}
 				switch {
 				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 					hostedFetches++
@@ -1053,6 +1103,9 @@ func newPrivateChannelGraph(t *testing.T) *privateChannelGraph {
 
 	g := &privateChannelGraph{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			g.hostedFetches++
@@ -1271,6 +1324,9 @@ func TestBackfillChannelMediaRefreshesUnknownTeamMembership(t *testing.T) {
 			rosterReadable := false
 			serverURL := ""
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if selfChatAbsent(w, r) {
+					return
+				}
 				switch {
 				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 					hostedFetches++
@@ -1376,6 +1432,9 @@ func TestLimitedChannelImportDoesNotAdvanceDelta(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1420,6 +1479,9 @@ func TestLimitedChannelImportStopsPagingAndDeltaPrime(t *testing.T) {
 	var secondPageRequests int
 	var deltaRequests int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1470,6 +1532,9 @@ func TestChannelReplyFetchErrorDoesNotAdvanceDelta(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1511,6 +1576,9 @@ func TestChannelDeltaPrimeErrorStillPersistsBackfill(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1563,6 +1631,9 @@ func TestChannelDeltaPrimeMessageReplacesBackfilledVersion(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1609,6 +1680,9 @@ func TestReplyBeforeRoot(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1661,6 +1735,9 @@ func TestRecipientAndMentionRows(t *testing.T) {
 	// - /chats/{id}/members → two members: alice (sender) and bob
 	// - chat /messages → one message from alice @mentioning bob
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1828,6 +1905,9 @@ func TestResumeFromCheckpoint(t *testing.T) {
 	// Server that returns one chat with one message newer than our pre-seeded cursor.
 	var requestedSince string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1890,6 +1970,9 @@ func TestFullIgnoresCursor(t *testing.T) {
 
 	var requestedSince string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1984,6 +2067,9 @@ func TestImportMigratesLegacyRawMessageIDBeforeDelete(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2076,6 +2162,9 @@ func TestTeamsReimportReplacesRemovedChildCollections(t *testing.T) {
 
 	includeChildren := true
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2129,6 +2218,9 @@ func TestCallRecordingAndAttachmentsPersisted(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2200,6 +2292,9 @@ func TestTeamsMixedInlineAndLinkAttachmentsRefreshMessageStats(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -2261,6 +2356,9 @@ func TestDuplicateMentionDedup(t *testing.T) {
 	// Message that @mentions bob twice should produce exactly one 'mention' row
 	// and sum.Errors should remain 0.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2341,6 +2439,9 @@ func newChatRosterGraph(t *testing.T, rosterSize int) *chatRosterGraph {
 
 	g := &chatRosterGraph{rosterSize: rosterSize}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			g.hostedFetches++
@@ -2615,6 +2716,9 @@ func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
 	var filters graphFilterFake
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2746,6 +2850,9 @@ func TestLimitedChatSyncDoesNotStrandTiedMessages(t *testing.T) {
 	var filters graphFilterFake
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2835,4 +2942,47 @@ func chatCursorAfterLastSync(t *testing.T, st *store.Store, chatID string) strin
 	state, err := LoadSyncState(run.CursorAfter.String)
 	require.NoError(t, err)
 	return state.ChatCursor(chatID)
+}
+
+// The Teams self chat is not listed by /me/chats and rejects a members read,
+// but its messages endpoint works. Its messages belong in the archive, and its
+// roster is the signed-in user rather than an unreadable one.
+func TestSyncImportsSelfChat(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var memberCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case r.URL.Path == "/me/joinedTeams":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/members"):
+			// Graph: "Call made for a thread which is not a ChatThread".
+			memberCalls.Add(1)
+			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
+		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
+			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+	sum, err := imp.Import(context.Background(), ImportOptions{Email: "me@example.com", IncludeChannels: false})
+	require.NoError(err)
+
+	assert.EqualValues(1, sum.MessagesAdded)
+	assert.EqualValues(0, sum.Errors)
+	assert.EqualValues(0, memberCalls.Load())
+
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	msgs, err := st.MessageExistsBatch(src.ID, []string{chatSourceMessageID(SelfChatID, "n1")})
+	require.NoError(err)
+	assert.Len(msgs, 1)
 }


### PR DESCRIPTION
Closes #787

Teams sync now archives the chat a user holds with themselves. Graph does
not return that chat from `/me/chats`, so the importer never saw it and the
conversation stayed out of the archive entirely.

The thread answers its messages endpoint normally, including the incremental
filter the importer already sends, so it syncs through the same path as every
other chat. It is probed once per run: an account that has never used it, and
a tenant where the thread is unavailable, are left alone rather than counted
as a sync error. A members read on the thread fails, so its roster is built
from the signed-in user, who is its only member.

On the account this was found with, a full backfill archives 26 messages dated
2023-03-29 to 2026-09-06 that no earlier run could reach. Four carry inline
images, which the built roster keeps: an unreadable roster would fail media
policy closed and drop them.

No configuration or usage changes.
