### PR TITLE
feat(mail): archive remote images behind explicit opt-in

### DIFF
--- a/cmd/msgvault/cmd/archive_remote_images.go
+++ b/cmd/msgvault/cmd/archive_remote_images.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/remoteimage"
+)
+
+func configuredRemoteImageFetcher() *remoteimage.Fetcher {
+	if cfg == nil || !cfg.Sync.ArchiveRemoteImages {
+		return nil
+	}
+	return remoteimage.NewFetcher()
+}
+
+func newArchiveRemoteImagesCmd() *cobra.Command {
+	var allowTracking bool
+	var sourceID int64
+	var limit int
+	command := &cobra.Command{
+		Use:   "archive-remote-images",
+		Short: "Archive remote images in existing email (requires tracking consent)",
+		Long:  "Download remote img src images from archived email for offline viewing.\n\nDownloading can activate tracking pixels and disclose the archive server's IP\naddress to senders. This command always requires --allow-tracking. It does not\nenable automatic archiving, change original messages, or re-fetch stored images.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !allowTracking {
+				return errors.New("remote image downloads can activate tracking pixels; pass --allow-tracking to consent")
+			}
+			if limit < 0 || sourceID < 0 {
+				return errors.New("source ID and limit must not be negative")
+			}
+			if !isDaemonCLISubprocess() {
+				return runDaemonCLICommandHTTPFromCobra(cmd, args)
+			}
+			st, cleanup, err := openWritableStoreAndInitForIngest()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			ctx, stop := withInterruptCancel(cmd, "\nInterrupted.")
+			defer stop()
+			result, err := remoteimage.NewFetcher().Backfill(ctx, st, cfg.AttachmentsDir(), sourceID, limit)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Messages: %d\nDownloaded: %d images\nAlready archived: %d images\nErrors: %d\n", result.Messages, result.Downloaded, result.Reused, result.Errors)
+			if result.Errors > 0 {
+				err = errors.Join(err, fmt.Errorf("%d remote image errors; successful downloads were preserved", result.Errors))
+			}
+			// Partial success and cancellation can still leave new attachments.
+			return errors.Join(err, rebuildCacheAfterWrite(cfg.DatabaseDSN()))
+		},
+	}
+	command.Flags().BoolVar(&allowTracking, "allow-tracking", false, "Consent to sender-controlled image requests and tracking pixels")
+	command.Flags().Int64Var(&sourceID, "source-id", 0, "Archive images for one source ID (default: all email sources)")
+	command.Flags().IntVar(&limit, "limit", 0, "Maximum messages to scan (0 = unlimited)")
+	return command
+}
+
+func init() { rootCmd.AddCommand(newArchiveRemoteImagesCmd()) }

--- a/cmd/msgvault/cmd/archive_remote_images.go
+++ b/cmd/msgvault/cmd/archive_remote_images.go
@@ -41,7 +41,7 @@ func newArchiveRemoteImagesCmd() *cobra.Command {
 			defer cleanup()
 			ctx, stop := withInterruptCancel(cmd, "\nInterrupted.")
 			defer stop()
-			result, err := remoteimage.NewFetcher().Backfill(ctx, st, cfg.AttachmentsDir(), sourceID, limit)
+			result, err := remoteimage.NewFetcher().Backfill(ctx, st, cfg.AttachmentsDir(), sourceID, limit, logger)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Messages: %d\nDownloaded: %d images\nAlready archived: %d images\nErrors: %d\n", result.Messages, result.Downloaded, result.Reused, result.Errors)
 			if result.Errors > 0 {
 				err = errors.Join(err, fmt.Errorf("%d remote image errors; successful downloads were preserved", result.Errors))

--- a/cmd/msgvault/cmd/archive_remote_images.go
+++ b/cmd/msgvault/cmd/archive_remote_images.go
@@ -46,6 +46,10 @@ func newArchiveRemoteImagesCmd() *cobra.Command {
 			if result.Errors > 0 {
 				err = errors.Join(err, fmt.Errorf("%d remote image errors; successful downloads were preserved", result.Errors))
 			}
+			// Attachment-only changes do not advance message or sync watermarks.
+			if result.Downloaded > 0 || result.Reused > 0 {
+				err = errors.Join(err, st.AdvanceDerivedDataRevision())
+			}
 			// Partial success and cancellation can still leave new attachments.
 			return errors.Join(err, rebuildCacheAfterWrite(cfg.DatabaseDSN()))
 		},

--- a/cmd/msgvault/cmd/archive_remote_images_test.go
+++ b/cmd/msgvault/cmd/archive_remote_images_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestArchiveRemoteImagesRequiresTrackingConsentBeforeDispatch(t *testing.T) {
+	require := require.New(t)
+	command := newArchiveRemoteImagesCmd()
+	require.ErrorContains(command.RunE(command, nil), "--allow-tracking")
+	require.NoError(command.Flags().Set("allow-tracking", "true"))
+	require.NoError(command.Flags().Set("limit", "-1"))
+	require.ErrorContains(command.RunE(command, nil), "limit")
+}
+
+func TestArchivedRemoteImagesThroughDaemonAdapter(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	assert.True(attachmentProducingCommand([]string{"archive-remote-images", "--allow-tracking"}))
+	st := testutil.NewTestStore(t)
+	configuration := config.NewDefaultConfig()
+	configuration.Data.DataDir = t.TempDir()
+	src, err := st.GetOrCreateSource("eml", "user@example.com")
+	require.NoError(err)
+	conv, err := st.EnsureConversation(src.ID, "remote-images", "Images")
+	require.NoError(err)
+	target := "https://images.example/chart.png"
+	key := fmt.Sprintf("remote-image:%x", sha256.Sum256([]byte(target)))
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message:  &store.Message{SourceID: src.ID, SourceMessageID: "remote-image", ConversationID: conv, MessageType: "email"},
+		BodyHTML: sql.NullString{String: `<img src="` + target + `">`, Valid: true},
+	})
+	require.NoError(err)
+	content := []byte("\x89PNG\r\n\x1a\nimage")
+	receipt, err := export.StoreAttachmentFileDurable(configuration.AttachmentsDir(), &mime.Attachment{ContentType: "image/png", Content: content})
+	require.NoError(err)
+	require.NoError(st.UpsertAttachmentRecord(t.Context(), id, store.AttachmentWrite{
+		Filename: "image.png", MIMEType: "image/png", StoragePath: receipt.StoragePath, ContentHash: receipt.ContentHash,
+		Size: int64(len(content)), SourceAttachmentID: key, SourcePartKey: key, ContentID: key,
+		Role: store.AttachmentRoleInline, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}))
+	daemon := api.NewServerWithOptions(api.ServerOptions{Config: configuration, Store: &storeAPIAdapter{store: st}, Logger: slog.Default()})
+	response := httptest.NewRecorder()
+	daemon.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d", id), nil))
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	assert.Contains(response.Body.String(), "cid:"+key)
+	response = httptest.NewRecorder()
+	daemon.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d/inline?cid=%s", id, key), nil))
+	require.Equal(http.StatusOK, response.Code, response.Body.String())
+	assert.Equal(content, response.Body.Bytes())
+}
+
+func TestConfiguredRemoteImageFetcherDefaultsOff(t *testing.T) {
+	assert := assert.New(t)
+	previous := cfg
+	t.Cleanup(func() { cfg = previous })
+	cfg = config.NewDefaultConfig()
+	assert.Nil(configuredRemoteImageFetcher())
+	cfg.Sync.ArchiveRemoteImages = true
+	assert.NotNil(configuredRemoteImageFetcher())
+	cfg.Sync.ArchiveRemoteImages = false
+	assert.Nil(configuredRemoteImageFetcher())
+}

--- a/cmd/msgvault/cmd/archive_remote_images_test.go
+++ b/cmd/msgvault/cmd/archive_remote_images_test.go
@@ -4,10 +4,14 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +19,7 @@ import (
 	"go.kenn.io/msgvault/internal/config"
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/query"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -74,4 +79,65 @@ func TestConfiguredRemoteImageFetcherDefaultsOff(t *testing.T) {
 	assert.NotNil(configuredRemoteImageFetcher())
 	cfg.Sync.ArchiveRemoteImages = false
 	assert.Nil(configuredRemoteImageFetcher())
+}
+
+func TestArchiveRemoteImagesRefreshesExistingCacheOnReuse(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	configuration := lifecycleTestConfig(t.TempDir())
+	withStoreResolverConfig(t, configuration)
+	t.Setenv(daemonCLISubprocessEnv, strconv.Itoa(os.Getppid()))
+
+	st, err := store.Open(configuration.DatabaseDSN())
+	require.NoError(err)
+	require.NoError(st.InitSchema())
+	src, err := st.GetOrCreateSource("eml", "user@example.com")
+	require.NoError(err)
+	conv, err := st.EnsureConversation(src.ID, "remote-images", "Images")
+	require.NoError(err)
+	target := "https://images.example/chart.png"
+	key := fmt.Sprintf("remote-image:%x", sha256.Sum256([]byte(target)))
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			SourceID: src.ID, SourceMessageID: "remote-image", ConversationID: conv, MessageType: "email",
+			SentAt: sql.NullTime{Time: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC), Valid: true},
+		},
+		BodyHTML: sql.NullString{String: `<img src="` + target + `">`, Valid: true},
+	})
+	require.NoError(err)
+	require.NoError(st.Close())
+	_, err = buildCache(configuration.DatabaseDSN(), configuration.AnalyticsDir(), true)
+	require.NoError(err)
+
+	// Model an interrupted backfill: bytes and rows exist, but the cache
+	// still represents the message before remote images were archived.
+	st, err = store.Open(configuration.DatabaseDSN())
+	require.NoError(err)
+	content := []byte("\x89PNG\r\n\x1a\nimage")
+	receipt, err := export.StoreAttachmentFileDurable(configuration.AttachmentsDir(), &mime.Attachment{ContentType: "image/png", Content: content})
+	require.NoError(err)
+	require.NoError(st.UpsertRemoteImageAttachment(t.Context(), id, store.AttachmentWrite{
+		Filename: "image.png", MIMEType: "image/png", StoragePath: receipt.StoragePath, ContentHash: receipt.ContentHash,
+		Size: int64(len(content)), SourceAttachmentID: key, SourcePartKey: key, ContentID: key,
+		Role: store.AttachmentRoleInline, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+	}))
+	require.NoError(st.Close())
+
+	command := newArchiveRemoteImagesCmd()
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	command.SetArgs([]string{"--allow-tracking"})
+	require.NoError(command.Execute())
+
+	engine, err := query.NewDuckDBEngine(configuration.AnalyticsDir(), "", nil)
+	require.NoError(err)
+	result, queryErr := engine.QuerySQL(t.Context(), `
+		SELECT m.attachment_count, m.has_attachments, COUNT(a.attachment_id)
+		FROM messages m LEFT JOIN attachments a ON a.message_id = m.id
+		GROUP BY m.id, m.attachment_count, m.has_attachments`)
+	require.NoError(engine.Close())
+	require.NoError(queryErr)
+	require.Len(result.Rows, 1)
+	assert.Equal("1", fmt.Sprint(result.Rows[0][0]), "cached attachment count")
+	assert.Equal(true, result.Rows[0][1], "cached attachment filter flag")
+	assert.Equal("1", fmt.Sprint(result.Rows[0][2]), "cached Files entry")
 }

