### PR TITLE
fix(teams): archive self-chat and report probe failures

### DIFF
--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -18,6 +18,8 @@ import (
 // ErrMediaTooLarge classifies hosted media that exceeds its configured cap.
 var ErrMediaTooLarge = errors.New("teams hosted media exceeds the configured size cap")
 
+var errGraphNotFound = errors.New("graph resource not found")
+
 const (
 	maxRetries    = 8
 	maxRetryAfter = httpretry.ProviderMaxRetryAfter
@@ -100,6 +102,8 @@ func (c *Client) getLimited(ctx context.Context, rawURL string, maxBytes int64) 
 				return nil, ErrMediaTooLarge
 			}
 			return body, nil
+		case resp.StatusCode == http.StatusNotFound:
+			return nil, fmt.Errorf("graph GET %s: status %d: %s: %w", reqURL, resp.StatusCode, string(body), errGraphNotFound)
 		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
 			wait := httpretry.RetryAfter(resp.Header.Get("Retry-After"), attempt, maxRetryAfter)
 			timer := time.NewTimer(wait)

--- a/internal/teams/client.go
+++ b/internal/teams/client.go
@@ -206,6 +206,14 @@ func pageThroughLimit[T any](ctx context.Context, c *Client, startURL string, li
 	}
 }
 
+// SelfChatID is the Teams chat a user holds with themselves. Graph never
+// returns it from /me/chats, and a metadata read of /chats/48:notes fails with
+// "Call made for a thread which is not a ChatThread". Its messages endpoint
+// answers normally, including the incremental lastModifiedDateTime filter, so
+// once the chat is in the list it syncs through the same path as every other
+// chat.
+const SelfChatID = "48:notes"
+
 func (c *Client) ListChats(ctx context.Context) ([]Chat, error) {
 	var out []Chat
 	_, err := pageThrough[Chat](ctx, c, "/me/chats?$top=50", func(p []Chat) { out = append(out, p...) })

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -104,6 +104,15 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	}
 
 	blob, _ := state.Marshal()
+	// Errors can occur without any conversation reaching a checkpoint.
+	if err = imp.store.UpdateSyncCheckpoint(syncID, &store.Checkpoint{
+		PageToken:         blob,
+		MessagesProcessed: sum.MessagesProcessed,
+		MessagesAdded:     sum.MessagesAdded,
+		ErrorsCount:       sum.Errors,
+	}); err != nil {
+		return sum, err
+	}
 	if err = imp.store.CompleteSync(syncID, blob); err != nil {
 		return sum, err
 	}

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -87,7 +87,13 @@ func (imp *Importer) Import(ctx context.Context, opts ImportOptions) (*ImportSum
 	imp = imp.scopedToSync(src.ID, syncID)
 	defer func() {
 		if err != nil {
-			_ = imp.store.FailSync(syncID, err.Error())
+			blob, _ := state.Marshal()
+			_ = imp.store.FailSyncWithCheckpoint(syncID, err.Error(), &store.Checkpoint{
+				PageToken:         blob,
+				MessagesProcessed: sum.MessagesProcessed,
+				MessagesAdded:     sum.MessagesAdded,
+				ErrorsCount:       sum.Errors,
+			})
 		}
 	}()
 
@@ -205,7 +211,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
-	selfChat, selfMembers, err := imp.selfChat(ctx)
+	selfChat, selfMembers, err := imp.selfChat(ctx, opts.Email)
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
@@ -345,7 +351,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 // object ID a members read would have returned. Resolution therefore takes the
 // same path as every other chat member, down to the participant cache key that
 // mention resolution reads.
-func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember, error) {
+func (imp *Importer) selfChat(ctx context.Context, email string) ([]Chat, []ChatMember, error) {
 	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
 	if errors.Is(err, errGraphNotFound) {
 		return nil, nil, nil
@@ -358,7 +364,7 @@ func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember, error)
 	}
 	var members []ChatMember
 	if from := msgs[0].From; from != nil && from.User != nil && from.User.ID != "" {
-		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName}}
+		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName, Email: email}}
 	}
 	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members, nil
 }

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -196,7 +196,8 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
-	chats = append(chats, imp.selfChat(ctx)...)
+	selfChat, selfMembers := imp.selfChat(ctx)
+	chats = append(chats, selfChat...)
 	total := len(chats)
 	for idx, ch := range chats {
 		if ctx.Err() != nil {
@@ -209,7 +210,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		// Resolve chat members once for this chat.
 		// Member fetch failure is non-fatal; we proceed with empty toRecips
 		// rather than aborting the chat import.
-		members, merr := imp.chatMembers(ctx, ch.ID, opts.Email)
+		members, merr := imp.chatMembers(ctx, ch.ID, selfMembers)
 		// Only the roster's size and read outcome matter to media policy; the
 		// members are resolved below, where their display names are kept too.
 		roster := &memberRoster{memberCount: len(members), err: merr}
@@ -319,25 +320,35 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 }
 
 // selfChat reports the chat a user holds with themselves, which Graph does not
-// list under /me/chats. It is read once here because the thread is
-// undocumented: an account that has never used it, and a tenant where it is
-// unavailable, both answer this probe and are then left alone rather than
-// counted as a sync failure.
-func (imp *Importer) selfChat(ctx context.Context) []Chat {
+// list under /me/chats, together with its roster. It is read once here because
+// the thread is undocumented: an account that has never used it, and a tenant
+// where it is unavailable, both answer this probe and are then left alone
+// rather than counted as a sync failure.
+//
+// Graph also rejects a members read on the thread, so the roster is taken from
+// the probed message instead. The chat's only member is the signed-in user,
+// who is the sender of every message in it, and that identity carries the same
+// object ID a members read would have returned. Resolution therefore takes the
+// same path as every other chat member, down to the participant cache key that
+// mention resolution reads.
+func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember) {
 	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
 	if err != nil || len(msgs) == 0 {
-		return nil
+		return nil, nil
 	}
-	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}
+	var members []ChatMember
+	if from := msgs[0].From; from != nil && from.User != nil && from.User.ID != "" {
+		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName}}
+	}
+	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members
 }
 
