### PR TITLE
feat(tui): save the current email as .eml

### DIFF
--- a/docs/usage/tui.md
+++ b/docs/usage/tui.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-08-09"
+last_edited: "2026-09-07"
 title: Interactive TUI
 description: Terminal interface for exploring email, text messages, and meeting transcripts.
 ---
@@ -226,6 +226,17 @@ From any message list (after drilling into a sender, label, domain, etc.), press
 </figure>
 Press `Esc` to return to the message list.
 
+## Save an email
+
+Open an email with `Enter`, then press `s` to save its original MIME content,
+including attachments, as `message-<id>.eml` in the directory where you launched
+the TUI. Existing files are preserved: repeated saves add `_1`, `_2`, and so on.
+The result dialog shows the saved path or the error if the email could not be
+saved. This requires raw email content in the archive.
+
+When connected to a remote server, the file is saved on the machine running the
+TUI. In message lists and aggregate views, `s` continues to cycle the sort field.
+
 ## Keyboard Shortcuts
 
 | Key | Action |
@@ -236,7 +247,7 @@ Press `Esc` to return to the message list.
 | `Esc` / `Backspace` | Go back |
 | `m` | Cycle through Email, Texts, and Meetings (skips unavailable Texts) |
 | `g` | Cycle view mode |
-| `s` | Cycle sort field (Name / Count / Size) |
+| `s` | Save email as `.eml` in message detail; cycle sort field in lists |
 | `v` | Reverse sort direction |
 | `t` | Jump to Time view (cycle granularity when already in Time) |
 | `a` | Show all individual messages in current view |

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -23,7 +23,7 @@ import (
 	"go.kenn.io/msgvault/internal/textutil"
 )
 
-// ExportResultMsg is returned when attachment export completes.
+// ExportResultMsg is returned when a message or attachment action completes.
 type ExportResultMsg struct {
 	Title  string
 	Result string

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -1095,6 +1095,17 @@ func (m Model) handleMessageDetailKeys(msg tea.KeyPressMsg) (tea.Model, tea.Cmd)
 			return m, m.loadThreadMessages(m.messageDetail.ConversationID)
 		}
 
