### PR TITLE
test: scale SQLite suite scheduling to available resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,17 @@ go vet ./...                   # Check for issues
 
 `make test` automatically overlaps the CLI, store, API, and query package shards
 with the remaining SQLite packages when at least 32 CPUs and 64 GiB of available
-memory are detected. Each large package gets the smallest of 16 shards, one
-quarter of the CPU budget, or one shard per 8 GiB of available memory. The
-concurrent profile uses `GOMAXPROCS=4` per process to limit nested Go parallelism.
-This changes scheduling, not test coverage.
+memory are detected. The planner reserves four test-process slots for the
+unsharded remainder, then divides the remaining slots across the sharded
+packages, up to 16 shards each. Each slot budgets two Go execution threads
+(`GOMAXPROCS=2`) and a 2 GiB memory allowance. For four sharded packages, a
+32-CPU budget permits three shards per package; 128 CPUs permits fifteen,
+provided memory also permits them. This changes scheduling, not test coverage.
+
+The planner emits the per-process and remainder settings with its shard count,
+so execution uses the same aggregate budget. Shard builds use `go -p=1`; the
+remainder uses `go test -p=4`. Memory allowances guide scheduling and do not
+enforce per-process limits, including native allocations.
 
 Detection accounts for CPU affinity and `GOMAXPROCS`. On Linux it also accounts
 for visible cgroup v2 ancestor CPU quotas and remaining memory under both hard

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,6 +349,7 @@ automatically:
 ```bash
 make install-hooks             # Install pre-commit hook via prek
 make test                      # Run tests (SQLite default)
+make test TEST_PROFILE=standard # Keep sequential package jobs and four shards
 make test-pg-both              # Both PostgreSQL configurations, needs MSGVAULT_TEST_DB
 make test-pg                   # PostgreSQL, pgvector build only
 make test-pg-shipped           # PostgreSQL, shipped build only
@@ -362,6 +363,27 @@ go vet ./...                   # Check for issues
 - Default gofmt configuration
 - Use `error` return values, wrap with context using `fmt.Errorf`
 - Table-driven tests
+
+### Local test scheduling
+
+`make test` automatically overlaps the CLI, store, API, and query package shards
+with the remaining SQLite packages when at least 32 CPUs and 64 GiB of available
+memory are detected. Each large package gets the smallest of 16 shards, one
+quarter of the CPU budget, or one shard per 8 GiB of available memory. The
+concurrent profile uses `GOMAXPROCS=4` per process to limit nested Go parallelism.
+This changes scheduling, not test coverage.
+
+Detection accounts for CPU affinity and `GOMAXPROCS`. On Linux it also accounts
+for visible cgroup v2 ancestor CPU quotas and remaining memory under both hard
+and soft limits. macOS uses available system memory. Smaller budgets, cgroup v1,
+other platforms, and unreadable limits retain the standard schedule. Detection
+is a snapshot, not a reservation of resources against other workloads.
+
+Use `TEST_PROFILE=standard` to disable automatic scaling. Setting `TEST_SHARDS`
+explicitly also retains sequential package jobs with the requested shard count.
+The PostgreSQL targets keep their existing connection-oriented concurrency
+limits; setting `MSGVAULT_TEST_DB` disables automatic scaling in `make test` too.
+CI's explicit `test-unsharded` and package-shard jobs keep their existing layout.
 
 ## Code Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ PG_TEST_PARALLEL ?= 4
 # `make test` and `make test-pg-shipped` still run every package.
 SHARDED_TEST_PKGS := ./cmd/msgvault/cmd ./internal/store ./internal/api
 TEST_SHARDS ?= 4
+TEST_PROFILE ?= auto
+# Only the automatic SQLite profile adds query and overlaps package jobs.
+SQLITE_SHARDED_TEST_PKGS := $(sort $(SHARDED_TEST_PKGS) ./internal/query)
+SQLITE_SHARD_TARGETS := $(addprefix test-sqlite-shard/,$(SQLITE_SHARDED_TEST_PKGS))
 GOLANGCI_LINT_VERSION ?= v2.13.1
 GOVULNCHECK_VERSION ?= v1.7.0
 GO_INSTALL_BIN := $(shell go env GOBIN)
@@ -115,12 +119,32 @@ clean:
 	rm -f msgvault msgvault.exe mimeshootout
 	rm -rf bin/
 
-# Run the full SQLite suite. The three largest packages run as shards after the
-# unsharded remainder so one test binary cannot set the full wall clock. CI runs
-# the same two parts as separate jobs.
+# Scale the SQLite suite when both CPU and memory budgets allow it. An explicit
+# TEST_SHARDS, a database URL, or TEST_PROFILE=standard keeps the existing layout.
 test:
+	@case "$(TEST_PROFILE)" in auto|standard) ;; *) echo "TEST_PROFILE must be auto or standard" >&2; exit 1 ;; esac; \
+	shards=0; \
+	if [ "$(TEST_PROFILE)" = auto ] && [ "$(origin TEST_SHARDS)" = file ] && [ -z "$(MSGVAULT_TEST_DB)" ]; then \
+		shards=$$(go run ./scripts/test-resources) || exit $$?; \
+	fi; \
+	if [ "$$shards" -gt 0 ]; then \
+		echo "SQLite tests: concurrent packages, $$shards shards per large package"; \
+		GOMAXPROCS=4 $(MAKE) -j5 test-unsharded $(SQLITE_SHARD_TARGETS) \
+			SHARDED_TEST_PKGS="$(SQLITE_SHARDED_TEST_PKGS)" TEST_SHARDS=$$shards; \
+	else \
+		echo "Tests: standard package schedule, $(TEST_SHARDS) shards"; \
+		$(MAKE) test-standard; \
+	fi
+
+.PHONY: test-standard $(SQLITE_SHARD_TARGETS)
+test-standard:
 	$(MAKE) test-unsharded
 	$(MAKE) test-shards
+
+# These explicit goals let make own job waiting and error propagation. The
+# regular test-shards target remains sequential, including PostgreSQL callers.
+$(SQLITE_SHARD_TARGETS): test-sqlite-shard/%:
+	scripts/test-package-shards.sh $* $(TEST_SHARDS) "$(BUILD_TAGS)" $(TEST_TIMEOUT)
 
 # Everything except SHARDED_TEST_PKGS. CI's test lane runs this alongside the
 # sharded jobs; together they cover exactly what `make test` covers.
@@ -452,7 +476,7 @@ help:
 	@echo "  build-release  - Release build (optimized, stripped)"
 	@echo "  install        - Install to ~/.local/bin or GOPATH"
 	@echo ""
-	@echo "  test           - Run tests"
+	@echo "  test           - Run SQLite tests with automatic CPU/memory scaling (TEST_PROFILE=standard disables)"
 	@echo "  test-v         - Run tests (verbose)"
 	@echo "  test-shards    - Run SHARDED_TEST_PKGS as TEST_SHARDS concurrent processes each"
 	@echo "  test-unsharded - Run every package except SHARDED_TEST_PKGS (CI's test lane)"

--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,14 @@ test:
 	@case "$(TEST_PROFILE)" in auto|standard) ;; *) echo "TEST_PROFILE must be auto or standard" >&2; exit 1 ;; esac; \
 	shards=0; \
 	if [ "$(TEST_PROFILE)" = auto ] && [ "$(origin TEST_SHARDS)" = file ] && [ -z "$(MSGVAULT_TEST_DB)" ]; then \
-		shards=$$(go run ./scripts/test-resources) || exit $$?; \
+		profile=$$(go run ./scripts/test-resources -packages $(words $(SQLITE_SHARDED_TEST_PKGS))) || exit $$?; \
+		set -- $$profile; shards=$$1; \
 	fi; \
 	if [ "$$shards" -gt 0 ]; then \
 		echo "SQLite tests: concurrent packages, $$shards shards per large package"; \
-		GOMAXPROCS=4 $(MAKE) -j5 test-unsharded $(SQLITE_SHARD_TARGETS) \
-			SHARDED_TEST_PKGS="$(SQLITE_SHARDED_TEST_PKGS)" TEST_SHARDS=$$shards; \
+		$(MAKE) -j$$(($(words $(SQLITE_SHARDED_TEST_PKGS)) + 1)) GOMAXPROCS=$$2 GOFLAGS="$(GOFLAGS) -p=1" \
+			test-unsharded $(SQLITE_SHARD_TARGETS) SHARDED_TEST_PKGS="$(SQLITE_SHARDED_TEST_PKGS)" \
+			TEST_SHARDS=$$shards TEST_REMAINDER_PARALLEL=$$3; \
 	else \
 		echo "Tests: standard package schedule, $(TEST_SHARDS) shards"; \
 		$(MAKE) test-standard; \
@@ -150,7 +152,7 @@ $(SQLITE_SHARD_TARGETS): test-sqlite-shard/%:
 # sharded jobs; together they cover exactly what `make test` covers.
 test-unsharded:
 	@excluded=$$(go list $(SHARDED_TEST_PKGS) | sed 's/^/-e /' | tr '\n' ' '); \
-	go test -timeout $(TEST_TIMEOUT) -tags "$(BUILD_TAGS)" $$(go list ./... | grep -vxF $$excluded)
+	go test -timeout $(TEST_TIMEOUT) $(if $(TEST_REMAINDER_PARALLEL),-p $(TEST_REMAINDER_PARALLEL),) -tags "$(BUILD_TAGS)" $$(go list ./... | grep -vxF $$excluded)
 
 # SHARDED_TEST_PKGS, each as TEST_SHARDS concurrent processes. Same binary,
 # same tests, same per-package timeout; only the process boundary is new.

--- a/scripts/test-resources/main.go
+++ b/scripts/test-resources/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"os"
@@ -18,13 +19,24 @@ type resources struct {
 	available uint64
 }
 
+const (
+	processProcs      = 2
+	remainderParallel = 4
+	processMemory     = 2 << 30
+)
+
 // Zero selects the existing sequential package schedule. Wider execution needs
 // both CPU and memory headroom, with an upper bound even on very large hosts.
-func shardBudget(r resources) int {
-	if r.cpus < 32 || r.available < 64<<30 {
+func shardBudget(r resources, packages int) int {
+	if r.cpus < 32 || r.available < 64<<30 || packages < 1 {
 		return 0
 	}
-	return min(16, r.cpus/4, int(min(uint64(16), r.available/(8<<30))))
+	// Reserve the remainder first, then divide the remaining process slots
+	// across all concurrent shard groups. Memory is a planning allowance, not
+	// an enforced per-process limit (in particular for native allocations).
+	cpuShards := (r.cpus/processProcs - remainderParallel) / packages
+	memoryShards := (r.available/processMemory - remainderParallel) / uint64(packages)
+	return min(16, cpuShards, int(min(uint64(16), memoryShards)))
 }
 
 func limitCgroup(fsys fs.FS, group string, r resources) (resources, error) {
@@ -117,11 +129,14 @@ func detect() (resources, error) {
 }
 
 func main() {
+	packages := flag.Int("packages", 4, "number of concurrent sharded packages")
+	flag.Parse()
 	r, err := detect()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Resource detection unavailable; using standard test scheduling")
-		fmt.Println(0)
-		return
+		r = resources{}
 	}
-	fmt.Println(shardBudget(r))
+	// Emit the settings together so make uses the same per-process budget and
+	// remainder concurrency that the shard calculation reserves.
+	fmt.Println(shardBudget(r, *packages), processProcs, remainderParallel)
 }

--- a/scripts/test-resources/main.go
+++ b/scripts/test-resources/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+type resources struct {
+	cpus      int
+	available uint64
+}
+
+// Zero selects the existing sequential package schedule. Wider execution needs
+// both CPU and memory headroom, with an upper bound even on very large hosts.
+func shardBudget(r resources) int {
+	if r.cpus < 32 || r.available < 64<<30 {
+		return 0
+	}
+	return min(16, r.cpus/4, int(min(uint64(16), r.available/(8<<30))))
+}
+
+func limitCgroup(fsys fs.FS, group string, r resources) (resources, error) {
+	if !fs.ValidPath(group) {
+		return resources{}, errors.New("invalid cgroup path")
+	}
+	for {
+		cpu, err := fs.ReadFile(fsys, path.Join(group, "cpu.max"))
+		if err != nil && (group != "." || !errors.Is(err, fs.ErrNotExist)) {
+			return resources{}, fmt.Errorf("read cgroup CPU limit: %w", err)
+		}
+		if err == nil {
+			fields := strings.Fields(string(cpu))
+			if len(fields) != 2 {
+				return resources{}, errors.New("invalid cpu.max")
+			}
+			period, err := strconv.Atoi(fields[1])
+			if err != nil || period <= 0 {
+				return resources{}, errors.New("invalid cpu.max period")
+			}
+			if fields[0] != "max" {
+				quota, err := strconv.Atoi(fields[0])
+				if err != nil || quota < 0 {
+					return resources{}, errors.New("invalid cpu.max quota")
+				}
+				r.cpus = min(r.cpus, quota/period)
+			}
+		}
+		for _, name := range []string{"memory.max", "memory.high"} {
+			data, err := fs.ReadFile(fsys, path.Join(group, name))
+			if group == "." && errors.Is(err, fs.ErrNotExist) {
+				continue // The host's cgroup root has no resource limit files.
+			}
+			if err != nil {
+				return resources{}, fmt.Errorf("read cgroup memory limit: %w", err)
+			}
+			if strings.TrimSpace(string(data)) == "max" {
+				continue
+			}
+			limit, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+			if err != nil {
+				return resources{}, fmt.Errorf("parse cgroup memory limit: %w", err)
+			}
+			data, err = fs.ReadFile(fsys, path.Join(group, "memory.current"))
+			if err != nil {
+				return resources{}, fmt.Errorf("read cgroup memory usage: %w", err)
+			}
+			used, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+			if err != nil {
+				return resources{}, fmt.Errorf("parse cgroup memory usage: %w", err)
+			}
+			r.available = min(r.available, limit-min(limit, used))
+		}
+		if group == "." {
+			return r, nil
+		}
+		group = path.Dir(group)
+	}
+}
+
+func detect() (resources, error) {
+	// Respect affinity, the caller's GOMAXPROCS, and the runtime's cgroup quota
+	// even when an explicit GOMAXPROCS would otherwise override that quota.
+	cpus := min(runtime.NumCPU(), runtime.GOMAXPROCS(0))
+	runtime.SetDefaultGOMAXPROCS()
+	cpus = min(cpus, runtime.GOMAXPROCS(0))
+	memory, err := mem.VirtualMemory()
+	if err != nil {
+		return resources{}, fmt.Errorf("read available memory: %w", err)
+	}
+	r := resources{cpus, memory.Available}
+	switch runtime.GOOS {
+	case "darwin":
+		return r, nil
+	case "linux":
+		data, err := os.ReadFile("/proc/self/cgroup")
+		if err != nil {
+			return resources{}, fmt.Errorf("read process cgroup: %w", err)
+		}
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if group, ok := strings.CutPrefix(line, "0::/"); ok {
+				if group == "" {
+					group = "."
+				}
+				return limitCgroup(os.DirFS("/sys/fs/cgroup"), group, r)
+			}
+		}
+	}
+	return resources{}, errors.New("resource limits could not be determined")
+}
+
+func main() {
+	r, err := detect()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Resource detection unavailable; using standard test scheduling")
+		fmt.Println(0)
+		return
+	}
+	fmt.Println(shardBudget(r))
+}

--- a/scripts/test-resources/main_test.go
+++ b/scripts/test-resources/main_test.go
@@ -18,18 +18,20 @@ func TestShardBudget(t *testing.T) {
 		{"small CPU budget", 8, 256, 0},
 		{"small memory budget", 128, 32, 0},
 		{"unknown memory", 128, 0, 0},
-		{"CPU limited", 32, 256, 8},
-		{"memory limited", 128, 64, 8},
-		{"large budget", 128, 256, 16},
+		{"CPU limited", 32, 256, 3},
+		{"memory limited", 128, 64, 7},
+		{"large budget", 128, 256, 15},
 		{"cap very large budgets", 512, 1024, 16},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, shardBudget(resources{tc.cpus, tc.gib << 30}))
+			assert.Equal(t, tc.want, shardBudget(resources{tc.cpus, tc.gib << 30}, 4))
 		})
 	}
 }
 
 func TestCgroupAncestorLimits(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	files := fstest.MapFS{
 		"parent/child/cpu.max":        {Data: []byte("max 100000\n")},
 		"parent/child/memory.max":     {Data: []byte("max\n")},
@@ -41,18 +43,35 @@ func TestCgroupAncestorLimits(t *testing.T) {
 		"parent/memory.current":       {Data: []byte("4294967296\n")},  // 4 GiB
 	}
 	got, err := limitCgroup(files, "parent/child", resources{128, 256 << 30})
-	require.NoError(t, err)
-	assert.Equal(t, resources{2, 12 << 30}, got)
-	assert.Zero(t, shardBudget(got))
+	require.NoError(err)
+	assert.Equal(resources{2, 12 << 30}, got)
+	assert.Zero(shardBudget(got, 4))
 
 	// A soft memory limit can already be exceeded; subtraction must not wrap.
 	files["parent/memory.current"].Data = []byte("21474836480\n")
 	got, err = limitCgroup(files, "parent/child", resources{128, 256 << 30})
-	require.NoError(t, err)
-	assert.Zero(t, got.available)
+	require.NoError(err)
+	assert.Zero(got.available)
+}
+
+func TestAggregateBudgetIncludesRemainder(t *testing.T) {
+	assert := assert.New(t)
+	for _, r := range []resources{{32, 64 << 30}, {64, 64 << 30}, {128, 256 << 30}, {512, 1024 << 30}} {
+		for packages := 1; packages <= 16; packages++ {
+			shards := shardBudget(r, packages)
+			if shards == 0 {
+				continue
+			}
+			processes := packages*shards + remainderParallel
+			assert.LessOrEqual(processes*processProcs, r.cpus, "CPU budget, %d groups", packages)
+			assert.LessOrEqual(uint64(processes)*processMemory, r.available, "memory allowance, %d groups", packages)
+		}
+	}
 }
 
 func TestCgroupRootLimits(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	// A cgroup namespace may expose its container's limits at the mount root.
 	files := fstest.MapFS{
 		"cpu.max":        {Data: []byte("6400000 100000\n")},
@@ -61,12 +80,12 @@ func TestCgroupRootLimits(t *testing.T) {
 		"memory.current": {Data: []byte("68719476736\n")},
 	}
 	got, err := limitCgroup(files, ".", resources{128, 256 << 30})
-	require.NoError(t, err)
-	assert.Equal(t, resources{64, 64 << 30}, got)
-	assert.Equal(t, 8, shardBudget(got))
+	require.NoError(err)
+	assert.Equal(resources{64, 64 << 30}, got)
+	assert.Equal(7, shardBudget(got, 4))
 	files["cpu.max"].Data = []byte("bad quota")
 	_, err = limitCgroup(files, ".", resources{128, 256 << 30})
-	require.Error(t, err)
+	require.Error(err)
 }
 
 func TestCgroupMissingOrInvalidPath(t *testing.T) {

--- a/scripts/test-resources/main_test.go
+++ b/scripts/test-resources/main_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cpus int
+		gib  uint64
+		want int
+	}{
+		{"small CPU budget", 8, 256, 0},
+		{"small memory budget", 128, 32, 0},
+		{"unknown memory", 128, 0, 0},
+		{"CPU limited", 32, 256, 8},
+		{"memory limited", 128, 64, 8},
+		{"large budget", 128, 256, 16},
+		{"cap very large budgets", 512, 1024, 16},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, shardBudget(resources{tc.cpus, tc.gib << 30}))
+		})
+	}
+}
+
+func TestCgroupAncestorLimits(t *testing.T) {
+	files := fstest.MapFS{
+		"parent/child/cpu.max":        {Data: []byte("max 100000\n")},
+		"parent/child/memory.max":     {Data: []byte("max\n")},
+		"parent/child/memory.high":    {Data: []byte("max\n")},
+		"parent/child/memory.current": {Data: []byte("0\n")},
+		"parent/cpu.max":              {Data: []byte("250000 100000\n")},
+		"parent/memory.max":           {Data: []byte("34359738368\n")}, // 32 GiB
+		"parent/memory.high":          {Data: []byte("17179869184\n")}, // 16 GiB
+		"parent/memory.current":       {Data: []byte("4294967296\n")},  // 4 GiB
+	}
+	got, err := limitCgroup(files, "parent/child", resources{128, 256 << 30})
+	require.NoError(t, err)
+	assert.Equal(t, resources{2, 12 << 30}, got)
+	assert.Zero(t, shardBudget(got))
+
+	// A soft memory limit can already be exceeded; subtraction must not wrap.
+	files["parent/memory.current"].Data = []byte("21474836480\n")
+	got, err = limitCgroup(files, "parent/child", resources{128, 256 << 30})
+	require.NoError(t, err)
+	assert.Zero(t, got.available)
+}
+
+func TestCgroupRootLimits(t *testing.T) {
+	// A cgroup namespace may expose its container's limits at the mount root.
+	files := fstest.MapFS{
+		"cpu.max":        {Data: []byte("6400000 100000\n")},
+		"memory.max":     {Data: []byte("137438953472\n")},
+		"memory.high":    {Data: []byte("max\n")},
+		"memory.current": {Data: []byte("68719476736\n")},
+	}
+	got, err := limitCgroup(files, ".", resources{128, 256 << 30})
+	require.NoError(t, err)
+	assert.Equal(t, resources{64, 64 << 30}, got)
+	assert.Equal(t, 8, shardBudget(got))
+	files["cpu.max"].Data = []byte("bad quota")
+	_, err = limitCgroup(files, ".", resources{128, 256 << 30})
+	require.Error(t, err)
+}
+
+func TestCgroupMissingOrInvalidPath(t *testing.T) {
+	for _, group := range []string{"missing", "../outside"} {
+		_, err := limitCgroup(fstest.MapFS{}, group, resources{128, 256 << 30})
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
`make test` now overlaps the four largest SQLite test packages with the remaining packages when at least 32 CPUs and 64 GiB of available memory are detected. Detection accounts for CPU affinity, `GOMAXPROCS`, and visible Linux cgroup limits.

The planner budgets all concurrent groups together, reserving four processes for the unsharded remainder. Each process budgets two Go execution slots and a 2 GiB memory allowance; the remaining capacity determines shard counts, capped at 16 per package. Make uses the emitted settings for both test and build concurrency. Memory allowances guide scheduling rather than enforce allocation limits.

Smaller or unknown resource budgets keep the existing schedule. `TEST_PROFILE=standard` or an explicit `TEST_SHARDS` setting disables automatic scaling. PostgreSQL targets and the explicitly split CI lanes retain their existing concurrency.