--- a/cmd/msgvault/cmd/attachment_maintenance.go
+++ b/cmd/msgvault/cmd/attachment_maintenance.go
@@ -320,7 +320,8 @@ func attachmentProducingCommand(args []string) bool {
 		return false
 	}
 	switch args[0] {
-	case "backfill-beeper-media",
+	case "archive-remote-images",
+		"backfill-beeper-media",
 		"backfill-discord-media",
 		"backfill-slack-media",
 		"backfill-teams-media",

--- a/cmd/msgvault/cmd/import_eml.go
+++ b/cmd/msgvault/cmd/import_eml.go
@@ -63,6 +63,7 @@ duplicate messages receive every mailbox label where they appear.`,
 				NoResume:           flags.noResume,
 				CheckpointInterval: flags.checkpointInterval,
 				AttachmentsDir:     attachmentsDir,
+				RemoteImages:       configuredRemoteImageFetcher(),
 				Logger:             logger,
 			})
 			if importErr != nil {

--- a/cmd/msgvault/cmd/import_emlx.go
+++ b/cmd/msgvault/cmd/import_emlx.go
@@ -188,6 +188,7 @@ func importSingleAccount(
 			NoResume:           importEmlxNoResume,
 			CheckpointInterval: importEmlxCheckpointInterval,
 			AttachmentsDir:     attachmentsDir,
+			RemoteImages:       configuredRemoteImageFetcher(),
 			Logger:             logger,
 		},
 	)
@@ -321,6 +322,7 @@ func importAutoAccounts(
 				NoResume:           importEmlxNoResume,
 				CheckpointInterval: importEmlxCheckpointInterval,
 				AttachmentsDir:     attachmentsDir,
+				RemoteImages:       configuredRemoteImageFetcher(),
 				Logger:             logger,
 			},
 		)

--- a/cmd/msgvault/cmd/import_mbox.go
+++ b/cmd/msgvault/cmd/import_mbox.go
@@ -260,6 +260,7 @@ Examples:
 				NoResume:           importMboxNoResume,
 				CheckpointInterval: importMboxCheckpointInterval,
 				AttachmentsDir:     attachmentsDir,
+				RemoteImages:       configuredRemoteImageFetcher(),
 				Logger:             logger,
 			})
 			if err != nil {

--- a/cmd/msgvault/cmd/import_pst.go
+++ b/cmd/msgvault/cmd/import_pst.go
@@ -114,6 +114,7 @@ Examples:
 			NoResume:           importPstNoResume,
 			CheckpointInterval: importPstCheckpointInterval,
 			AttachmentsDir:     attachmentsDir,
+			RemoteImages:       configuredRemoteImageFetcher(),
 			Logger:             logger,
 		})
 		if err != nil {

--- a/cmd/msgvault/cmd/provider_identity_refresh.go
+++ b/cmd/msgvault/cmd/provider_identity_refresh.go
@@ -12,7 +12,12 @@ import (
 var fastmailIdentityInventoryFactory provideridentity.Factory = provideridentity.NewFastmailInventory
 
 func newMessageSyncer(client gmail.API, st *store.Store, opts *msgsync.Options) *msgsync.Syncer {
-	return withAutomaticProviderIdentityRefresh(msgsync.New(client, st, opts), st)
+	if opts == nil {
+		opts = msgsync.DefaultOptions()
+	}
+	configured := *opts
+	configured.RemoteImages = configuredRemoteImageFetcher()
+	return withAutomaticProviderIdentityRefresh(msgsync.New(client, st, &configured), st)
 }
 
 func withAutomaticProviderIdentityRefresh(syncer *msgsync.Syncer, st *store.Store) *msgsync.Syncer {

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1461,6 +1461,10 @@ func (a *storeAPIAdapter) GetMessage(id int64) (*api.APIMessage, error) {
 	return a.store.GetMessage(id)
 }
 
+func (a *storeAPIAdapter) MessageRemoteImages(id int64) (map[string]store.AttachmentRef, error) {
+	return a.store.MessageRemoteImages(id)
+}
+
 func (a *storeAPIAdapter) GetMessagesSummariesByIDs(ids []int64) ([]api.APIMessage, error) {
 	return a.store.GetMessagesSummariesByIDs(ids)
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-09-03"
+last_edited: "2026-09-07"
 title: CLI Reference
 description: Complete command reference for all msgvault commands.
 ---
@@ -476,6 +476,33 @@ cancellation failures fail the sync and preserve the prior successful cursor.
 | `--probe` | `false` | Print the MCP tool inventory and a sample result instead of syncing |
 
 See [Meeting Transcripts](/docs/usage/meetings/) for setup and what gets stored.
+
+---
+
+## archive-remote-images
+
+Download remote `<img src>` images from existing email for offline viewing.
+This is separate from the default-off `[sync].archive_remote_images` setting.
+
+```bash
+msgvault archive-remote-images --allow-tracking
+msgvault archive-remote-images --allow-tracking --source-id 1 --limit 100
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--allow-tracking` | `false` | Required consent to image requests that can activate tracking pixels |
+| `--source-id` | `0` | Restrict to one source; 0 includes all email sources |
+| `--limit` | `0` | Maximum messages to scan; 0 scans all matching email |
+
+Requests originate from the archive server, not the browser. Private-network
+destinations are blocked, but public hosts can still track requests. The command
+requires `--allow-tracking` even when automatic archiving is enabled.
+
+Already archived images are reused. Failed downloads can be retried by running
+the command again; successful downloads are preserved if other images fail.
+The summary reports messages scanned, images downloaded or reused, and errors.
+Any image errors produce a nonzero exit status. Original messages are unchanged.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-03
+last_edited: 2026-09-07
 title: Configuration
 description: Configuration file reference, environment variables, and file locations.
 ---
@@ -566,6 +566,36 @@ Use `msgvault logs` to view and tail log files from the selected local or remote
 | Key | Default | Description |
 |---|---|---|
 | `rate_limit_qps` | `5` | Gmail API requests per second |
+| `archive_remote_images` | `false` | Download remote email images during Gmail/IMAP sync and EML, EMLX, MBOX, and PST imports |
+
+Remote image archiving is **off by default**. Enabling it sends requests to
+sender-controlled servers. Those requests can activate tracking pixels and
+disclose the archive server's IP address. Private-network targets are blocked,
+but this does not prevent tracking by public image hosts.
+
+```toml
+[sync]
+archive_remote_images = true
+```
+
+Restart the daemon after changing this setting. It applies to newly ingested
+messages, not mail already in the archive. To process existing mail explicitly:
+
+```bash
+msgvault archive-remote-images --allow-tracking
+```
+
+Downloaded PNG, JPEG, GIF, and WebP images are stored locally and displayed
+offline in message and conversation views. Raw MIME and stored HTML are left
+unchanged. Disabling the setting stops automatic downloads without removing
+images already archived. Missing images remain subject to the reader's existing
+remote-image consent control.
+
+Archiving handles HTTP(S) `<img src>` URLs, including protocol-relative URLs.
+It does not fetch CSS backgrounds, `srcset` candidates, linked pages, or external
+stylesheets. Each message is limited to 64 distinct image URLs, 10 MiB per
+image, and 30 MiB of newly archived image data. Failed downloads are reported
+without failing the mail import.
 
 ### `[server]`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -585,11 +585,19 @@ messages, not mail already in the archive. To process existing mail explicitly:
 msgvault archive-remote-images --allow-tracking
 ```
 
+For large initial syncs or imports, leave this setting off and run the backfill
+command afterward. Images are fetched sequentially, with a 15-second timeout
+per fetch and a 60-second budget per message, so slow image hosts can
+substantially delay mail ingestion.
+
 Downloaded PNG, JPEG, GIF, and WebP images are stored locally and displayed
 offline in message and conversation views. Raw MIME and stored HTML are left
 unchanged. Disabling the setting stops automatic downloads without removing
 images already archived. Missing images remain subject to the reader's existing
 remote-image consent control.
+
+Archived images count as inline attachments, including small logos and tracking
+pixels. They affect attachment counts and filters and appear in the Files view.
 
 Archiving handles HTTP(S) `<img src>` URLs, including protocol-relative URLs.
 It does not fetch CSS backgrounds, `srcset` candidates, linked pages, or external

--- a/internal/api/archived_remote_images.go
+++ b/internal/api/archived_remote_images.go
@@ -66,12 +66,12 @@ func (s *Server) serveArchivedRemoteImage(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, "not_found", "Archived image bytes unavailable")
 		return
 	}
-	body, readErr := io.ReadAll(io.LimitReader(stream, remoteImageMaxBytes+1))
+	body, readErr := io.ReadAll(io.LimitReader(stream, remoteimage.MaxImageBytes+1))
 	if err := errors.Join(readErr, stream.Close()); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Cannot read archived image")
 		return
 	}
-	if len(body) > remoteImageMaxBytes {
+	if len(body) > remoteimage.MaxImageBytes {
 		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Archived image exceeds size cap")
 		return
 	}

--- a/internal/api/archived_remote_images.go
+++ b/internal/api/archived_remote_images.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+
+	msgexport "go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/remoteimage"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type archivedRemoteImageReader interface {
+	MessageRemoteImages(messageID int64) (map[string]store.AttachmentRef, error)
+}
+
+func (s *Server) archivedRemoteImageHTML(id int64, body string) string {
+	reader, ok := s.store.(archivedRemoteImageReader)
+	if !ok || body == "" {
+		return body
+	}
+	refs, err := reader.MessageRemoteImages(id)
+	if err != nil {
+		s.logger.Warn("cannot read archived remote images", "message", id, "error", err)
+		return body
+	}
+	return remoteimage.RewriteHTML(body, refs)
+}
+
+// serveArchivedRemoteImage resolves a CID through the owning message before
+// accessing CAS. Possession of a digest is never enough to select another
+// message's image, and no missing image triggers an outbound request.
+func (s *Server) serveArchivedRemoteImage(w http.ResponseWriter, r *http.Request, id int64, cid string) {
+	reader, ok := s.store.(archivedRemoteImageReader)
+	if !ok {
+		writeError(w, http.StatusServiceUnavailable, "store_unavailable", "Archived images unavailable")
+		return
+	}
+	refs, err := reader.MessageRemoteImages(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Cannot read archived images")
+		return
+	}
+	ref, ok := refs[cid]
+	if !ok || ref.ContentID != cid || ref.StoragePath == "" || msgexport.ValidateContentHash(ref.ContentHash) != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Archived image not found")
+		return
+	}
+	var stream io.ReadCloser
+	if s.blobStore != nil {
+		stream, _, err = s.blobStore.OpenStream(r.Context(), ref.ContentHash)
+	} else if s.cfg != nil {
+		var path string
+		path, err = msgexport.StoragePath(s.cfg.AttachmentsDir(), ref.ContentHash)
+		if err == nil {
+			// The hash was validated and StoragePath anchors it in configured CAS.
+			stream, err = os.Open(path)
+		}
+	} else {
+		err = errors.New("attachment store unavailable")
+	}
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Archived image bytes unavailable")
+		return
+	}
+	body, readErr := io.ReadAll(io.LimitReader(stream, remoteImageMaxBytes+1))
+	if err := errors.Join(readErr, stream.Close()); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Cannot read archived image")
+		return
+	}
+	if len(body) > remoteImageMaxBytes {
+		writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Archived image exceeds size cap")
+		return
+	}
+	sum := sha256.Sum256(body)
+	if hex.EncodeToString(sum[:]) != ref.ContentHash {
+		writeError(w, http.StatusInternalServerError, "invalid_content", "Archived image bytes failed verification")
+		return
+	}
+	switch ref.MimeType {
+	case "image/png", "image/jpeg", "image/gif", "image/webp":
+	default:
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_type", "Archived image type not permitted")
+		return
+	}
+	if http.DetectContentType(body) != ref.MimeType {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_type", "Archived image type does not match its bytes")
+		return
+	}
+	w.Header().Set("Content-Type", ref.MimeType)
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write(body)
+}