+	// Save the current email to the TUI process's working directory.
+	case "s":
+		if m.loading || m.savingMessage {
+			return m, nil
+		}
+		if m.messageDetail == nil {
+			return m.showFlash("No message to save")
+		}
+		m.savingMessage = true
+		return m, m.actions.SaveMessage(m.messageDetail)
+
 	// Export attachments
 	case "e":
 		if m.messageDetail != nil && len(m.messageDetail.Attachments) > 0 {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -361,6 +361,7 @@ type Model struct {
 
 	// Loading state
 	loading         bool
+	savingMessage   bool
 	deletionLoading bool // True while resolving every message matching the current filter
 	deletionCancel  context.CancelFunc
 	err             error
@@ -1299,6 +1300,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handlePeopleActivityMessageLoaded(msg)
 	case ExportResultMsg:
 		return m.handleExportResult(msg)
+	case saveMessageResultMsg:
+		m.savingMessage = false
+		return m.showExportResult(ExportResultMsg(msg))
 	case messagesLoadedMsg:
 		return m.handleMessagesLoaded(msg)
 	case messageDetailLoadedMsg:
@@ -1793,9 +1797,13 @@ func (m Model) handleFlashClear() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleExportResult processes attachment export completion.
+// handleExportResult processes message and attachment action completion.
 func (m Model) handleExportResult(msg exportResultMsg) (tea.Model, tea.Cmd) {
 	m.loading = false
+	return m.showExportResult(msg)
+}
+
+func (m Model) showExportResult(msg ExportResultMsg) (tea.Model, tea.Cmd) {
 	m.modal = modalExportResult
 	m.modalResultTitle = msg.Title
 	if msg.Err != nil && msg.Result == "" {

--- a/internal/tui/save_message.go
+++ b/internal/tui/save_message.go
@@ -43,7 +43,8 @@ func (c *ActionController) SaveMessage(detail *query.MessageDetail) tea.Cmd {
 			return fail(errors.New("raw email is not available in the archive"))
 		}
 		// Use only the local numeric ID, never untrusted headers, in the name.
-		file, path, err := export.CreateExclusiveFile(filepath.Join(dir, fmt.Sprintf("message-%d.eml", id)), 0o600)
+		name := filepath.Join(dir, fmt.Sprintf("message-%d.eml", id))
+		file, path, err := export.CreateExclusiveFile(name, 0o600)
 		if err != nil {
 			return fail(fmt.Errorf("create message file: %w", err))
 		}

--- a/internal/tui/save_message.go
+++ b/internal/tui/save_message.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	tea "charm.land/bubbletea/v2"
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/query"
+)
+
+// Keep save completion separate from actions that own the view's loading state.
+type saveMessageResultMsg ExportResultMsg
+
+// SaveMessage saves the archived email, including MIME attachments, in the
+// current directory. Capture the destination and identity before queuing I/O.
+func (c *ActionController) SaveMessage(detail *query.MessageDetail) tea.Cmd {
+	if detail == nil {
+		return nil
+	}
+	id, messageType := detail.ID, detail.MessageType
+	dir, dirErr := os.Getwd()
+	return func() tea.Msg {
+		fail := func(err error) saveMessageResultMsg {
+			return saveMessageResultMsg{Title: "Save Failed", Err: err}
+		}
+		if dirErr != nil {
+			return fail(fmt.Errorf("get current directory: %w", dirErr))
+		}
+		if messageType != "" && messageType != "email" {
+			return fail(errors.New("saving as .eml is only available for email messages"))
+		}
+		raw, err := c.queries.GetMessageRaw(context.Background(), id)
+		if err != nil {
+			return fail(fmt.Errorf("read message: %w", err))
+		}
+		if len(raw) == 0 {
+			return fail(errors.New("raw email is not available in the archive"))
+		}
+		// Use only the local numeric ID, never untrusted headers, in the name.
+		file, path, err := export.CreateExclusiveFile(filepath.Join(dir, fmt.Sprintf("message-%d.eml", id)), 0o600)
+		if err != nil {
+			return fail(fmt.Errorf("create message file: %w", err))
+		}
+		_, writeErr := io.Copy(file, bytes.NewReader(raw))
+		if err := errors.Join(writeErr, file.Close()); err != nil {
+			removeErr := os.Remove(path)
+			return fail(fmt.Errorf("write message file: %w", errors.Join(err, removeErr)))
+		}
+		return saveMessageResultMsg{Title: "Message Saved", Result: "Saved to:\n" + path}
+	}
+}

--- a/internal/tui/save_message_test.go
+++ b/internal/tui/save_message_test.go
@@ -141,8 +141,10 @@ func TestSaveMessageKeyReportsWriteFailure(t *testing.T) {
 	m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: []byte("Subject: Test\r\n\r\nFull message")}}, "", nil)
 	_, cmd := m.Update(key('s'))
 	require.NotNil(cmd)
-	// Move the destination after queuing the save, before its I/O runs.
-	t.Chdir(parent)
+	// Move the destination after queuing the save, before its I/O runs. Leave
+	// with os.Chdir: t.Chdir would hold dir open, which blocks the rename on
+	// Windows. The first t.Chdir already restores the original directory.
+	require.NoError(os.Chdir(parent)) //nolint:usetesting // t.Chdir pins dir open
 	moved := dir + "-moved"
 	require.NoError(os.Rename(dir, moved))
 	t.Cleanup(func() { require.NoError(os.Rename(moved, dir)) })

--- a/internal/tui/save_message_test.go
+++ b/internal/tui/save_message_test.go
@@ -1,0 +1,173 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/query/querytest"
+)
+
+func TestSaveMessageKeyWritesRawEmailWithoutOverwriting(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Chdir(t.TempDir())
+	raw := []byte("From: sender@example.com\r\nTo: user@example.com\r\nSubject: Test\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=test\r\n\r\n--test\r\nContent-Type: text/plain\r\n\r\nFull message\r\n--test\r\nContent-Type: application/octet-stream\r\nContent-Transfer-Encoding: base64\r\n\r\nAAEC\r\n--test--\r\n")
+	detail := &query.MessageDetail{ID: 42, MessageType: "email", Subject: "../../unsafe\x1b[31m"}
+	m := NewBuilder().WithLevel(levelMessageDetail).WithDetail(detail).Build()
+	m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: raw}}, t.TempDir(), nil)
+	require.NoError(os.WriteFile("message-42.eml", []byte("keep me"), 0o600))
+
+	updated, cmd := m.Update(key('s'))
+	require.NotNil(cmd, "s must start a save from message detail")
+	result, ok := cmd().(saveMessageResultMsg)
+	require.True(ok)
+	require.NoError(result.Err)
+	data, err := os.ReadFile("message-42_1.eml")
+	require.NoError(err)
+	assert.Equal(raw, data, "preserve the complete MIME message including attachments")
+	original, err := os.ReadFile("message-42.eml")
+	require.NoError(err)
+	assert.Equal("keep me", string(original))
+	info, err := os.Stat("message-42_1.eml")
+	require.NoError(err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(os.FileMode(0o600), info.Mode().Perm())
+	}
+	finished, _ := updated.Update(result)
+	saved := asModel(t, finished)
+	assert.False(saved.loading)
+	assert.Equal(modalExportResult, saved.modal)
+	assert.Contains(saved.modalResult, "message-42_1.eml")
+}
+
+func TestSaveMessageKeyDoesNotWriteMissingOrNonEmailRaw(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		messageType string
+		raw         []byte
+	}{
+		{name: "no raw message"},
+		{name: "non-email payload", messageType: "slack", raw: []byte(`{"text":"Test message"}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			t.Chdir(t.TempDir())
+			m := NewBuilder().WithLevel(levelMessageDetail).WithDetail(&query.MessageDetail{ID: 42, MessageType: tc.messageType}).Build()
+			m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: tc.raw}}, "", nil)
+			_, cmd := m.Update(key('s'))
+			require.NotNil(cmd)
+			result, ok := cmd().(saveMessageResultMsg)
+			require.True(ok)
+			require.Error(result.Err)
+			entries, err := os.ReadDir(".")
+			require.NoError(err)
+			assert.Empty(entries)
+		})
+	}
+}
+
+func TestSaveMessageKeyReportsReadFailureWithoutCreatingFile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Chdir(t.TempDir())
+	m := NewBuilder().WithLevel(levelMessageDetail).WithDetail(&query.MessageDetail{ID: 42}).Build()
+	m.actions = NewActionController(&querytest.MockEngine{
+		GetMessageRawFunc: func(context.Context, int64) ([]byte, error) {
+			return nil, errors.New("archive unavailable")
+		},
+	}, "", nil)
+	updated, cmd := m.Update(key('s'))
+	require.NotNil(cmd)
+	result, ok := cmd().(saveMessageResultMsg)
+	require.True(ok)
+	require.ErrorContains(result.Err, "archive unavailable")
+	finished, _ := updated.Update(result)
+	assert.Contains(asModel(t, finished).modalResult, "archive unavailable")
+	entries, err := os.ReadDir(".")
+	require.NoError(err)
+	assert.Empty(entries)
+}
+
+func TestSaveMessageKeyWithoutLoadedDetail(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Chdir(t.TempDir())
+	m := NewBuilder().WithLevel(levelMessageDetail).WithLoading(false).Build()
+	updated, _ := m.Update(key('s'))
+	assert.False(asModel(t, updated).loading)
+	entries, err := os.ReadDir(".")
+	require.NoError(err)
+	assert.Empty(entries)
+}
+
+func TestSaveMessageKeyDoesNotFollowSymlink(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Chdir(t.TempDir())
+	target := filepath.Join(t.TempDir(), "original.eml")
+	require.NoError(os.WriteFile(target, []byte("keep me"), 0o600))
+	if err := os.Symlink(target, "message-42.eml"); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	m := NewBuilder().WithLevel(levelMessageDetail).WithDetail(&query.MessageDetail{ID: 42}).Build()
+	m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: []byte("Subject: Test\r\n\r\nFull message")}}, "", nil)
+	_, cmd := m.Update(key('s'))
+	require.NotNil(cmd)
+	result, ok := cmd().(saveMessageResultMsg)
+	require.True(ok)
+	require.NoError(result.Err)
+	data, err := os.ReadFile(target)
+	require.NoError(err)
+	assert.Equal("keep me", string(data))
+	assert.FileExists("message-42_1.eml")
+}
+
+func TestSaveMessageKeyReportsWriteFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "output")
+	require.NoError(os.Mkdir(dir, 0o700))
+	t.Chdir(dir)
+	m := NewBuilder().WithLevel(levelMessageDetail).WithDetail(&query.MessageDetail{ID: 42}).Build()
+	m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: []byte("Subject: Test\r\n\r\nFull message")}}, "", nil)
+	_, cmd := m.Update(key('s'))
+	require.NotNil(cmd)
+	// Move the destination after queuing the save, before its I/O runs.
+	t.Chdir(parent)
+	moved := dir + "-moved"
+	require.NoError(os.Rename(dir, moved))
+	t.Cleanup(func() { require.NoError(os.Rename(moved, dir)) })
+	result, ok := cmd().(saveMessageResultMsg)
+	require.True(ok)
+	require.Error(result.Err)
+	assert.NoFileExists(filepath.Join(parent, "message-42.eml"), "must not change the destination at execution time")
+}
+
+func TestSaveMessageCompletionPreservesPendingDetailLoad(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	t.Chdir(t.TempDir())
+	m := NewBuilder().WithLevel(levelMessageDetail).
+		WithMessages(query.MessageSummary{ID: 42}, query.MessageSummary{ID: 43}).
+		WithDetail(&query.MessageDetail{ID: 42}).Build()
+	m.actions = NewActionController(&querytest.MockEngine{RawMessages: map[int64][]byte{42: []byte("Subject: Test\r\n\r\nFull message")}}, "", nil)
+	saving, saveCmd := sendKey(t, m, key('s'))
+	require.NotNil(saveCmd)
+	navigated, loadCmd := sendKey(t, saving, key('l'))
+	require.NotNil(loadCmd)
+	require.True(navigated.loading)
+	finished := sendMsg(t, navigated, saveCmd())
+	assert.True(finished.loading, "saving A must not finish B's pending load")
+	dismissed, _ := sendKey(t, finished, key(' '))
+	_, secondSave := sendKey(t, dismissed, key('s'))
+	assert.Nil(secondSave, "cannot save stale detail while the next message loads")
+}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1097,6 +1097,11 @@ func (m Model) footerView() string {
 			"↑/↓ scroll",
 			"/ find",
 		}
+		if m.savingMessage {
+			keys = append(keys, "saving .eml")
+		} else {
+			keys = append(keys, "s save .eml")
+		}
 		if m.detailSearchQuery != "" {
 			keys = append(keys, "n/N next/prev")
 		}
@@ -1224,6 +1229,7 @@ var rawHelpLines = []string{
 	"  A           Select account",
 	"  f           Filter (attachments, deleted)",
 	"  e           Browse attachments (in message view)",
+	"  s           Save email to current directory (in message view)",
 	"  m           Cycle Email/Texts/Meetings/People",
 	"  ,           Open Settings",
 	"  q           Quit",


### PR DESCRIPTION
## What changed

- Press `s` in email detail to save the original message, including MIME attachments, as an `.eml` file.
- Files land in the TUI's current directory. Existing files are preserved, and the result dialog shows the saved path or an error.

## Why

Saving a message should be available while reading it in the TUI, without switching to the CLI.

## Usage

Open an email with `Enter`, then press `s`. Files use `message-<id>.eml`, adding `_1`, `_2`, and so on when a name already exists. Remote TUI sessions save on the client machine. Raw email content must be present in the archive.

Closes #107
