### PR TITLE
fix(emlx): report mailbox discovery read errors

### DIFF
--- a/internal/applemail/accounts.go
+++ b/internal/applemail/accounts.go
@@ -173,7 +173,8 @@ func findV10GUIDs(mailDir string) ([]string, error) {
 // given GUID within mailDir. Searches V* directories from newest to
 // oldest, preferring the newest directory that contains mailbox
 // subdirectories (.mbox/.imapmbox). Falls back to the newest
-// existing directory if none are populated.
+// existing directory if none are populated. A discovery error keeps the
+// candidate selected so the importer can report it instead of using older mail.
 func V10AccountDir(mailDir, guid string) (string, error) {
 	vDirs, err := sortedVDirs(mailDir)
 	if err != nil {
@@ -195,11 +196,11 @@ func V10AccountDir(mailDir, guid string) (string, error) {
 		if firstMatch == "" {
 			firstMatch = candidate
 		}
-		mailboxes, _ := emlx.DiscoverMailboxes(candidate)
-		// Readable mailboxes still prove this version is populated. Import
-		// performs discovery again and reports any partial-discovery errors.
-		if len(mailboxes) > 0 {
-			return candidate, nil
+		mailboxes, discoveryErr := emlx.DiscoverMailboxes(candidate)
+		// A failed read cannot prove this version is empty. Import performs
+		// discovery again and reports errors, including wholly unreadable mail.
+		if len(mailboxes) > 0 || discoveryErr != nil {
+			return candidate, nil //nolint:nilerr // The importer reports discovery errors for the selected directory.
 		}
 	}
 

--- a/internal/applemail/accounts.go
+++ b/internal/applemail/accounts.go
@@ -195,8 +195,10 @@ func V10AccountDir(mailDir, guid string) (string, error) {
 		if firstMatch == "" {
 			firstMatch = candidate
 		}
-		mailboxes, discErr := emlx.DiscoverMailboxes(candidate)
-		if discErr == nil && len(mailboxes) > 0 {
+		mailboxes, _ := emlx.DiscoverMailboxes(candidate)
+		// Readable mailboxes still prove this version is populated. Import
+		// performs discovery again and reports any partial-discovery errors.
+		if len(mailboxes) > 0 {
 			return candidate, nil
 		}
 	}

--- a/internal/applemail/accounts_permissions_test.go
+++ b/internal/applemail/accounts_permissions_test.go
@@ -1,0 +1,29 @@
+package applemail
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV10AccountDir_PartiallyReadableNewest(t *testing.T) {
+	mailDir := t.TempDir()
+	guid := "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+	for _, version := range []string{"V9", "V10"} {
+		writeTestEmlx(t, filepath.Join(mailDir, version, guid, "Inbox.mbox", "Messages"), "2.emlx")
+	}
+	newest := filepath.Join(mailDir, "V10", guid)
+	blocked := filepath.Join(newest, "Blocked.mbox", "Messages")
+	require.NoError(t, os.MkdirAll(blocked, 0700))
+	require.NoError(t, os.Chmod(blocked, 0))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+	if _, err := os.ReadDir(blocked); err == nil {
+		t.Skip("requires a user subject to filesystem permissions")
+	}
+	got, err := V10AccountDir(mailDir, guid)
+	require.NoError(t, err)
+	assert.Equal(t, newest, got)
+}

--- a/internal/applemail/accounts_permissions_test.go
+++ b/internal/applemail/accounts_permissions_test.go
@@ -28,3 +28,22 @@ func TestV10AccountDir_PartiallyReadableNewest(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(t, newest, got)
 }
+
+func TestV10AccountDir_UnreadableNewest(t *testing.T) {
+	require := require.New(t)
+	mailDir := t.TempDir()
+	guid := "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
+	for _, version := range []string{"V9", "V10"} {
+		writeTestEmlx(t, filepath.Join(mailDir, version, guid, "Inbox.mbox", "Messages"), "2.emlx")
+	}
+	newest := filepath.Join(mailDir, "V10", guid)
+	blocked := filepath.Join(newest, "Inbox.mbox", "Messages")
+	require.NoError(os.Chmod(blocked, 0))
+	t.Cleanup(func() { require.NoError(os.Chmod(blocked, 0700)) })
+	if _, err := os.ReadDir(blocked); err == nil {
+		t.Skip("requires a user subject to filesystem permissions")
+	}
+	got, err := V10AccountDir(mailDir, guid)
+	require.NoError(err)
+	assert.Equal(t, newest, got)
+}

--- a/internal/applemail/accounts_permissions_test.go
+++ b/internal/applemail/accounts_permissions_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestV10AccountDir_PartiallyReadableNewest(t *testing.T) {
+	require := require.New(t)
 	mailDir := t.TempDir()
 	guid := "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"
 	for _, version := range []string{"V9", "V10"} {
@@ -17,13 +18,13 @@ func TestV10AccountDir_PartiallyReadableNewest(t *testing.T) {
 	}
 	newest := filepath.Join(mailDir, "V10", guid)
 	blocked := filepath.Join(newest, "Blocked.mbox", "Messages")
-	require.NoError(t, os.MkdirAll(blocked, 0700))
-	require.NoError(t, os.Chmod(blocked, 0))
-	t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+	require.NoError(os.MkdirAll(blocked, 0700))
+	require.NoError(os.Chmod(blocked, 0))
+	t.Cleanup(func() { require.NoError(os.Chmod(blocked, 0700)) })
 	if _, err := os.ReadDir(blocked); err == nil {
 		t.Skip("requires a user subject to filesystem permissions")
 	}
 	got, err := V10AccountDir(mailDir, guid)
-	require.NoError(t, err)
+	require.NoError(err)
 	assert.Equal(t, newest, got)
 }

--- a/internal/emlx/discover.go
+++ b/internal/emlx/discover.go
@@ -1,12 +1,71 @@
 package emlx
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 )
+
+// DiscoveryError reports failed filesystem reads. Discovery may still return
+// readable mailboxes alongside this error; callers must report the failures.
+type DiscoveryError struct {
+	Errors []error
+}
+
+func (e *DiscoveryError) Error() string {
+	message := "emlx discover: " + errors.Join(e.Errors...).Error()
+	if errors.Is(e, os.ErrPermission) {
+		message += "; on macOS, check Full Disk Access for the process running the import (including the daemon), then restart the daemon from that context"
+	}
+	return message
+}
+
+func (e *DiscoveryError) Unwrap() []error { return e.Errors }
+
+type discovery struct {
+	errors []error
+	seen   map[string]bool
+}
+
+func (d *discovery) record(err error) {
+	if err == nil {
+		return
+	}
+	key := err.Error()
+	if pathErr, ok := errors.AsType[*os.PathError](err); ok {
+		key = pathErr.Path
+	}
+	if !d.seen[key] {
+		d.seen[key] = true
+		d.errors = append(d.errors, err)
+	}
+}
+
+func (d *discovery) err() error {
+	if len(d.errors) == 0 {
+		return nil
+	}
+	return &DiscoveryError{Errors: d.errors}
+}
+
+func (d *discovery) readDir(path string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(path)
+	d.record(err)
+	return entries, err
+}
+
+// statOptional probes optional layout components. Missing components are normal;
+// access failures are not evidence that a layout is absent.
+func (d *discovery) statOptional(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if !os.IsNotExist(err) {
+		d.record(err)
+	}
+	return info, err
+}
 
 // Mailbox represents an Apple Mail mailbox directory containing .emlx files.
 type Mailbox struct {
@@ -33,7 +92,10 @@ type Mailbox struct {
 // If rootDir itself is a mailbox directory (ends in .mbox or .imapmbox
 // and contains a Messages/ subdirectory with .emlx files), only that
 // single mailbox is returned.
+// A non-nil error can accompany partial results. An empty result with an error
+// must not be treated as an empty source tree.
 func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
+	discovery := &discovery{seen: make(map[string]bool)}
 	abs, err := filepath.Abs(rootDir)
 	if err != nil {
 		return nil, fmt.Errorf("emlx discover: abs path: %w", err)
@@ -41,7 +103,8 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 
 	info, err := os.Stat(abs)
 	if err != nil {
-		return nil, fmt.Errorf("emlx discover: stat %q: %w", abs, err)
+		discovery.record(err)
+		return nil, discovery.err()
 	}
 	if !info.IsDir() {
 		return nil, fmt.Errorf(
@@ -51,30 +114,30 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 
 	// Auto-detect: if the path itself is a mailbox, import just that one.
 	if isMailboxDir(abs) {
-		msgDir, files, err := listEmlxFiles(abs)
-		if err != nil {
-			return nil, err
-		}
+		msgDir, files := discovery.listEmlxFiles(abs)
 		if len(files) > 0 {
 			label := LabelFromPath(filepath.Dir(abs), abs)
 			return []Mailbox{{
 				Path: abs, MsgDir: msgDir,
 				Label: label, Files: files,
-			}}, nil
+			}}, discovery.err()
 		}
 	}
 
 	var mailboxes []Mailbox
 	err = filepath.WalkDir(abs, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil //nolint:nilerr // skip unreadable entries; partial discovery beats abort
+			discovery.record(err)
+			return nil // Preserve readable siblings, but report this failure.
 		}
 		if !d.IsDir() {
 			return nil
 		}
 
 		// listEmlxFiles reads Messages/ directly, so skip walking it.
-		if d.Name() == "Messages" {
+		if d.Name() == "Messages" && path != abs {
+			// Check readability even when no enclosing mailbox was recognized.
+			_, _ = discovery.readDir(path)
 			return filepath.SkipDir
 		}
 
@@ -83,9 +146,9 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 			return nil
 		}
 
-		msgDir, files, listErr := listEmlxFiles(path)
-		if listErr != nil || len(files) == 0 {
-			return nil //nolint:nilerr // unreadable mailbox is the same as empty for discovery
+		msgDir, files := discovery.listEmlxFiles(path)
+		if len(files) == 0 {
+			return nil
 		}
 
 		label := LabelFromPath(abs, path)
@@ -103,7 +166,7 @@ func DiscoverMailboxes(rootDir string) ([]Mailbox, error) {
 	sort.Slice(mailboxes, func(i, j int) bool {
 		return mailboxes[i].Path < mailboxes[j].Path
 	})
-	return mailboxes, nil
+	return mailboxes, discovery.err()
 }
 
 // LabelFromPath derives a human-readable label from a mailbox path
@@ -160,40 +223,43 @@ func isMailboxDir(path string) bool {
 		return false
 	}
 
-	return findMessagesDir(path) != ""
+	return true
 }
 
 // findMessagesDir locates the Messages/ directory within a .mbox.
 // Returns "" if none found. Checks both legacy (Messages/) and
 // modern V10 (<GUID>/Data/Messages/) layouts. When both exist,
 // prefers whichever contains .emlx files (directly or in partitions).
-func findMessagesDir(mailboxPath string) string {
+func (d *discovery) findMessagesDir(mailboxPath string) string {
 	var candidates []string
+	entries, err := d.readDir(mailboxPath)
+	if err != nil {
+		return ""
+	}
 
 	// Legacy: direct Messages/ subdirectory.
 	legacy := filepath.Join(mailboxPath, "Messages")
-	if info, err := os.Stat(legacy); err == nil && info.IsDir() {
+	if info, err := d.statOptional(legacy); err == nil && info.IsDir() {
 		candidates = append(candidates, legacy)
 	}
 
 	// Modern V10: <subdir>/Data/Messages/ subdirectory.
 	// Also handles partition-only layouts where Data/Messages/ doesn't exist.
-	entries, err := os.ReadDir(mailboxPath)
 	if err == nil {
 		for _, e := range entries {
 			if !e.IsDir() || e.Name() == "Messages" {
 				continue
 			}
 			dataDir := filepath.Join(mailboxPath, e.Name(), "Data")
-			dataStat, statErr := os.Stat(dataDir)
+			dataStat, statErr := d.statOptional(dataDir)
 			if statErr != nil || !dataStat.IsDir() {
 				continue
 			}
 			modern := filepath.Join(dataDir, "Messages")
-			msgStat, statErr := os.Stat(modern)
+			msgStat, statErr := d.statOptional(modern)
 			if statErr == nil && msgStat.IsDir() {
 				candidates = append(candidates, modern)
-			} else if hasEmlxFilesInPartitions(dataDir) {
+			} else if d.hasEmlxFilesInPartitions(dataDir) {
 				// Partition-only: Data/Messages/ absent but partitions exist.
 				candidates = append(candidates, modern)
 			}
@@ -207,13 +273,13 @@ func findMessagesDir(mailboxPath string) string {
 	// Prefer the first candidate that has .emlx files directly or
 	// within numeric partition subdirectories (V10 only).
 	for _, dir := range candidates {
-		if hasEmlxFiles(dir) {
+		if d.hasEmlxFiles(dir) {
 			return dir
 		}
 		// For V10 layout the parent is Data/; check partitions there.
 		dataDir := filepath.Dir(dir)
 		if filepath.Base(dataDir) == "Data" &&
-			hasEmlxFilesInPartitions(dataDir) {
+			d.hasEmlxFilesInPartitions(dataDir) {
 			return dir
 		}
 	}
@@ -224,9 +290,13 @@ func findMessagesDir(mailboxPath string) string {
 
 // hasEmlxFiles returns true if dir contains at least one .emlx file
 // (including *.partial.emlx).
-func hasEmlxFiles(dir string) bool {
+func (d *discovery) hasEmlxFiles(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
+		// A partition-only layout has no primary Messages directory.
+		if !os.IsNotExist(err) {
+			d.record(err)
+		}
 		return false
 	}
 	for _, e := range entries {
@@ -239,8 +309,8 @@ func hasEmlxFiles(dir string) bool {
 
 // hasEmlxFilesInPartitions returns true if dir contains .emlx files
 // within Messages/ subdirectories or nested numeric partition dirs (0-9).
-func hasEmlxFilesInPartitions(dir string) bool {
-	entries, err := os.ReadDir(dir)
+func (d *discovery) hasEmlxFilesInPartitions(dir string) bool {
+	entries, err := d.readDir(dir)
 	if err != nil {
 		return false
 	}
@@ -250,11 +320,11 @@ func hasEmlxFilesInPartitions(dir string) bool {
 		}
 		name := e.Name()
 		if name == "Messages" {
-			if hasEmlxFiles(filepath.Join(dir, name)) {
+			if d.hasEmlxFiles(filepath.Join(dir, name)) {
 				return true
 			}
 		} else if isDigitDir(name) {
-			if hasEmlxFilesInPartitions(filepath.Join(dir, name)) {
+			if d.hasEmlxFilesInPartitions(filepath.Join(dir, name)) {
 				return true
 			}
 		}
@@ -345,19 +415,19 @@ func stripMailboxSuffix(name string) string {
 // listEmlxFiles returns the Messages directory path and sorted
 // absolute paths to .emlx files (from both the primary Messages/ dir
 // and numeric partition subdirectories).
-// Returns ("", nil, nil) if no Messages directory is found.
-func listEmlxFiles(
+// Returns ("", nil) if no Messages directory is found, recording read failures.
+func (d *discovery) listEmlxFiles(
 	mailboxPath string,
-) (string, []string, error) {
-	msgDir := findMessagesDir(mailboxPath)
+) (string, []string) {
+	msgDir := d.findMessagesDir(mailboxPath)
 	if msgDir == "" {
-		return "", nil, nil
+		return "", nil
 	}
 
 	entries, err := os.ReadDir(msgDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", nil, fmt.Errorf("read Messages dir: %w", err)
+			d.record(err)
 		}
 		// Primary Messages/ dir absent (partition-only layout); continue
 		// so that partition files are still collected below.
@@ -374,11 +444,11 @@ func listEmlxFiles(
 	// primary Messages/ dir which was already handled above.
 	dataDir := filepath.Dir(msgDir)
 	if filepath.Base(dataDir) == "Data" {
-		topEntries, readErr := os.ReadDir(dataDir)
+		topEntries, readErr := d.readDir(dataDir)
 		if readErr == nil {
 			for _, e := range topEntries {
 				if e.IsDir() && isDigitDir(e.Name()) {
-					collectPartitionFiles(
+					d.collectPartitionFiles(
 						filepath.Join(dataDir, e.Name()), &files,
 					)
 				}
@@ -387,14 +457,14 @@ func listEmlxFiles(
 	}
 
 	sort.Strings(files)
-	return msgDir, files, nil
+	return msgDir, files
 }
 
 // collectPartitionFiles recursively walks dir for Messages/ subdirs
 // and numeric partition dirs (0-9), appending absolute .emlx file
 // paths to files.
-func collectPartitionFiles(dir string, files *[]string) {
-	entries, err := os.ReadDir(dir)
+func (d *discovery) collectPartitionFiles(dir string, files *[]string) {
+	entries, err := d.readDir(dir)
 	if err != nil {
 		return
 	}
@@ -405,7 +475,7 @@ func collectPartitionFiles(dir string, files *[]string) {
 		name := e.Name()
 		if name == "Messages" {
 			msgDir := filepath.Join(dir, name)
-			msgs, err := os.ReadDir(msgDir)
+			msgs, err := d.readDir(msgDir)
 			if err != nil {
 				continue
 			}
@@ -413,7 +483,7 @@ func collectPartitionFiles(dir string, files *[]string) {
 				*files = append(*files, filepath.Join(msgDir, n))
 			}
 		} else if isDigitDir(name) {
-			collectPartitionFiles(filepath.Join(dir, name), files)
+			d.collectPartitionFiles(filepath.Join(dir, name), files)
 		}
 	}
 }

--- a/internal/emlx/discover_permissions_test.go
+++ b/internal/emlx/discover_permissions_test.go
@@ -45,20 +45,22 @@ func TestDiscoverMailboxes_UnreadableDescendant(t *testing.T) {
 				name = denied + "/partial"
 			}
 			t.Run(name, func(t *testing.T) {
+				require := require.New(t)
+				assert := assert.New(t)
 				root := t.TempDir()
 				blocked := filepath.Join(root, filepath.FromSlash(denied))
-				require.NoError(t, os.MkdirAll(blocked, 0700))
+				require.NoError(os.MkdirAll(blocked, 0700))
 				if readable {
 					mkMailbox(t, filepath.Join(root, "Readable.mbox"), "1.emlx")
 				}
 				denyDirectory(t, blocked)
 				mailboxes, err := DiscoverMailboxes(root)
-				require.ErrorIs(t, err, os.ErrPermission)
+				require.ErrorIs(err, os.ErrPermission)
 				if readable {
-					require.Len(t, mailboxes, 1)
-					assert.Equal(t, "Readable", mailboxes[0].Label)
+					require.Len(mailboxes, 1)
+					assert.Equal("Readable", mailboxes[0].Label)
 				} else {
-					assert.Empty(t, mailboxes)
+					assert.Empty(mailboxes)
 				}
 			})
 		}
@@ -66,13 +68,14 @@ func TestDiscoverMailboxes_UnreadableDescendant(t *testing.T) {
 }
 
 func TestDiscoverMailboxes_UnreadablePartitionPreservesFiles(t *testing.T) {
+	require := require.New(t)
 	root := filepath.Join(t.TempDir(), "Inbox.mbox")
 	mkV10Mailbox(t, root, "1.emlx")
 	partition := filepath.Join(root, testMailboxGUID, "Data", "0", "Messages")
-	require.NoError(t, os.MkdirAll(partition, 0700))
+	require.NoError(os.MkdirAll(partition, 0700))
 	denyDirectory(t, partition)
 	mailboxes, err := DiscoverMailboxes(root)
-	require.ErrorIs(t, err, os.ErrPermission)
-	require.Len(t, mailboxes, 1)
+	require.ErrorIs(err, os.ErrPermission)
+	require.Len(mailboxes, 1)
 	assert.Len(t, mailboxes[0].Files, 1)
 }

--- a/internal/emlx/discover_permissions_test.go
+++ b/internal/emlx/discover_permissions_test.go
@@ -1,0 +1,78 @@
+package emlx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func denyDirectory(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.Chmod(path, 0))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(path, 0700)) })
+	if _, err := os.ReadDir(path); err == nil {
+		t.Skip("requires a user subject to filesystem permissions")
+	}
+}
+
+func TestDiscoverMailboxes_UnreadableRoot(t *testing.T) {
+	for _, name := range []string{"Mail", "Inbox.mbox"} {
+		t.Run(name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), name)
+			mkMailbox(t, root, "1.emlx")
+			denyDirectory(t, root)
+			mailboxes, err := DiscoverMailboxes(root)
+			require.ErrorIs(t, err, os.ErrPermission)
+			assert.Empty(t, mailboxes)
+		})
+	}
+}
+
+func TestDiscoverMailboxes_UnreadableDescendant(t *testing.T) {
+	for _, denied := range []string{
+		"Blocked", "Blocked.mbox", "Blocked.mbox/Messages",
+		"Blocked.mbox/Container", "Blocked.mbox/Container/Data",
+		"Blocked.mbox/Container/Data/Messages",
+		"Blocked.mbox/Container/Data/0",
+		"Blocked.mbox/Container/Data/0/Messages",
+	} {
+		for _, readable := range []bool{false, true} {
+			name := denied + "/alone"
+			if readable {
+				name = denied + "/partial"
+			}
+			t.Run(name, func(t *testing.T) {
+				root := t.TempDir()
+				blocked := filepath.Join(root, filepath.FromSlash(denied))
+				require.NoError(t, os.MkdirAll(blocked, 0700))
+				if readable {
+					mkMailbox(t, filepath.Join(root, "Readable.mbox"), "1.emlx")
+				}
+				denyDirectory(t, blocked)
+				mailboxes, err := DiscoverMailboxes(root)
+				require.ErrorIs(t, err, os.ErrPermission)
+				if readable {
+					require.Len(t, mailboxes, 1)
+					assert.Equal(t, "Readable", mailboxes[0].Label)
+				} else {
+					assert.Empty(t, mailboxes)
+				}
+			})
+		}
+	}
+}
+
+func TestDiscoverMailboxes_UnreadablePartitionPreservesFiles(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Inbox.mbox")
+	mkV10Mailbox(t, root, "1.emlx")
+	partition := filepath.Join(root, testMailboxGUID, "Data", "0", "Messages")
+	require.NoError(t, os.MkdirAll(partition, 0700))
+	denyDirectory(t, partition)
+	mailboxes, err := DiscoverMailboxes(root)
+	require.ErrorIs(t, err, os.ErrPermission)
+	require.Len(t, mailboxes, 1)
+	assert.Len(t, mailboxes[0].Files, 1)
+}

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -121,7 +121,13 @@ func ImportEmlxDir(
 	// Discover mailboxes.
 	mailboxes, err := emlx.DiscoverMailboxes(rootDir)
 	if err != nil {
-		return nil, fmt.Errorf("discover mailboxes: %w", err)
+		discoveryErr, ok := errors.AsType[*emlx.DiscoveryError](err)
+		if len(mailboxes) == 0 || !ok {
+			return nil, fmt.Errorf("discover mailboxes: %w", err)
+		}
+		summary.Errors = int64(len(discoveryErr.Errors))
+		log.Warn("partial mailbox discovery", "error", discoveryErr,
+			"errors", summary.Errors)
 	}
 	summary.MailboxesTotal = len(mailboxes)
 	if len(mailboxes) == 0 {
@@ -224,6 +230,10 @@ func ImportEmlxDir(
 		}
 	}
 
+	// Like message/checkpoint failures, discovery failures count per attempt.
+	// The checkpoint is cumulative across resumes; summary.Errors reports only
+	// this invocation. Skipping this on resume would lose newly denied paths.
+	cp.ErrorsCount += summary.Errors
 	syncID, err = execution.StartSyncContext(ownershipCtx, "import-emlx", "")
 	if err != nil {
 		return nil, fmt.Errorf("start sync: %w", err)

--- a/internal/importer/emlx_permissions_test.go
+++ b/internal/importer/emlx_permissions_test.go
@@ -1,0 +1,117 @@
+package importer
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil/email"
+)
+
+func TestImportEmlxDir_DiscoveryPermissions(t *testing.T) {
+	for _, partial := range []bool{false, true} {
+		name := "no readable mailboxes"
+		if partial {
+			name = "partial import"
+		}
+		t.Run(name, func(t *testing.T) {
+			st, tmp := openTestStore(t)
+			root := filepath.Join(tmp, "Mail")
+			blocked := filepath.Join(root, "Blocked.mbox", "Messages")
+			require.NoError(t, os.MkdirAll(blocked, 0700))
+			require.NoError(t, os.Chmod(blocked, 0))
+			t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+			if _, err := os.ReadDir(blocked); err == nil {
+				t.Skip("requires a user subject to filesystem permissions")
+			}
+			if partial {
+				mkMailboxDir(t, filepath.Join(root, "Readable.mbox"), map[string][]byte{
+					"1.emlx": email.NewMessage().From("user@example.com").
+						To("other@example.com").Subject("Permission fixture").
+						Body("Synthetic message.").Bytes(),
+				})
+			}
+			var logs bytes.Buffer
+			summary, err := ImportEmlxDir(context.Background(), st, root, EmlxImportOptions{
+				Identifier: "user@example.com",
+				Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+			})
+			if !partial {
+				require.ErrorIs(t, err, os.ErrPermission)
+				assert.Nil(t, summary)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, summary)
+			assert.Equal(t, int64(1), summary.MessagesAdded)
+			assert.Equal(t, int64(1), summary.Errors)
+			assert.False(t, summary.HardErrors)
+			assert.Contains(t, logs.String(), "WARN")
+			assert.Contains(t, logs.String(), blocked)
+			var errorsCount int64
+			require.NoError(t, st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ?", summary.SourceID).Scan(&errorsCount))
+			assert.Equal(t, int64(1), errorsCount)
+		})
+	}
+}
+
+func TestImportEmlxDir_DiscoveryErrorsOnResume(t *testing.T) {
+	for _, initiallyDenied := range []bool{false, true} {
+		name := "new denial on resume"
+		if initiallyDenied {
+			name = "repeated denial"
+		}
+		t.Run(name, func(t *testing.T) {
+			st, tmp := openTestStore(t)
+			root := filepath.Join(tmp, "Mail")
+			blocked := filepath.Join(root, "Blocked.mbox", "Messages")
+			require.NoError(t, os.MkdirAll(blocked, 0700))
+			t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+			deny := func() {
+				t.Helper()
+				require.NoError(t, os.Chmod(blocked, 0))
+				if _, err := os.ReadDir(blocked); err == nil {
+					t.Skip("requires a user subject to filesystem permissions")
+				}
+			}
+			if initiallyDenied {
+				deny()
+			}
+			mkMailboxDir(t, filepath.Join(root, "Readable.mbox"), map[string][]byte{
+				"1.emlx": email.NewMessage().From("user@example.com").
+					Subject("Resume fixture").Body("Synthetic message.").Bytes(),
+			})
+			opts := EmlxImportOptions{Identifier: "user@example.com"}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			first, err := ImportEmlxDir(ctx, st, root, opts)
+			require.NoError(t, err)
+			require.NotNil(t, first)
+			var firstErrors int64
+			if initiallyDenied {
+				firstErrors = 1
+			}
+			assert.Equal(t, firstErrors, first.Errors)
+			deny()
+
+			resumed, err := ImportEmlxDir(context.Background(), st, root, opts)
+			require.NoError(t, err)
+			require.NotNil(t, resumed)
+			assert.True(t, resumed.WasResumed)
+			assert.Equal(t, int64(1), resumed.MessagesAdded)
+			// The user sees one failure in this invocation, whether the same
+			// path failed before or permissions changed during the interruption.
+			assert.Equal(t, int64(1), resumed.Errors)
+			var totalErrors int64
+			require.NoError(t, st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1", resumed.SourceID).Scan(&totalErrors))
+			// Persistent progress includes failed attempts, like ingestion and
+			// checkpoint errors, rather than unique paths across invocations.
+			assert.Equal(t, firstErrors+1, totalErrors)
+		})
+	}
+}

--- a/internal/importer/emlx_permissions_test.go
+++ b/internal/importer/emlx_permissions_test.go
@@ -20,12 +20,14 @@ func TestImportEmlxDir_DiscoveryPermissions(t *testing.T) {
 			name = "partial import"
 		}
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			st, tmp := openTestStore(t)
 			root := filepath.Join(tmp, "Mail")
 			blocked := filepath.Join(root, "Blocked.mbox", "Messages")
-			require.NoError(t, os.MkdirAll(blocked, 0700))
-			require.NoError(t, os.Chmod(blocked, 0))
-			t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+			require.NoError(os.MkdirAll(blocked, 0700))
+			require.NoError(os.Chmod(blocked, 0))
+			t.Cleanup(func() { require.NoError(os.Chmod(blocked, 0700)) })
 			if _, err := os.ReadDir(blocked); err == nil {
 				t.Skip("requires a user subject to filesystem permissions")
 			}
@@ -42,20 +44,20 @@ func TestImportEmlxDir_DiscoveryPermissions(t *testing.T) {
 				Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
 			})
 			if !partial {
-				require.ErrorIs(t, err, os.ErrPermission)
-				assert.Nil(t, summary)
+				require.ErrorIs(err, os.ErrPermission)
+				assert.Nil(summary)
 				return
 			}
-			require.NoError(t, err)
-			require.NotNil(t, summary)
-			assert.Equal(t, int64(1), summary.MessagesAdded)
-			assert.Equal(t, int64(1), summary.Errors)
-			assert.False(t, summary.HardErrors)
-			assert.Contains(t, logs.String(), "WARN")
-			assert.Contains(t, logs.String(), blocked)
+			require.NoError(err)
+			require.NotNil(summary)
+			assert.Equal(int64(1), summary.MessagesAdded)
+			assert.Equal(int64(1), summary.Errors)
+			assert.False(summary.HardErrors)
+			assert.Contains(logs.String(), "WARN")
+			assert.Contains(logs.String(), blocked)
 			var errorsCount int64
-			require.NoError(t, st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ?", summary.SourceID).Scan(&errorsCount))
-			assert.Equal(t, int64(1), errorsCount)
+			require.NoError(st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ?", summary.SourceID).Scan(&errorsCount))
+			assert.Equal(int64(1), errorsCount)
 		})
 	}
 }
@@ -67,14 +69,16 @@ func TestImportEmlxDir_DiscoveryErrorsOnResume(t *testing.T) {
 			name = "repeated denial"
 		}
 		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			st, tmp := openTestStore(t)
 			root := filepath.Join(tmp, "Mail")
 			blocked := filepath.Join(root, "Blocked.mbox", "Messages")
-			require.NoError(t, os.MkdirAll(blocked, 0700))
-			t.Cleanup(func() { require.NoError(t, os.Chmod(blocked, 0700)) })
+			require.NoError(os.MkdirAll(blocked, 0700))
+			t.Cleanup(func() { require.NoError(os.Chmod(blocked, 0700)) })
 			deny := func() {
 				t.Helper()
-				require.NoError(t, os.Chmod(blocked, 0))
+				require.NoError(os.Chmod(blocked, 0))
 				if _, err := os.ReadDir(blocked); err == nil {
 					t.Skip("requires a user subject to filesystem permissions")
 				}
@@ -90,28 +94,28 @@ func TestImportEmlxDir_DiscoveryErrorsOnResume(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			first, err := ImportEmlxDir(ctx, st, root, opts)
-			require.NoError(t, err)
-			require.NotNil(t, first)
+			require.NoError(err)
+			require.NotNil(first)
 			var firstErrors int64
 			if initiallyDenied {
 				firstErrors = 1
 			}
-			assert.Equal(t, firstErrors, first.Errors)
+			assert.Equal(firstErrors, first.Errors)
 			deny()
 
 			resumed, err := ImportEmlxDir(context.Background(), st, root, opts)
-			require.NoError(t, err)
-			require.NotNil(t, resumed)
-			assert.True(t, resumed.WasResumed)
-			assert.Equal(t, int64(1), resumed.MessagesAdded)
+			require.NoError(err)
+			require.NotNil(resumed)
+			assert.True(resumed.WasResumed)
+			assert.Equal(int64(1), resumed.MessagesAdded)
 			// The user sees one failure in this invocation, whether the same
 			// path failed before or permissions changed during the interruption.
-			assert.Equal(t, int64(1), resumed.Errors)
+			assert.Equal(int64(1), resumed.Errors)
 			var totalErrors int64
-			require.NoError(t, st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1", resumed.SourceID).Scan(&totalErrors))
+			require.NoError(st.DB().QueryRow("SELECT errors_count FROM sync_runs WHERE source_id = ? ORDER BY id DESC LIMIT 1", resumed.SourceID).Scan(&totalErrors))
 			// Persistent progress includes failed attempts, like ingestion and
 			// checkpoint errors, rather than unique paths across invocations.
-			assert.Equal(t, firstErrors+1, totalErrors)
+			assert.Equal(firstErrors+1, totalErrors)
 		})
 	}
 }


### PR DESCRIPTION
`import-emlx` now reports unreadable mail directories instead of treating them as empty archives. Imports fail when discovery returns no readable mailboxes and a read error; partial imports continue, warn about skipped reads, and count those errors. Permission errors include macOS Full Disk Access guidance.

Account selection keeps newer Mail directories when discovery encounters read errors, preventing silent fallback to an older archive. Readable empty newer directories can still fall back to an older populated version.

Closes #613
