### PR TITLE
feat(import): add Maildir archive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-08-30"
+last_edited: "2026-09-07"
 ---
 
 <p align="center">
@@ -31,7 +31,7 @@ Your messages are yours. Decades of correspondence, attachments, and history sho
 
 Currently supports Gmail, Google Calendar, Microsoft Teams, Discord, Slack, CardDAV,
 Granola, Circleback, Notion AI Meeting Notes, Beeper Desktop, and IMAP sync,
-plus offline imports from Slackdump, MBOX exports, Apple Mail (`.emlx`)
+plus offline imports from Slackdump, MBOX exports, Maildir archives, Apple Mail (`.emlx`)
 directories, PST archives, and common chat/text export formats.
 
 ## Features
@@ -48,7 +48,7 @@ directories, PST archives, and common chat/text export formats.
 - **CardDAV contacts**: pull address books, explicitly publish curated people, and resolve conflicts without losing remote card data
 - **Provider-neutral people sweeps**: maintain consented profile fields through explicit OpenAI Chat, OpenAI Responses, Anthropic Messages, or Gemini protocol profiles
 - **Incremental backup snapshots**: verifiable `msgvault backup` repositories for the SQLite archive and attachments
-- **MBOX / Apple Mail / PST import**: import email from local export formats
+- **MBOX / Maildir / Apple Mail / PST import**: import email from local export formats
 - **First-party web UI**: dense, keyboard-driven search and grouping across people, domains, mailing lists, time, source, and modality, plus file, source, and deletion workspaces served directly by the daemon
 - **Interactive TUI**: drill-down analytics over your entire message history, powered by DuckDB over Parquet — connects to a remote `msgvault serve` instance or runs locally
 - **Full-text search**: FTS5 with Gmail-like query syntax (`from:`, `list:` / `list-id:`, `has:attachment`, date ranges)
@@ -162,6 +162,7 @@ available with `msgvault tui`.
 | `verify EMAIL` | Verify archive integrity against Gmail |
 | `export-eml` | Export a message as `.eml` |
 | `import-mbox` | Import email from an MBOX export or `.zip` of MBOX files |
+| `import-maildir` | Import email from Maildir and Maildir++ archives |
 | `import-emlx` | Import email from an Apple Mail directory tree |
 | `build-cache` | Rebuild the Parquet analytics cache |
 | `update` | Update msgvault to the latest version |
@@ -191,14 +192,15 @@ A separate MCP tool, `find_similar_messages`, returns nearest neighbors for a se
 
 Large archives can scope an embedding generation with `[vector.embed.scope] message_types = ["sms", "mms"]`. Scoped vector and hybrid searches must include a matching `message_type` filter so a partial index is never used as if it covered the whole archive.
 
-## Importing from MBOX or Apple Mail
+## Importing from MBOX, Maildir, or Apple Mail
 