--- a/internal/api/archived_remote_images_test.go
+++ b/internal/api/archived_remote_images_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/attachmentstore"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/remoteimage"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestArchivedRemoteImagesRenderOfflineAndAreMessageScoped(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	st := testutil.NewTestStore(t)
+	cfg := config.NewDefaultConfig()
+	cfg.Data.DataDir = t.TempDir()
+	src, err := st.GetOrCreateSource("eml", "user@example.com")
+	require.NoError(err)
+	conv, err := st.EnsureConversation(src.ID, "thread", "Images")
+	require.NoError(err)
+	original := `<img src="http://images.example/chart.png">`
+	largeImage := append(append([]byte(nil), fakePNG...), make([]byte, 6<<20)...)
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message:  &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conv, MessageType: "email"},
+		BodyHTML: sql.NullString{String: original, Valid: true}, RawMIME: []byte("From: user@example.com\r\n\r\nOriginal"),
+	})
+	require.NoError(err)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(largeImage)
+	}))
+	defer upstream.Close()
+	fetcher := remoteimage.NewFetcher()
+	fetcher.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	fetcher.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+	}
+	result := fetcher.Archive(t.Context(), st, cfg.AttachmentsDir(), id, original)
+	require.Empty(result.Errors)
+	require.Equal(1, result.Downloaded)
+	upstream.Close() // The original image host is now unavailable.
+	srv := NewServerWithOptions(ServerOptions{Config: cfg, Store: st, Logger: testLogger()})
+	detailResponse := httptest.NewRecorder()
+	srv.Router().ServeHTTP(detailResponse, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d", id), nil))
+	require.Equal(http.StatusOK, detailResponse.Code, detailResponse.Body.String())
+	var detail MessageDetail
+	require.NoError(json.Unmarshal(detailResponse.Body.Bytes(), &detail))
+	assert.NotContains(detail.BodyHTML, "http://images.example")
+	assert.Contains(detail.BodyHTML, "cid:remote-image:")
+	conversationResponse := httptest.NewRecorder()
+	srv.Router().ServeHTTP(conversationResponse, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/conversations/%d?anchor=%d", conv, id), nil))
+	require.Equal(http.StatusOK, conversationResponse.Code, conversationResponse.Body.String())
+	var conversation ConversationResponse
+	require.NoError(json.Unmarshal(conversationResponse.Body.Bytes(), &conversation))
+	require.Len(conversation.Messages, 1)
+	assert.Contains(conversation.Messages[0].BodyHTML, "cid:remote-image:")
+	refs, err := st.MessageRemoteImages(id)
+	require.NoError(err)
+	require.Len(refs, 1)
+	for cid := range refs {
+		response := httptest.NewRecorder()
+		srv.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d/inline?cid=%s", id, cid), nil))
+		require.Equal(http.StatusOK, response.Code, response.Body.String())
+		assert.Equal(largeImage, response.Body.Bytes())
+		assert.Equal("image/png", response.Header().Get("Content-Type"))
+		response = httptest.NewRecorder()
+		srv.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d/inline?cid=%s", id+1, cid), nil))
+		assert.Equal(http.StatusNotFound, response.Code)
+	}
+	saved, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(original, saved.BodyHTML)
+
+	// Compact the same bytes into a real pack, then remove only the test's
+	// loose copy: the reader must resolve through the configured blob store.
+	entry := buildTestPack(t, cfg.AttachmentsDir(), largeImage)
+	require.NoError(st.RecordPackedBlobs(store.PackRecord{
+		PackID: entry.PackID, EntryCount: 1, StoredBytes: entry.StoredLen, CreatedAt: time.Now(),
+	}, []store.PackIndexEntry{entry}))
+	path, err := export.StoragePath(cfg.AttachmentsDir(), entry.BlobHash)
+	require.NoError(err)
+	require.NoError(os.Remove(path))
+	bs, err := attachmentstore.New(store.NewPackCatalog(st), cfg.AttachmentsDir())
+	require.NoError(err)
+	t.Cleanup(func() { assert.NoError(bs.Close()) })
+	srv = NewServerWithOptions(ServerOptions{Config: cfg, Store: st, BlobStore: bs, Logger: testLogger()})
+	for cid := range refs {
+		response := httptest.NewRecorder()
+		srv.Router().ServeHTTP(response, httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/messages/%d/inline?cid=%s", id, cid), nil))
+		require.Equal(http.StatusOK, response.Code, response.Body.String())
+		assert.Equal(largeImage, response.Body.Bytes())
+	}
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1619,6 +1619,7 @@ func cliRunCommandAllowed(args []string) bool {
 	}
 	switch args[0] {
 	case "add-account",
+		"archive-remote-images",
 		"activity",
 		"add-beeper",
 		"add-calendar",

--- a/internal/api/conversations.go
+++ b/internal/api/conversations.go
@@ -184,7 +184,7 @@ func (s *Server) handleGetConversation(w http.ResponseWriter, r *http.Request) {
 		detail := MessageDetail{
 			MessageSummary: toMessageSummary(message),
 			Body:           message.Body,
-			BodyHTML:       message.BodyHTML,
+			BodyHTML:       s.archivedRemoteImageHTML(message.ID, message.BodyHTML),
 			BodyOmitted:    message.BodyOmitted,
 			IsFromMe:       message.IsFromMe,
 			Attachments:    make([]AttachmentInfo, 0, len(message.Attachments)),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -683,7 +683,9 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "not_found", "Message not found")
 			return
 		case err == nil:
-			writeJSON(w, http.StatusOK, messageDetailFromQuery(qMsg))
+			detail := messageDetailFromQuery(qMsg)
+			detail.BodyHTML = s.archivedRemoteImageHTML(id, detail.BodyHTML)
+			writeJSON(w, http.StatusOK, detail)
 			return
 		}
 		// err is unsupported sentinel — fall through to store path so
@@ -722,6 +724,7 @@ func (s *Server) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 		attachments = append(attachments, attachmentInfoFromStore(att))
 	}
 	detail.Attachments = attachments
+	detail.BodyHTML = s.archivedRemoteImageHTML(id, detail.BodyHTML)
 
 	writeJSON(w, http.StatusOK, detail)
 }
@@ -4151,10 +4154,6 @@ type archivedMessageRawReader interface {
 // without ambiguity in the routing layer.
 func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 	engine := s.queryEngineForContext(r.Context())
-	if engine == nil {
-		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
-		return
-	}
 
 	idStr := r.PathValue("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)
@@ -4166,6 +4165,14 @@ func (s *Server) handleMessageInline(w http.ResponseWriter, r *http.Request) {
 	cidParam := r.URL.Query().Get("cid")
 	if cidParam == "" {
 		writeError(w, http.StatusBadRequest, "missing_cid", "Missing 'cid' query parameter")
+		return
+	}
+	if strings.HasPrefix(cidParam, "remote-image:") {
+		s.serveArchivedRemoteImage(w, r, id, cidParam)
+		return
+	}
+	if engine == nil {
+		writeError(w, http.StatusServiceUnavailable, "engine_unavailable", "Query engine not available")
 		return
 	}
 

--- a/internal/api/remote_image.go
+++ b/internal/api/remote_image.go
@@ -3,33 +3,15 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/netip"
-	"net/url"
-	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"go.kenn.io/msgvault/internal/netguard"
+	"go.kenn.io/msgvault/internal/remoteimage"
 )
 
-// POST /api/v1/content/remote-image is the SSRF-hardened proxy consented
-// remote mail images load through. The browser never contacts a
-// sender-controlled host directly: the daemon fetches the image itself,
-// which closes DNS rebinding (a public hostname resolving to a private
-// address at fetch time) because every resolved address is validated here
-// and the connection is dialed against the validated IP only. It also stops
-// mail senders from learning the reader's browser IP.
-//
-// The route is POST (JSON body) rather than GET on purpose: browsers cannot
-// make an <img> element or a navigation issue a POST, and the session CSRF
-// middleware enforces same-origin plus X-Csrf-Token on every unsafe method,
-// so a same-site sibling origin cannot trigger authenticated outbound
-// fetches through a victim's session.
 const (
 	remoteImagePath = "/api/v1/content/remote-image"
 
@@ -39,22 +21,10 @@ const (
 	remoteImageMaxURLBytes     = 4096
 	remoteImageMaxRequestBytes = 16 << 10 // JSON body carries one bounded URL
 	remoteImageUserAgent       = "msgvault-image-proxy"
-
-	remoteImageErrInvalidURL      = "invalid_url"
-	remoteImageErrProhibitedHost  = "prohibited_host"
-	remoteImageErrProhibitedDest  = "prohibited_destination"
-	remoteImageErrFetchFailed     = "fetch_failed"
-	remoteImageErrTooManyRedirect = "too_many_redirects"
-	remoteImageErrUpstream        = "upstream_error"
-	remoteImageErrTooLarge        = "image_too_large"
-	remoteImageErrUnsupportedType = "unsupported_type"
 )
 
-// prohibitedRemoteIP and prohibitedRemoteHostname retain the package-private
-// wrappers used by the image proxy while the shared policy lives in netguard.
+// prohibitedRemoteIP retains the proxy's policy-test seam.
 func prohibitedRemoteIP(addr netip.Addr) bool { return netguard.ProhibitedIP(addr) }
-
-func prohibitedRemoteHostname(hostname string) bool { return netguard.ProhibitedHostname(hostname) }
 
 // remoteImageFetchError is a fetch failure mapped to an API error response.
 // The fetched bytes are never echoed on error.
@@ -75,196 +45,17 @@ type remoteImageFetcher struct {
 }
 
 func newRemoteImageFetcher() *remoteImageFetcher {
-	dialer := &net.Dialer{Timeout: 10 * time.Second}
-	return &remoteImageFetcher{
-		lookupNetIP: func(ctx context.Context, host string) ([]netip.Addr, error) {
-			addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
-			if err != nil {
-				return nil, fmt.Errorf("resolving remote image host %q: %w", host, err)
-			}
-			return addrs, nil
-		},
-		dialContext:  dialer.DialContext,
-		maxBytes:     remoteImageMaxBytes,
-		maxRedirects: remoteImageMaxRedirects,
-	}
+	f := remoteimage.NewFetcher()
+	return &remoteImageFetcher{f.LookupNetIP, f.DialContext, f.MaxBytes, f.MaxRedirects}
 }
 
-// validateTarget applies every pre-connection check to one URL hop and
-// returns the address the connection must be pinned to: scheme http/https,
-// no userinfo, hostname-spelling gate, private-literal rejection, and
-// validation of every resolved A/AAAA answer. Dialing only the returned
-// address closes the check-then-resolve-again (TOCTOU rebinding) window.
-func (f *remoteImageFetcher) validateTarget(
-	ctx context.Context, rawURL string,
-) (*url.URL, netip.AddrPort, *remoteImageFetchError) {
-	var none netip.AddrPort
-	if len(rawURL) > remoteImageMaxURLBytes {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL is too long"}
-	}
-	target, err := url.Parse(rawURL)
+func (f *remoteImageFetcher) fetch(ctx context.Context, url string) (string, []byte, *remoteImageFetchError) {
+	shared := &remoteimage.Fetcher{LookupNetIP: f.lookupNetIP, DialContext: f.dialContext, MaxBytes: f.maxBytes, MaxRedirects: f.maxRedirects}
+	ct, body, err := shared.Fetch(ctx, url)
 	if err != nil {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL could not be parsed"}
+		return "", nil, &remoteImageFetchError{err.Status, err.Code, err.Message}
 	}
-	scheme := strings.ToLower(target.Scheme)
-	if scheme != "http" && scheme != schemeHTTPS {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL must use http or https"}
-	}
-	if target.User != nil {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL must not carry credentials"}
-	}
-	host := target.Hostname()
-	if host == "" {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL has no host"}
-	}
-	port := uint16(80)
-	if scheme == schemeHTTPS {
-		port = 443
-	}
-	if portText := target.Port(); portText != "" {
-		parsed, err := strconv.ParseUint(portText, 10, 16)
-		if err != nil || parsed == 0 {
-			return nil, none, &remoteImageFetchError{
-				http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL has an invalid port"}
-		}
-		port = uint16(parsed)
-	}
-	if literal, err := netip.ParseAddr(host); err == nil {
-		if prohibitedRemoteIP(literal) {
-			return nil, none, &remoteImageFetchError{
-				http.StatusBadRequest, remoteImageErrProhibitedHost,
-				"Remote image URL targets a private or reserved address"}
-		}
-		return target, netip.AddrPortFrom(literal.Unmap(), port), nil
-	}
-	if prohibitedRemoteHostname(host) {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadRequest, remoteImageErrProhibitedHost,
-			"Remote image URL targets a reserved or private hostname"}
-	}
-	addrs, err := f.lookupNetIP(ctx, host)
-	if err != nil || len(addrs) == 0 {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image host could not be resolved"}
-	}
-	if slices.ContainsFunc(addrs, prohibitedRemoteIP) {
-		return nil, none, &remoteImageFetchError{
-			http.StatusBadGateway, remoteImageErrProhibitedDest,
-			"Remote image host resolves to a private or reserved address"}
-	}
-	return target, netip.AddrPortFrom(addrs[0].Unmap(), port), nil
-}
-
-// doPinned performs one GET against a single validated hop. The transport's
-// DialContext ignores the address derived from the URL and dials the
-// already-validated IP, so a rebinding resolver cannot swap the destination
-// between validation and connection. TLS verification still uses the URL
-// hostname. No cookies or stored credentials ever travel outbound.
-func (f *remoteImageFetcher) doPinned(
-	ctx context.Context, target *url.URL, pinned netip.AddrPort,
-) (*http.Response, error) {
-	transport := &http.Transport{
-		DialContext: func(dialCtx context.Context, network, _ string) (net.Conn, error) {
-			return f.dialContext(dialCtx, network, pinned.String())
-		},
-		TLSHandshakeTimeout: 10 * time.Second,
-		DisableKeepAlives:   true,
-	}
-	client := &http.Client{
-		Transport: transport,
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			// Redirects are followed manually in fetch so every hop is
-			// re-validated and re-pinned.
-			return http.ErrUseLastResponse
-		},
-	}
-	// The user-supplied URL is intentionally fetched: this handler IS the
-	// SSRF mitigation. validateTarget rejected private/reserved hosts and
-	// resolved addresses, and the transport above dials only the pinned,
-	// validated IP.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("building remote image request: %w", err)
-	}
-	req.Header.Set("Accept", "image/*")
-	req.Header.Set("User-Agent", remoteImageUserAgent)
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching remote image: %w", err)
-	}
-	return resp, nil
-}
-
-// fetch retrieves one consented remote image, re-validating and re-pinning
-// every redirect hop, and enforces the image/* content type and the byte
-// cap before any byte is returned.
-func (f *remoteImageFetcher) fetch(
-	ctx context.Context, rawURL string,
-) (contentType string, body []byte, fetchErr *remoteImageFetchError) {
-	current := rawURL
-	for hop := 0; ; hop++ {
-		target, pinned, ferr := f.validateTarget(ctx, current)
-		if ferr != nil {
-			return "", nil, ferr
-		}
-		resp, err := f.doPinned(ctx, target, pinned)
-		if err != nil {
-			return "", nil, &remoteImageFetchError{
-				http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image could not be fetched"}
-		}
-		switch resp.StatusCode {
-		case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
-			http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
-			location := resp.Header.Get("Location")
-			_ = resp.Body.Close()
-			if hop >= f.maxRedirects {
-				return "", nil, &remoteImageFetchError{
-					http.StatusBadGateway, remoteImageErrTooManyRedirect, "Remote image redirected too many times"}
-			}
-			next, err := target.Parse(location)
-			if location == "" || err != nil {
-				return "", nil, &remoteImageFetchError{
-					http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image redirect target is invalid"}
-			}
-			current = next.String()
-			continue
-		case http.StatusOK:
-			contentType, body, fetchErr = f.readImageBody(resp)
-			_ = resp.Body.Close()
-			return contentType, body, fetchErr
-		default:
-			_ = resp.Body.Close()
-			return "", nil, &remoteImageFetchError{
-				http.StatusBadGateway, remoteImageErrUpstream,
-				fmt.Sprintf("Remote image host returned status %d", resp.StatusCode)}
-		}
-	}
-}
-
-func (f *remoteImageFetcher) readImageBody(resp *http.Response) (string, []byte, *remoteImageFetchError) {
-	contentType := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
-	if base, _, found := strings.Cut(contentType, ";"); found {
-		contentType = strings.TrimSpace(base)
-	}
-	if !strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "image/svg") {
-		return "", nil, &remoteImageFetchError{
-			http.StatusUnsupportedMediaType, "unsupported_type", "Remote content is not a permitted image type"}
-	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, f.maxBytes+1))
-	if err != nil {
-		return "", nil, &remoteImageFetchError{
-			http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image body could not be read"}
-	}
-	if int64(len(body)) > f.maxBytes {
-		return "", nil, &remoteImageFetchError{
-			http.StatusBadGateway, remoteImageErrTooLarge, "Remote image exceeds the proxy size limit"}
-	}
-	return contentType, body, nil
+	return ct, body, nil
 }
 
 // RemoteImageRequest is the JSON body of POST /api/v1/content/remote-image.

--- a/internal/api/remote_image.go
+++ b/internal/api/remote_image.go
@@ -3,10 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/netip"
-	"time"
 
 	"go.kenn.io/msgvault/internal/netguard"
 	"go.kenn.io/msgvault/internal/remoteimage"
@@ -15,48 +13,11 @@ import (
 const (
 	remoteImagePath = "/api/v1/content/remote-image"
 
-	remoteImageMaxBytes        = 10 << 20 // 10 MiB hard cap on the proxied body
-	remoteImageTimeout         = 15 * time.Second
-	remoteImageMaxRedirects    = 3
-	remoteImageMaxURLBytes     = 4096
 	remoteImageMaxRequestBytes = 16 << 10 // JSON body carries one bounded URL
-	remoteImageUserAgent       = "msgvault-image-proxy"
 )
 
 // prohibitedRemoteIP retains the proxy's policy-test seam.
 func prohibitedRemoteIP(addr netip.Addr) bool { return netguard.ProhibitedIP(addr) }
-
-// remoteImageFetchError is a fetch failure mapped to an API error response.
-// The fetched bytes are never echoed on error.
-type remoteImageFetchError struct {
-	status  int
-	code    string
-	message string
-}
-
-// remoteImageFetcher performs the hardened fetch. The resolver and dialer
-// are injectable so tests can simulate DNS rebinding and private resolution
-// without real DNS; production uses the default resolver and a plain dialer.
-type remoteImageFetcher struct {
-	lookupNetIP  func(ctx context.Context, host string) ([]netip.Addr, error)
-	dialContext  func(ctx context.Context, network, address string) (net.Conn, error)
-	maxBytes     int64
-	maxRedirects int
-}
-
-func newRemoteImageFetcher() *remoteImageFetcher {
-	f := remoteimage.NewFetcher()
-	return &remoteImageFetcher{f.LookupNetIP, f.DialContext, f.MaxBytes, f.MaxRedirects}
-}
-
-func (f *remoteImageFetcher) fetch(ctx context.Context, url string) (string, []byte, *remoteImageFetchError) {
-	shared := &remoteimage.Fetcher{LookupNetIP: f.lookupNetIP, DialContext: f.dialContext, MaxBytes: f.maxBytes, MaxRedirects: f.maxRedirects}
-	ct, body, err := shared.Fetch(ctx, url)
-	if err != nil {
-		return "", nil, &remoteImageFetchError{err.Status, err.Code, err.Message}
-	}
-	return ct, body, nil
-}
 
 // RemoteImageRequest is the JSON body of POST /api/v1/content/remote-image.
 type RemoteImageRequest struct {
@@ -82,13 +43,13 @@ func (s *Server) handleRemoteImage(w http.ResponseWriter, r *http.Request) {
 	}
 	fetcher := s.remoteImages
 	if fetcher == nil {
-		fetcher = newRemoteImageFetcher()
+		fetcher = remoteimage.NewFetcher()
 	}
-	ctx, cancel := context.WithTimeout(r.Context(), remoteImageTimeout)
+	ctx, cancel := context.WithTimeout(r.Context(), remoteimage.Timeout)
 	defer cancel()
-	contentType, body, ferr := fetcher.fetch(ctx, req.URL)
+	contentType, body, ferr := fetcher.Fetch(ctx, req.URL)
 	if ferr != nil {
-		writeError(w, ferr.status, ferr.code, ferr.message)
+		writeError(w, ferr.Status, ferr.Code, ferr.Message)
 		return
 	}
 	w.Header().Set("Content-Type", contentType)

--- a/internal/api/remote_image_test.go
+++ b/internal/api/remote_image_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/remoteimage"
 )
 
 // fakePNG is a minimal PNG signature — enough for a byte-identity check; the
@@ -75,12 +76,9 @@ func (s *remoteImageSeams) dialedAddresses() []string {
 func newRemoteImageTestServer(t *testing.T, seams *remoteImageSeams) *Server {
 	t.Helper()
 	srv, _ := newTestServerWithMockStore(t)
-	srv.remoteImages = &remoteImageFetcher{
-		lookupNetIP:  seams.lookup,
-		dialContext:  seams.dial,
-		maxBytes:     remoteImageMaxBytes,
-		maxRedirects: remoteImageMaxRedirects,
-	}
+	srv.remoteImages = remoteimage.NewFetcher()
+	srv.remoteImages.LookupNetIP = seams.lookup
+	srv.remoteImages.DialContext = seams.dial
 	return srv
 }
 
@@ -140,7 +138,7 @@ func TestRemoteImageRejectsProhibitedTargetsBeforeAnyNetworkUse(t *testing.T) {
 		{"javascript scheme", "javascript:alert(1)", "invalid_url"},
 		{"userinfo", "http://user:pass@images.example/a.png", "invalid_url"},
 		{"empty host", "http:///a.png", "invalid_url"},
-		{"overlong url", "http://images.example/" + strings.Repeat("a", remoteImageMaxURLBytes), "invalid_url"},
+		{"overlong url", "http://images.example/" + strings.Repeat("a", 4096), "invalid_url"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -258,12 +256,9 @@ func TestRemoteImageSessionCSRFEnforcement(t *testing.T) {
 				answers:  map[string][]netip.Addr{"images.example": {netip.MustParseAddr("203.0.113.7")}},
 				upstream: upstream.Listener.Addr().String(),
 			}
-			srv.remoteImages = &remoteImageFetcher{
-				lookupNetIP:  seams.lookup,
-				dialContext:  seams.dial,
-				maxBytes:     remoteImageMaxBytes,
-				maxRedirects: remoteImageMaxRedirects,
-			}
+			srv.remoteImages = remoteimage.NewFetcher()
+			srv.remoteImages.LookupNetIP = seams.lookup
+			srv.remoteImages.DialContext = seams.dial
 
 			login := performSessionRequest(t, srv, http.MethodPost, sessionLoginPath,
 				[]byte(`{"api_key":"`+testSessionAPIKey+`"}`), nil, false)
@@ -401,7 +396,7 @@ func TestRemoteImageHappyPathPinsValidatedAddress(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Empty(r.Header.Get("Cookie"), "no cookies may travel outbound")
 		assert.Equal("image/*", r.Header.Get("Accept"))
-		assert.Equal(remoteImageUserAgent, r.Header.Get("User-Agent"))
+		assert.Equal("msgvault-image-proxy", r.Header.Get("User-Agent"))
 		w.Header().Set("Content-Type", "image/png")
 		_, _ = w.Write(fakePNG)
 	}))
@@ -518,7 +513,7 @@ func TestRemoteImageRedirectChainIsCapped(t *testing.T) {
 
 	assert.Equal(http.StatusBadGateway, resp.Code, "body: %s", resp.Body.String())
 	assert.Contains(resp.Body.String(), "too_many_redirects")
-	assert.Equal(remoteImageMaxRedirects+1, seams.dialCount(),
+	assert.Equal(srv.remoteImages.MaxRedirects+1, seams.dialCount(),
 		"the chain must stop after the redirect cap")
 }
 
@@ -574,7 +569,7 @@ func TestRemoteImageEnforcesByteCapWhileStreaming(t *testing.T) {
 		upstream: upstream.Listener.Addr().String(),
 	}
 	srv := newRemoteImageTestServer(t, seams)
-	srv.remoteImages.maxBytes = 1024
+	srv.remoteImages.MaxBytes = 1024
 
 	resp := postRemoteImage(t, srv, "http://images.example/huge.png")
 
@@ -610,12 +605,9 @@ func TestRemoteImageRequiresAuthentication(t *testing.T) {
 		nil, nil, testLogger(),
 	)
 	seams := &remoteImageSeams{answers: map[string][]netip.Addr{}}
-	srv.remoteImages = &remoteImageFetcher{
-		lookupNetIP:  seams.lookup,
-		dialContext:  seams.dial,
-		maxBytes:     remoteImageMaxBytes,
-		maxRedirects: remoteImageMaxRedirects,
-	}
+	srv.remoteImages = remoteimage.NewFetcher()
+	srv.remoteImages.LookupNetIP = seams.lookup
+	srv.remoteImages.DialContext = seams.dial
 
 	resp := postRemoteImage(t, srv, "http://images.example/chart.png")
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/msgvault/internal/providercredentials"
 	"go.kenn.io/msgvault/internal/provideridentity"
 	"go.kenn.io/msgvault/internal/query"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/scheduler"
 	"go.kenn.io/msgvault/internal/search"
 	"go.kenn.io/msgvault/internal/store"
@@ -376,7 +377,7 @@ type Server struct {
 	// remoteImages is the SSRF-hardened fetcher behind
 	// POST /api/v1/content/remote-image. Tests replace it to inject a fake
 	// resolver and dialer.
-	remoteImages *remoteImageFetcher
+	remoteImages *remoteimage.Fetcher
 	// inlineCache parses each message's raw MIME once and serves every cid: from
 	// that result, collapsing the per-cid fan-out (see inline_cache.go).
 	inlineCache *inlineParseCache
@@ -563,7 +564,7 @@ func NewServerWithOptions(opts ServerOptions) *Server {
 		importContext:            importContext,
 		cancelImports:            cancelImports,
 		blobStore:                opts.BlobStore,
-		remoteImages:             newRemoteImageFetcher(),
+		remoteImages:             remoteimage.NewFetcher(),
 		inlineCache:              newInlineParseCache(inlineCacheMaxEntries, inlineCacheMaxBytes),
 		spaHandler:               opts.SPAHandler,
 		sessions:                 newSessionStore(defaultSessionTTL),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -645,6 +645,9 @@ func (c *MicrosoftConfig) EffectiveTenantID() string {
 // SyncConfig holds sync-related configuration.
 type SyncConfig struct {
 	RateLimitQPS int `toml:"rate_limit_qps"`
+	// ArchiveRemoteImages opts into sender-controlled HTTP requests, which
+	// can activate tracking pixels. Unset is deliberately false.
+	ArchiveRemoteImages bool `toml:"archive_remote_images"`
 }
 
 // DefaultHome returns the default msgvault home directory.

--- a/internal/config/remote_images_test.go
+++ b/internal/config/remote_images_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteImageArchivingRequiresExplicitTrue(t *testing.T) {
+	assert.False(t, NewDefaultConfig().Sync.ArchiveRemoteImages)
+	for _, tc := range []struct {
+		name, content string
+		want          bool
+	}{
+		{"absent", "[sync]\nrate_limit_qps = 5\n", false},
+		{"disabled", "[sync]\narchive_remote_images = false\n", false},
+		{"enabled", "[sync]\narchive_remote_images = true\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0600))
+			cfg, err := Load(path, "")
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.Sync.ArchiveRemoteImages)
+		})
+	}
+}

--- a/internal/importer/eml_import.go
+++ b/internal/importer/eml_import.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"go.kenn.io/msgvault/internal/eml"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -26,7 +27,9 @@ type EMLImportOptions struct {
 	NoResume           bool
 	CheckpointInterval int
 	AttachmentsDir     string
-	MaxMessageBytes    int64
+	// RemoteImages is nil unless remote image archiving was explicitly enabled.
+	RemoteImages    *remoteimage.Fetcher
+	MaxMessageBytes int64
 	// IngestFunc overrides message ingestion for focused importer tests.
 	// Nil uses IngestRawMessage.
 	IngestFunc func(
@@ -83,7 +86,7 @@ func ImportEMLDir(
 	}
 	ingestFn := opts.IngestFunc
 	if ingestFn == nil {
-		ingestFn = IngestRawMessage
+		ingestFn = rawMessageIngester(opts.RemoteImages)
 	}
 	log := opts.Logger
 	if log == nil {

--- a/internal/importer/emlx_import.go
+++ b/internal/importer/emlx_import.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"go.kenn.io/msgvault/internal/emlx"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -36,6 +37,8 @@ type EmlxImportOptions struct {
 	// AttachmentsDir controls where attachments are written.
 	// Empty means no disk storage.
 	AttachmentsDir string
+	// RemoteImages is nil unless remote image archiving was explicitly enabled.
+	RemoteImages *remoteimage.Fetcher
 
 	// MaxMessageBytes limits the maximum .emlx file size to read.
 	// Defaults to 128 MiB.
@@ -108,7 +111,7 @@ func ImportEmlxDir(
 	}
 	ingestFn := opts.IngestFunc
 	if ingestFn == nil {
-		ingestFn = IngestRawMessage
+		ingestFn = rawMessageIngester(opts.RemoteImages)
 	}
 	log := opts.Logger
 	if log == nil {

--- a/internal/importer/ingest.go
+++ b/internal/importer/ingest.go
@@ -10,6 +10,7 @@ import (
 
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/textutil"
 )
@@ -33,6 +34,24 @@ func IngestRawMessage(
 	labelIDs []int64, sourceMsgID, rawHash string,
 	raw []byte, fallbackDate time.Time,
 	log *slog.Logger,
+) error {
+	return ingestRawMessage(ctx, st, sourceID, identifier, attachmentsDir, labelIDs, sourceMsgID, rawHash, raw, fallbackDate, log, nil)
+}
+
+type rawMessageIngestFunc func(context.Context, *store.Store, int64, string, string, []int64, string, string, []byte, time.Time, *slog.Logger) error
+
+func rawMessageIngester(images *remoteimage.Fetcher) rawMessageIngestFunc {
+	return func(ctx context.Context, st *store.Store, sourceID int64, identifier, attachmentsDir string, labelIDs []int64, sourceMsgID, rawHash string, raw []byte, fallbackDate time.Time, log *slog.Logger) error {
+		return ingestRawMessage(ctx, st, sourceID, identifier, attachmentsDir, labelIDs, sourceMsgID, rawHash, raw, fallbackDate, log, images)
+	}
+}
+
+func ingestRawMessage(
+	ctx context.Context, st *store.Store,
+	sourceID int64, identifier, attachmentsDir string,
+	labelIDs []int64, sourceMsgID, rawHash string,
+	raw []byte, fallbackDate time.Time,
+	log *slog.Logger, images *remoteimage.Fetcher,
 ) error {
 	parsed, _ := mime.ParseWithRecovery(raw, "(MIME parse error)")
 
@@ -196,6 +215,13 @@ func IngestRawMessage(
 					"message", messageID, "error", err,
 				)
 			}
+		}
+	}
+
+	if images != nil {
+		result := images.Archive(ctx, st, attachmentsDir, messageID, bodyHTML)
+		for _, imageErr := range result.Errors {
+			log.Warn("failed to archive remote image", "message", messageID, "error", imageErr)
 		}
 	}
 

--- a/internal/importer/mbox_import.go
+++ b/internal/importer/mbox_import.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"go.kenn.io/msgvault/internal/mbox"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -39,6 +40,8 @@ type MboxImportOptions struct {
 	// AttachmentsDir controls where attachments are written.
 	// If empty, attachments are not written to disk (but messages are still imported).
 	AttachmentsDir string
+	// RemoteImages is nil unless remote image archiving was explicitly enabled.
+	RemoteImages *remoteimage.Fetcher
 
 	// MaxMessageBytes limits the maximum size of a single message read from the MBOX.
 	// If zero, a default of 128 MiB is used.
@@ -102,7 +105,7 @@ func ImportMbox(
 	}
 	ingestFn := opts.IngestFunc
 	if ingestFn == nil {
-		ingestFn = ingestRawEmail
+		ingestFn = mboxMessageIngester(opts.RemoteImages)
 	}
 	log := opts.Logger
 	if log == nil {
@@ -544,13 +547,19 @@ func ingestRawEmail(
 	labelIDs []int64, sourceMsgID, rawHash string,
 	msg *mbox.Message, log *slog.Logger,
 ) error {
-	var fallbackDate time.Time
-	if t, ok := parseFromLineDate(msg.FromLine); ok {
-		fallbackDate = t
+	return mboxMessageIngester(nil)(ctx, st, sourceID, identifier, attachmentsDir, labelIDs, sourceMsgID, rawHash, msg, log)
+}
+
+func mboxMessageIngester(images *remoteimage.Fetcher) func(context.Context, *store.Store, int64, string, string, []int64, string, string, *mbox.Message, *slog.Logger) error {
+	return func(ctx context.Context, st *store.Store, sourceID int64, identifier, attachmentsDir string, labelIDs []int64, sourceMsgID, rawHash string, msg *mbox.Message, log *slog.Logger) error {
+		var fallbackDate time.Time
+		if t, ok := parseFromLineDate(msg.FromLine); ok {
+			fallbackDate = t
+		}
+		return rawMessageIngester(images)(
+			ctx, st, sourceID, identifier, attachmentsDir,
+			labelIDs, sourceMsgID, rawHash,
+			msg.Raw, fallbackDate, log,
+		)
 	}
-	return IngestRawMessage(
-		ctx, st, sourceID, identifier, attachmentsDir,
-		labelIDs, sourceMsgID, rawHash,
-		msg.Raw, fallbackDate, log,
-	)
 }

--- a/internal/importer/pst_import.go
+++ b/internal/importer/pst_import.go
@@ -16,6 +16,7 @@ import (
 
 	pstlib "github.com/mooijtech/go-pst/v6/pkg"
 	pstreader "go.kenn.io/msgvault/internal/pst"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -41,6 +42,8 @@ type PstImportOptions struct {
 	// AttachmentsDir controls where attachment files are written.
 	// Empty string disables disk storage (messages still imported).
 	AttachmentsDir string
+	// RemoteImages is nil unless remote image archiving was explicitly enabled.
+	RemoteImages *remoteimage.Fetcher
 
 	// MaxMessageBytes limits the total byte size (body + attachments) read
 	// per message. Defaults to 128 MiB.
@@ -115,7 +118,7 @@ func ImportPst(
 
 	ingestFn := opts.IngestFunc
 	if ingestFn == nil {
-		ingestFn = IngestRawMessage
+		ingestFn = rawMessageIngester(opts.RemoteImages)
 	}
 
 	log := opts.Logger

--- a/internal/importer/remote_images_test.go
+++ b/internal/importer/remote_images_test.go
@@ -1,0 +1,68 @@
+package importer
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/remoteimage"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestRawImportRemoteImagesRequireOptIn(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "disabled"
+		if enabled {
+			name = "enabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			st := testutil.NewTestStore(t)
+			src, err := st.GetOrCreateSource("eml", "user@example.com")
+			require.NoError(err)
+			var requests atomic.Int64
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "image/png")
+				_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nsynthetic"))
+			}))
+			defer upstream.Close()
+			var fetcher *remoteimage.Fetcher
+			if enabled {
+				fetcher = remoteimage.NewFetcher()
+				fetcher.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+					return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+				}
+				fetcher.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+				}
+			}
+			raw := []byte("From: user@example.com\r\nTo: other@example.com\r\nSubject: Receipt\r\nContent-Type: text/html\r\n\r\n<img src=\"http://images.example/chart\">")
+			err = rawMessageIngester(fetcher)(t.Context(), st, src.ID, "user@example.com", t.TempDir(), nil, "message", "hash", raw, time.Time{}, slog.Default())
+			require.NoError(err)
+			var id int64
+			require.NoError(st.DB().QueryRow("SELECT id FROM messages").Scan(&id))
+			refs, err := st.MessageRemoteImages(id)
+			require.NoError(err)
+			if enabled {
+				assert.Len(refs, 1)
+				assert.Equal(int64(1), requests.Load())
+			} else {
+				assert.Empty(refs)
+				assert.Zero(requests.Load())
+			}
+			saved, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(raw, saved)
+		})
+	}
+}

--- a/internal/remoteimage/archive.go
+++ b/internal/remoteimage/archive.go
@@ -191,7 +191,7 @@ func (f *Fetcher) Archive(ctx context.Context, st *store.Store, dir string, mess
 			result.Errors = append(result.Errors, fmt.Errorf("store remote image bytes: %w", err))
 			continue
 		}
-		err = st.UpsertAttachmentRecord(ctx, messageID, store.AttachmentWrite{
+		err = st.UpsertRemoteImageAttachment(ctx, messageID, store.AttachmentWrite{
 			Filename: "remote-image-" + strings.TrimPrefix(key, "remote-image:") + rasterExtension(contentType),
 			MIMEType: contentType, StoragePath: receipt.StoragePath, ContentHash: receipt.ContentHash, Size: int64(len(body)),
 			SourceAttachmentID: key, SourcePartKey: key, ContentID: key, MediaType: "image",

--- a/internal/remoteimage/archive.go
+++ b/internal/remoteimage/archive.go
@@ -203,7 +203,7 @@ func (f *Fetcher) Archive(ctx context.Context, st *store.Store, dir string, mess
 		}
 		result.Downloaded++
 	}
-	if result.Downloaded > 0 {
+	if result.Downloaded > 0 || result.Reused > 0 {
 		if err := st.RecomputeMessageAttachmentStats(messageID); err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("update remote image metadata: %w", err))
 		}

--- a/internal/remoteimage/archive.go
+++ b/internal/remoteimage/archive.go
@@ -166,7 +166,7 @@ func (f *Fetcher) Archive(ctx context.Context, st *store.Store, dir string, mess
 			result.Errors = append(result.Errors, errors.New("remote image total bytes exceeds limit"))
 			break
 		}
-		fetchCtx, fetchCancel := context.WithTimeout(ctx, remoteImageTimeout)
+		fetchCtx, fetchCancel := context.WithTimeout(ctx, Timeout)
 		contentType, body, fetchErr := f.Fetch(fetchCtx, target)
 		fetchCancel()
 		if fetchErr != nil {
@@ -177,6 +177,9 @@ func (f *Fetcher) Archive(ctx context.Context, st *store.Store, dir string, mess
 		if total > maxArchiveBytes {
 			result.Errors = append(result.Errors, errors.New("remote image total bytes exceeds limit"))
 			break
+		}
+		if contentType == "image/jpg" {
+			contentType = "image/jpeg"
 		}
 		if !permittedRaster(contentType, body) {
 			result.Errors = append(result.Errors, errors.New("remote content is not a supported raster image"))

--- a/internal/remoteimage/archive.go
+++ b/internal/remoteimage/archive.go
@@ -1,0 +1,227 @@
+package remoteimage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	"golang.org/x/net/html"
+)
+
+const (
+	maxArchiveImages    = 64
+	maxArchiveBytes     = 30 << 20
+	maxArchiveHTMLBytes = 8 << 20
+	archiveTimeout      = time.Minute
+)
+
+// ArchiveResult reports best-effort image archiving, independently of mail
+// ingestion. Errors contain no sender URLs or query parameters.
+type ArchiveResult struct {
+	Downloaded int
+	Reused     int
+	Errors     []error
+}
+
+func imageKey(rawURL string) string {
+	sum := sha256.Sum256([]byte(rawURL))
+	return "remote-image:" + hex.EncodeToString(sum[:])
+}
+
+func remoteURL(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "//") {
+		value = "https:" + value
+	}
+	u, err := url.Parse(value)
+	if err != nil || u.Host == "" || u.User != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return ""
+	}
+	u.Fragment = ""
+	return u.String()
+}
+
+// mapImageSources preserves the original HTML bytes except for successful
+// img src replacements. Tokenization never evaluates HTML or loads resources.
+func mapImageSources(source string, replace func(string) string) string {
+	var out strings.Builder
+	tokens := html.NewTokenizer(strings.NewReader(source))
+	for {
+		kind := tokens.Next()
+		if kind == html.ErrorToken {
+			break
+		}
+		raw := string(tokens.Raw())
+		if kind != html.StartTagToken && kind != html.SelfClosingTagToken {
+			out.WriteString(raw)
+			continue
+		}
+		token := tokens.Token()
+		changed := false
+		if token.Data == "img" {
+			for i := range token.Attr {
+				if token.Attr[i].Key != "src" {
+					continue
+				}
+				target := remoteURL(token.Attr[i].Val)
+				if target == "" {
+					continue
+				}
+				if replacement := replace(target); replacement != "" {
+					token.Attr[i].Val = replacement
+					changed = true
+				}
+			}
+		}
+		if changed {
+			out.WriteString(token.String())
+		} else {
+			out.WriteString(raw)
+		}
+	}
+	return out.String()
+}
+
+// RewriteHTML substitutes only already archived, message-scoped image refs.
+// It performs no I/O and leaves the stored HTML and original MIME unchanged.
+func RewriteHTML(source string, refs map[string]store.AttachmentRef) string {
+	if len(refs) == 0 || len(source) > maxArchiveHTMLBytes {
+		return source
+	}
+	return mapImageSources(source, func(target string) string {
+		key := imageKey(target)
+		if ref, ok := refs[key]; ok && ref.ContentID == key && ref.StoragePath != "" && ref.ContentHash != "" {
+			return "cid:" + key
+		}
+		return ""
+	})
+}
+
+// Archive must only be called after explicit opt-in. Network and durable file
+// writes happen outside database transactions. Each URL has its own stable
+// occurrence identity even when different URLs share the same content bytes.
+func (f *Fetcher) Archive(ctx context.Context, st *store.Store, dir string, messageID int64, source string) ArchiveResult {
+	var result ArchiveResult
+	if err := ctx.Err(); err != nil {
+		result.Errors = append(result.Errors, err)
+		return result
+	}
+	if dir == "" {
+		result.Errors = append(result.Errors, errors.New("remote image storage directory is not configured"))
+		return result
+	}
+	if len(source) > maxArchiveHTMLBytes {
+		result.Errors = append(result.Errors, errors.New("remote image HTML exceeds size limit"))
+		return result
+	}
+	if source == "" {
+		return result
+	}
+	ctx, cancel := context.WithTimeout(ctx, archiveTimeout)
+	defer cancel()
+	refs, err := st.MessageRemoteImages(messageID)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("load archived remote images: %w", err))
+		return result
+	}
+	var targets []string
+	seen := map[string]bool{}
+	truncated := false
+	mapImageSources(source, func(target string) string {
+		if seen[target] {
+			return ""
+		}
+		if len(targets) >= maxArchiveImages {
+			truncated = true
+			return ""
+		}
+		seen[target] = true
+		targets = append(targets, target)
+		return ""
+	})
+	if truncated {
+		result.Errors = append(result.Errors, errors.New("remote image count exceeds limit"))
+	}
+	total := 0
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			result.Errors = append(result.Errors, err)
+			break
+		}
+		key := imageKey(target)
+		if ref, ok := refs[key]; ok && ref.ContentID == key && ref.ContentHash != "" && ref.StoragePath != "" {
+			result.Reused++
+			continue
+		}
+		if total >= maxArchiveBytes {
+			result.Errors = append(result.Errors, errors.New("remote image total bytes exceeds limit"))
+			break
+		}
+		fetchCtx, fetchCancel := context.WithTimeout(ctx, remoteImageTimeout)
+		contentType, body, fetchErr := f.Fetch(fetchCtx, target)
+		fetchCancel()
+		if fetchErr != nil {
+			result.Errors = append(result.Errors, fetchErr)
+			continue
+		}
+		total += len(body)
+		if total > maxArchiveBytes {
+			result.Errors = append(result.Errors, errors.New("remote image total bytes exceeds limit"))
+			break
+		}
+		if !permittedRaster(contentType, body) {
+			result.Errors = append(result.Errors, errors.New("remote content is not a supported raster image"))
+			continue
+		}
+		att := &mime.Attachment{ContentType: contentType, Content: body}
+		receipt, err := export.StoreAttachmentFileDurable(dir, att)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("store remote image bytes: %w", err))
+			continue
+		}
+		err = st.UpsertAttachmentRecord(ctx, messageID, store.AttachmentWrite{
+			Filename: "remote-image-" + strings.TrimPrefix(key, "remote-image:") + rasterExtension(contentType),
+			MIMEType: contentType, StoragePath: receipt.StoragePath, ContentHash: receipt.ContentHash, Size: int64(len(body)),
+			SourceAttachmentID: key, SourcePartKey: key, ContentID: key, MediaType: "image",
+			Role: store.AttachmentRoleInline, RoleSource: store.AttachmentRoleSourceImporterSemantics,
+		})
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("record remote image: %w", err))
+			continue
+		}
+		result.Downloaded++
+	}
+	if result.Downloaded > 0 {
+		if err := st.RecomputeMessageAttachmentStats(messageID); err != nil {
+			result.Errors = append(result.Errors, fmt.Errorf("update remote image metadata: %w", err))
+		}
+	}
+	return result
+}
+
+func rasterExtension(contentType string) string {
+	switch contentType {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	}
+	return ""
+}
+
+func permittedRaster(contentType string, body []byte) bool {
+	return rasterExtension(contentType) != "" && len(body) > 0 && http.DetectContentType(body) == contentType
+}

--- a/internal/remoteimage/archive_test.go
+++ b/internal/remoteimage/archive_test.go
@@ -1,9 +1,11 @@
 package remoteimage
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -91,12 +93,17 @@ func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
 	savedRaw, err := st.GetMessageRaw(id)
 	require.NoError(err)
 	assert.Equal(raw, savedRaw)
-	backfill, err := f.Backfill(t.Context(), st, dir, src.ID, 1)
+	var logs bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logs, nil))
+	backfill, err := f.Backfill(t.Context(), st, dir, src.ID, 1, log)
 	require.NoError(err)
 	assert.Equal(1, backfill.Messages)
 	assert.Zero(backfill.Downloaded)
 	assert.Equal(2, backfill.Reused)
 	assert.Equal(1, backfill.Errors)
+	assert.Contains(logs.String(), "level=WARN")
+	assert.Contains(logs.String(), fmt.Sprintf("message=%d", id))
+	assert.Contains(logs.String(), "Remote image host returned status 404")
 	replacement := []store.AttachmentWrite{}
 	_, err = st.PersistMessage(&store.MessagePersistData{
 		Message:  &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conversation, MessageType: "email"},
@@ -167,14 +174,14 @@ func TestBackfillHonorsSourceAndLimitAndSkipsNonEmail(t *testing.T) {
 			})
 			require.NoError(err)
 		}