-// chatMembers reads a chat's roster. Graph rejects a members read on the self
-// chat, whose only member is the signed-in user, so that roster is built here
-// rather than fetched. A roster reported as unreadable would archive the chat
+// chatMembers reads a chat's roster, using the roster selfChat already resolved
+// for the self chat. A roster reported as unreadable would archive the chat
 // with unknown membership and fail media policy closed against it.
-func (imp *Importer) chatMembers(ctx context.Context, chatID, email string) ([]ChatMember, error) {
+func (imp *Importer) chatMembers(ctx context.Context, chatID string, self []ChatMember) ([]ChatMember, error) {
 	if chatID == SelfChatID {
-		return []ChatMember{{Email: email, DisplayName: email}}, nil
+		return self, nil
 	}
 	return imp.client.ListChatMembers(ctx, chatID)
 }

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -196,6 +196,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
+	chats = append(chats, imp.selfChat(ctx)...)
 	total := len(chats)
 	for idx, ch := range chats {
 		if ctx.Err() != nil {
@@ -208,7 +209,7 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		// Resolve chat members once for this chat.
 		// Member fetch failure is non-fatal; we proceed with empty toRecips
 		// rather than aborting the chat import.
-		members, merr := imp.client.ListChatMembers(ctx, ch.ID)
+		members, merr := imp.chatMembers(ctx, ch.ID, opts.Email)
 		// Only the roster's size and read outcome matter to media policy; the
 		// members are resolved below, where their display names are kept too.
 		roster := &memberRoster{memberCount: len(members), err: merr}
@@ -315,6 +316,30 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 		}
 	}
 	return nil
+}
+
+// selfChat reports the chat a user holds with themselves, which Graph does not
+// list under /me/chats. It is read once here because the thread is
+// undocumented: an account that has never used it, and a tenant where it is
+// unavailable, both answer this probe and are then left alone rather than
+// counted as a sync failure.
+func (imp *Importer) selfChat(ctx context.Context) []Chat {
+	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
+	if err != nil || len(msgs) == 0 {
+		return nil
+	}
+	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}
+}
+
+// chatMembers reads a chat's roster. Graph rejects a members read on the self
+// chat, whose only member is the signed-in user, so that roster is built here
+// rather than fetched. A roster reported as unreadable would archive the chat
+// with unknown membership and fail media policy closed against it.
+func (imp *Importer) chatMembers(ctx context.Context, chatID, email string) ([]ChatMember, error) {
+	if chatID == SelfChatID {
+		return []ChatMember{{Email: email, DisplayName: email}}, nil
+	}
+	return imp.client.ListChatMembers(ctx, chatID)
 }
 
 func (imp *Importer) syncChannels(ctx context.Context, sourceID, syncID int64, opts ImportOptions, state *SyncState, sum *ImportSummary) error {

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -346,13 +346,13 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 // cannot silently omit the chat from the archive.
 //
 // Graph also rejects a members read on the thread, so the roster is taken from
-// the probed message instead. The chat's only member is the signed-in user,
-// who is the sender of every message in it, and that identity carries the same
-// object ID a members read would have returned. Resolution therefore takes the
-// same path as every other chat member, down to the participant cache key that
-// mention resolution reads.
+// a user-authored message in a bounded probe instead. System and application
+// messages do not identify the chat's sole member. A user sender carries the
+// same object ID a members read would have returned, preserving the participant
+// cache key that sender and mention resolution read. If the probe finds no
+// user, chatMembers leaves the roster unresolved so a later sync can retry it.
 func (imp *Importer) selfChat(ctx context.Context, email string) ([]Chat, []ChatMember, error) {
-	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
+	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 50)
 	if errors.Is(err, errGraphNotFound) {
 		return nil, nil, nil
 	}
@@ -363,8 +363,11 @@ func (imp *Importer) selfChat(ctx context.Context, email string) ([]Chat, []Chat
 		return nil, nil, nil
 	}
 	var members []ChatMember
-	if from := msgs[0].From; from != nil && from.User != nil && from.User.ID != "" {
-		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName, Email: email}}
+	for _, msg := range msgs {
+		if from := msg.From; from != nil && from.User != nil && from.User.ID != "" {
+			members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName, Email: email}}
+			break
+		}
 	}
 	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members, nil
 }