-Import email from providers that offer MBOX exports or from a local Apple Mail data directory:
+Import email from MBOX exports, Maildir archives, or a local Apple Mail data directory:
 
 ```bash
 msgvault init-db
 msgvault import-mbox you@example.com /path/to/export.mbox
 msgvault import-mbox you@example.com /path/to/export.zip   # zip of MBOX files
+msgvault import-maildir ~/Maildir --identifier you@example.com
 msgvault import-emlx                                        # auto-discover Apple Mail accounts
 msgvault import-emlx you@example.com ~/Library/Mail/V10     # explicit path
 ```

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -325,6 +325,7 @@ func attachmentProducingCommand(args []string) bool {
 		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
+		"import-maildir",
 		"import-eml",
 		"import-emlx",
 		"import-gvoice",

--- a/cmd/msgvault/cmd/attachment_maintenance_test.go
+++ b/cmd/msgvault/cmd/attachment_maintenance_test.go
@@ -507,6 +507,7 @@ func TestAttachmentProducingCommandExactAllowlist(t *testing.T) {
 		"backfill-slack-media",
 		"backfill-teams-media",
 		"import",
+		"import-maildir",
 		"import-eml",
 		"import-emlx",
 		"import-gvoice",

--- a/cmd/msgvault/cmd/import_eml.go
+++ b/cmd/msgvault/cmd/import_eml.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,16 +24,20 @@ type importEMLFlags struct {
 }
 
 func newImportEMLCommand() *cobra.Command {
+	return newImportRawDirectoryCommand("eml", importer.ImportEMLDir)
+}
+
+func newImportRawDirectoryCommand(format string, runImport func(context.Context, *store.Store, string, importer.EMLImportOptions) (*importer.EMLImportSummary, error)) *cobra.Command {
 	var flags importEMLFlags
 	cmd := &cobra.Command{
-		Use:   "import-eml <mail-dir>",
+		Use:   "import-" + format + " <mail-dir>",
 		Short: "Import a tree of RFC 5322 .eml files",
 		Long: `Import RFC 5322 .eml files stored in MailMate-style .mailbox
 directories. Nested mailbox names become slash-separated labels, and exact
 duplicate messages receive every mailbox label where they appear.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return usageErr(cmd, errors.New("import-eml requires exactly 1 arg: <mail-dir>"))
+				return usageErr(cmd, fmt.Errorf("import-%s requires exactly 1 arg: <mail-dir>", format))
 			}
 			return nil
 		},
@@ -57,7 +62,7 @@ duplicate messages receive every mailbox label where they appear.`,
 				attachmentsDir = ""
 			}
 			dbPath := cfg.DatabaseDSN()
-			summary, importErr := importer.ImportEMLDir(ctx, st, args[0], importer.EMLImportOptions{
+			summary, importErr := runImport(ctx, st, args[0], importer.EMLImportOptions{
 				SourceType:         flags.sourceType,
 				Identifier:         flags.identifier,
 				NoResume:           flags.noResume,
@@ -91,8 +96,19 @@ duplicate messages receive every mailbox label where they appear.`,
 		},
 	}
 
+	if format == "maildir" {
+		cmd.Short = "Import a Maildir or Maildir++ archive"
+		cmd.Long = `Import raw MIME messages from Maildir cur and new directories.
+Nested folders become slash-separated labels. Exact duplicate messages collect
+all folder and flag labels. The importer never modifies mailbox files and
+ignores tmp directories and symlinks. Import a stable mailbox snapshot.
+
+Example:
+  msgvault import-maildir ~/Maildir --identifier you@example.com`
+	}
+
 	cmd.Flags().StringVar(&flags.identifier, "identifier", "", "Account identifier for imported messages (required)")
-	cmd.Flags().StringVar(&flags.sourceType, "source-type", "eml", "Source type stored for imported messages")
+	cmd.Flags().StringVar(&flags.sourceType, "source-type", format, "Source type stored for imported messages")
 	cmd.Flags().BoolVar(&flags.noResume, "no-resume", false, "Start a new import instead of resuming an active checkpoint")
 	cmd.Flags().IntVar(&flags.checkpointInterval, "checkpoint-interval", 200, "Save progress after this many messages")
 	cmd.Flags().BoolVar(&flags.noAttachments, "no-attachments", false, "Do not write attachment files")

--- a/cmd/msgvault/cmd/import_maildir.go
+++ b/cmd/msgvault/cmd/import_maildir.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/importer"
+)
+
+func newImportMaildirCommand() *cobra.Command {
+	return newImportRawDirectoryCommand("maildir", importer.ImportMaildir)
+}
+
+func init() { rootCmd.AddCommand(newImportMaildirCommand()) }

--- a/cmd/msgvault/cmd/import_maildir_test.go
+++ b/cmd/msgvault/cmd/import_maildir_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestImportMaildirCommandArchivesMail(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dataDir := t.TempDir()
+	testCfg := lifecycleTestConfig(dataDir)
+	withStoreResolverConfig(t, testCfg)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+	root := filepath.Join(dataDir, "mail")
+	for _, dir := range []string{"new", "cur", "tmp"} {
+		require.NoError(os.MkdirAll(filepath.Join(root, dir), 0700))
+	}
+	require.NoError(os.WriteFile(filepath.Join(root, "new", "one"), []byte("From: alice@example.com\r\nSubject: Maildir CLI\r\n\r\nbody"), 0600))
+	command := newImportMaildirCommand()
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{root, "--identifier", "alice@example.com"})
+	require.NoError(command.Execute())
+	st, err := store.Open(testCfg.DatabaseDSN())
+	require.NoError(err)
+	t.Cleanup(func() { _ = st.Close() })
+	var subject, sourceType string
+	require.NoError(st.DB().QueryRow(`SELECT m.subject,s.source_type FROM messages m JOIN sources s ON s.id=m.source_id`).Scan(&subject, &sourceType))
+	assert.Equal("Maildir CLI", subject)
+	assert.Equal("maildir", sourceType)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-09-03"
+last_edited: "2026-09-07"
 title: CLI Reference
 description: Complete command reference for all msgvault commands.
 ---
@@ -744,6 +744,46 @@ The export file may be a plain mbox file (any extension) or a `.zip` containing 
 | `--no-default-identity` | `false` | Do not auto-confirm the identifier as this source's "me" identity |
 
 See [Importing Local Email](/docs/usage/importing/) for usage examples.
+
+---
+
+## import-maildir
+
+Import a Maildir archive without changing its files:
+
+```bash
+msgvault import-maildir ~/Maildir --identifier you@example.com
+```
+
+Reads regular message files in `cur` and `new`; skips `tmp`, symlinks, and
+mailbox bookkeeping files. The root mailbox receives the `INBOX` label.
+Nested directories and Maildir++ folders such as `.Projects.Go` become
+slash-separated labels (`Projects/Go`). Use a stable snapshot of the mailbox
+so delivery and flag renames cannot race the import.
+
+Stores raw MIME, bodies, recipients, and attachments. As with other local email
+imports, attachment-write failures are logged; the original attachment bytes
+remain in raw MIME, but a rerun does not retry those writes. Exact duplicate raw
+messages within the same source are stored once and collect all folder and
+flag labels. Rerunning the import adds missing messages and labels; it does
+not remove archived messages or labels. Moving a message from `new` to `cur`
+or changing its filename flags does not create another copy.
+
+Maildir flags become `DRAFT`, `STARRED`, `PASSED`, `REPLIED`, and `TRASH`
+labels. Messages without the seen (`S`) flag receive `UNREAD`. Trashed
+messages are still archived.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--identifier` | — | Required account identifier |
+| `--source-type` | `maildir` | Source type stored for the archive |
+| `--no-resume` | `false` | Start a fresh run instead of resuming a checkpoint |
+| `--checkpoint-interval` | `200` | Save progress after this many messages |
+| `--no-attachments` | `false` | Skip writing attachment files |
+| `--no-default-identity` | `false` | Skip confirming the identifier as the source identity |
+
+Interrupted imports resume by rescanning the tree and skipping stored messages.
+Messages larger than 128 MiB are reported as errors and left unimported.
 
 ---
 

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1645,6 +1645,7 @@ func cliRunCommandAllowed(args []string) bool {
 		"export-messages",
 		"gc",
 		"import",
+		"import-maildir",
 		"import-eml",
 		"import-emlx",
 		"import-gvoice",

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1740,6 +1740,7 @@ func TestHandleCLIRunBackupSubcommandAdmission(t *testing.T) {
 		{"backup unknown subcommand rejected", []string{"backup", "restore"}, false},
 		{"logs still allowed", []string{"logs"}, true},
 		{"gc allowed", []string{"gc", "--yes"}, true},
+		{"import-maildir allowed", []string{"import-maildir", "--identifier", "me@example.test", "dir"}, true},
 		{"import-eml allowed", []string{"import-eml", "--identifier", "me@example.test", "dir"}, true},
 		{"remove-account still allowed", []string{"remove-account", "alice@example.com", "--yes"}, true},
 		{"purge excluded media dry-run allowed", []string{"purge-excluded-media", "--dry-run"}, true},

--- a/internal/importer/eml_import.go
+++ b/internal/importer/eml_import.go
@@ -247,7 +247,12 @@ func importRawDirectory(ctx context.Context, st *store.Store, root string,
 						}
 						flagLabelIDs[label] = id
 					}
-					labelIDs = append(labelIDs, id)
+					// A folder named like a flag (for example TRASH) shares
+					// the flag's label row; listing it twice would violate
+					// the message_labels primary key.
+					if id != labelID {
+						labelIDs = append(labelIDs, id)
+					}
 				}
 			}
 			hash := sha256.Sum256(raw)

--- a/internal/importer/eml_import.go
+++ b/internal/importer/eml_import.go
@@ -39,7 +39,7 @@ type EMLImportOptions struct {
 	Logger *slog.Logger
 }
 
-// EMLImportSummary reports the result of an EML tree import.
+// EMLImportSummary reports the result of a directory tree import.
 type EMLImportSummary struct {
 	SourceID          int64
 	WasResumed        bool
@@ -68,12 +68,44 @@ func ImportEMLDir(
 	st *store.Store,
 	root string,
 	opts EMLImportOptions,
+) (*EMLImportSummary, error) {
+	return importRawDirectory(ctx, st, root, opts, rawDirectoryLayout{
+		sourceType: "eml",
+		discover: func(root string) ([]directoryMailbox, error) {
+			boxes, err := eml.DiscoverMailboxes(root)
+			result := make([]directoryMailbox, len(boxes))
+			for i, box := range boxes {
+				result[i] = directoryMailbox(box)
+			}
+			return result, err
+		},
+		read: readEMLFile,
+	})
+}
+
+type directoryMailbox struct {
+	Path  string
+	Label string
+	Files []string
+}
+
+type rawDirectoryLayout struct {
+	sourceType string
+	discover   func(string) ([]directoryMailbox, error)
+	labels     func(string) []string
+	read       func(string, int64) ([]byte, error)
+}
+
+// importRawDirectory owns the shared source lease, checkpoint, and ingestion
+// lifecycle for directory-based raw MIME formats.
+func importRawDirectory(ctx context.Context, st *store.Store, root string,
+	opts EMLImportOptions, layout rawDirectoryLayout,
 ) (retSummary *EMLImportSummary, retErr error) {
 	if opts.Identifier == "" {
 		return nil, errors.New("identifier is required")
 	}
 	if opts.SourceType == "" {
-		opts.SourceType = "eml"
+		opts.SourceType = layout.sourceType
 	}
 	if opts.CheckpointInterval <= 0 {
 		opts.CheckpointInterval = 200
@@ -91,19 +123,19 @@ func ImportEMLDir(
 	}
 
 	started := time.Now()
-	mailboxes, err := eml.DiscoverMailboxes(root)
+	mailboxes, err := layout.discover(root)
 	if err != nil {
-		return nil, fmt.Errorf("discover EML mailboxes: %w", err)
+		return nil, fmt.Errorf("discover directory mailboxes: %w", err)
 	}
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		return nil, fmt.Errorf("resolve EML root: %w", err)
+		return nil, fmt.Errorf("resolve directory root: %w", err)
 	}
 	summary := &EMLImportSummary{MailboxesTotal: len(mailboxes)}
 
 	source, err := st.GetOrCreateSource(opts.SourceType, opts.Identifier)
 	if err != nil {
-		return nil, fmt.Errorf("get or create EML source: %w", err)
+		return nil, fmt.Errorf("get or create directory source: %w", err)
 	}
 	summary.SourceID = source.ID
 	ownershipCtx := context.WithoutCancel(ctx)
@@ -121,31 +153,32 @@ func ImportEMLDir(
 		startBox   int
 	)
 	if !opts.NoResume {
-		resumable, err := st.GetLatestCheckpointedSyncByType(source.ID, "import-eml")
+		resumable, err := st.GetLatestCheckpointedSyncByType(source.ID, "import-"+layout.sourceType)
 		if err != nil && !errors.Is(err, store.ErrSyncRunNotFound) {
-			return nil, fmt.Errorf("find resumable EML import: %w", err)
+			return nil, fmt.Errorf("find resumable directory import: %w", err)
 		}
 		if resumable != nil {
 			var saved emlCheckpoint
 			if err := json.Unmarshal([]byte(resumable.CursorBefore.String), &saved); err != nil {
-				return nil, fmt.Errorf("decode EML checkpoint: %w", err)
+				return nil, fmt.Errorf("decode directory checkpoint: %w", err)
 			}
 			if saved.RootDir != absRoot {
 				return nil, fmt.Errorf(
-					"saved EML import is for a different directory (%q), not %q; rerun with --no-resume to start fresh",
+					"saved directory import is for a different directory (%q), not %q; rerun with --no-resume to start fresh",
 					saved.RootDir, absRoot,
 				)
 			}
 			if saved.MailboxIndex < 0 || saved.MailboxIndex >= len(mailboxes) {
-				return nil, fmt.Errorf("EML checkpoint mailbox index %d is out of range", saved.MailboxIndex)
+				return nil, fmt.Errorf("directory checkpoint mailbox index %d is out of range", saved.MailboxIndex)
 			}
 			if saved.MailboxPath != "" && mailboxes[saved.MailboxIndex].Path != saved.MailboxPath {
-				return nil, fmt.Errorf("EML mailbox tree changed at checkpoint index %d", saved.MailboxIndex)
+				return nil, fmt.Errorf("directory mailbox tree changed at checkpoint index %d", saved.MailboxIndex)
 			}
 			checkpoint.MessagesProcessed = resumable.MessagesProcessed
 			checkpoint.MessagesAdded = resumable.MessagesAdded
 			checkpoint.MessagesUpdated = resumable.MessagesUpdated
-			checkpoint.ErrorsCount = resumable.ErrorsCount
+			// Errors belong to this generation: the full rescan below retries
+			// every failed file and counts any failures that remain.
 			// Resume rescans the full tree. Raw-content IDs make successful
 			// files idempotent, while a rescan also finds files inserted or
 			// changed before the last lexical checkpoint.
@@ -153,9 +186,9 @@ func ImportEMLDir(
 			summary.WasResumed = true
 		}
 	}
-	syncID, err = execution.StartSyncContext(ownershipCtx, "import-eml", "")
+	syncID, err = execution.StartSyncContext(ownershipCtx, "import-"+layout.sourceType, "")
 	if err != nil {
-		return nil, fmt.Errorf("start EML import: %w", err)
+		return nil, fmt.Errorf("start directory import: %w", err)
 	}
 	st = st.ScopedToSync(source.ID, syncID)
 
@@ -172,17 +205,18 @@ func ImportEMLDir(
 	lastFile := ""
 	if err := saveEMLCheckpoint(st, syncID, absRoot, lastBox, lastPath, lastFile, &checkpoint); err != nil {
 		failSync(err.Error())
-		return nil, fmt.Errorf("save initial EML checkpoint: %w", err)
+		return nil, fmt.Errorf("save initial directory checkpoint: %w", err)
 	}
 
 	hardErrors := false
 	checkpointBlocked := false
+	flagLabelIDs := make(map[string]int64)
 	for boxIndex := startBox; boxIndex < len(mailboxes); boxIndex++ {
 		mailbox := mailboxes[boxIndex]
 		labelID, err := st.EnsureLabel(source.ID, mailbox.Label, mailbox.Label, "user")
 		if err != nil {
 			failSync(err.Error())
-			return nil, fmt.Errorf("ensure EML label %q: %w", mailbox.Label, err)
+			return nil, fmt.Errorf("ensure directory label %q: %w", mailbox.Label, err)
 		}
 
 		for _, filename := range mailbox.Files {
@@ -191,46 +225,61 @@ func ImportEMLDir(
 			}
 			checkpoint.MessagesProcessed++
 			summary.MessagesProcessed++
-			raw, err := readEMLFile(filename, opts.MaxMessageBytes)
+			raw, err := layout.read(filename, opts.MaxMessageBytes)
 			if err != nil {
 				checkpoint.ErrorsCount++
 				summary.Errors++
 				hardErrors = true
 				checkpointBlocked = true
-				log.Warn("failed to read EML message", "file", filename, "error", err)
+				log.Warn("failed to read directory message", "file", filename, "error", err)
 				continue
 			}
 
+			labelIDs := []int64{labelID}
+			if layout.labels != nil {
+				for _, label := range layout.labels(filename) {
+					id, ok := flagLabelIDs[label]
+					if !ok {
+						id, err = st.EnsureLabel(source.ID, label, label, "system")
+						if err != nil {
+							failSync(err.Error())
+							return nil, fmt.Errorf("ensure message flag label: %w", err)
+						}
+						flagLabelIDs[label] = id
+					}
+					labelIDs = append(labelIDs, id)
+				}
+			}
 			hash := sha256.Sum256(raw)
 			rawHash := hex.EncodeToString(hash[:])
-			sourceMessageID := "eml-" + rawHash
+			sourceMessageID := layout.sourceType + "-" + rawHash
 			existing, err := st.MessageExistsWithRawBatch(source.ID, []string{sourceMessageID})
 			if err != nil {
 				failSync(err.Error())
-				return nil, fmt.Errorf("check existing EML message: %w", err)
+				return nil, fmt.Errorf("check existing directory message: %w", err)
 			}
 			if messageID, ok := existing[sourceMessageID]; ok {
-				if err := st.AddMessageLabels(messageID, []int64{labelID}); err != nil {
+				if err := st.AddMessageLabels(messageID, labelIDs); err != nil {
 					failSync(err.Error())
-					return nil, fmt.Errorf("add EML label to existing message: %w", err)
+					return nil, fmt.Errorf("add directory label to existing message: %w", err)
 				}
 				summary.MessagesSkipped++
 			} else {
 				existingAny, err := st.MessageExistsBatch(source.ID, []string{sourceMessageID})
 				if err != nil {
 					failSync(err.Error())
-					return nil, fmt.Errorf("check EML message metadata: %w", err)
+					return nil, fmt.Errorf("check directory message metadata: %w", err)
 				}
 				_, updating := existingAny[sourceMessageID]
 				if err := ingestFn(
 					ctx, st, source.ID, opts.Identifier, opts.AttachmentsDir,
-					[]int64{labelID}, sourceMessageID, rawHash, raw, time.Time{}, log,
+					labelIDs, sourceMessageID, rawHash, raw, time.Time{}, log,
 				); err != nil {
 					checkpoint.ErrorsCount++
 					summary.Errors++
 					hardErrors = true
 					checkpointBlocked = true
-					log.Warn("failed to ingest EML message", "file", filename, "error", err)
+					log.Warn("failed to ingest directory message", "file", filename, "error", err)
 					continue
 				}
 				if updating {
@@ -249,7 +298,7 @@ func ImportEMLDir(
 				if checkpoint.MessagesProcessed%int64(opts.CheckpointInterval) == 0 {
 					if err := saveEMLCheckpoint(st, syncID, absRoot, lastBox, lastPath, lastFile, &checkpoint); err != nil {
 						failSync(err.Error())
-						return nil, fmt.Errorf("save EML checkpoint: %w", err)
+						return nil, fmt.Errorf("save directory checkpoint: %w", err)
 					}
 				}
 			}
@@ -264,19 +313,19 @@ func ImportEMLDir(
 	summary.HardErrors = hardErrors
 	if err := saveEMLCheckpoint(st, syncID, absRoot, lastBox, lastPath, lastFile, &checkpoint); err != nil {
 		failSync(err.Error())
-		return nil, fmt.Errorf("save final EML checkpoint: %w", err)
+		return nil, fmt.Errorf("save final directory checkpoint: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return summary, err
 	}
 	if hardErrors {
 		if err := st.FailSync(syncID, fmt.Sprintf("completed with %d errors", checkpoint.ErrorsCount)); err != nil {
-			return nil, fmt.Errorf("fail EML import: %w", err)
+			return nil, fmt.Errorf("fail directory import: %w", err)
 		}
 		return summary, nil
 	}
 	if err := st.CompleteSync(syncID, fmt.Sprintf("mailboxes:%d messages:%d", summary.MailboxesImported, summary.MessagesAdded)); err != nil {
-		return nil, fmt.Errorf("complete EML import: %w", err)
+		return nil, fmt.Errorf("complete directory import: %w", err)
 	}
 	return summary, nil
 }

--- a/internal/importer/eml_import_test.go
+++ b/internal/importer/eml_import_test.go
@@ -211,6 +211,7 @@ func TestImportEMLDirResumesFailedCheckpoint(t *testing.T) {
 	latest, err := st.GetLatestSync(resumed.SourceID)
 	require.NoError(err)
 	assert.Equal(store.SyncStatusCompleted, latest.Status)
+	assert.Zero(latest.ErrorsCount, "a fully recovered scan must be classified as successful")
 }
 
 func TestImportEMLDirRejectsConcurrentSourceExecution(t *testing.T) {

--- a/internal/importer/maildir_import.go
+++ b/internal/importer/maildir_import.go
@@ -1,0 +1,85 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/msgvault/internal/maildir"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// MaildirImportOptions configures a read-only Maildir archive import.
+// CheckpointInterval defaults to 200 and MaxMessageBytes to 128 MiB.
+type MaildirImportOptions = EMLImportOptions
+
+// MaildirImportSummary reports Maildir import progress and recoverable errors.
+type MaildirImportSummary = EMLImportSummary
+
+// ImportMaildir archives delivered Maildir messages. Content hashes make
+// filename/flag renames idempotent; duplicate copies accumulate archive labels.
+// Import a stable snapshot rather than a mailbox being modified concurrently.
+func ImportMaildir(ctx context.Context, st *store.Store, root string, opts MaildirImportOptions) (*MaildirImportSummary, error) {
+	if opts.Identifier == "" {
+		return nil, errors.New("identifier is required")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	// Confinement also protects against files replaced with external symlinks
+	// between discovery and read.
+	dir, err := os.OpenRoot(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open Maildir root: %w", err)
+	}
+	defer func() { _ = dir.Close() }()
+	return importRawDirectory(ctx, st, absRoot, opts, rawDirectoryLayout{
+		sourceType: "maildir",
+		discover: func(root string) ([]directoryMailbox, error) {
+			boxes, err := maildir.Discover(root)
+			result := make([]directoryMailbox, len(boxes))
+			for i, box := range boxes {
+				result[i] = directoryMailbox(box)
+			}
+			return result, err
+		},
+		labels: maildir.Flags,
+		read: func(path string, maxBytes int64) ([]byte, error) {
+			rel, err := filepath.Rel(absRoot, path)
+			if err != nil {
+				return nil, err
+			}
+			info, err := dir.Lstat(rel)
+			if err != nil {
+				return nil, err
+			}
+			if !info.Mode().IsRegular() {
+				return nil, errors.New("maildir message is not a regular file")
+			}
+			file, err := dir.Open(rel)
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = file.Close() }()
+			opened, err := file.Stat()
+			if err != nil {
+				return nil, err
+			}
+			if !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+				return nil, errors.New("maildir message changed during import")
+			}
+			raw, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+			if err != nil {
+				return nil, err
+			}
+			if int64(len(raw)) > maxBytes {
+				return nil, fmt.Errorf("message exceeds %d-byte limit", maxBytes)
+			}
+			return raw, nil
+		},
+	})
+}

--- a/internal/importer/maildir_import_test.go
+++ b/internal/importer/maildir_import_test.go
@@ -151,3 +151,34 @@ func TestImportMaildirRecoveredFailureIsSuccessful(t *testing.T) {
 	assert.Equal("completed", run.Status)
 	assert.Zero(run.ErrorsCount, "a fully recovered scan must be classified as successful")
 }
+
+func TestImportMaildirFolderNamedLikeFlagLabel(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	maildirFixture(t, filepath.Join(root, ".TRASH"))
+	trashedName := "one:2,T"
+	if runtime.GOOS == "windows" {
+		trashedName = "one-trashed"
+	}
+	raw := []byte("From: alice@example.com\r\nSubject: trashed\r\n\r\nbody\r\n")
+	require.NoError(os.WriteFile(filepath.Join(root, ".TRASH", "cur", trashedName), raw, 0600))
+	summary, err := ImportMaildir(t.Context(), st, root, MaildirImportOptions{Identifier: "alice@example.com"})
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MessagesAdded)
+	assert.Zero(summary.Errors)
+	assert.False(summary.HardErrors)
+	rows, err := st.DB().Query(`SELECT l.name FROM message_labels ml JOIN labels l ON l.id=ml.label_id ORDER BY l.name`)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	var labels []string
+	for rows.Next() {
+		var name string
+		require.NoError(rows.Scan(&name))
+		labels = append(labels, name)
+	}
+	require.NoError(rows.Err())
+	assert.Equal([]string{"TRASH", "UNREAD"}, labels)
+}

--- a/internal/importer/maildir_import_test.go
+++ b/internal/importer/maildir_import_test.go
@@ -1,0 +1,153 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil/email"
+)
+
+func maildirFixture(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{"cur", "new", "tmp"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, dir), 0700))
+	}
+}
+
+func TestImportMaildirPreservesRawAndMergesFolders(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	maildirFixture(t, filepath.Join(root, ".Archive"))
+	raw := []byte("From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Maildir message\r\nMessage-ID: <one@example.com>\r\n\r\nArchive me.\r\n")
+	seenName := "one:2,S"
+	if runtime.GOOS == "windows" {
+		// Colons select alternate data streams on Windows, not regular files.
+		seenName = "one-seen"
+	}
+	for _, path := range []string{"new/one", filepath.Join(".Archive", "cur", seenName)} {
+		require.NoError(os.WriteFile(filepath.Join(root, path), raw, 0600))
+	}
+	require.NoError(os.WriteFile(filepath.Join(root, "tmp", "pending"), []byte("Subject: incomplete\r\n\r\n"), 0600))
+	opts := MaildirImportOptions{Identifier: "alice@example.com"}
+	summary, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	assert.Equal(int64(1), summary.MessagesAdded)
+	assert.Equal(int64(1), summary.MessagesSkipped)
+	var sourceType, rawFormat string
+	require.NoError(st.DB().QueryRow(`SELECT s.source_type, mr.raw_format FROM messages m JOIN sources s ON s.id=m.source_id JOIN message_raw mr ON mr.message_id=m.id`).Scan(&sourceType, &rawFormat))
+	assert.Equal("maildir", sourceType)
+	assert.Equal("mime", rawFormat)
+	var messageID int64
+	require.NoError(st.DB().QueryRow(`SELECT id FROM messages`).Scan(&messageID))
+	storedRaw, err := st.GetMessageRaw(messageID)
+	require.NoError(err)
+	assert.Equal(raw, storedRaw)
+	rows, err := st.DB().Query(`SELECT l.name FROM message_labels ml JOIN labels l ON l.id=ml.label_id ORDER BY l.name`)
+	require.NoError(err)
+	defer func() { require.NoError(rows.Close()) }()
+	var labels []string
+	for rows.Next() {
+		var name string
+		require.NoError(rows.Scan(&name))
+		labels = append(labels, name)
+	}
+	require.NoError(rows.Err())
+	assert.Equal([]string{"Archive", "INBOX", "UNREAD"}, labels)
+	require.NoError(os.Rename(filepath.Join(root, "new/one"), filepath.Join(root, "cur", seenName)))
+	second, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	assert.Zero(second.MessagesAdded)
+	assert.Equal(int64(2), second.MessagesSkipped)
+	got, err := os.ReadFile(filepath.Join(root, "cur", seenName))
+	require.NoError(err)
+	assert.Equal(raw, got)
+}
+
+func TestImportMaildirCancellationAndResume(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	require.NoError(os.WriteFile(filepath.Join(root, "new/one"), []byte("Subject: resume\r\n\r\nbody"), 0600))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	first, err := ImportMaildir(ctx, st, root, MaildirImportOptions{Identifier: "alice@example.com"})
+	require.ErrorIs(err, context.Canceled)
+	require.NotNil(first)
+	second, err := ImportMaildir(t.Context(), st, root, MaildirImportOptions{Identifier: "alice@example.com"})
+	require.NoError(err)
+	assert.True(second.WasResumed)
+	assert.Equal(int64(1), second.MessagesAdded)
+}
+
+func TestImportMaildirEmptyAndOversized(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	opts := MaildirImportOptions{Identifier: "alice@example.com", MaxMessageBytes: 16}
+	empty, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	assert.Zero(empty.MessagesAdded)
+	require.NoError(os.WriteFile(filepath.Join(root, "new/large"), []byte("Subject: too large\r\n\r\nthis message exceeds the limit"), 0600))
+	result, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	assert.True(result.HardErrors)
+	assert.Equal(int64(1), result.Errors)
+	assert.Zero(result.MessagesAdded)
+}
+
+func TestImportMaildirStoresAttachment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	raw := email.NewMessage().WithAttachment("sample.txt", "text/plain", []byte("synthetic attachment")).Bytes()
+	require.NoError(os.WriteFile(filepath.Join(root, "cur/message"), raw, 0600))
+	attachments := filepath.Join(tmp, "attachments")
+	result, err := ImportMaildir(t.Context(), st, root, MaildirImportOptions{Identifier: "alice@example.com", AttachmentsDir: attachments})
+	require.NoError(err)
+	assert.Equal(int64(1), result.MessagesAdded)
+	var path string
+	require.NoError(st.DB().QueryRow(`SELECT storage_path FROM attachments`).Scan(&path))
+	stored, err := os.ReadFile(filepath.Join(attachments, path))
+	require.NoError(err)
+	assert.Equal([]byte("synthetic attachment"), stored)
+}
+
+func TestImportMaildirRecoveredFailureIsSuccessful(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, tmp := openTestStore(t)
+	root := filepath.Join(tmp, "mail")
+	maildirFixture(t, root)
+	require.NoError(os.WriteFile(filepath.Join(root, "new/one"), []byte("Subject: retry\r\n\r\nbody"), 0600))
+	_, err := st.DB().Exec(`CREATE TRIGGER fail_maildir_insert BEFORE INSERT ON messages BEGIN SELECT RAISE(ABORT,'transient import failure'); END`)
+	require.NoError(err)
+	opts := MaildirImportOptions{Identifier: "alice@example.com"}
+	first, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	require.True(first.HardErrors)
+	assert.Equal(int64(1), first.Errors)
+	_, err = st.DB().Exec(`DROP TRIGGER fail_maildir_insert`)
+	require.NoError(err)
+	recovered, err := ImportMaildir(t.Context(), st, root, opts)
+	require.NoError(err)
+	require.True(recovered.WasResumed)
+	assert.Equal(int64(1), recovered.MessagesAdded)
+	run, err := st.GetLatestSync(recovered.SourceID)
+	require.NoError(err)
+	assert.Equal("completed", run.Status)
+	assert.Zero(run.ErrorsCount, "a fully recovered scan must be classified as successful")
+}

--- a/internal/maildir/discover.go
+++ b/internal/maildir/discover.go
@@ -16,7 +16,8 @@ type Mailbox struct {
 }
 
 // Discover finds standard and Maildir++ mailboxes below root. It never follows
-// symlinks or descends into cur, new, or tmp directories.
+// symlinks or descends into cur, new, or tmp directories, and it skips
+// dotfiles in cur and new because Maildir unique names never start with a dot.
 func Discover(root string) ([]Mailbox, error) {
 	root, err := filepath.Abs(root)
 	if err != nil {
@@ -75,6 +76,11 @@ func Discover(root string) ([]Mailbox, error) {
 				return err
 			}
 			for _, file := range entries {
+				// Unique names never start with a dot; such entries are
+				// bookkeeping files, not messages.
+				if strings.HasPrefix(file.Name(), ".") {
+					continue
+				}
 				info, err := file.Info()
 				if err != nil {
 					return fmt.Errorf("inspect Maildir entry: %w", err)

--- a/internal/maildir/discover.go
+++ b/internal/maildir/discover.go
@@ -1,0 +1,119 @@
+// Package maildir reads Maildir layouts without modifying mailbox files.
+package maildir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Mailbox contains the delivered files and archive label of one Maildir.
+type Mailbox struct {
+	Path  string
+	Label string
+	Files []string
+}
+
+// Discover finds standard and Maildir++ mailboxes below root. It never follows
+// symlinks or descends into cur, new, or tmp directories.
+func Discover(root string) ([]Mailbox, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	var boxes []Mailbox
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if path != root {
+			switch entry.Name() {
+			case "cur", "new", "tmp":
+				return filepath.SkipDir
+			}
+		}
+		valid := true
+		for _, dir := range []string{"cur", "new", "tmp"} {
+			info, err := os.Lstat(filepath.Join(path, dir))
+			if os.IsNotExist(err) {
+				valid = false
+				break
+			}
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				valid = false
+				break
+			}
+		}
+		if !valid {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		label := "INBOX"
+		if rel != "." {
+			parts := strings.Split(filepath.ToSlash(rel), "/")
+			for i, part := range parts {
+				if trimmed, ok := strings.CutPrefix(part, "."); ok {
+					parts[i] = strings.ReplaceAll(trimmed, ".", "/")
+				}
+			}
+			label = strings.Join(parts, "/")
+		}
+		box := Mailbox{Path: path, Label: label}
+		for _, dir := range []string{"cur", "new"} {
+			entries, err := os.ReadDir(filepath.Join(path, dir))
+			if err != nil {
+				return err
+			}
+			for _, file := range entries {
+				info, err := file.Info()
+				if err != nil {
+					return fmt.Errorf("inspect Maildir entry: %w", err)
+				}
+				if info.Mode().IsRegular() {
+					box.Files = append(box.Files, filepath.Join(path, dir, file.Name()))
+				}
+			}
+		}
+		boxes = append(boxes, box)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discover Maildir: %w", err)
+	}
+	if len(boxes) == 0 {
+		return nil, fmt.Errorf("no Maildir mailboxes (cur, new, tmp) found under %q", root)
+	}
+	return boxes, nil
+}
+
+// Flags returns archival labels for the standard Maildir info suffix. Unknown
+// flags are ignored. Absence of the seen flag denotes an unread message.
+func Flags(path string) []string {
+	name := filepath.Base(path)
+	flags := ""
+	if i := strings.LastIndex(name, ":2,"); i >= 0 {
+		flags = name[i+3:]
+	}
+	var labels []string
+	if !strings.Contains(flags, "S") {
+		labels = append(labels, "UNREAD")
+	}
+	for _, flag := range []struct{ letter, label string }{
+		{"D", "DRAFT"}, {"F", "STARRED"}, {"P", "PASSED"}, {"R", "REPLIED"}, {"T", "TRASH"},
+	} {
+		if strings.Contains(flags, flag.letter) {
+			labels = append(labels, flag.label)
+		}
+	}
+	return labels
+}

--- a/internal/maildir/discover_test.go
+++ b/internal/maildir/discover_test.go
@@ -1,0 +1,84 @@
+package maildir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMailbox(t *testing.T, root string) {
+	t.Helper()
+	for _, dir := range []string{"cur", "new", "tmp"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, dir), 0700))
+	}
+}
+
+func TestDiscoverReadsDeliveredMessagesAndNestedFolders(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+	makeMailbox(t, root)
+	makeMailbox(t, filepath.Join(root, ".Projects.Go"))
+	makeMailbox(t, filepath.Join(root, "Archive", "2024"))
+	for _, file := range []string{"cur/one", "new/two", "tmp/incomplete", ".Projects.Go/cur/three", "Archive/2024/new/four", "dovecot-uidlist"} {
+		require.NoError(os.WriteFile(filepath.Join(root, file), []byte("Subject: test\r\n\r\nbody"), 0600))
+	}
+	boxes, err := Discover(root)
+	require.NoError(err)
+	require.Len(boxes, 3)
+	labels := map[string]int{}
+	for _, box := range boxes {
+		labels[box.Label] = len(box.Files)
+	}
+	assert.Equal(map[string]int{"INBOX": 2, "Projects/Go": 1, "Archive/2024": 1}, labels)
+}
+
+func TestDiscoverRejectsNonMaildirAndDoesNotFollowSymlinks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+	_, err := Discover(root)
+	require.Error(err)
+	makeMailbox(t, root)
+	outside := t.TempDir()
+	makeMailbox(t, outside)
+	require.NoError(os.WriteFile(filepath.Join(outside, "new", "secret"), []byte("private"), 0600))
+	require.NoError(os.Symlink(outside, filepath.Join(root, ".Linked")))
+	require.NoError(os.Symlink(filepath.Join(outside, "new", "secret"), filepath.Join(root, "cur", "link")))
+	boxes, err := Discover(root)
+	require.NoError(err)
+	require.Len(boxes, 1)
+	assert.Empty(boxes[0].Files)
+}
+
+func TestFlags(t *testing.T) {
+	for _, tt := range []struct {
+		path string
+		want []string
+	}{
+		{"new/one", []string{"UNREAD"}},
+		{"cur/one:2,S", nil},
+		{"cur/one:2,DFPRST", []string{"DRAFT", "STARRED", "PASSED", "REPLIED", "TRASH"}},
+		{"cur/one:2,FX", []string{"UNREAD", "STARRED"}},
+	} {
+		t.Run(tt.path, func(t *testing.T) { assert.Equal(t, tt.want, Flags(tt.path)) })
+	}
+}
+
+func TestDiscoverDoesNotDescendIntoMessageOrTemporaryDirectories(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+	makeMailbox(t, root)
+	for _, dir := range []string{"cur/nested", "new/nested", "tmp/.Hidden"} {
+		makeMailbox(t, filepath.Join(root, dir))
+		require.NoError(os.WriteFile(filepath.Join(root, dir, "new/message"), []byte("body"), 0600))
+	}
+	boxes, err := Discover(root)
+	require.NoError(err)
+	require.Len(boxes, 1)
+	assert.Empty(boxes[0].Files)
+}

--- a/internal/maildir/discover_test.go
+++ b/internal/maildir/discover_test.go
@@ -23,7 +23,10 @@ func TestDiscoverReadsDeliveredMessagesAndNestedFolders(t *testing.T) {
 	makeMailbox(t, root)
 	makeMailbox(t, filepath.Join(root, ".Projects.Go"))
 	makeMailbox(t, filepath.Join(root, "Archive", "2024"))
-	for _, file := range []string{"cur/one", "new/two", "tmp/incomplete", ".Projects.Go/cur/three", "Archive/2024/new/four", "dovecot-uidlist"} {
+	for _, file := range []string{
+		"cur/one", "new/two", "tmp/incomplete", ".Projects.Go/cur/three", "Archive/2024/new/four",
+		"dovecot-uidlist", "cur/.DS_Store", "new/.nfs0001",
+	} {
 		require.NoError(os.WriteFile(filepath.Join(root, file), []byte("Subject: test\r\n\r\nbody"), 0600))
 	}
 	boxes, err := Discover(root)

--- a/internal/store/migrate_legacy_identity.go
+++ b/internal/store/migrate_legacy_identity.go
@@ -307,7 +307,7 @@ func (s *Store) legacyIdentityMigrationAppliedTx(ctx context.Context, tx *logged
 
 func SourceTypeUsesEmailIdentity(sourceType string) bool {
 	switch sourceType {
-	case "gmail", "imap", "o365", "mbox", "hey", "apple-mail", "pst", "eml":
+	case "gmail", "imap", "o365", "mbox", "hey", "apple-mail", "pst", "eml", "maildir":
 		return true
 	}
 	return false

--- a/internal/store/migrate_legacy_identity_test.go
+++ b/internal/store/migrate_legacy_identity_test.go
@@ -25,6 +25,7 @@ func TestSourceTypeUsesEmailIdentity(t *testing.T) {
 		{"apple-mail", true},
 		{"pst", true},
 		{"eml", true},
+		{"maildir", true},
 		// Phone/handle-keyed sources.
 		{"whatsapp", false},
 		{"apple_messages", false},


### PR DESCRIPTION
## What changed

- Add `import-maildir` for Maildir and Maildir++ archives, including nested folders and attachments.
- Preserve raw messages and folder/flag labels without changing mailbox files. Reruns and interrupted imports skip messages already archived, even after filename changes.
- Report a recovered import retry as successful once all failed files import.

## Why

Maildir archives currently need conversion before msgvault can import them. This lets users archive them directly alongside their MBOX exports.

## Usage

```bash
msgvault import-maildir ~/Maildir --identifier you@example.com
```

Import a stable mailbox snapshot. The importer reads `cur` and `new`, skips `tmp` and symlinks, and adds archive labels without removing previously stored labels.

Closes #156