-		result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 1)
+		result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 1, slog.Default())
 		require.NoError(err)
 		assert.Equal(1, result.Messages)
-		result, err = NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 0)
+		result, err = NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 0, slog.Default())
 		require.NoError(err)
 		assert.Equal(2, result.Messages)
 	}
-	result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), 0, 0)
+	result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), 0, 0, slog.Default())
 	require.NoError(err)
 	assert.Equal(4, result.Messages)
 }
@@ -194,4 +201,53 @@ func TestArchiveCancellationAndEmptyStorageDoNotFetch(t *testing.T) {
 	require.ErrorIs(result.Errors[0], context.Canceled)
 	result = f.Archive(t.Context(), st, "", 1, `<img src="http://images.example/a">`)
 	require.NotEmpty(result.Errors)
+}
+
+func TestArchiveJPEGContentTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name, contentType string
+		body              []byte
+		wantDownloaded    int
+	}{
+		{"jpeg", "image/jpeg", []byte("\xff\xd8\xffsynthetic"), 1},
+		{"jpg", "image/jpg", []byte("\xff\xd8\xffsynthetic"), 1},
+		{"jpg with non-JPEG bytes", "image/jpg", []byte("\x89PNG\r\n\x1a\nsynthetic"), 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := testutil.NewTestStore(t)
+			src, err := st.GetOrCreateSource("eml", "user@example.com")
+			require.NoError(t, err)
+			conv, err := st.EnsureConversation(src.ID, "thread", "Images")
+			require.NoError(t, err)
+			id, err := st.PersistMessage(&store.MessagePersistData{
+				Message: &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conv, MessageType: "email"},
+			})
+			require.NoError(t, err)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				_, _ = w.Write(tc.body)
+			}))
+			defer upstream.Close()
+			f := NewFetcher()
+			f.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+				return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+			}
+			f.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, upstream.Listener.Addr().String())
+			}
+			dir := t.TempDir()
+			result := f.Archive(t.Context(), st, dir, id, `<img src="http://images.example/photo">`)
+			require.Equal(t, tc.wantDownloaded, result.Downloaded)
+			refs, err := st.MessageRemoteImages(id)
+			require.NoError(t, err)
+			require.Len(t, refs, tc.wantDownloaded)
+			for _, ref := range refs {
+				assert.Equal(t, "image/jpeg", ref.MimeType)
+				assert.Equal(t, ".jpg", filepath.Ext(ref.Filename))
+				body, err := os.ReadFile(filepath.Join(dir, ref.StoragePath))
+				require.NoError(t, err)
+				assert.Equal(t, tc.body, body)
+			}
+		})
+	}
 }