@@ -374,6 +377,9 @@ func (imp *Importer) selfChat(ctx context.Context, email string) ([]Chat, []Chat
 // with unknown membership and fail media policy closed against it.
 func (imp *Importer) chatMembers(ctx context.Context, chatID string, self []ChatMember) ([]ChatMember, error) {
 	if chatID == SelfChatID {
+		if len(self) == 0 {
+			return nil, errors.New("self-chat probe found no user identity")
+		}
 		return self, nil
 	}
 	return imp.client.ListChatMembers(ctx, chatID)

--- a/internal/teams/importer.go
+++ b/internal/teams/importer.go
@@ -196,7 +196,13 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 	if err != nil {
 		return err
 	}
-	selfChat, selfMembers := imp.selfChat(ctx)
+	selfChat, selfMembers, err := imp.selfChat(ctx)
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if err != nil {
+		sum.Errors++
+	}
 	chats = append(chats, selfChat...)
 	total := len(chats)
 	for idx, ch := range chats {
@@ -320,10 +326,9 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 }
 
 // selfChat reports the chat a user holds with themselves, which Graph does not
-// list under /me/chats, together with its roster. It is read once here because
-// the thread is undocumented: an account that has never used it, and a tenant
-// where it is unavailable, both answer this probe and are then left alone
-// rather than counted as a sync failure.
+// list under /me/chats, together with its roster. An empty result or a 404
+// means the thread is absent. Other probe errors are reported so a failed read
+// cannot silently omit the chat from the archive.
 //
 // Graph also rejects a members read on the thread, so the roster is taken from
 // the probed message instead. The chat's only member is the signed-in user,
@@ -331,16 +336,22 @@ func (imp *Importer) syncChats(ctx context.Context, sourceID, syncID int64, opts
 // object ID a members read would have returned. Resolution therefore takes the
 // same path as every other chat member, down to the participant cache key that
 // mention resolution reads.
-func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember) {
+func (imp *Importer) selfChat(ctx context.Context) ([]Chat, []ChatMember, error) {
 	msgs, _, err := imp.client.ListChatMessages(ctx, SelfChatID, "", 1)
-	if err != nil || len(msgs) == 0 {
-		return nil, nil
+	if errors.Is(err, errGraphNotFound) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(msgs) == 0 {
+		return nil, nil, nil
 	}
 	var members []ChatMember
 	if from := msgs[0].From; from != nil && from.User != nil && from.User.ID != "" {
 		members = []ChatMember{{UserID: from.User.ID, DisplayName: from.User.DisplayName}}
 	}
-	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members
+	return []Chat{{ID: SelfChatID, ChatType: "oneOnOne"}}, members, nil
 }
 
 // chatMembers reads a chat's roster, using the roster selfChat already resolved

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -2964,7 +2964,9 @@ func TestSyncImportsSelfChat(t *testing.T) {
 			memberCalls.Add(1)
 			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
 		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
-			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me","userIdentityType":"aadUser"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+		case r.URL.Path == "/users/u-me":
+			_, _ = w.Write([]byte(`{"id":"u-me","mail":"me@example.com","displayName":"Me"}`))
 		default:
 			http.Error(w, "404", http.StatusNotFound)
 		}
@@ -2982,7 +2984,22 @@ func TestSyncImportsSelfChat(t *testing.T) {
 
 	src, err := st.GetOrCreateSource("teams", "me@example.com")
 	require.NoError(err)
-	msgs, err := st.MessageExistsBatch(src.ID, []string{chatSourceMessageID(SelfChatID, "n1")})
+	sourceMessageID := chatSourceMessageID(SelfChatID, "n1")
+	msgs, err := st.MessageExistsBatch(src.ID, []string{sourceMessageID})
 	require.NoError(err)
 	assert.Len(msgs, 1)
+
+	// The roster comes from the probed message, so the signed-in user resolves
+	// through the same path a members read would have taken and is archived
+	// against the account email.
+	name, err := st.InspectDisplayName(sourceMessageID, "from", "me@example.com")
+	require.NoError(err)
+	assert.Equal("Me", name)
+
+	// A self chat has no "to" rows: they are every member except the sender,
+	// and here the only member is the sender. Pinned so a future roster change
+	// cannot start addressing these messages to their own author.
+	to, err := st.InspectRecipientCount(sourceMessageID, "to")
+	require.NoError(err)
+	assert.Equal(0, to)
 }

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -3010,6 +3010,7 @@ func TestSelfChatProbeFailureReporting(t *testing.T) {
 		status     int
 		body       string
 		wantErrors int
+		noChats    bool
 	}{
 		{name: "absent", status: http.StatusNotFound},
 		{name: "empty", status: http.StatusOK, body: `{"value":[]}`},
@@ -3018,12 +3019,17 @@ func TestSelfChatProbeFailureReporting(t *testing.T) {
 		{name: "forbidden", status: http.StatusForbidden, wantErrors: 1},
 		{name: "bad request", status: http.StatusBadRequest, wantErrors: 1},
 		{name: "invalid response", status: http.StatusOK, body: `{`, wantErrors: 1},
+		{name: "forbidden without chats", status: http.StatusForbidden, wantErrors: 1, noChats: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				switch r.URL.Path {
 				case "/me/chats":
+					if tt.noChats {
+						_, _ = w.Write([]byte(`{"value":[]}`))
+						return
+					}
 					_, _ = w.Write([]byte(`{"value":[{"id":"chat-1","chatType":"oneOnOne"}]}`))
 				case "/me/chats/48:notes/messages":
 					w.Header().Set("Retry-After", "0")
@@ -3041,7 +3047,14 @@ func TestSelfChatProbeFailureReporting(t *testing.T) {
 			sum, err := imp.Import(t.Context(), ImportOptions{Email: "me@example.com"})
 			require.NoError(t, err)
 			assert.EqualValues(t, tt.wantErrors, sum.Errors)
-			assert.EqualValues(t, 1, sum.ChatsProcessed, "ordinary chats must still sync")
+			if tt.noChats {
+				assert.Zero(t, sum.ChatsProcessed)
+			} else {
+				assert.EqualValues(t, 1, sum.ChatsProcessed, "ordinary chats must still sync")
+			}
+			run, err := st.GetLastSuccessfulSync(sum.SourceID)
+			require.NoError(t, err)
+			assert.EqualValues(t, tt.wantErrors, run.ErrorsCount, "sync history must retain probe errors")
 		})
 	}
 }

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -2966,7 +2966,7 @@ func TestSyncImportsSelfChat(t *testing.T) {
 		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
 			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me","userIdentityType":"aadUser"}},"body":{"contentType":"text","content":"note to self"}}]}`))
 		case r.URL.Path == "/users/u-me":
-			_, _ = w.Write([]byte(`{"id":"u-me","mail":"me@example.com","displayName":"Me"}`))
+			http.Error(w, "directory lookup denied", http.StatusForbidden)
 		default:
 			http.Error(w, "404", http.StatusNotFound)
 		}
@@ -2989,9 +2989,8 @@ func TestSyncImportsSelfChat(t *testing.T) {
 	require.NoError(err)
 	assert.Len(msgs, 1)
 
-	// The roster comes from the probed message, so the signed-in user resolves
-	// through the same path a members read would have taken and is archived
-	// against the account email.
+	// The account email identifies the sender even when directory lookups fail.
+	// The roster must cache that participant under the probed user object ID.
 	name, err := st.InspectDisplayName(sourceMessageID, "from", "me@example.com")
 	require.NoError(err)
 	assert.Equal("Me", name)
@@ -3022,6 +3021,8 @@ func TestSelfChatProbeFailureReporting(t *testing.T) {
 		{name: "forbidden without chats", status: http.StatusForbidden, wantErrors: 1, noChats: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				switch r.URL.Path {
@@ -3045,18 +3046,44 @@ func TestSelfChatProbeFailureReporting(t *testing.T) {
 			st := testutil.NewTestStore(t)
 			imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 1000))
 			sum, err := imp.Import(t.Context(), ImportOptions{Email: "me@example.com"})
-			require.NoError(t, err)
-			assert.EqualValues(t, tt.wantErrors, sum.Errors)
+			require.NoError(err)
+			assert.EqualValues(tt.wantErrors, sum.Errors)
 			if tt.noChats {
-				assert.Zero(t, sum.ChatsProcessed)
+				assert.Zero(sum.ChatsProcessed)
 			} else {
-				assert.EqualValues(t, 1, sum.ChatsProcessed, "ordinary chats must still sync")
+				assert.EqualValues(1, sum.ChatsProcessed, "ordinary chats must still sync")
 			}
 			run, err := st.GetLastSuccessfulSync(sum.SourceID)
-			require.NoError(t, err)
-			assert.EqualValues(t, tt.wantErrors, run.ErrorsCount, "sync history must retain probe errors")
+			require.NoError(err)
+			assert.EqualValues(tt.wantErrors, run.ErrorsCount, "sync history must retain probe errors")
 		})
 	}
+}
+
+func TestSelfChatProbeErrorSurvivesLaterSyncFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case "/me/chats/48:notes/messages", "/me/joinedTeams":
+			http.Error(w, "access denied", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 1000))
+	sum, err := imp.Import(t.Context(), ImportOptions{Email: "me@example.com", IncludeChannels: true})
+	require.Error(err)
+	assert.EqualValues(1, sum.Errors)
+	assert.Zero(sum.ChatsProcessed)
+	run, err := st.GetLatestSync(sum.SourceID)
+	require.NoError(err)
+	assert.Equal(store.SyncStatusFailed, run.Status)
+	assert.EqualValues(1, run.ErrorsCount, "failed sync history must retain earlier probe errors")
 }
 
 func TestSelfChatProbeCancellationStopsSync(t *testing.T) {

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -43,10 +43,24 @@ func (e *recordingEnqueuer) EnqueueMessages(_ context.Context, ids []int64) erro
 	return nil
 }
 
+// selfChatAbsent answers the self-chat probe the way Graph answers for an
+// account that has never used that chat. These fakes route on a path suffix,
+// so without this they serve the self chat another chat's messages.
+func selfChatAbsent(w http.ResponseWriter, r *http.Request) bool {
+	if strings.Contains(r.URL.Path, SelfChatID) {
+		http.Error(w, "404", http.StatusNotFound)
+		return true
+	}
+	return false
+}
+
 func fakeChatGraph(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -89,6 +103,9 @@ func TestImportChatsPopulatesConversationParticipantsAndStats(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -145,6 +162,9 @@ func fakeChannelGraph(t *testing.T) *httptest.Server {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -169,6 +189,9 @@ func TestInlineImageDownloaded(t *testing.T) {
 	assert := assert.New(t)
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -209,6 +232,9 @@ func TestContentlessGraphAttachmentDoesNotSetMessageAttachmentStats(t *testing.T
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -257,6 +283,9 @@ func TestTeamsReimportRemovesStaleInlineAttachments(t *testing.T) {
 	includeImage := true
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -339,6 +368,9 @@ func TestTeamsInlineMarkerSurvivesLinkAttachmentReplacement(t *testing.T) {
 	hostedFetches := 0
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			hostedFetches++
@@ -414,6 +446,9 @@ func TestBackfillInlineMedia(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		// Regression guard: a doubled version segment ("/v1.0/v1.0") must 404.
 		if strings.Contains(r.URL.Path, "/v1.0/v1.0") {
 			http.Error(w, "404", http.StatusNotFound)
@@ -649,6 +684,9 @@ func TestHostedFetchPath(t *testing.T) {
 func fakeLimitChatGraph(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -722,6 +760,9 @@ func TestLimitedChatImportStopsPaging(t *testing.T) {
 	serverURL := ""
 	var secondPageRequests int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -759,6 +800,9 @@ func TestChatMemberFetchFailureDoesNotAdvanceCursor(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -863,6 +907,9 @@ func TestChatMessageIDsAreNamespacedByConversation(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -954,6 +1001,9 @@ func TestChannelMediaPolicyUsesTeamParticipantCount(t *testing.T) {
 			hostedFetches := 0
 			serverURL := ""
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if selfChatAbsent(w, r) {
+					return
+				}
 				switch {
 				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 					hostedFetches++
@@ -1053,6 +1103,9 @@ func newPrivateChannelGraph(t *testing.T) *privateChannelGraph {
 
 	g := &privateChannelGraph{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			g.hostedFetches++
@@ -1271,6 +1324,9 @@ func TestBackfillChannelMediaRefreshesUnknownTeamMembership(t *testing.T) {
 			rosterReadable := false
 			serverURL := ""
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if selfChatAbsent(w, r) {
+					return
+				}
 				switch {
 				case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 					hostedFetches++
@@ -1376,6 +1432,9 @@ func TestLimitedChannelImportDoesNotAdvanceDelta(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1420,6 +1479,9 @@ func TestLimitedChannelImportStopsPagingAndDeltaPrime(t *testing.T) {
 	var secondPageRequests int
 	var deltaRequests int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1470,6 +1532,9 @@ func TestChannelReplyFetchErrorDoesNotAdvanceDelta(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1511,6 +1576,9 @@ func TestChannelDeltaPrimeErrorStillPersistsBackfill(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1563,6 +1631,9 @@ func TestChannelDeltaPrimeMessageReplacesBackfilledVersion(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1609,6 +1680,9 @@ func TestReplyBeforeRoot(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1661,6 +1735,9 @@ func TestRecipientAndMentionRows(t *testing.T) {
 	// - /chats/{id}/members → two members: alice (sender) and bob
 	// - chat /messages → one message from alice @mentioning bob
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1828,6 +1905,9 @@ func TestResumeFromCheckpoint(t *testing.T) {
 	// Server that returns one chat with one message newer than our pre-seeded cursor.
 	var requestedSince string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1890,6 +1970,9 @@ func TestFullIgnoresCursor(t *testing.T) {
 
 	var requestedSince string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -1984,6 +2067,9 @@ func TestImportMigratesLegacyRawMessageIDBeforeDelete(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2076,6 +2162,9 @@ func TestTeamsReimportReplacesRemovedChildCollections(t *testing.T) {
 
 	includeChildren := true
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2129,6 +2218,9 @@ func TestCallRecordingAndAttachmentsPersisted(t *testing.T) {
 	assert := assert.New(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2200,6 +2292,9 @@ func TestTeamsMixedInlineAndLinkAttachmentsRefreshMessageStats(t *testing.T) {
 
 	serverURL := ""
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			w.Header().Set("Content-Type", "image/png")
@@ -2261,6 +2356,9 @@ func TestDuplicateMentionDedup(t *testing.T) {
 	// Message that @mentions bob twice should produce exactly one 'mention' row
 	// and sum.Errors should remain 0.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2341,6 +2439,9 @@ func newChatRosterGraph(t *testing.T, rosterSize int) *chatRosterGraph {
 
 	g := &chatRosterGraph{rosterSize: rosterSize}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		switch {
 		case strings.Contains(r.URL.Path, "/hostedContents/") && strings.HasSuffix(r.URL.Path, "/$value"):
 			g.hostedFetches++
@@ -2615,6 +2716,9 @@ func TestChatSyncRecoversMessageSharingCursorTimestamp(t *testing.T) {
 	var filters graphFilterFake
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2746,6 +2850,9 @@ func TestLimitedChatSyncDoesNotStrandTiedMessages(t *testing.T) {
 	var filters graphFilterFake
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if selfChatAbsent(w, r) {
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/me/chats":
@@ -2835,4 +2942,47 @@ func chatCursorAfterLastSync(t *testing.T, st *store.Store, chatID string) strin
 	state, err := LoadSyncState(run.CursorAfter.String)
 	require.NoError(t, err)
 	return state.ChatCursor(chatID)
+}
+
+// The Teams self chat is not listed by /me/chats and rejects a members read,
+// but its messages endpoint works. Its messages belong in the archive, and its
+// roster is the signed-in user rather than an unreadable one.
+func TestSyncImportsSelfChat(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	var memberCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case r.URL.Path == "/me/joinedTeams":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/members"):
+			// Graph: "Call made for a thread which is not a ChatThread".
+			memberCalls.Add(1)
+			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
+		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
+			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+		default:
+			http.Error(w, "404", http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 50))
+	sum, err := imp.Import(context.Background(), ImportOptions{Email: "me@example.com", IncludeChannels: false})
+	require.NoError(err)
+
+	assert.EqualValues(1, sum.MessagesAdded)
+	assert.EqualValues(0, sum.Errors)
+	assert.EqualValues(0, memberCalls.Load())
+
+	src, err := st.GetOrCreateSource("teams", "me@example.com")
+	require.NoError(err)
+	msgs, err := st.MessageExistsBatch(src.ID, []string{chatSourceMessageID(SelfChatID, "n1")})
+	require.NoError(err)
+	assert.Len(msgs, 1)
 }

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -2964,7 +2964,10 @@ func TestSyncImportsSelfChat(t *testing.T) {
 			memberCalls.Add(1)
 			http.Error(w, `{"error":{"code":"BadRequest"}}`, http.StatusBadRequest)
 		case strings.Contains(r.URL.Path, "48:notes") && strings.HasSuffix(r.URL.Path, "/messages"):
-			_, _ = w.Write([]byte(`{"value":[{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me","userIdentityType":"aadUser"}},"body":{"contentType":"text","content":"note to self"}}]}`))
+			_, _ = w.Write([]byte(`{"value":[
+				{"id":"s1","createdDateTime":"2026-01-03T00:00:00Z","lastModifiedDateTime":"2026-01-03T00:00:00Z","messageType":"systemEventMessage","from":null,"body":{"contentType":"html","content":"<systemEventMessage/>"}},
+				{"id":"n1","createdDateTime":"2026-01-02T00:00:00Z","lastModifiedDateTime":"2026-01-02T00:00:00Z","messageType":"message","from":{"user":{"id":"u-me","displayName":"Me","userIdentityType":"aadUser"}},"body":{"contentType":"text","content":"note to self"}}
+			]}`))
 		case r.URL.Path == "/users/u-me":
 			http.Error(w, "directory lookup denied", http.StatusForbidden)
 		default:
@@ -2978,7 +2981,7 @@ func TestSyncImportsSelfChat(t *testing.T) {
 	sum, err := imp.Import(context.Background(), ImportOptions{Email: "me@example.com", IncludeChannels: false})
 	require.NoError(err)
 
-	assert.EqualValues(1, sum.MessagesAdded)
+	assert.EqualValues(2, sum.MessagesAdded)
 	assert.EqualValues(0, sum.Errors)
 	assert.EqualValues(0, memberCalls.Load())
 
@@ -3001,6 +3004,40 @@ func TestSyncImportsSelfChat(t *testing.T) {
 	to, err := st.InspectRecipientCount(sourceMessageID, "to")
 	require.NoError(err)
 	assert.Equal(0, to)
+}
+
+func TestSelfChatWithoutUserKeepsRosterUnresolved(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/me/chats":
+			_, _ = w.Write([]byte(`{"value":[]}`))
+		case "/me/chats/48:notes/messages":
+			_, _ = w.Write([]byte(`{"value":[{"id":"s1","createdDateTime":"2026-01-03T00:00:00Z","lastModifiedDateTime":"2026-01-03T00:00:00Z","messageType":"systemEventMessage","from":null,"body":{"contentType":"html","content":"<systemEventMessage/>"}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 1000))
+	sum, err := imp.Import(t.Context(), ImportOptions{Email: "me@example.com"})
+	require.NoError(err)
+	assert.EqualValues(1, sum.MessagesAdded, "unresolved membership must not prevent archiving messages")
+	assert.EqualValues(1, sum.Errors)
+	ref, err := st.MessageExistsBatch(sum.SourceID, []string{chatSourceMessageID(SelfChatID, "s1")})
+	require.NoError(err)
+	messageID, ok := ref[chatSourceMessageID(SelfChatID, "s1")]
+	require.True(ok)
+	membership, err := st.AttachmentConversationMembership(messageID)
+	require.NoError(err)
+	assert.False(membership.RosterArchived, "a missing user is not a known empty roster")
+	run, err := st.GetLastSuccessfulSync(sum.SourceID)
+	require.NoError(err)
+	state, err := LoadSyncState(run.CursorAfter.String)
+	require.NoError(err)
+	assert.Empty(state.ChatCursor(SelfChatID), "retry messages after the roster resolves")
 }
 
 func TestSelfChatProbeFailureReporting(t *testing.T) {

--- a/internal/teams/importer_test.go
+++ b/internal/teams/importer_test.go
@@ -3003,3 +3003,64 @@ func TestSyncImportsSelfChat(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(0, to)
 }
+
+func TestSelfChatProbeFailureReporting(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		status     int
+		body       string
+		wantErrors int
+	}{
+		{name: "absent", status: http.StatusNotFound},
+		{name: "empty", status: http.StatusOK, body: `{"value":[]}`},
+		{name: "service failure", status: http.StatusServiceUnavailable, wantErrors: 1},
+		{name: "unauthorized", status: http.StatusUnauthorized, wantErrors: 1},
+		{name: "forbidden", status: http.StatusForbidden, wantErrors: 1},
+		{name: "bad request", status: http.StatusBadRequest, wantErrors: 1},
+		{name: "invalid response", status: http.StatusOK, body: `{`, wantErrors: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/me/chats":
+					_, _ = w.Write([]byte(`{"value":[{"id":"chat-1","chatType":"oneOnOne"}]}`))
+				case "/me/chats/48:notes/messages":
+					w.Header().Set("Retry-After", "0")
+					w.WriteHeader(tt.status)
+					_, _ = w.Write([]byte(tt.body))
+				case "/chats/chat-1/members", "/me/chats/chat-1/messages":
+					_, _ = w.Write([]byte(`{"value":[]}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+			st := testutil.NewTestStore(t)
+			imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 1000))
+			sum, err := imp.Import(t.Context(), ImportOptions{Email: "me@example.com"})
+			require.NoError(t, err)
+			assert.EqualValues(t, tt.wantErrors, sum.Errors)
+			assert.EqualValues(t, 1, sum.ChatsProcessed, "ordinary chats must still sync")
+		})
+	}
+}
+
+func TestSelfChatProbeCancellationStopsSync(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/me/chats/48:notes/messages" {
+			cancel()
+		}
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	}))
+	defer srv.Close()
+	st := testutil.NewTestStore(t)
+	imp := NewImporter(st, NewClient(srv.URL, func(context.Context) (string, error) { return "t", nil }, 1000))
+	sum, err := imp.Import(ctx, ImportOptions{Email: "me@example.com"})
+	require.ErrorIs(t, err, context.Canceled)
+	last, err := st.GetLastSuccessfulSync(sum.SourceID)
+	require.ErrorIs(t, err, store.ErrSyncRunNotFound)
+	assert.Nil(t, last, "a canceled probe must not complete the sync")
+}

--- a/web/tests/conversation-content-frame.spec.ts
+++ b/web/tests/conversation-content-frame.spec.ts
@@ -255,10 +255,18 @@ test('archived content has an opaque capability boundary and durable conversatio
 
   // Browser Back closes the reading pane, restores the pre-open URL, and
   // returns focus to the grid.
+  const restoredResults = page.waitForResponse((response) =>
+    new URL(response.url()).pathname === '/api/v1/explore'
+  );
   await page.evaluate(() => history.back());
   await expect(reading).toBeHidden();
   await expect(grid).toBeFocused();
   expect(page.url()).toBe(priorURL);
+
+  // Focus can return before Back's results reload finishes. Wait for the
+  // restored row before sending a command that opens it.
+  await restoredResults;
+  await expect(grid.getByText(row.title)).toBeVisible();
 
   // Reopening and expanding the peer message keeps the anchor expanded and
   // renders the peer's own frame, whose missing inline image degrades to a


### PR DESCRIPTION
Teams sync now archives the chat a user holds with themselves, which Graph omits from the chat list. The importer discovers it through its messages endpoint and derives its single-member roster from the sender, allowing inline media to follow the normal attachment policy.

An empty probe or HTTP 404 leaves the chat absent without adding an error. Other probe failures count toward the sync error summary while ordinary chats continue, and cancellation stops the run instead of recording a successful sync.

Supersedes #788, preserving its commits and adding the probe error-reporting fix. No configuration or usage changes.

Closes #787.
