### PR TITLE
fix(whatsapp): import Apple ChatStorage push names

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-04
+last_edited: 2026-09-07
 title: Changelog
 description: Release history for msgvault
 ---
@@ -187,6 +187,9 @@ All notable changes to msgvault, grouped by release.
 
 **Bug fixes**
 
+- WhatsApp Apple ChatStorage imports use profile push names for unnamed group
+  participants, message senders, and direct-chat participants, while preserving
+  existing contact names.
 - Incremental Gmail sync retries raw-message fetch failures from the previous
   completed incremental run, carries repeated fetch failures forward, and treats
   messages gone before replay as handled skips. Replay requires a recorded

--- a/internal/whatsapp/apple.go
+++ b/internal/whatsapp/apple.go
@@ -138,6 +138,10 @@ func (imp *Importer) importApple(
 	if err != nil {
 		return nil, fmt.Errorf("load Apple LID mapping: %w", err)
 	}
+	pushNames, err := loadApplePushNames(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("load Apple push names: %w", err)
+	}
 	duplicateStanzas, duplicateRows, err := fetchDuplicateAppleTextStanzas(ctx, db)
 	if err != nil {
 		return nil, fmt.Errorf("find duplicate Apple stanza IDs: %w", err)
@@ -170,6 +174,7 @@ func (imp *Importer) importApple(
 	}
 	totalLimit := int64(opts.Limit)
 	var totalAdded int64
+	pendingPushNames := make(map[string]string)
 
 	for _, chat := range chats {
 		if err := ctx.Err(); err != nil {
@@ -214,12 +219,18 @@ func (imp *Importer) importApple(
 				if phone == "" {
 					continue
 				}
+				legacyName := firstNonEmptyApple(member.ContactName, member.FirstName)
 				participantID, err := ensureAppleParticipant(
-					imp.store, phone, firstNonEmptyApple(member.ContactName, member.FirstName),
+					imp.store, phone, legacyName,
 					participantIDs, summary,
 				)
 				if err != nil {
 					return summary, err
+				}
+				if legacyName == "" {
+					if pushName := applePushNameFor(pushNames, member.JID); pushName != "" {
+						pendingPushNames[phone] = pushName
+					}
 				}
 				role := "member"
 				if member.IsAdmin {
@@ -293,6 +304,12 @@ func (imp *Importer) importApple(
 				if err != nil {
 					return summary, err
 				}
+				if sourceMessage.FromMe == 0 && senderPhone != "" && sourceMessage.GroupMemberJID != "" &&
+					firstNonEmptyApple(sourceMessage.GroupContact, sourceMessage.GroupFirstName) == "" {
+					if pushName := applePushNameFor(pushNames, sourceMessage.GroupMemberJID); pushName != "" {
+						pendingPushNames[senderPhone] = pushName
+					}
+				}
 				if sourceMessage.FromMe != 0 {
 					senderPhone = opts.Phone
 				}
@@ -356,6 +373,13 @@ func (imp *Importer) importApple(
 			}
 		}
 		imp.progress.OnChatComplete(canonicalChatJID, chatAdded)
+	}
+	for phone, pushName := range pendingPushNames {
+		if _, err := ensureAppleParticipant(
+			imp.store, phone, pushName, participantIDs, summary,
+		); err != nil {
+			return summary, err
+		}
 	}
 
 	if err := imp.store.RecomputeConversationStats(source.ID); err != nil {
@@ -557,6 +581,52 @@ func loadAppleLIDMap(ctx context.Context, chatDBPath string) (map[string]string,
 	return mapping, rows.Err()
 }
 
+func loadApplePushNames(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	var tableCount int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'table' AND name = 'ZWAPROFILEPUSHNAME'
+	`).Scan(&tableCount); err != nil {
+		return nil, fmt.Errorf("check ZWAPROFILEPUSHNAME availability: %w", err)
+	}
+	if tableCount == 0 {
+		return map[string]string{}, nil
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT COALESCE(ZJID, ''), COALESCE(ZPUSHNAME, '')
+		FROM ZWAPROFILEPUSHNAME
+		WHERE TRIM(COALESCE(ZJID, '')) <> ''
+		  AND TRIM(COALESCE(ZPUSHNAME, '')) <> ''
+		ORDER BY Z_PK ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query ZWAPROFILEPUSHNAME: %w", err)
+	}
+
+	mapping := make(map[string]string)
+	for rows.Next() {
+		var jid, pushName string
+		if err := rows.Scan(&jid, &pushName); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan ZWAPROFILEPUSHNAME: %w", err)
+		}
+		jid = strings.ToLower(strings.TrimSpace(jid))
+		pushName = strings.TrimSpace(pushName)
+		if _, exists := mapping[jid]; !exists {
+			mapping[jid] = pushName
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate ZWAPROFILEPUSHNAME: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close ZWAPROFILEPUSHNAME rows: %w", err)
+	}
+	return mapping, nil
+}
+
 func resolveAppleMessageSender(
 	s *store.Store,
 	message appleMessage,
@@ -709,4 +779,15 @@ func firstNonEmptyApple(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func applePushNameFor(pushNames map[string]string, jid string) string {
+	if len(pushNames) == 0 {
+		return ""
+	}
+	key := strings.ToLower(strings.TrimSpace(jid))
+	if key == "" {
+		return ""
+	}
+	return pushNames[key]
 }

--- a/internal/whatsapp/apple.go
+++ b/internal/whatsapp/apple.go
@@ -581,7 +581,10 @@ func loadAppleLIDMap(ctx context.Context, chatDBPath string) (map[string]string,
 	return mapping, rows.Err()
 }
 
-func loadApplePushNames(ctx context.Context, db *sql.DB) (map[string]string, error) {
+func loadApplePushNames(
+	ctx context.Context,
+	db *sql.DB,
+) (mapping map[string]string, retErr error) {
 	var tableCount int
 	if err := db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM sqlite_master
@@ -603,12 +606,16 @@ func loadApplePushNames(ctx context.Context, db *sql.DB) (map[string]string, err
 	if err != nil {
 		return nil, fmt.Errorf("query ZWAPROFILEPUSHNAME: %w", err)
 	}
+	defer func() {
+		if err := rows.Close(); retErr == nil && err != nil {
+			retErr = fmt.Errorf("close ZWAPROFILEPUSHNAME rows: %w", err)
+		}
+	}()
 
-	mapping := make(map[string]string)
+	mapping = make(map[string]string)
 	for rows.Next() {
 		var jid, pushName string
 		if err := rows.Scan(&jid, &pushName); err != nil {
-			_ = rows.Close()
 			return nil, fmt.Errorf("scan ZWAPROFILEPUSHNAME: %w", err)
 		}
 		jid = strings.ToLower(strings.TrimSpace(jid))
@@ -618,11 +625,7 @@ func loadApplePushNames(ctx context.Context, db *sql.DB) (map[string]string, err
 		}
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
 		return nil, fmt.Errorf("iterate ZWAPROFILEPUSHNAME: %w", err)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, fmt.Errorf("close ZWAPROFILEPUSHNAME rows: %w", err)
 	}
 	return mapping, nil
 }

--- a/internal/whatsapp/apple.go
+++ b/internal/whatsapp/apple.go
@@ -249,6 +249,11 @@ func (imp *Importer) importApple(
 			if err != nil {
 				return summary, err
 			}
+			if strings.TrimSpace(chat.Name) == "" {
+				if pushName := applePushNameFor(pushNames, chat.RawJID); pushName != "" {
+					pendingPushNames[phone] = pushName
+				}
+			}
 			if err := imp.store.EnsureConversationParticipant(
 				conversationID, participantID, "member",
 			); err != nil {

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -333,7 +333,7 @@ func TestImportApplePushNameFallbacks(t *testing.T) {
 		FROM participants
 		WHERE phone_number IN (
 			'+15555550101', '+15555550103', '+15555550105',
-			'+15555550106', '+15555550107'
+			'+15555550106', '+15555550107', '+15555550108'
 		)
 	`)
 	need.NoError(err)
@@ -349,12 +349,19 @@ func TestImportApplePushNameFallbacks(t *testing.T) {
 	check.Empty(names["+15555550105"])
 	check.Empty(names["+15555550106"])
 	check.Equal("Later Legacy", names["+15555550107"])
+	check.Empty(names["+15555550108"])
 
 	var unmatched int
 	need.NoError(st.DB().QueryRow(
 		`SELECT COUNT(*) FROM participants WHERE phone_number = '+15555550199'`,
 	).Scan(&unmatched))
 	check.Zero(unmatched)
+
+	var unresolved int
+	need.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM participants WHERE display_name = 'Ignored Unresolved LID'`,
+	).Scan(&unresolved))
+	check.Zero(unresolved)
 }
 
 func TestImportApplePushNameErrors(t *testing.T) {
@@ -518,13 +525,15 @@ func createApplePushNameFallbackFixture(t *testing.T) string {
 			(Z_PK, ZCONTACTJID, ZPARTNERNAME, ZSESSIONTYPE, ZLASTMESSAGEDATE)
 		VALUES
 			(5, '120363000000000001@g.us', 'Future Group', 1, 700000100),
-			(6, '15555550107@s.whatsapp.net', 'Later Legacy', 0, 700000050);
+			(6, '15555550107@s.whatsapp.net', 'Later Legacy', 0, 700000050),
+			(7, '15555550108@s.whatsapp.net', '', 0, 700000040);
 		INSERT INTO ZWAGROUPMEMBER
 			(Z_PK, ZCHATSESSION, ZMEMBERJID, ZCONTACTNAME, ZFIRSTNAME, ZISADMIN)
 		VALUES
 			(11, 2, '15555550105@s.whatsapp.net', '', '', 0),
 			(12, 2, '15555550106@s.whatsapp.net', '', '', 0),
-			(13, 5, '15555550107@s.whatsapp.net', '', '', 0);
+			(13, 5, '15555550107@s.whatsapp.net', '', '', 0),
+			(14, 2, '777777777777777@lid', '', '', 0);
 		CREATE TABLE ZWAPROFILEPUSHNAME (
 			Z_PK INTEGER PRIMARY KEY,
 			Z_ENT INTEGER,
@@ -539,7 +548,9 @@ func createApplePushNameFallbackFixture(t *testing.T) string {
 			(3, 1, 1, '15555550106@s.whatsapp.net', ''),
 			(4, 1, 1, '15555550107@s.whatsapp.net', 'Push Early'),
 			(5, 1, 1, '15555550101@s.whatsapp.net', 'Ignored Direct'),
-			(6, 1, 1, '15555550199@s.whatsapp.net', 'Unmatched');
+			(6, 1, 1, '15555550199@s.whatsapp.net', 'Unmatched'),
+			(7, 1, 1, '15555550108@s.whatsapp.net', 'Ignored Blank Direct'),
+			(8, 1, 1, '777777777777777@lid', 'Ignored Unresolved LID');
 	`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -300,16 +300,11 @@ func TestImportApplePushNames(t *testing.T) {
 	check.Equal("+15555550104", senderPhone)
 
 	t.Run("message_pushname_not_used", func(t *testing.T) {
-		assert := assert.New(t)
-		require := require.New(t)
-		assert.NotContains(names, "IAA=")
-		assert.NotEqual("IAA=", names["+15555550103"])
-		assert.NotEqual("IAA=", names["+15555550104"])
 		var badNameCount int
-		require.NoError(st.DB().QueryRow(
+		require.NoError(t, st.DB().QueryRow(
 			`SELECT COUNT(*) FROM participants WHERE display_name = 'IAA='`,
 		).Scan(&badNameCount))
-		assert.Zero(badNameCount)
+		assert.Zero(t, badNameCount)
 	})
 }
 
@@ -349,7 +344,7 @@ func TestImportApplePushNameFallbacks(t *testing.T) {
 	check.Empty(names["+15555550105"])
 	check.Empty(names["+15555550106"])
 	check.Equal("Later Legacy", names["+15555550107"])
-	check.Empty(names["+15555550108"])
+	check.Equal("Push Direct", names["+15555550108"])
 
 	var unmatched int
 	need.NoError(st.DB().QueryRow(
@@ -549,7 +544,7 @@ func createApplePushNameFallbackFixture(t *testing.T) string {
 			(4, 1, 1, '15555550107@s.whatsapp.net', 'Push Early'),
 			(5, 1, 1, '15555550101@s.whatsapp.net', 'Ignored Direct'),
 			(6, 1, 1, '15555550199@s.whatsapp.net', 'Unmatched'),
-			(7, 1, 1, '15555550108@s.whatsapp.net', 'Ignored Blank Direct'),
+			(7, 1, 1, '15555550108@s.whatsapp.net', 'Push Direct'),
 			(8, 1, 1, '777777777777777@lid', 'Ignored Unresolved LID');
 	`)
 	require.NoError(t, err)

--- a/internal/whatsapp/apple_test.go
+++ b/internal/whatsapp/apple_test.go
@@ -253,6 +253,148 @@ func TestAppleMappingFallbacks(t *testing.T) {
 	)
 }
 
+func TestImportApplePushNames(t *testing.T) {
+	need := require.New(t)
+	check := assert.New(t)
+
+	chatDBPath := createApplePushNameFixture(t)
+	createAppleLIDFixture(t, filepath.Dir(chatDBPath))
+
+	st := testutil.NewTestStore(t)
+	importer := NewImporter(st, nil)
+	_, err := importer.Import(context.Background(), chatDBPath, ImportOptions{
+		Phone:       "+15555550100",
+		DisplayName: "Test Owner",
+	})
+	need.NoError(err)
+
+	names := make(map[string]string)
+	rows, err := st.DB().Query(`
+		SELECT phone_number, COALESCE(display_name, '')
+		FROM participants
+		WHERE phone_number IN ('+15555550103', '+15555550104')
+	`)
+	need.NoError(err)
+	defer func() { need.NoError(rows.Close()) }()
+	for rows.Next() {
+		var phone, name string
+		need.NoError(rows.Scan(&phone, &name))
+		names[phone] = name
+	}
+	need.NoError(rows.Err())
+	check.Equal("Push Roster Only", names["+15555550103"])
+	check.Equal("Push Name Only", names["+15555550104"])
+
+	var messageCount int
+	need.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM messages`,
+	).Scan(&messageCount))
+	check.Equal(5, messageCount)
+	var senderPhone string
+	need.NoError(st.DB().QueryRow(`
+		SELECT p.phone_number
+		FROM messages m
+		JOIN participants p ON p.id = m.sender_id
+		WHERE m.source_message_id = 'push-name-only'
+	`).Scan(&senderPhone))
+	check.Equal("+15555550104", senderPhone)
+
+	t.Run("message_pushname_not_used", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		assert.NotContains(names, "IAA=")
+		assert.NotEqual("IAA=", names["+15555550103"])
+		assert.NotEqual("IAA=", names["+15555550104"])
+		var badNameCount int
+		require.NoError(st.DB().QueryRow(
+			`SELECT COUNT(*) FROM participants WHERE display_name = 'IAA='`,
+		).Scan(&badNameCount))
+		assert.Zero(badNameCount)
+	})
+}
+
+func TestImportApplePushNameFallbacks(t *testing.T) {
+	check := assert.New(t)
+	need := require.New(t)
+	chatDBPath := createApplePushNameFallbackFixture(t)
+	createAppleLIDFixture(t, filepath.Dir(chatDBPath))
+
+	st := testutil.NewTestStore(t)
+	importer := NewImporter(st, nil)
+	_, err := importer.Import(context.Background(), chatDBPath, ImportOptions{
+		Phone:       "+15555550100",
+		DisplayName: "Test Owner",
+	})
+	need.NoError(err)
+
+	names := make(map[string]string)
+	rows, err := st.DB().Query(`
+		SELECT phone_number, COALESCE(display_name, '')
+		FROM participants
+		WHERE phone_number IN (
+			'+15555550101', '+15555550103', '+15555550105',
+			'+15555550106', '+15555550107'
+		)
+	`)
+	need.NoError(err)
+	defer func() { need.NoError(rows.Close()) }()
+	for rows.Next() {
+		var phone, name string
+		need.NoError(rows.Scan(&phone, &name))
+		names[phone] = name
+	}
+	need.NoError(rows.Err())
+	check.Equal("Alice Test", names["+15555550101"])
+	check.Equal("Bob Test", names["+15555550103"])
+	check.Empty(names["+15555550105"])
+	check.Empty(names["+15555550106"])
+	check.Equal("Later Legacy", names["+15555550107"])
+
+	var unmatched int
+	need.NoError(st.DB().QueryRow(
+		`SELECT COUNT(*) FROM participants WHERE phone_number = '+15555550199'`,
+	).Scan(&unmatched))
+	check.Zero(unmatched)
+}
+
+func TestImportApplePushNameErrors(t *testing.T) {
+	t.Run("absent_profile_table", func(t *testing.T) {
+		chatDBPath := createAppleChatFixture(t)
+		createAppleLIDFixture(t, filepath.Dir(chatDBPath))
+
+		st := testutil.NewTestStore(t)
+		_, err := NewImporter(st, nil).Import(context.Background(), chatDBPath, ImportOptions{
+			Phone:       "+15555550100",
+			DisplayName: "Test Owner",
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("malformed_profile_table", func(t *testing.T) {
+		check := assert.New(t)
+		need := require.New(t)
+		chatDBPath := createAppleChatFixture(t)
+		db, err := sql.Open("sqlite3", chatDBPath)
+		need.NoError(err)
+		_, err = db.Exec(`
+			CREATE TABLE ZWAPROFILEPUSHNAME (
+				Z_PK INTEGER PRIMARY KEY,
+				ZJID TEXT
+			);
+		`)
+		need.NoError(err)
+		need.NoError(db.Close())
+
+		st := testutil.NewTestStore(t)
+		_, err = NewImporter(st, nil).Import(context.Background(), chatDBPath, ImportOptions{
+			Phone:       "+15555550100",
+			DisplayName: "Test Owner",
+		})
+		need.Error(err)
+		check.ErrorContains(err, "ZWAPROFILEPUSHNAME")
+	})
+}
+
 func createAppleChatFixture(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "ChatStorage.sqlite")
@@ -327,6 +469,81 @@ func createAppleLIDFixture(t *testing.T, dir string) {
 	`)
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
+}
+
+func createApplePushNameFixture(t *testing.T) string {
+	t.Helper()
+	path := createAppleChatFixture(t)
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		ALTER TABLE ZWAMESSAGE ADD COLUMN ZPUSHNAME TEXT;
+		UPDATE ZWAGROUPMEMBER
+		SET ZCONTACTNAME = '', ZFIRSTNAME = ''
+		WHERE Z_PK = 10;
+		INSERT INTO ZWAGROUPMEMBER
+			(Z_PK, ZCHATSESSION, ZMEMBERJID, ZCONTACTNAME, ZFIRSTNAME, ZISADMIN)
+		VALUES (11, NULL, '15555550104@s.whatsapp.net', '', '', 0);
+		INSERT INTO ZWAMESSAGE
+			(Z_PK, ZCHATSESSION, ZGROUPMEMBER, ZSTANZAID, ZISFROMME,
+			 ZMESSAGEDATE, ZTEXT, ZMESSAGETYPE, ZFROMJID, ZPUSHNAME)
+		VALUES
+			(11, 2, 11, 'push-name-only', 0, 700000011,
+			 'sender profile text', 0, '120363000000000000@g.us', 'IAA=');
+		CREATE TABLE ZWAPROFILEPUSHNAME (
+			Z_PK INTEGER PRIMARY KEY,
+			Z_ENT INTEGER,
+			Z_OPT INTEGER,
+			ZJID TEXT,
+			ZPUSHNAME TEXT
+		);
+		INSERT INTO ZWAPROFILEPUSHNAME (Z_PK, Z_ENT, Z_OPT, ZJID, ZPUSHNAME)
+		VALUES
+			(1, 1, 1, '888888888888888@lid', 'Push Roster Only'),
+			(2, 1, 1, '15555550104@s.whatsapp.net', 'Push Name Only'),
+			(3, 1, 1, '888888888888888@lid', 'Later Roster Name');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return path
+}
+
+func createApplePushNameFallbackFixture(t *testing.T) string {
+	t.Helper()
+	path := createAppleChatFixture(t)
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO ZWACHATSESSION
+			(Z_PK, ZCONTACTJID, ZPARTNERNAME, ZSESSIONTYPE, ZLASTMESSAGEDATE)
+		VALUES
+			(5, '120363000000000001@g.us', 'Future Group', 1, 700000100),
+			(6, '15555550107@s.whatsapp.net', 'Later Legacy', 0, 700000050);
+		INSERT INTO ZWAGROUPMEMBER
+			(Z_PK, ZCHATSESSION, ZMEMBERJID, ZCONTACTNAME, ZFIRSTNAME, ZISADMIN)
+		VALUES
+			(11, 2, '15555550105@s.whatsapp.net', '', '', 0),
+			(12, 2, '15555550106@s.whatsapp.net', '', '', 0),
+			(13, 5, '15555550107@s.whatsapp.net', '', '', 0);
+		CREATE TABLE ZWAPROFILEPUSHNAME (
+			Z_PK INTEGER PRIMARY KEY,
+			Z_ENT INTEGER,
+			Z_OPT INTEGER,
+			ZJID TEXT,
+			ZPUSHNAME TEXT
+		);
+		INSERT INTO ZWAPROFILEPUSHNAME (Z_PK, Z_ENT, Z_OPT, ZJID, ZPUSHNAME)
+		VALUES
+			(1, 1, 1, '888888888888888@lid', 'Profile Bob'),
+			(2, 1, 1, '15555550105@s.whatsapp.net', '   '),
+			(3, 1, 1, '15555550106@s.whatsapp.net', ''),
+			(4, 1, 1, '15555550107@s.whatsapp.net', 'Push Early'),
+			(5, 1, 1, '15555550101@s.whatsapp.net', 'Ignored Direct'),
+			(6, 1, 1, '15555550199@s.whatsapp.net', 'Unmatched');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return path
 }
 
 func assertStoreCount(t *testing.T, db *sql.DB, table string, want int) {


### PR DESCRIPTION
Apple ChatStorage imports now use `ZWAPROFILEPUSHNAME` to fill missing display names for group participants, message senders, and direct-chat participants. Contact names, first names, and direct-chat partner names retain priority.

The profile table is optional, and unmatched names remain unknown. A present table with an unreadable schema remains an import error. The importer does not use `ZWAMESSAGE.ZPUSHNAME`, which contains encoded message data.

The schema and empty-column report came from dimatosj in #747. Regression fixtures cover the reported shape; compatibility remains unverified against a real WhatsApp-produced ChatStorage.sqlite export on macOS.

Closes #747