--- a/internal/remoteimage/archive_test.go
+++ b/internal/remoteimage/archive_test.go
@@ -92,6 +92,9 @@ func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
 	assert.Equal(3, strings.Count(rendered, `src="cid:remote-image:`))
 	assert.Contains(rendered, `src="http://images.example/missing"`)
 	assert.Contains(rendered, `src="cid:original"`)
+	// Attachment rows can persist before the separate statistics update.
+	_, err = st.DB().Exec(st.Rebind(`UPDATE messages SET attachment_count = 0, has_attachments = FALSE WHERE id = ?`), id)
+	require.NoError(err)
 	result = f.Archive(t.Context(), st, dir, id, original)
 	assert.Zero(result.Downloaded)
 	assert.Equal(2, result.Reused)
@@ -101,6 +104,10 @@ func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
 	saved, err := st.GetMessage(id)
 	require.NoError(err)
 	assert.Equal(original, saved.BodyHTML)
+	assert.True(saved.HasAttachments, "reusing archived images must repair the attachment flag")
+	var storedAttachmentCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT attachment_count FROM messages WHERE id = ?`), id).Scan(&storedAttachmentCount))
+	assert.Equal(3, storedAttachmentCount, "reusing archived images must recount all attachment occurrences")
 	savedRaw, err := st.GetMessageRaw(id)
 	require.NoError(err)
 	assert.Equal(raw, savedRaw)

--- a/internal/remoteimage/archive_test.go
+++ b/internal/remoteimage/archive_test.go
@@ -1,0 +1,197 @@
+package remoteimage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("eml", "user@example.com")
+	require.NoError(err)
+	conversation, err := st.EnsureConversation(src.ID, "thread", "Images")
+	require.NoError(err)
+	original := `<p>Receipt</p><img src="http://images.example/a?tracking=secret"><img src="http://images.example/a?tracking=secret"><img src="http://images.example/b"><img src="http://images.example/missing"><img src="cid:original">`
+	raw := []byte("original MIME bytes")
+	id, err := st.PersistMessage(&store.MessagePersistData{
+		Message:  &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conversation, MessageType: "email"},
+		BodyHTML: sql.NullString{String: original, Valid: true}, RawMIME: raw,
+	})
+	require.NoError(err)
+	image := []byte("\x89PNG\r\n\x1a\nsynthetic")
+	requests := map[string]int{}
+	var requestsMu sync.Mutex
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestsMu.Lock()
+		requests[r.URL.Path]++
+		requestsMu.Unlock()
+		if r.URL.Path == "/missing" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(image)
+	}))
+	defer upstream.Close()
+	f := NewFetcher()
+	f.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	f.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+	}
+	dir := t.TempDir()
+	result := f.Archive(t.Context(), st, dir, id, original)
+	assert.Equal(2, result.Downloaded)
+	require.Len(result.Errors, 1)
+	assert.NotContains(result.Errors[0].Error(), "tracking")
+	refs, err := st.MessageRemoteImages(id)
+	require.NoError(err)
+	require.Len(refs, 2)
+	paths := map[string]bool{}
+	for _, ref := range refs {
+		assert.Equal(store.AttachmentRoleInline, ref.Role)
+		assert.Equal(store.AttachmentRoleSourceImporterSemantics, ref.RoleSource)
+		bytes, err := os.ReadFile(filepath.Join(dir, ref.StoragePath))
+		require.NoError(err)
+		assert.Equal(image, bytes)
+		paths[ref.StoragePath] = true
+	}
+	assert.Len(paths, 1, "CAS deduplicates content, not source URL occurrences")
+	rendered := RewriteHTML(original, refs)
+	assert.Equal(3, strings.Count(rendered, `src="cid:remote-image:`))
+	assert.Contains(rendered, `src="http://images.example/missing"`)
+	assert.Contains(rendered, `src="cid:original"`)
+	result = f.Archive(t.Context(), st, dir, id, original)
+	assert.Zero(result.Downloaded)
+	assert.Equal(2, result.Reused)
+	requestsMu.Lock()
+	assert.Equal(map[string]int{"/a": 1, "/b": 1, "/missing": 2}, requests)
+	requestsMu.Unlock()
+	saved, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(original, saved.BodyHTML)
+	savedRaw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(raw, savedRaw)
+	backfill, err := f.Backfill(t.Context(), st, dir, src.ID, 1)
+	require.NoError(err)
+	assert.Equal(1, backfill.Messages)
+	assert.Zero(backfill.Downloaded)
+	assert.Equal(2, backfill.Reused)
+	assert.Equal(1, backfill.Errors)
+	replacement := []store.AttachmentWrite{}
+	_, err = st.PersistMessage(&store.MessagePersistData{
+		Message:  &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conversation, MessageType: "email"},
+		BodyHTML: sql.NullString{String: original, Valid: true}, RawMIME: raw, MIMEAttachmentReplacement: &replacement,
+	})
+	require.NoError(err)
+	preserved, err := st.MessageRemoteImages(id)
+	require.NoError(err)
+	assert.Equal(refs, preserved, "MIME repair must preserve archived remote image occurrences")
+}
+
+func TestArchiveBoundsNetworkRequestsByCountAndBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		urls, size, want int
+	}{
+		{"count", 65, 16, 64},
+		{"bytes", 5, 10 << 20, 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			st := testutil.NewTestStore(t)
+			src, err := st.GetOrCreateSource("eml", "user@example.com")
+			require.NoError(err)
+			conv, err := st.EnsureConversation(src.ID, "thread", "Images")
+			require.NoError(err)
+			id, err := st.PersistMessage(&store.MessagePersistData{Message: &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conv, MessageType: "email"}})
+			require.NoError(err)
+			image := make([]byte, tc.size)
+			copy(image, "\x89PNG\r\n\x1a\n")
+			var requests atomic.Int64
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "image/png")
+				_, _ = w.Write(image)
+			}))
+			defer upstream.Close()
+			f := NewFetcher()
+			f.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+				return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+			}
+			f.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+			}
+			var body strings.Builder
+			for i := range tc.urls {
+				fmt.Fprintf(&body, `<img src="http://images.example/%d">`, i)
+			}
+			result := f.Archive(t.Context(), st, t.TempDir(), id, body.String())
+			assert.Equal(tc.want, result.Downloaded)
+			assert.Equal(int64(tc.want), requests.Load())
+			assert.NotEmpty(result.Errors)
+		})
+	}
+}
+
+func TestBackfillHonorsSourceAndLimitAndSkipsNonEmail(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	st := testutil.NewTestStore(t)
+	for _, source := range []string{"one@example.com", "two@example.com"} {
+		src, err := st.GetOrCreateSource("eml", source)
+		require.NoError(err)
+		conv, err := st.EnsureConversation(src.ID, "thread", "Empty")
+		require.NoError(err)
+		for i, kind := range []string{"email", "email", "slack"} {
+			_, err := st.PersistMessage(&store.MessagePersistData{
+				Message: &store.Message{SourceID: src.ID, SourceMessageID: fmt.Sprintf("%s-%d", kind, i), ConversationID: conv, MessageType: kind},
+			})
+			require.NoError(err)
+		}
+		result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 1)
+		require.NoError(err)
+		assert.Equal(1, result.Messages)
+		result, err = NewFetcher().Backfill(t.Context(), st, t.TempDir(), src.ID, 0)
+		require.NoError(err)
+		assert.Equal(2, result.Messages)
+	}
+	result, err := NewFetcher().Backfill(t.Context(), st, t.TempDir(), 0, 0)
+	require.NoError(err)
+	assert.Equal(4, result.Messages)
+}
+
+func TestArchiveCancellationAndEmptyStorageDoNotFetch(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	st := testutil.NewTestStore(t)
+	f := NewFetcher()
+	f.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		assert.Fail("unexpected DNS request")
+		return nil, nil
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	result := f.Archive(ctx, st, t.TempDir(), 1, `<img src="http://images.example/a">`)
+	require.NotEmpty(result.Errors)
+	require.ErrorIs(result.Errors[0], context.Canceled)
+	result = f.Archive(t.Context(), st, "", 1, `<img src="http://images.example/a">`)
+	require.NotEmpty(result.Errors)
+}

