### PR TITLE
fix(cli): verify cached Gmail account identities

### DIFF
--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -272,10 +272,14 @@ func warnOnWiderThanRequestedGrant(out io.Writer, mgr *oauth.Manager, email, res
 // addAccountGrantFlagSuffix renders the grant-affecting flags of the current
 // run for inclusion in remediation commands.
 func addAccountGrantFlagSuffix() string {
-	if readonlyGrant {
-		return " --readonly"
+	var suffix string
+	if oauthAppName != "" {
+		suffix = " --oauth-app " + oauth.ShellQuote(oauthAppName)
 	}
-	return ""
+	if readonlyGrant {
+		suffix += " --readonly"
+	}
+	return suffix
 }
 
 // runAddAccountHTTP completes any needed browser authorization in this
@@ -546,7 +550,15 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("load stored token: %w", err)
 		}
 		if err := oauth.ValidateTokenEmail(cmd.Context(), ts, email); err != nil {
-			return fmt.Errorf("verify stored token: %w", err)
+			err = fmt.Errorf("verify stored token: %w", err)
+			if _, ok := errors.AsType[*oauth.TokenMismatchError](err); ok {
+				if existingSource == nil {
+					return addAccountAuthorizeError(err, false)
+				}
+				return fmt.Errorf("%w\nFor recovery steps for an existing mislabeled account, see:\n"+
+					"  https://msgvault.io/usage/multi-account/#recovering-an-older-mislabeled-gmail-account", err)
+			}
+			return err
 		}
 		if grantDecided {
 			warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email, resolvedApp)

--- a/cmd/msgvault/cmd/addaccount.go
+++ b/cmd/msgvault/cmd/addaccount.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/mail"
 	"os"
 	"slices"
 	"strings"
@@ -49,8 +50,11 @@ var addAccountCmd = &cobra.Command{
 By default, opens a browser for authorization. Use --headless to see instructions
 for authorizing on headless servers (Google does not support Gmail in device flow).
 
-If a token already exists, the command skips authorization. Use --force to delete
-the existing token and start a fresh OAuth flow.
+The email must match the Google account selected during authorization. Use
+--display-name for a label such as "Work".
+
+If a token already exists, the command verifies its mailbox and skips browser
+authorization. Use --force to delete the existing token and start a fresh OAuth flow.
 
 By default msgvault requests Gmail read and modify access. Use --readonly to
 request read access only.
@@ -71,7 +75,7 @@ Examples:
   msgvault add-account you@gmail.com --readonly
   msgvault add-account you@acme.com --oauth-app acme
   msgvault add-account you@gmail.com --display-name "Work Account"`,
-	Args: cobra.ExactArgs(1),
+	Args: validateAddAccountArgs,
 	RunE: runAddAccountLocal,
 }
 
@@ -80,7 +84,7 @@ func newAddAccountCmd() *cobra.Command {
 		Use:   addAccountUse,
 		Short: addAccountCmd.Short,
 		Long:  addAccountCmd.Long,
-		Args:  cobra.ExactArgs(1),
+		Args:  validateAddAccountArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if headless && forceReauth {
 				return usageErr(cmd, errors.New("--headless and --force cannot be used together: --force requires browser-based OAuth which is not available in headless mode"))
@@ -93,6 +97,17 @@ func newAddAccountCmd() *cobra.Command {
 	}
 	registerAddAccountFlags(cmd)
 	return cmd
+}
+
+func validateAddAccountArgs(cmd *cobra.Command, args []string) error {
+	if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+		return err
+	}
+	address, err := mail.ParseAddress(args[0])
+	if err != nil || address.Address != args[0] {
+		return errors.New("account must be a bare email address; use --display-name for a label")
+	}
+	return nil
 }
 
 // addAccountGrantDecided reports whether the daemon authenticated a completed
@@ -524,6 +539,15 @@ func runAddAccountLocal(cmd *cobra.Command, args []string) error {
 
 	tokenReusable := !forceReauth && addAccountTokenReusable(oauthMgr, email, binding, grantDecided)
 	if tokenReusable {
+		// A token's filename and OAuth client do not establish which mailbox
+		// it accesses. Verify copied and legacy tokens before changing the source.
+		ts, err := oauthMgr.TokenSource(cmd.Context(), email)
+		if err != nil {
+			return fmt.Errorf("load stored token: %w", err)
+		}
+		if err := oauth.ValidateTokenEmail(cmd.Context(), ts, email); err != nil {
+			return fmt.Errorf("verify stored token: %w", err)
+		}
 		if grantDecided {
 			warnOnWiderThanRequestedGrant(cmd.OutOrStdout(), oauthMgr, email, resolvedApp)
 		}

--- a/cmd/msgvault/cmd/addaccount_identity_test.go
+++ b/cmd/msgvault/cmd/addaccount_identity_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/oauth"
+	"go.kenn.io/msgvault/internal/store"
+	"golang.org/x/oauth2"
+)
+
+func TestAddAccountRejectsInvalidAddress(t *testing.T) {
+	saveAddAccountFlags(t)
+	for _, email := range []string{"not-an-email", "", "User <user@example.com>", "user@example.com,other@example.com", " user@example.com", "user@example.com\n"} {
+		t.Run(email, func(t *testing.T) {
+			cmd := newAddAccountCmd()
+			err := cmd.ValidateArgs([]string{email})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "email")
+		})
+	}
+}
+
+func TestAddAccountAcceptsEmailAddress(t *testing.T) {
+	saveAddAccountFlags(t)
+	for _, email := range []string{"user@example.com", "User.Name+archive@gmail.com", "user@googlemail.com"} {
+		t.Run(email, func(t *testing.T) {
+			cmd := newAddAccountCmd()
+			require.NoError(t, cmd.ValidateArgs([]string{email}))
+		})
+	}
+}
+
+type gmailProfileTransport struct {
+	server *httptest.Server
+}
+
+func (tr gmailProfileTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.String() != "https://gmail.googleapis.com/gmail/v1/users/me/profile" {
+		return nil, fmt.Errorf("unexpected OAuth request: %s", req.URL)
+	}
+	forward := req.Clone(req.Context())
+	forward.URL.Scheme = "http"
+	forward.URL.Host = tr.server.Listener.Addr().String()
+	return tr.server.Client().Transport.RoundTrip(forward)
+}
+
+// gmailProfileContext supplies only the external Gmail profile response.
+// Account registration, token loading, and all database writes remain real.
+func gmailProfileContext(t *testing.T, email string) context.Context {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"emailAddress": email})
+	}))
+	t.Cleanup(srv.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	t.Cleanup(cancel)
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: gmailProfileTransport{srv}})
+}
+
+// A cached token must prove mailbox ownership before add-account creates a
+// source or changes its display name, even if its OAuth client is correct.
+func TestAddAccountCachedTokenIdentity(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		for _, legacy := range []bool{false, true} {
+			for _, profile := range []string{"user@example.com", "other@example.com", "unavailable"} {
+				t.Run(fmt.Sprintf("existing=%t/legacy=%t/profile=%s", existing, legacy, profile), func(t *testing.T) {
+					assert, require := assert.New(t), require.New(t)
+					saveAddAccountFlags(t)
+					home := t.TempDir()
+					secrets := filepath.Join(home, "client.json")
+					require.NoError(os.WriteFile(secrets, []byte(fakeClientSecrets), 0600))
+					savedCfg, savedLogger := cfg, logger
+					t.Cleanup(func() { cfg, logger = savedCfg, savedLogger })
+					cfg = &config.Config{HomeDir: home, Data: config.DataConfig{DataDir: home}, OAuth: config.OAuthConfig{ClientSecrets: secrets}}
+					logger = slog.New(slog.DiscardHandler)
+					require.NoError(os.MkdirAll(cfg.TokensDir(), 0700))
+					tokenFields := map[string]any{"access_token": "synthetic-token", "token_type": "Bearer"}
+					if !legacy {
+						tokenFields["client_id"] = "test.apps.googleusercontent.com"
+						tokenFields["scopes"] = oauth.Scopes
+					}
+					token, err := json.Marshal(tokenFields)
+					require.NoError(err)
+					tokenPath := oauth.TokenFilePath(cfg.TokensDir(), "user@example.com")
+					require.NoError(os.WriteFile(tokenPath, token, 0600))
+					s, err := store.Open(cfg.DatabaseDSN())
+					require.NoError(err)
+					t.Cleanup(func() { _ = s.Close() })
+					require.NoError(s.InitSchema())
+					if existing {
+						source, err := s.GetOrCreateSource("gmail", "user@example.com")
+						require.NoError(err)
+						require.NoError(s.UpdateSourceDisplayName(source.ID, "Original"))
+					}
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if profile == "unavailable" {
+							w.WriteHeader(http.StatusServiceUnavailable)
+							return
+						}
+						_ = json.NewEncoder(w).Encode(map[string]string{"emailAddress": profile})
+					}))
+					defer srv.Close()
+					ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: gmailProfileTransport{srv}})
+					cmd := &cobra.Command{Use: addAccountUse, RunE: runAddAccountLocal}
+					registerAddAccountFlags(cmd)
+					cmd.SetArgs([]string{"user@example.com", "--display-name", "Updated", "--no-default-identity"})
+					err = cmd.ExecuteContext(ctx)
+					if profile == "user@example.com" {
+						require.NoError(err)
+						source, err := findGmailSource(s, "user@example.com")
+						require.NoError(err)
+						assert.Equal("Updated", source.DisplayName.String)
+						return
+					}
+					require.Error(err)
+					if profile == "other@example.com" {
+						var mismatch *oauth.TokenMismatchError
+						require.ErrorAs(err, &mismatch)
+					}
+					source, lookupErr := findGmailSource(s, "user@example.com")
+					if existing {
+						require.NoError(lookupErr)
+						assert.Equal("Original", source.DisplayName.String)
+					} else {
+						require.ErrorIs(lookupErr, errGmailSourceNotFound)
+					}
+					after, readErr := os.ReadFile(tokenPath)
+					require.NoError(readErr)
+					assert.Equal(token, after)
+				})
+			}
+		}
+	}
+}

--- a/cmd/msgvault/cmd/addaccount_identity_test.go
+++ b/cmd/msgvault/cmd/addaccount_identity_test.go
@@ -1,16 +1,16 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -44,30 +44,37 @@ func TestAddAccountAcceptsEmailAddress(t *testing.T) {
 }
 
 type gmailProfileTransport struct {
-	server *httptest.Server
+	email      string
+	statusCode int
 }
 
 func (tr gmailProfileTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.String() != "https://gmail.googleapis.com/gmail/v1/users/me/profile" {
 		return nil, fmt.Errorf("unexpected OAuth request: %s", req.URL)
 	}
-	forward := req.Clone(req.Context())
-	forward.URL.Scheme = "http"
-	forward.URL.Host = tr.server.Listener.Addr().String()
-	return tr.server.Client().Transport.RoundTrip(forward)
+	body, err := json.Marshal(map[string]string{"emailAddress": tr.email})
+	if err != nil {
+		return nil, fmt.Errorf("encode Gmail profile fixture: %w", err)
+	}
+	return &http.Response{
+		StatusCode: tr.statusCode,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Request:    req,
+	}, nil
 }
 
 // gmailProfileContext supplies only the external Gmail profile response.
 // Account registration, token loading, and all database writes remain real.
+// The in-memory transport accepts a cancelled context so an unexpected fallthrough
+// to browser authorization fails before opening a browser or callback listener.
 func gmailProfileContext(t *testing.T, email string) context.Context {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"emailAddress": email})
-	}))
-	t.Cleanup(srv.Close)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	t.Cleanup(cancel)
-	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: gmailProfileTransport{srv}})
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: gmailProfileTransport{email: email, statusCode: http.StatusOK},
+	})
 }
 
 // A cached token must prove mailbox ownership before add-account creates a
@@ -105,15 +112,12 @@ func TestAddAccountCachedTokenIdentity(t *testing.T) {
 						require.NoError(err)
 						require.NoError(s.UpdateSourceDisplayName(source.ID, "Original"))
 					}
-					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-						if profile == "unavailable" {
-							w.WriteHeader(http.StatusServiceUnavailable)
-							return
-						}
-						_ = json.NewEncoder(w).Encode(map[string]string{"emailAddress": profile})
-					}))
-					defer srv.Close()
-					ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: gmailProfileTransport{srv}})
+					ctx := gmailProfileContext(t, profile)
+					if profile == "unavailable" {
+						ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+							Transport: gmailProfileTransport{statusCode: http.StatusServiceUnavailable},
+						})
+					}
 					cmd := &cobra.Command{Use: addAccountUse, RunE: runAddAccountLocal}
 					registerAddAccountFlags(cmd)
 					cmd.SetArgs([]string{"user@example.com", "--display-name", "Updated", "--no-default-identity"})
@@ -129,6 +133,13 @@ func TestAddAccountCachedTokenIdentity(t *testing.T) {
 					if profile == "other@example.com" {
 						var mismatch *oauth.TokenMismatchError
 						require.ErrorAs(err, &mismatch)
+						if existing {
+							assert.Contains(err.Error(), "https://msgvault.io/usage/multi-account/#recovering-an-older-mislabeled-gmail-account")
+						} else {
+							assert.Contains(err.Error(), "msgvault add-account other@example.com")
+						}
+					} else {
+						assert.Contains(err.Error(), "HTTP 503")
 					}
 					source, lookupErr := findGmailSource(s, "user@example.com")
 					if existing {

--- a/cmd/msgvault/cmd/addaccount_readonly_test.go
+++ b/cmd/msgvault/cmd/addaccount_readonly_test.go
@@ -83,6 +83,13 @@ func saveAddAccountFlags(t *testing.T) {
 // the absence of that failure.
 func runAddAccountForTest(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return runAddAccountForTestContext(ctx, t, args...)
+}
+
+func runAddAccountForTestContext(ctx context.Context, t *testing.T, args ...string) (string, error) {
+	t.Helper()
 	testCmd := &cobra.Command{
 		Use:  addAccountUse,
 		Args: cobra.ExactArgs(1),
@@ -106,8 +113,6 @@ func runAddAccountForTest(t *testing.T, args ...string) (string, error) {
 		captured <- buf.String()
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
 	runErr := root.ExecuteContext(ctx)
 
 	os.Stdout = savedStdout
@@ -583,7 +588,7 @@ func TestAddAccount_LegacyTokenStillReusableWithoutReadonly(t *testing.T) {
 	_, restore := seedTokenEnv(t, legacyTokenJSON)
 	defer restore()
 
-	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--no-default-identity")
+	out, err := runAddAccountForTestContext(gmailProfileContext(t, scopeEscalationAccount), t, scopeEscalationAccount, "--no-default-identity")
 
 	require.NoError(err)
 	assert.Contains(out, "already authorized")
@@ -599,7 +604,7 @@ func TestAddAccount_AuthenticatedPreflightRegistersWiderGrant(t *testing.T) {
 	defer restore()
 	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
 
-	out, err := runAddAccountForTest(t,
+	out, err := runAddAccountForTestContext(gmailProfileContext(t, scopeEscalationAccount), t,
 		scopeEscalationAccount, "--readonly", "--grant-decided", "--no-default-identity")
 
 	require.NoError(err)
@@ -791,7 +796,7 @@ func TestAddAccount_ReadonlyReusesAlreadyNarrowToken(t *testing.T) {
 	before, err := os.ReadFile(tokenPath)
 	require.NoError(err)
 
-	out, err := runAddAccountForTest(t, scopeEscalationAccount, "--readonly", "--no-default-identity")
+	out, err := runAddAccountForTestContext(gmailProfileContext(t, scopeEscalationAccount), t, scopeEscalationAccount, "--readonly", "--no-default-identity")
 
 	require.NoError(err)
 	assert.Contains(out, "already authorized")

--- a/cmd/msgvault/cmd/addaccount_test.go
+++ b/cmd/msgvault/cmd/addaccount_test.go
@@ -120,6 +120,9 @@ func TestAddAccount_InheritedBindingValidatesToken(t *testing.T) {
 			// No --oauth-app flag: binding inherited from DB
 			root.SetArgs([]string{"add-account", "user@acme.com"})
 
+			if !tc.wantError {
+				ctx = gmailProfileContext(t, "user@acme.com")
+			}
 			err = root.ExecuteContext(ctx)
 			if tc.wantError {
 				require.Error(err, "expected error for mismatched token")
@@ -228,8 +231,7 @@ func TestAddAccount_FullGmailScopeTokenCanBeReused(t *testing.T) {
 	}
 	logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	ctx := gmailProfileContext(t, "user@example.com")
 
 	testCmd := &cobra.Command{
 		Use: "add-account <email>", Args: cobra.ExactArgs(1),
@@ -346,7 +348,7 @@ func TestAddAccount_RebindWithExistingToken(t *testing.T) {
 	})
 
 	// Should succeed without opening a browser — token exists
-	err = root.Execute()
+	err = root.ExecuteContext(gmailProfileContext(t, "user@acme.com"))
 	require.NoError(err)
 
 	// Token file should still exist
@@ -559,10 +561,8 @@ func TestAddAccount_ExplicitDefaultAcceptsMatchingToken(t *testing.T) {
 	testCmd.Flags().StringVar(&accountDisplayName, "display-name", "", "")
 	testCmd.Flags().BoolVar(&noDefaultIdentityAddAccount, "no-default-identity", false, "")
 
-	// Pre-cancel so if regression causes auth attempt, it fails fast
-	// instead of opening a browser.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	// Verify the cached token against a synthetic Gmail profile.
+	ctx := gmailProfileContext(t, "user@example.com")
 
 	root := newTestRootCmd()
 	root.AddCommand(testCmd)
@@ -782,7 +782,7 @@ func TestAddAccount_AutoDefaultIdentityFires(t *testing.T) {
 	root.AddCommand(testCmd)
 	root.SetArgs([]string{"add-account", "user@example.com"})
 
-	require.NoError(root.Execute())
+	require.NoError(root.ExecuteContext(gmailProfileContext(t, "user@example.com")))
 
 	s, err := store.Open(dbPath)
 	require.NoError(err, "reopen store")
@@ -853,7 +853,7 @@ func TestAddAccount_NoDefaultIdentitySuppresses(t *testing.T) {
 	root.AddCommand(testCmd)
 	root.SetArgs([]string{"add-account", "user@example.com", "--no-default-identity"})
 
-	require.NoError(root.Execute())
+	require.NoError(root.ExecuteContext(gmailProfileContext(t, "user@example.com")))
 
 	s, err := store.Open(dbPath)
 	require.NoError(err, "reopen store")
@@ -934,7 +934,7 @@ func TestAddAccount_DeferredLegacyIdentityMigrationFires(t *testing.T) {
 	// the auto-default would otherwise add a third identity row.
 	root.SetArgs([]string{"add-account", "user@example.com", "--no-default-identity"})
 
-	require.NoError(root.Execute())
+	require.NoError(root.ExecuteContext(gmailProfileContext(t, "user@example.com")))
 
 	// The user-facing notice must only describe the applied path.
 	// Emitting the "deferred — will run on the next command" notice
@@ -1039,7 +1039,7 @@ func TestAddAccount_LegacyMigrationDoesNotSuppressDefaultIdentity(t *testing.T) 
 	// when the auto-default write is supposed to fire.
 	root.SetArgs([]string{"add-account", "user@example.com"})
 
-	require.NoError(root.Execute())
+	require.NoError(root.ExecuteContext(gmailProfileContext(t, "user@example.com")))
 
 	s, err := store.Open(dbPath)
 	require.NoError(err, "reopen store")

--- a/cmd/msgvault/cmd/addaccount_test.go
+++ b/cmd/msgvault/cmd/addaccount_test.go
@@ -102,8 +102,7 @@ func TestAddAccount_InheritedBindingValidatesToken(t *testing.T) {
 			}
 			logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			cancel()
+			ctx := gmailProfileContext(t, "user@acme.com")
 
 			testCmd := &cobra.Command{
 				Use: "add-account <email>", Args: cobra.ExactArgs(1),
@@ -120,12 +119,9 @@ func TestAddAccount_InheritedBindingValidatesToken(t *testing.T) {
 			// No --oauth-app flag: binding inherited from DB
 			root.SetArgs([]string{"add-account", "user@acme.com"})
 
-			if !tc.wantError {
-				ctx = gmailProfileContext(t, "user@acme.com")
-			}
 			err = root.ExecuteContext(ctx)
 			if tc.wantError {
-				require.Error(err, "expected error for mismatched token")
+				require.ErrorIs(err, context.Canceled, "unexpected browser authorization must stop at cancellation")
 			} else {
 				require.NoError(err)
 			}

--- a/cmd/msgvault/cmd/reauth_readonly_test.go
+++ b/cmd/msgvault/cmd/reauth_readonly_test.go
@@ -183,6 +183,7 @@ func TestReauthAliasMismatchUnchangedForWriteGrant(t *testing.T) {
 // account's recorded one — no token exists yet at that point.
 func TestAddAccountGrantFlagSuffix(t *testing.T) {
 	saveAddAccountFlags(t)
+	oauthAppName = ""
 
 	readonlyGrant = false
 	assert.Empty(t, addAccountGrantFlagSuffix())
@@ -197,6 +198,7 @@ func TestAddAccountGrantFlagSuffix(t *testing.T) {
 func TestAddAccountAuthorizeErrorRepeatsReadonly(t *testing.T) {
 	assert := assert.New(t)
 	saveAddAccountFlags(t)
+	oauthAppName = ""
 
 	mismatch := &oauth.TokenMismatchError{
 		Expected: "alias@gmail.com",
@@ -211,4 +213,9 @@ func TestAddAccountAuthorizeErrorRepeatsReadonly(t *testing.T) {
 	err = addAccountAuthorizeError(mismatch, false)
 	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com")
 	assert.NotContains(err.Error(), "--readonly")
+
+	oauthAppName = "work"
+	readonlyGrant = true
+	err = addAccountAuthorizeError(mismatch, false)
+	assert.Contains(err.Error(), "msgvault add-account primary@gmail.com --oauth-app 'work' --readonly")
 }

--- a/docs/usage/multi-account.md
+++ b/docs/usage/multi-account.md
@@ -1,4 +1,5 @@
 ---
+last_edited: 2026-09-07
 title: Accounts, Identities, and Collections
 description: How msgvault organizes every source into accounts, tracks which identifiers are "you," and groups accounts into collections for scoped search, stats, and deduplication.
 ---
@@ -59,6 +60,60 @@ msgvault list-accounts
 
 !!! tip "Add every account as a Test user"
     Each Gmail account must be listed as a **Test user** in the OAuth consent screen of the app that authorizes it. For Workspace accounts using a named OAuth app, add test users in that org's Google Cloud project. This is the most common reason a second account fails to authorize.
+
+### Gmail addresses and display names
+
+Pass your Gmail account's email address to `add-account`, then select that
+account in Google's consent screen. The argument is required and must be a bare
+email address. A label such as `Work` belongs in `--display-name`:
+
+```bash
+msgvault add-account user@example.com --display-name "Work"
+msgvault update-account user@example.com --display-name "Personal"
+```
+
+Msgvault checks the authenticated mailbox against the requested address, including
+when reusing a stored token. A mismatch or failed verification stops registration
+before account settings change. Gmail's equivalent spellings (dots,
+plus-addressing, and `googlemail.com`) are accepted. For Google Workspace, use the
+primary address returned by Google; a different local part is not assumed to be
+an alias of the same account.
+
+Changing a display name keeps the account identifier and archived mail intact.
+Commands such as `sync-full` continue to use the identifier from `list-accounts`.
+
+### Recovering an older mislabeled Gmail account
+
+Older versions could store credentials under a label that did not match the
+authenticated mailbox. Account identifiers cannot currently be renamed in place.
+If you only need a readable name, use `update-account --display-name` above.
+
+To replace an incorrect identifier, remove the old Gmail source and add the
+primary address. **Removal deletes that source's local messages and sync state.**
+Only use this recovery path if the mail is still available in Gmail. Take a
+verified backup first so you can roll back; restoring it preserves the old
+identifier rather than moving mail to the new one. Removal does not delete mail
+from Google.
+
+```bash
+msgvault list-accounts
+msgvault remove-account old-label --type gmail
+msgvault add-account user@example.com
+msgvault sync-full user@example.com
+```
+
+Reuse the `--oauth-app` value originally used for this account, if any. Named
+apps are defined under `[oauth.apps.<name>]` in `config.toml`; identify the
+applicable one before removal. Use `--readonly` if you want the replacement Gmail
+grant to be read-only. Update any `[[accounts]]` schedule in `config.toml` to use the correct
+address, and recreate custom collection memberships and source identities as
+needed.
+
+Gmail removal also removes its local Google token and attempts to revoke the
+grant. Calendar sources registered under the old address remain in the archive,
+but can no longer rely on that credential. If you also sync Calendar or Drive,
+record their settings and re-authorize those integrations under the primary
+address; the Gmail commands above do not migrate them.
 
 ## Syncing
 


### PR DESCRIPTION
## What changed

- Have `add-account` verify the mailbox behind a stored token before registering or updating the account.
- Reject labels and malformed addresses passed to `add-account`.
- Document display names and recovery for older mislabeled Gmail sources.

## Why

Fresh OAuth already rejects a different Google account, but reusing a stored token skips that check. A copied or older token can still register the wrong mailbox under the requested address.

## Usage

```bash
msgvault add-account user@example.com --display-name "Work"
```

The email remains required. Existing identifiers cannot be renamed in place; the account guide explains display-name changes and the remove-and-recreate recovery path.

Closes #96
