### PR TITLE
fix(ci): retry Linux Go downloads after connection failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Install Go
         run: |
           GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go_arch_name }}.tar.gz" -o go.tar.gz
+          curl -fsSL --retry 5 --retry-all-errors --retry-max-time 120 \
+            "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go_arch_name }}.tar.gz" -o go.tar.gz
           tar -C /usr/local -xzf go.tar.gz
           rm go.tar.gz
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,8 @@ jobs:
       - name: Install Go
         run: |
           GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go_arch_name }}.tar.gz" -o go.tar.gz
+          curl -fsSL --retry 5 --retry-all-errors --retry-max-time 120 \
+            "https://go.dev/dl/go${GO_VERSION}.linux-${{ matrix.go_arch_name }}.tar.gz" -o go.tar.gz
           tar -C /usr/local -xzf go.tar.gz
           rm go.tar.gz
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
Retry Go archive downloads in the Linux smoke and release jobs after connection failures, including TLS handshake resets. Allow up to five retries within a 120-second retry window before failing the step.

The [failed smoke job on #788](https://github.com/kenn-io/msgvault/actions/runs/34072162986/job/101591368403) stopped with curl error 35 before building the binary. Ordinary curl retries do not cover this error.