--- a/internal/remoteimage/archive_test.go
+++ b/internal/remoteimage/archive_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/testutil"
 )
@@ -60,6 +62,15 @@ func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
 		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
 	}
 	dir := t.TempDir()
+	legacyBytes, err := export.StoreAttachmentFileDurable(dir, &mime.Attachment{ContentType: "image/png", Content: image})
+	require.NoError(err)
+	require.NoError(st.UpsertAttachment(id, "receipt.png", "image/png", legacyBytes.StoragePath, legacyBytes.ContentHash, len(image)))
+	var legacyID int64
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT id FROM attachments WHERE message_id = ?`), id).Scan(&legacyID))
+	legacy, err := st.GetFileMetadata(t.Context(), legacyID)
+	require.NoError(err)
+	require.NotNil(legacy)
+
 	result := f.Archive(t.Context(), st, dir, id, original)
 	assert.Equal(2, result.Downloaded)
 	require.Len(result.Errors, 1)
@@ -93,6 +104,12 @@ func TestArchivePersistsDistinctURLIdentitiesAndReusesBytes(t *testing.T) {
 	savedRaw, err := st.GetMessageRaw(id)
 	require.NoError(err)
 	assert.Equal(raw, savedRaw)
+	preservedLegacy, err := st.GetFileMetadata(t.Context(), legacyID)
+	require.NoError(err)
+	assert.Equal(legacy, preservedLegacy, "remote image downloads must not relabel a MIME attachment with identical bytes")
+	var attachmentCount int
+	require.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM attachments WHERE message_id = ?`), id).Scan(&attachmentCount))
+	assert.Equal(3, attachmentCount, "the MIME part and both remote URL occurrences must coexist after retry")
 	var logs bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&logs, nil))
 	backfill, err := f.Backfill(t.Context(), st, dir, src.ID, 1, log)

--- a/internal/remoteimage/archive_test.go
+++ b/internal/remoteimage/archive_test.go
@@ -214,15 +214,16 @@ func TestArchiveJPEGContentTypes(t *testing.T) {
 		{"jpg with non-JPEG bytes", "image/jpg", []byte("\x89PNG\r\n\x1a\nsynthetic"), 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
 			st := testutil.NewTestStore(t)
 			src, err := st.GetOrCreateSource("eml", "user@example.com")
-			require.NoError(t, err)
+			require.NoError(err)
 			conv, err := st.EnsureConversation(src.ID, "thread", "Images")
-			require.NoError(t, err)
+			require.NoError(err)
 			id, err := st.PersistMessage(&store.MessagePersistData{
 				Message: &store.Message{SourceID: src.ID, SourceMessageID: "message", ConversationID: conv, MessageType: "email"},
 			})
-			require.NoError(t, err)
+			require.NoError(err)
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", tc.contentType)
 				_, _ = w.Write(tc.body)
@@ -237,16 +238,16 @@ func TestArchiveJPEGContentTypes(t *testing.T) {
 			}
 			dir := t.TempDir()
 			result := f.Archive(t.Context(), st, dir, id, `<img src="http://images.example/photo">`)
-			require.Equal(t, tc.wantDownloaded, result.Downloaded)
+			require.Equal(tc.wantDownloaded, result.Downloaded)
 			refs, err := st.MessageRemoteImages(id)
-			require.NoError(t, err)
-			require.Len(t, refs, tc.wantDownloaded)
+			require.NoError(err)
+			require.Len(refs, tc.wantDownloaded)
 			for _, ref := range refs {
-				assert.Equal(t, "image/jpeg", ref.MimeType)
-				assert.Equal(t, ".jpg", filepath.Ext(ref.Filename))
+				assert.Equal("image/jpeg", ref.MimeType)
+				assert.Equal(".jpg", filepath.Ext(ref.Filename))
 				body, err := os.ReadFile(filepath.Join(dir, ref.StoragePath))
-				require.NoError(t, err)
-				assert.Equal(t, tc.body, body)
+				require.NoError(err)
+				assert.Equal(tc.body, body)
 			}
 		})
 	}

--- a/internal/remoteimage/backfill.go
+++ b/internal/remoteimage/backfill.go
@@ -3,6 +3,7 @@ package remoteimage
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"go.kenn.io/msgvault/internal/store"
 )
@@ -16,7 +17,7 @@ type BackfillResult struct {
 
 // Backfill archives remote images in existing email. Callers must obtain
 // explicit tracking consent and the normal archive mutation gate first.
-func (f *Fetcher) Backfill(ctx context.Context, st *store.Store, dir string, sourceID int64, limit int) (BackfillResult, error) {
+func (f *Fetcher) Backfill(ctx context.Context, st *store.Store, dir string, sourceID int64, limit int, logger *slog.Logger) (BackfillResult, error) {
 	var result BackfillResult
 	if sourceID < 0 || limit < 0 {
 		return result, errors.New("source ID and limit must not be negative")
@@ -50,6 +51,9 @@ func (f *Fetcher) Backfill(ctx context.Context, st *store.Store, dir string, sou
 			result.Downloaded += archived.Downloaded
 			result.Reused += archived.Reused
 			result.Errors += len(archived.Errors)
+			for _, imageErr := range archived.Errors {
+				logger.Warn("failed to archive remote image", "message", id, "error", imageErr)
+			}
 			after = id
 			if err := ctx.Err(); err != nil {
 				return result, err

--- a/internal/remoteimage/backfill.go
+++ b/internal/remoteimage/backfill.go
@@ -1,0 +1,59 @@
+package remoteimage
+
+import (
+	"context"
+	"errors"
+
+	"go.kenn.io/msgvault/internal/store"
+)
+
+type BackfillResult struct {
+	Messages   int
+	Downloaded int
+	Reused     int
+	Errors     int
+}
+
+// Backfill archives remote images in existing email. Callers must obtain
+// explicit tracking consent and the normal archive mutation gate first.
+func (f *Fetcher) Backfill(ctx context.Context, st *store.Store, dir string, sourceID int64, limit int) (BackfillResult, error) {
+	var result BackfillResult
+	if sourceID < 0 || limit < 0 {
+		return result, errors.New("source ID and limit must not be negative")
+	}
+	var after int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		pageSize := 100
+		if limit > 0 {
+			if result.Messages >= limit {
+				return result, nil
+			}
+			pageSize = min(pageSize, limit-result.Messages)
+		}
+		ids, err := st.RemoteImageBackfillMessageIDs(ctx, after, sourceID, pageSize)
+		if err != nil {
+			return result, err
+		}
+		if len(ids) == 0 {
+			return result, nil
+		}
+		for _, id := range ids {
+			message, err := st.GetMessageContext(ctx, id)
+			if err != nil {
+				return result, err
+			}
+			archived := f.Archive(ctx, st, dir, id, message.BodyHTML)
+			result.Messages++
+			result.Downloaded += archived.Downloaded
+			result.Reused += archived.Reused
+			result.Errors += len(archived.Errors)
+			after = id
+			if err := ctx.Err(); err != nil {
+				return result, err
+			}
+		}
+	}
+}

--- a/internal/remoteimage/fetch.go
+++ b/internal/remoteimage/fetch.go
@@ -21,8 +21,6 @@ import (
 // Callers own consent; a successful fetch must not imply permission to fetch
 // another URL or enable automatic archiving.
 const (
-	remoteImageMaxBytes     = 10 << 20 // 10 MiB hard cap on the proxied body
-	remoteImageTimeout      = 15 * time.Second
 	remoteImageMaxRedirects = 3
 	remoteImageMaxURLBytes  = 4096
 	remoteImageUserAgent    = "msgvault-image-proxy"
@@ -36,6 +34,12 @@ const (
 	remoteImageErrTooLarge        = "image_too_large"
 	remoteImageErrUnsupportedType = "unsupported_type"
 )
+
+// MaxImageBytes caps each downloaded or locally served remote image at 10 MiB.
+const MaxImageBytes = 10 << 20
+
+// Timeout bounds each remote image fetch in the proxy and archiver.
+const Timeout = 15 * time.Second
 
 // prohibitedRemoteIP and prohibitedRemoteHostname retain the package-private
 // wrappers used by the image proxy while the shared policy lives in netguard.
@@ -72,7 +76,7 @@ func NewFetcher() *Fetcher {
 			return addrs, nil
 		},
 		DialContext:  dialer.DialContext,
-		MaxBytes:     remoteImageMaxBytes,
+		MaxBytes:     MaxImageBytes,
 		MaxRedirects: remoteImageMaxRedirects,
 	}
 }

--- a/internal/remoteimage/fetch.go
+++ b/internal/remoteimage/fetch.go
@@ -1,0 +1,257 @@
+// Package remoteimage fetches and archives explicitly consented remote mail images.
+package remoteimage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/netguard"
+)
+
+// The proxy and archiver share destination validation and pinned transports.
+// Callers own consent; a successful fetch must not imply permission to fetch
+// another URL or enable automatic archiving.
+const (
+	remoteImageMaxBytes     = 10 << 20 // 10 MiB hard cap on the proxied body
+	remoteImageTimeout      = 15 * time.Second
+	remoteImageMaxRedirects = 3
+	remoteImageMaxURLBytes  = 4096
+	remoteImageUserAgent    = "msgvault-image-proxy"
+
+	remoteImageErrInvalidURL      = "invalid_url"
+	remoteImageErrProhibitedHost  = "prohibited_host"
+	remoteImageErrProhibitedDest  = "prohibited_destination"
+	remoteImageErrFetchFailed     = "fetch_failed"
+	remoteImageErrTooManyRedirect = "too_many_redirects"
+	remoteImageErrUpstream        = "upstream_error"
+	remoteImageErrTooLarge        = "image_too_large"
+	remoteImageErrUnsupportedType = "unsupported_type"
+)
+
+// prohibitedRemoteIP and prohibitedRemoteHostname retain the package-private
+// wrappers used by the image proxy while the shared policy lives in netguard.
+func prohibitedRemoteIP(addr netip.Addr) bool { return netguard.ProhibitedIP(addr) }
+
+func prohibitedRemoteHostname(hostname string) bool { return netguard.ProhibitedHostname(hostname) }
+
+// FetchError is a fetch failure mapped to an API error response.
+// The fetched bytes are never echoed on error.
+type FetchError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// Fetcher performs the hardened fetch. The resolver and dialer
+// are injectable so tests can simulate DNS rebinding and private resolution
+// without real DNS; production uses the default resolver and a plain dialer.
+type Fetcher struct {
+	LookupNetIP  func(ctx context.Context, host string) ([]netip.Addr, error)
+	DialContext  func(ctx context.Context, network, address string) (net.Conn, error)
+	MaxBytes     int64
+	MaxRedirects int
+}
+
+func NewFetcher() *Fetcher {
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	return &Fetcher{
+		LookupNetIP: func(ctx context.Context, host string) ([]netip.Addr, error) {
+			addrs, err := net.DefaultResolver.LookupNetIP(ctx, "ip", host)
+			if err != nil {
+				return nil, fmt.Errorf("resolving remote image host %q: %w", host, err)
+			}
+			return addrs, nil
+		},
+		DialContext:  dialer.DialContext,
+		MaxBytes:     remoteImageMaxBytes,
+		MaxRedirects: remoteImageMaxRedirects,
+	}
+}
+
+// validateTarget applies every pre-connection check to one URL hop and
+// returns the address the connection must be pinned to: scheme http/https,
+// no userinfo, hostname-spelling gate, private-literal rejection, and
+// validation of every resolved A/AAAA answer. Dialing only the returned
+// address closes the check-then-resolve-again (TOCTOU rebinding) window.
+func (f *Fetcher) validateTarget(
+	ctx context.Context, rawURL string,
+) (*url.URL, netip.AddrPort, *FetchError) {
+	var none netip.AddrPort
+	if len(rawURL) > remoteImageMaxURLBytes {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL is too long"}
+	}
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL could not be parsed"}
+	}
+	scheme := strings.ToLower(target.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL must use http or https"}
+	}
+	if target.User != nil {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL must not carry credentials"}
+	}
+	host := target.Hostname()
+	if host == "" {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL has no host"}
+	}
+	port := uint16(80)
+	if scheme == "https" {
+		port = 443
+	}
+	if portText := target.Port(); portText != "" {
+		parsed, err := strconv.ParseUint(portText, 10, 16)
+		if err != nil || parsed == 0 {
+			return nil, none, &FetchError{
+				http.StatusBadRequest, remoteImageErrInvalidURL, "Remote image URL has an invalid port"}
+		}
+		port = uint16(parsed)
+	}
+	if literal, err := netip.ParseAddr(host); err == nil {
+		if prohibitedRemoteIP(literal) {
+			return nil, none, &FetchError{
+				http.StatusBadRequest, remoteImageErrProhibitedHost,
+				"Remote image URL targets a private or reserved address"}
+		}
+		return target, netip.AddrPortFrom(literal.Unmap(), port), nil
+	}
+	if prohibitedRemoteHostname(host) {
+		return nil, none, &FetchError{
+			http.StatusBadRequest, remoteImageErrProhibitedHost,
+			"Remote image URL targets a reserved or private hostname"}
+	}
+	addrs, err := f.LookupNetIP(ctx, host)
+	if err != nil || len(addrs) == 0 {
+		return nil, none, &FetchError{
+			http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image host could not be resolved"}
+	}
+	if slices.ContainsFunc(addrs, prohibitedRemoteIP) {
+		return nil, none, &FetchError{
+			http.StatusBadGateway, remoteImageErrProhibitedDest,
+			"Remote image host resolves to a private or reserved address"}
+	}
+	return target, netip.AddrPortFrom(addrs[0].Unmap(), port), nil
+}
+
+// doPinned performs one GET against a single validated hop. The transport's
+// DialContext ignores the address derived from the URL and dials the
+// already-validated IP, so a rebinding resolver cannot swap the destination
+// between validation and connection. TLS verification still uses the URL
+// hostname. No cookies or stored credentials ever travel outbound.
+func (f *Fetcher) doPinned(
+	ctx context.Context, target *url.URL, pinned netip.AddrPort,
+) (*http.Response, error) {
+	transport := &http.Transport{
+		DialContext: func(dialCtx context.Context, network, _ string) (net.Conn, error) {
+			return f.DialContext(dialCtx, network, pinned.String())
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+		DisableKeepAlives:   true,
+	}
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			// Redirects are followed manually in fetch so every hop is
+			// re-validated and re-pinned.
+			return http.ErrUseLastResponse
+		},
+	}
+	// The user-supplied URL is intentionally fetched: this handler IS the
+	// SSRF mitigation. validateTarget rejected private/reserved hosts and
+	// resolved addresses, and the transport above dials only the pinned,
+	// validated IP.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("building remote image request: %w", err)
+	}
+	req.Header.Set("Accept", "image/*")
+	req.Header.Set("User-Agent", remoteImageUserAgent)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching remote image: %w", err)
+	}
+	return resp, nil
+}
+
+// Fetch retrieves one consented remote image, re-validating and re-pinning
+// every redirect hop, and enforces the image/* content type and the byte
+// cap before any byte is returned.
+func (f *Fetcher) Fetch(
+	ctx context.Context, rawURL string,
+) (contentType string, body []byte, fetchErr *FetchError) {
+	current := rawURL
+	for hop := 0; ; hop++ {
+		target, pinned, ferr := f.validateTarget(ctx, current)
+		if ferr != nil {
+			return "", nil, ferr
+		}
+		resp, err := f.doPinned(ctx, target, pinned)
+		if err != nil {
+			return "", nil, &FetchError{
+				http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image could not be fetched"}
+		}
+		switch resp.StatusCode {
+		case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther,
+			http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+			location := resp.Header.Get("Location")
+			_ = resp.Body.Close()
+			if hop >= f.MaxRedirects {
+				return "", nil, &FetchError{
+					http.StatusBadGateway, remoteImageErrTooManyRedirect, "Remote image redirected too many times"}
+			}
+			next, err := target.Parse(location)
+			if location == "" || err != nil {
+				return "", nil, &FetchError{
+					http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image redirect target is invalid"}
+			}
+			current = next.String()
+			continue
+		case http.StatusOK:
+			contentType, body, fetchErr = f.readImageBody(resp)
+			_ = resp.Body.Close()
+			return contentType, body, fetchErr
+		default:
+			_ = resp.Body.Close()
+			return "", nil, &FetchError{
+				http.StatusBadGateway, remoteImageErrUpstream,
+				fmt.Sprintf("Remote image host returned status %d", resp.StatusCode)}
+		}
+	}
+}
+
+func (f *Fetcher) readImageBody(resp *http.Response) (string, []byte, *FetchError) {
+	contentType := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
+	if base, _, found := strings.Cut(contentType, ";"); found {
+		contentType = strings.TrimSpace(base)
+	}
+	if !strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "image/svg") {
+		return "", nil, &FetchError{
+			http.StatusUnsupportedMediaType, remoteImageErrUnsupportedType, "Remote content is not a permitted image type"}
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, f.MaxBytes+1))
+	if err != nil {
+		return "", nil, &FetchError{
+			http.StatusBadGateway, remoteImageErrFetchFailed, "Remote image body could not be read"}
+	}
+	if int64(len(body)) > f.MaxBytes {
+		return "", nil, &FetchError{
+			http.StatusBadGateway, remoteImageErrTooLarge, "Remote image exceeds the proxy size limit"}
+	}
+	return contentType, body, nil
+}
+
+func (e *FetchError) Error() string { return e.Message }

--- a/internal/remoteimage/fetch_test.go
+++ b/internal/remoteimage/fetch_test.go
@@ -1,0 +1,50 @@
+package remoteimage
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A real upstream with only DNS/dial substituted exercises the same pinned
+// transport as production without ever contacting an external image host.
+func TestFetcherPinsPublicAddressAndRejectsPrivateRedirect(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	var requests atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Empty(r.Header.Get("Cookie"))
+		assert.Empty(r.Header.Get("Referer"))
+		if r.URL.Path == "/redirect" {
+			http.Redirect(w, r, "http://127.0.0.1/private", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nsynthetic"))
+	}))
+	defer upstream.Close()
+	f := NewFetcher()
+	f.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	f.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		assert.Equal("93.184.216.34:80", address)
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+	}
+	ct, body, err := f.Fetch(t.Context(), "http://images.example/chart")
+	require.Nil(err)
+	assert.Equal("image/png", ct)
+	assert.Equal([]byte("\x89PNG\r\n\x1a\nsynthetic"), body)
+	_, _, err = f.Fetch(t.Context(), "http://images.example/redirect")
+	require.NotNil(err)
+	assert.Equal("prohibited_host", err.Code)
+	assert.Equal(int64(2), requests.Load())
+}

--- a/internal/store/attachment_roles.go
+++ b/internal/store/attachment_roles.go
@@ -216,6 +216,7 @@ type attachmentConflictPolicy int
 const (
 	updateAttachmentConflicts attachmentConflictPolicy = iota
 	preserveProviderAttachmentConflicts
+	preserveLegacyAttachmentRows
 )
 
 func (s *Store) upsertAttachmentRecord(q querier, messageID int64, write AttachmentWrite) error {
@@ -232,7 +233,7 @@ func (s *Store) upsertAttachmentRecordWithPolicy(
 		keyedConflictPredicate = " WHERE attachments.source_attachment_id IS NULL"
 	}
 
-	if write.SourcePartKey != "" && write.ContentHash != "" {
+	if conflictPolicy != preserveLegacyAttachmentRows && write.SourcePartKey != "" && write.ContentHash != "" {
 		// Upgrade the pre-provenance row in place when a resync supplies a
 		// stable source occurrence for the same bytes. This preserves its row
 		// identity and prevents a later raw-MIME repair from colliding with a

--- a/internal/store/remote_images.go
+++ b/internal/store/remote_images.go
@@ -11,7 +11,8 @@ func (s *Store) MessageRemoteImages(messageID int64) (map[string]AttachmentRef, 
 // RemoteImageBackfillMessageIDs pages email identities without scanning body
 // storage. Bodies are subsequently read by message primary key.
 func (s *Store) RemoteImageBackfillMessageIDs(ctx context.Context, after, sourceID int64, limit int) ([]int64, error) {
-	query := "SELECT id FROM messages WHERE id > ? AND message_type = 'email' AND deleted_at IS NULL"
+	// Match IsEmailMessageType: legacy NULL and empty types also denote email.
+	query := "SELECT id FROM messages WHERE id > ? AND COALESCE(message_type, '') IN ('', 'email') AND deleted_at IS NULL"
 	args := []any{after}
 	if sourceID != 0 {
 		query += " AND source_id = ?"

--- a/internal/store/remote_images.go
+++ b/internal/store/remote_images.go
@@ -1,0 +1,36 @@
+package store
+
+import "context"
+
+// MessageRemoteImages returns only this message's archived remote images.
+// The namespace survives MIME repair, which replaces MIME-owned rows only.
+func (s *Store) MessageRemoteImages(messageID int64) (map[string]AttachmentRef, error) {
+	return s.messageProviderAttachments(messageID, "remote-image:")
+}
+
+// RemoteImageBackfillMessageIDs pages email identities without scanning body
+// storage. Bodies are subsequently read by message primary key.
+func (s *Store) RemoteImageBackfillMessageIDs(ctx context.Context, after, sourceID int64, limit int) ([]int64, error) {
+	query := "SELECT id FROM messages WHERE id > ? AND message_type = 'email' AND deleted_at IS NULL"
+	args := []any{after}
+	if sourceID != 0 {
+		query += " AND source_id = ?"
+		args = append(args, sourceID)
+	}
+	query += " ORDER BY id LIMIT ?"
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/internal/store/remote_images.go
+++ b/internal/store/remote_images.go
@@ -1,6 +1,24 @@
 package store
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// UpsertRemoteImageAttachment stores a distinct remote URL occurrence. Matching
+// bytes never establish that a legacy MIME attachment is the same occurrence.
+func (s *Store) UpsertRemoteImageAttachment(ctx context.Context, messageID int64, write AttachmentWrite) error {
+	write = write.normalized()
+	if err := write.validate(); err != nil {
+		return err
+	}
+	if write.SourcePartKey == "" {
+		return errors.New("remote image attachment requires a source-part key")
+	}
+	return s.withSyncMessageWriteContext(ctx, messageID, func(q querier) error {
+		return s.upsertAttachmentRecordWithPolicy(q, messageID, write, preserveLegacyAttachmentRows)
+	})
+}
 
 // MessageRemoteImages returns only this message's archived remote images.
 // The namespace survives MIME repair, which replaces MIME-owned rows only.

--- a/internal/store/remote_images_test.go
+++ b/internal/store/remote_images_test.go
@@ -1,0 +1,41 @@
+package store_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func TestRemoteImageBackfillIncludesLegacyEmailTypes(t *testing.T) {
+	assert, require := assert.New(t), require.New(t)
+	st, sourceID, conversationID := newLegacyNullableMessageTypeStore(t)
+	var want []int64
+	for i, messageType := range []any{"email", "", nil, "slack"} {
+		id, err := st.UpsertMessage(&store.Message{
+			SourceID: sourceID, ConversationID: conversationID,
+			SourceMessageID: fmt.Sprintf("remote-image-%d", i), MessageType: store.MessageTypeEmail,
+		})
+		require.NoError(err)
+		// Persist the historical representation; normal ingestion defaults to email.
+		_, err = st.DB().Exec(st.Rebind(`UPDATE messages SET message_type = ? WHERE id = ?`), messageType, id)
+		require.NoError(err)
+		if i < 3 {
+			want = append(want, id)
+		}
+	}
+
+	ids, err := st.RemoteImageBackfillMessageIDs(t.Context(), 0, sourceID, 100)
+	require.NoError(err)
+	assert.Equal(want, ids, "explicit, empty, and NULL email types must all be eligible")
+	ids, err = st.RemoteImageBackfillMessageIDs(t.Context(), want[0], sourceID, 1)
+	require.NoError(err)
+	assert.Equal(want[1:2], ids, "legacy email must respect the cursor and page limit")
+	_, err = st.DB().Exec(st.Rebind(`UPDATE messages SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?`), want[2])
+	require.NoError(err)
+	ids, err = st.RemoteImageBackfillMessageIDs(t.Context(), 0, sourceID, 100)
+	require.NoError(err)
+	assert.Equal(want[:2], ids, "deleted legacy email must stay excluded")
+}

--- a/internal/sync/remote_images_test.go
+++ b/internal/sync/remote_images_test.go
@@ -1,0 +1,68 @@
+package sync
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/remoteimage"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestSyncRemoteImagesRequireOptIn(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "disabled"
+		if enabled {
+			name = "enabled"
+		}
+		t.Run(name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			st := testutil.NewTestStore(t)
+			src, err := st.GetOrCreateSource("gmail", "user@example.com")
+			require.NoError(err)
+			var requests atomic.Int64
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests.Add(1)
+				w.Header().Set("Content-Type", "image/png")
+				_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nsynthetic"))
+			}))
+			defer upstream.Close()
+			var fetcher *remoteimage.Fetcher
+			if enabled {
+				fetcher = remoteimage.NewFetcher()
+				fetcher.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+					return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+				}
+				fetcher.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+					return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+				}
+			}
+			raw := []byte("From: user@example.com\r\nTo: other@example.com\r\nSubject: Receipt\r\nContent-Type: text/html\r\n\r\n<img src=\"http://images.example/chart\">")
+			syncer := New(nil, st, &Options{AttachmentsDir: t.TempDir(), RemoteImages: fetcher})
+			_, err = syncer.ingestMessage(t.Context(), src.ID, &gmail.RawMessage{ID: "message", Raw: raw}, "thread", nil)
+			require.NoError(err)
+			var id int64
+			require.NoError(st.DB().QueryRow("SELECT id FROM messages").Scan(&id))
+			refs, err := st.MessageRemoteImages(id)
+			require.NoError(err)
+			if enabled {
+				assert.Len(refs, 1)
+				assert.Equal(int64(1), requests.Load())
+			} else {
+				assert.Empty(refs)
+				assert.Zero(requests.Load())
+			}
+			saved, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(raw, saved)
+		})
+	}
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/msgvault/internal/gmail"
 	"go.kenn.io/msgvault/internal/identityops"
 	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/remoteimage"
 	"go.kenn.io/msgvault/internal/store"
 	"go.kenn.io/msgvault/internal/textutil"
 )
@@ -52,6 +53,8 @@ type Options struct {
 
 	// AttachmentsDir is where to store attachments
 	AttachmentsDir string
+	// RemoteImages is nil unless remote image archiving was explicitly enabled.
+	RemoteImages *remoteimage.Fetcher
 
 	// Limit caps the number of messages scanned per sync (0 = unlimited).
 	// Enforced by truncating the message ID list before downloading content.
@@ -1854,7 +1857,13 @@ func (s *Syncer) ingestMessage(
 		}
 	}
 
-	_, err = s.persistMessage(data, labelMap)
+	messageID, err := s.persistMessage(data, labelMap)
+	if err == nil && s.opts.RemoteImages != nil && data.message.MessageType == store.MessageTypeEmail {
+		archived := s.opts.RemoteImages.Archive(ctx, s.store, s.opts.AttachmentsDir, messageID, data.bodyHTML)
+		for _, imageErr := range archived.Errors {
+			s.logger.Warn("failed to archive remote image", "message", messageID, "error", imageErr)
+		}
+	}
 	return false, err
 }
 

--- a/web/src/lib/components/reader/inline-images.test.ts
+++ b/web/src/lib/components/reader/inline-images.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createAPIClient } from '../../api/client';
 import type { ArchivedInlineImage } from '../../content/sanitize';
+import { sanitizeArchivedHTML } from '../../content/sanitize';
 import {
   MAX_ARCHIVED_INLINE_IMAGE_BYTES,
   MAX_ARCHIVED_INLINE_IMAGE_CIDS,
@@ -52,6 +53,27 @@ async function resolveWithPublicationByteLimit(
 }
 
 describe('resolveArchivedInlineImages', () => {
+  it('hydrates archived remote images with their own budget alongside original MIME images', async () => {
+    const cids = [
+      ...Array.from({ length: 32 }, (_, i) => `mime-${i}@example.com`),
+      ...Array.from({ length: 64 }, (_, i) => `remote-image:${i.toString(16).padStart(64, '0')}`)
+    ];
+    const input = sanitizeArchivedHTML(cids.map((cid) => `<img src="cid:${cid}">`).join(''), { messageId: 42 });
+    expect(input.remoteImages).toHaveLength(0);
+    const fetchFn = vi.fn<typeof fetch>(async (request) => {
+      const cid = new URL((request as Request).url).searchParams.get('cid');
+      return pngResponse(cid === cids[32] ? 6 * 1024 * 1024 : 16);
+    });
+    const html = await resolveArchivedInlineImages({
+      ...input,
+      client: createAPIClient(fetchFn),
+      messageId: 42,
+      signal: new AbortController().signal
+    });
+    expect(parse(html).querySelectorAll('img')).toHaveLength(96);
+    expect(html).not.toContain('Inline image unavailable');
+    expect(fetchFn.mock.calls.every(([request]) => new URL((request as Request).url).pathname.endsWith('/inline'))).toBe(true);
+  }, 30_000);
   it('exports conservative request and decoded-byte budgets', () => {
     expect(MAX_ARCHIVED_INLINE_IMAGE_CIDS).toBe(32);
     expect(MAX_ARCHIVED_INLINE_IMAGE_BYTES).toBe(5 * 1024 * 1024);

--- a/web/src/lib/components/reader/inline-images.ts
+++ b/web/src/lib/components/reader/inline-images.ts
@@ -2,6 +2,13 @@ import { getMessageInlinePart as generatedGetMessageInlinePart } from '../../api
 import type { APIClient } from '../../api/client';
 import type { ArchivedInlineImage } from '../../content/sanitize';
 import { hardBoundedLimit, imagePlaceholderBlock, inertTemplate } from '../../content/sanitize';
+import {
+  MAX_ARCHIVED_REMOTE_IMAGE_URLS,
+  MAX_ARCHIVED_REMOTE_IMAGE_BYTES,
+  MAX_ARCHIVED_REMOTE_IMAGE_TOTAL_BYTES,
+  MAX_ARCHIVED_REMOTE_IMAGE_OCCURRENCES,
+  MAX_ARCHIVED_REMOTE_IMAGE_SERIALIZED_BYTES,
+} from './remote-image-limits';
 export { hardBoundedLimit };
 export const MAX_ARCHIVED_INLINE_IMAGE_CIDS = 32;
 export const MAX_ARCHIVED_INLINE_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -19,6 +26,7 @@ interface InlineOccurrence {
 }
 interface InlineGroup {
   cid: string;
+  remote: boolean;
   bytes?: Uint8Array;
   mimeType?: string;
   dataURL?: string;
@@ -107,6 +115,7 @@ async function fetchInlineImage(
   cid: string,
   budget: DecodedByteBudget,
   signal: AbortSignal,
+  limits: DecodedByteLimits,
 ): Promise<{
   bytes: Uint8Array;
   mimeType: string;
@@ -131,23 +140,20 @@ async function fetchInlineImage(
     throw new Error('Inline image type is not permitted');
   }
   const contentLength = response.headers.get('Content-Length');
-  const remainingBytes = MAX_ARCHIVED_INLINE_IMAGE_TOTAL_BYTES - budget.used;
+  const remainingBytes = limits.totalBytes - budget.used;
   if (contentLength !== null) {
     const declaredSize = Number(contentLength);
     if (
       !Number.isFinite(declaredSize) ||
       declaredSize < 0 ||
-      declaredSize > MAX_ARCHIVED_INLINE_IMAGE_BYTES ||
+      declaredSize > limits.imageBytes ||
       declaredSize > remainingBytes
     ) {
       await data.cancel();
       throw new Error('Inline image exceeds decoded byte budget');
     }
   }
-  const bytes = await readBoundedStream(data, budget, signal, {
-    imageBytes: MAX_ARCHIVED_INLINE_IMAGE_BYTES,
-    totalBytes: MAX_ARCHIVED_INLINE_IMAGE_TOTAL_BYTES,
-  });
+  const bytes = await readBoundedStream(data, budget, signal, limits);
   throwIfAborted(signal);
   return { bytes, mimeType };
 }
@@ -168,6 +174,7 @@ export async function resolveArchivedInlineImages(options: {
     if (Number.isSafeInteger(index) && index >= 0) placeholders.set(index, element);
   }
   const groups = new Map<string, InlineGroup>();
+  const counts = { inline: 0, remote: 0 };
   const orderedOccurrences: InlineOccurrence[] = [];
   options.inlineImages.forEach((inline, index) => {
     const loadingPlaceholder = placeholders.get(index);
@@ -175,20 +182,29 @@ export async function resolveArchivedInlineImages(options: {
     const placeholder = unavailableInlineImage(inline.alt);
     loadingPlaceholder.replaceWith(placeholder);
     const cid = normalizedCID(inline.cid);
+    const remote = /^remote-image:[0-9a-f]{64}$/.test(cid);
+    const kind = remote ? 'remote' : 'inline';
+    const maxCIDs = remote ? MAX_ARCHIVED_REMOTE_IMAGE_URLS : MAX_ARCHIVED_INLINE_IMAGE_CIDS;
     let admittedCID: string | undefined;
     if (cid && groups.has(cid)) admittedCID = cid;
-    else if (cid && groups.size < MAX_ARCHIVED_INLINE_IMAGE_CIDS) {
-      groups.set(cid, { cid });
+    else if (cid && counts[kind] < maxCIDs) {
+      groups.set(cid, { cid, remote });
+      counts[kind] += 1;
       admittedCID = cid;
     }
     orderedOccurrences.push({ alt: inline.alt, cid: admittedCID, placeholder });
   });
-  const budget: DecodedByteBudget = { used: 0 };
+  const budgets = { inline: { used: 0 }, remote: { used: 0 } };
   for (const group of groups.values()) {
     throwIfAborted(options.signal);
-    if (!options.client || budget.used >= MAX_ARCHIVED_INLINE_IMAGE_TOTAL_BYTES) continue;
+    const budget = budgets[group.remote ? 'remote' : 'inline'];
+    const limits = {
+      imageBytes: group.remote ? MAX_ARCHIVED_REMOTE_IMAGE_BYTES : MAX_ARCHIVED_INLINE_IMAGE_BYTES,
+      totalBytes: group.remote ? MAX_ARCHIVED_REMOTE_IMAGE_TOTAL_BYTES : MAX_ARCHIVED_INLINE_IMAGE_TOTAL_BYTES,
+    };
+    if (!options.client || budget.used >= limits.totalBytes) continue;
     try {
-      const decoded = await fetchInlineImage(options.client, options.messageId, group.cid, budget, options.signal);
+      const decoded = await fetchInlineImage(options.client, options.messageId, group.cid, budget, options.signal, limits);
       group.bytes = decoded.bytes;
       group.mimeType = decoded.mimeType;
     } catch (error) {
@@ -205,11 +221,19 @@ export async function resolveArchivedInlineImages(options: {
     options.publicationLimits?.dataURLBytes,
     MAX_ARCHIVED_INLINE_IMAGE_SERIALIZED_BYTES,
   );
-  let publishedOccurrences = 0;
-  let serializedBytes = 0;
+  const publication = {
+    inline: { occurrences: 0, bytes: 0, maxOccurrences: maxPublishedOccurrences, maxBytes: maxSerializedBytes },
+    remote: {
+      occurrences: 0,
+      bytes: 0,
+      maxOccurrences: hardBoundedLimit(options.publicationLimits?.occurrences, MAX_ARCHIVED_REMOTE_IMAGE_OCCURRENCES),
+      maxBytes: hardBoundedLimit(options.publicationLimits?.dataURLBytes, MAX_ARCHIVED_REMOTE_IMAGE_SERIALIZED_BYTES),
+    },
+  };
   for (const occurrence of orderedOccurrences) {
-    if (publishedOccurrences >= maxPublishedOccurrences) break;
     const group = occurrence.cid ? groups.get(occurrence.cid) : undefined;
+    const budget = publication[group?.remote ? 'remote' : 'inline'];
+    if (budget.occurrences >= budget.maxOccurrences) continue;
     if (group && !group.dataURL && group.bytes && group.mimeType) {
       group.dataURL = bytesToDataURL(group.bytes, group.mimeType);
       group.bytes = undefined;
@@ -218,13 +242,13 @@ export async function resolveArchivedInlineImages(options: {
     if (!dataURL) continue;
     // Data URLs produced above are ASCII, so string length is also their exact
     // UTF-8 serialized byte charge, including MIME prefix and base64 expansion.
-    if (serializedBytes + dataURL.length > maxSerializedBytes) continue;
+    if (budget.bytes + dataURL.length > budget.maxBytes) continue;
     const image = document.createElement('img');
     image.alt = occurrence.alt;
     image.src = dataURL;
     occurrence.placeholder.replaceWith(image);
-    publishedOccurrences += 1;
-    serializedBytes += dataURL.length;
+    budget.occurrences += 1;
+    budget.bytes += dataURL.length;
   }
   throwIfAborted(options.signal);
   return template.innerHTML;

--- a/web/src/lib/components/reader/remote-image-limits.ts
+++ b/web/src/lib/components/reader/remote-image-limits.ts
@@ -1,0 +1,6 @@
+// Shared by consented proxy requests and locally archived remote-image CIDs.
+export const MAX_ARCHIVED_REMOTE_IMAGE_URLS = 64;
+export const MAX_ARCHIVED_REMOTE_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_ARCHIVED_REMOTE_IMAGE_TOTAL_BYTES = 30 * 1024 * 1024;
+export const MAX_ARCHIVED_REMOTE_IMAGE_OCCURRENCES = 128;
+export const MAX_ARCHIVED_REMOTE_IMAGE_SERIALIZED_BYTES = 36 * 1024 * 1024;

--- a/web/src/lib/components/reader/remote-images.ts
+++ b/web/src/lib/components/reader/remote-images.ts
@@ -18,11 +18,14 @@ import {
 // redirect hop server-side, which also closes DNS rebinding. The proxy is
 // POST so the daemon's session CSRF machinery (same-origin + X-Csrf-Token,
 // injected by the API client for unsafe methods) guards every fetch.
-export const MAX_ARCHIVED_REMOTE_IMAGE_URLS = 64;
-export const MAX_ARCHIVED_REMOTE_IMAGE_BYTES = 10 * 1024 * 1024;
-export const MAX_ARCHIVED_REMOTE_IMAGE_TOTAL_BYTES = 30 * 1024 * 1024;
-export const MAX_ARCHIVED_REMOTE_IMAGE_OCCURRENCES = 128;
-export const MAX_ARCHIVED_REMOTE_IMAGE_SERIALIZED_BYTES = 36 * 1024 * 1024;
+import {
+  MAX_ARCHIVED_REMOTE_IMAGE_URLS,
+  MAX_ARCHIVED_REMOTE_IMAGE_BYTES,
+  MAX_ARCHIVED_REMOTE_IMAGE_TOTAL_BYTES,
+  MAX_ARCHIVED_REMOTE_IMAGE_OCCURRENCES,
+  MAX_ARCHIVED_REMOTE_IMAGE_SERIALIZED_BYTES,
+} from './remote-image-limits';
+export * from './remote-image-limits';
 interface RemoteImagePublicationLimits {
   occurrences?: number;
   dataURLBytes?: number;


### PR DESCRIPTION
## What changed

- Add optional remote-image archiving during Gmail/IMAP sync and EML, EMLX, MBOX, and PST imports. It is off by default.
- Serve archived images locally in message and conversation views. Original messages and stored HTML stay unchanged.
- Add an explicit backfill command for existing email. Image failures do not abort mail ingestion.

## Why

Newsletter charts, receipt images, and logos can disappear when their remote hosts stop serving them. Keeping the image bytes makes those messages usable offline, but downloading can activate tracking pixels, so it requires opt-in.

## Usage

Enable archiving for new mail in configuration, then restart the daemon:

```toml
[sync]
archive_remote_images = true
```

Archive images in existing email separately:

```sh
msgvault archive-remote-images --allow-tracking
```

Downloads cover HTTP(S) `img src` images, not CSS backgrounds or `srcset`. Disabling the setting leaves already archived images available.

Closes #588
