### PR TITLE
fix(people): expose stale provider consent and add reverify

### DIFF
--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -343,7 +343,7 @@ func newPersonProviderReverifyCommand(deps personProviderCommandDeps) *cobra.Com
 			if !deps.isDaemonSubprocess() {
 				return deps.proxy(command, args, nil)
 			}
-			runDeps, err := personProviderDepsForName(deps, args[0], false)
+			runDeps, err := personProviderDepsForName(deps, args[0])
 			if err != nil {
 				return err
 			}
@@ -390,7 +390,7 @@ func newPersonProviderStatusCommand(deps personProviderCommandDeps) *cobra.Comma
 					return errors.New("a named people provider cannot be combined with --all or --semantic-embeddings")
 				}
 				var err error
-				runDeps, err = personProviderDepsForName(deps, args[0], false)
+				runDeps, err = personProviderDepsForName(deps, args[0])
 				if err != nil {
 					return err
 				}
@@ -989,7 +989,7 @@ func newPersonProviderConsentCommand(deps personProviderCommandDeps) *cobra.Comm
 					return errors.New("a named people provider cannot be combined with --semantic-embeddings")
 				}
 				var err error
-				runDeps, err = personProviderDepsForName(deps, args[0], false)
+				runDeps, err = personProviderDepsForName(deps, args[0])
 				if err != nil {
 					return err
 				}
@@ -1040,7 +1040,7 @@ func newPersonProviderRevokeCommand(deps personProviderCommandDeps) *cobra.Comma
 					return errors.New("a named people provider cannot be combined with --all or --semantic-embeddings")
 				}
 				var err error
-				runDeps, err = personProviderDepsForName(deps, args[0], false)
+				runDeps, err = personProviderDepsForName(deps, args[0])
 				if err != nil {
 					return err
 				}
@@ -1678,18 +1678,12 @@ func selectPersonProviderConfig(config peoplesweep.Config, name string) (peoples
 func personProviderDepsForName(
 	deps personProviderCommandDeps,
 	name string,
-	requireEnabled bool,
 ) (personProviderCommandDeps, error) {
 	selected, err := selectPersonProviderConfig(deps.config(), name)
 	if err != nil {
 		return personProviderCommandDeps{}, err
 	}
-	if requireEnabled && !selected.Enabled {
-		return personProviderCommandDeps{}, errors.New("people sweep provider is disabled")
-	}
-	if !requireEnabled {
-		selected.Enabled = true
-	}
+	selected.Enabled = true
 	deps.config = func() peoplesweep.Config { return selected }
 	return deps, nil
 }

--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -83,10 +84,12 @@ type personProviderCommandDeps struct {
 }
 
 type personProviderStatusOutput struct {
-	Profile        peoplesweep.ProviderProfile         `json:"profile"`
-	Check          *store.PersonInferenceCheck         `json:"check,omitempty"`
-	Consent        store.PersonInferenceConsentStatus  `json:"consent"`
-	CodexIsolation *personProviderCodexIsolationStatus `json:"codex_isolation,omitempty"`
+	Profile             peoplesweep.ProviderProfile         `json:"profile"`
+	Check               *store.PersonInferenceCheck         `json:"check,omitempty"`
+	Consent             store.PersonInferenceConsentStatus  `json:"consent"`
+	StaleProgramCheck   bool                                `json:"stale_program_check,omitempty"`
+	StaleProgramConsent bool                                `json:"stale_program_consent,omitempty"`
+	CodexIsolation      *personProviderCodexIsolationStatus `json:"codex_isolation,omitempty"`
 }
 
 type personProviderUseOutput struct {
@@ -319,6 +322,7 @@ func newPersonProviderCommand(deps personProviderCommandDeps) *cobra.Command {
 		newPersonProviderUseCommand(deps),
 		newPersonProviderStatusCommand(deps),
 		newPersonProviderConsentCommand(deps),
+		newPersonProviderReverifyCommand(deps),
 		newPersonProviderRevokeCommand(deps),
 		newPersonProviderHistoryCommand(deps),
 		newPersonProviderCheckCommand(deps),
@@ -326,6 +330,29 @@ func newPersonProviderCommand(deps personProviderCommandDeps) *cobra.Command {
 		newPersonProviderModelsCommand(deps),
 	)
 	return provider
+}
+
+func newPersonProviderReverifyCommand(deps personProviderCommandDeps) *cobra.Command {
+	var confirmed bool
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:   "reverify <name>",
+		Short: "Re-run the exact provider check and consent",
+		Args:  exactPersonProviderNameArgs,
+		RunE: func(command *cobra.Command, args []string) error {
+			if !deps.isDaemonSubprocess() {
+				return deps.proxy(command, args, nil)
+			}
+			runDeps, err := personProviderDepsForName(deps, args[0], false)
+			if err != nil {
+				return err
+			}
+			return runPersonProviderReverify(command, runDeps, confirmed, jsonOutput)
+		},
+	}
+	command.Flags().BoolVar(&confirmed, "yes", false, "Confirm the disclosed provider policy")
+	command.Flags().BoolVar(&jsonOutput, flagJSON, false, "Output structured JSON")
+	return command
 }
 
 func exactPersonProviderNameArgs(command *cobra.Command, args []string) error {
@@ -1241,6 +1268,12 @@ func runPersonProviderStatus(
 		return err
 	}
 	output.CodexIsolation = codexIsolation
+	output.StaleProgramCheck, output.StaleProgramConsent, err = personProviderStaleProgramState(
+		command.Context(), st, profile, output,
+	)
+	if err != nil {
+		return err
+	}
 	return writePersonProviderStatus(command.OutOrStdout(), output, jsonOutput)
 }
 
@@ -1525,6 +1558,44 @@ func runPersonProviderCheck(
 	return writePersonProviderCheckOutput(command.OutOrStdout(), output, jsonOutput)
 }
 
+func runPersonProviderReverify(
+	command *cobra.Command,
+	deps personProviderCommandDeps,
+	confirmed bool,
+	jsonOutput bool,
+) error {
+	profile, err := deps.config().Profile()
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		printPersonProviderDisclosure(command.OutOrStdout(), profile)
+		return errors.New("people inference reverify requires --yes after reviewing the provider disclosure")
+	}
+	if _, err := checkPersonProvider(command, deps, ""); err != nil {
+		return err
+	}
+	st, cleanup, err := deps.openStore()
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if _, _, err := st.GrantPersonInferenceConsent(
+		command.Context(), profile.Fingerprint, personProviderConsentActor,
+	); err != nil {
+		return err
+	}
+	if jsonOutput {
+		output, err := personProviderStatusFor(command.Context(), st, profile)
+		if err != nil {
+			return err
+		}
+		return writePersonProviderStatus(command.OutOrStdout(), output, true)
+	}
+	_, _ = fmt.Fprintf(command.OutOrStdout(), "People inference provider reverified (fingerprint=%s).\n", profile.Fingerprint)
+	return nil
+}
+
 // checkPersonProvider runs the synthetic capability check for one exact
 // profile and records it. It performs no consent grant.
 func checkPersonProvider(
@@ -1768,6 +1839,58 @@ func personProviderStatusFor(
 	return personProviderStatusOutput{Profile: profile, Check: check, Consent: *status}, nil
 }
 
+func personProviderStaleProgramState(
+	ctx context.Context,
+	st personProviderStore,
+	current peoplesweep.ProviderProfile,
+	status personProviderStatusOutput,
+) (bool, bool, error) {
+	profiles, err := st.ListPersonInferenceProfiles(ctx)
+	if err != nil {
+		return false, false, err
+	}
+	staleCheck, staleConsent := false, false
+	for _, historical := range profiles {
+		if historical.ProgramFingerprint == current.ProgramFingerprint ||
+			historical.Fingerprint == current.Fingerprint ||
+			!samePersonProviderPolicyExceptProgram(current, historical) {
+			continue
+		}
+		historicalCheck, err := st.GetPersonInferenceCheck(ctx, historical.Fingerprint)
+		if err != nil {
+			return false, false, err
+		}
+		historicalConsent, err := st.GetPersonInferenceConsentStatus(ctx, historical.Fingerprint)
+		if err != nil {
+			return false, false, err
+		}
+		if historicalCheck != nil && status.Check == nil {
+			staleCheck = true
+		}
+		if historicalConsent != nil && historicalConsent.Active && !status.Consent.Active {
+			staleConsent = true
+		}
+	}
+	return staleCheck, staleConsent, nil
+}
+
+func samePersonProviderPolicyExceptProgram(
+	left, right peoplesweep.ProviderProfile,
+) bool {
+	leftValue, rightValue := reflect.ValueOf(left), reflect.ValueOf(right)
+	typeOfProfile := leftValue.Type()
+	for index := range typeOfProfile.NumField() {
+		name := typeOfProfile.Field(index).Name
+		if name == "Fingerprint" || name == "PolicyJSON" || name == "ProgramFingerprint" {
+			continue
+		}
+		if !reflect.DeepEqual(leftValue.Field(index).Interface(), rightValue.Field(index).Interface()) {
+			return false
+		}
+	}
+	return true
+}
+
 func writePersonProviderStatus(
 	w io.Writer,
 	output personProviderStatusOutput,
@@ -1783,6 +1906,9 @@ func writePersonProviderStatus(
 		_, _ = fmt.Fprintf(w, "Check: %s (model_version=%s)\n",
 			output.Check.CheckedAt.Format(time.RFC3339), output.Check.ModelVersion)
 	}
+	if output.StaleProgramCheck {
+		_, _ = fmt.Fprintln(w, "Check: a matching record uses an earlier extraction program; run msgvault person provider reverify <name> --yes")
+	}
 	state := "inactive"
 	if output.Consent.Active {
 		state = "active"
@@ -1790,6 +1916,9 @@ func writePersonProviderStatus(
 		state = "revoked"
 	}
 	_, _ = fmt.Fprintf(w, "Consent: %s\n", state)
+	if output.StaleProgramConsent {
+		_, _ = fmt.Fprintln(w, "Consent: a matching grant uses an earlier extraction program; run msgvault person provider reverify <name> --yes")
+	}
 	if output.CodexIsolation != nil {
 		availability := "unavailable"
 		if output.CodexIsolation.Available {

--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -1907,7 +1907,7 @@ func writePersonProviderStatus(
 			output.Check.CheckedAt.Format(time.RFC3339), output.Check.ModelVersion)
 	}
 	if output.StaleProgramCheck {
-		_, _ = fmt.Fprintln(w, "Check: a matching record uses an earlier extraction program; run msgvault person provider reverify <name> --yes")
+		_, _ = fmt.Fprintln(w, "Check: a matching record uses a different extraction program; run msgvault person provider reverify <name> --yes")
 	}
 	state := "inactive"
 	if output.Consent.Active {
@@ -1917,7 +1917,7 @@ func writePersonProviderStatus(
 	}
 	_, _ = fmt.Fprintf(w, "Consent: %s\n", state)
 	if output.StaleProgramConsent {
-		_, _ = fmt.Fprintln(w, "Consent: a matching grant uses an earlier extraction program; run msgvault person provider reverify <name> --yes")
+		_, _ = fmt.Fprintln(w, "Consent: a matching grant uses a different extraction program; run msgvault person provider reverify <name> --yes")
 	}
 	if output.CodexIsolation != nil {
 		availability := "unavailable"

--- a/cmd/msgvault/cmd/person_provider.go
+++ b/cmd/msgvault/cmd/person_provider.go
@@ -84,6 +84,7 @@ type personProviderCommandDeps struct {
 }
 
 type personProviderStatusOutput struct {
+	Name                string                              `json:"name,omitempty"`
 	Profile             peoplesweep.ProviderProfile         `json:"profile"`
 	Check               *store.PersonInferenceCheck         `json:"check,omitempty"`
 	Consent             store.PersonInferenceConsentStatus  `json:"consent"`
@@ -336,16 +337,20 @@ func newPersonProviderReverifyCommand(deps personProviderCommandDeps) *cobra.Com
 	var confirmed bool
 	var jsonOutput bool
 	command := &cobra.Command{
-		Use:   "reverify <name>",
+		Use:   "reverify [name]",
 		Short: "Re-run the exact provider check and consent",
-		Args:  exactPersonProviderNameArgs,
+		Args:  optionalPersonProviderNameArgs,
 		RunE: func(command *cobra.Command, args []string) error {
 			if !deps.isDaemonSubprocess() {
 				return deps.proxy(command, args, nil)
 			}
-			runDeps, err := personProviderDepsForName(deps, args[0])
-			if err != nil {
-				return err
+			runDeps := deps
+			if len(args) == 1 {
+				var err error
+				runDeps, err = personProviderDepsForName(deps, args[0])
+				if err != nil {
+					return err
+				}
 			}
 			return runPersonProviderReverify(command, runDeps, confirmed, jsonOutput)
 		},
@@ -1219,11 +1224,13 @@ func runPersonProviderStatus(
 		return runPersonSemanticProviderStatus(command, deps, all, jsonOutput)
 	}
 	var codexIsolation *personProviderCodexIsolationStatus
+	var profileName string
 	if !all {
-		_, provider, err := deps.config().ActiveProviderConfig()
+		name, provider, err := deps.config().ActiveProviderConfig()
 		if err != nil {
 			return err
 		}
+		profileName = name
 		if provider.Protocol == peoplesweep.ProtocolCodexAppServer {
 			boundary := provider.ExecutionBoundary
 			_, err := currentPersonProviderCodexClient(deps)
@@ -1267,6 +1274,7 @@ func runPersonProviderStatus(
 	if err != nil {
 		return err
 	}
+	output.Name = profileName
 	output.CodexIsolation = codexIsolation
 	output.StaleProgramCheck, output.StaleProgramConsent, err = personProviderStaleProgramState(
 		command.Context(), st, profile, output,
@@ -1592,6 +1600,7 @@ func runPersonProviderReverify(
 		}
 		return writePersonProviderStatus(command.OutOrStdout(), output, true)
 	}
+	printPersonProviderDisclosure(command.OutOrStdout(), profile)
 	_, _ = fmt.Fprintf(command.OutOrStdout(), "People inference provider reverified (fingerprint=%s).\n", profile.Fingerprint)
 	return nil
 }
@@ -1901,7 +1910,7 @@ func writePersonProviderStatus(
 			output.Check.CheckedAt.Format(time.RFC3339), output.Check.ModelVersion)
 	}
 	if output.StaleProgramCheck {
-		_, _ = fmt.Fprintln(w, "Check: a matching record uses a different extraction program; run msgvault person provider reverify <name> --yes")
+		_, _ = fmt.Fprintf(w, "Check: a matching record uses a different extraction program; run msgvault person provider reverify %s --yes\n", output.Name)
 	}
 	state := "inactive"
 	if output.Consent.Active {
@@ -1911,7 +1920,7 @@ func writePersonProviderStatus(
 	}
 	_, _ = fmt.Fprintf(w, "Consent: %s\n", state)
 	if output.StaleProgramConsent {
-		_, _ = fmt.Fprintln(w, "Consent: a matching grant uses a different extraction program; run msgvault person provider reverify <name> --yes")
+		_, _ = fmt.Fprintf(w, "Consent: a matching grant uses a different extraction program; run msgvault person provider reverify %s --yes\n", output.Name)
 	}
 	if output.CodexIsolation != nil {
 		availability := "unavailable"

--- a/cmd/msgvault/cmd/person_provider_daemon_test.go
+++ b/cmd/msgvault/cmd/person_provider_daemon_test.go
@@ -244,6 +244,9 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	_, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes")
 	require.NoError(err)
 	captured := <-requests
+	consentOutput, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
+	require.NoError(err)
+	assert.Contains(consentOutput, `"active":true`)
 	output, err := executePersonProviderCommand(t, deps, "check", "--json")
 	require.NoError(err)
 	assert.JSONEq(`{

--- a/cmd/msgvault/cmd/person_provider_daemon_test.go
+++ b/cmd/msgvault/cmd/person_provider_daemon_test.go
@@ -241,8 +241,10 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	t.Setenv("TEST_PROVIDER_KEY", environmentSecretCanary)
 	deps := defaultPersonProviderCommandDeps()
 
-	_, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes")
+	reverifyOutput, err := executePersonProviderCommand(t, deps, "reverify", "--yes")
 	require.NoError(err)
+	assert.Contains(reverifyOutput, "People inference provider disclosure")
+	assert.Contains(reverifyOutput, provider.URL+"/v1")
 	captured := <-requests
 	consentOutput, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
 	require.NoError(err)
@@ -266,7 +268,7 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	require.True(ok)
 	assert.Equal("Return an object with ok set to true.", message["content"])
 	assert.NotContains(string(mustJSON(t, captured.Body)), "archive")
-	for range 2 {
+	for range 3 {
 		req := <-requestsToDaemon
 		wire := mustJSON(t, req)
 		assert.Empty(req.Env)

--- a/cmd/msgvault/cmd/person_provider_daemon_test.go
+++ b/cmd/msgvault/cmd/person_provider_daemon_test.go
@@ -275,7 +275,7 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	}
 	assert.NotContains(output, environmentSecretCanary)
 	assert.NotContains(daemonLogs.String(), environmentSecretCanary)
-	_ = <-requests
+	<-requests
 
 	_, err = executePersonProviderCommand(t, deps, "revoke", "--json")
 	require.NoError(err)

--- a/cmd/msgvault/cmd/person_provider_daemon_test.go
+++ b/cmd/msgvault/cmd/person_provider_daemon_test.go
@@ -241,8 +241,9 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	t.Setenv("TEST_PROVIDER_KEY", environmentSecretCanary)
 	deps := defaultPersonProviderCommandDeps()
 
-	_, err := executePersonProviderCommand(t, deps, "consent", "--yes", "--json")
+	_, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes")
 	require.NoError(err)
+	captured := <-requests
 	output, err := executePersonProviderCommand(t, deps, "check", "--json")
 	require.NoError(err)
 	assert.JSONEq(`{
@@ -252,7 +253,6 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 		"usage":{"input_tokens":9,"output_tokens":2}
 	}`, output)
 
-	captured := <-requests
 	assert.Equal("Bearer "+environmentSecretCanary, captured.Authorization)
 	assert.Equal("/v1/chat/completions", captured.Path)
 	assert.Equal("test-model", captured.Body["model"])
@@ -272,6 +272,7 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 	}
 	assert.NotContains(output, environmentSecretCanary)
 	assert.NotContains(daemonLogs.String(), environmentSecretCanary)
+	_ = <-requests
 
 	_, err = executePersonProviderCommand(t, deps, "revoke", "--json")
 	require.NoError(err)
@@ -283,7 +284,7 @@ func TestPersonProviderRealDaemonSyntheticCheckAndRevoke(t *testing.T) {
 		"model":"test-model",
 		"usage":{"input_tokens":9,"output_tokens":2}
 	}`, output)
-	assert.Equal(int64(2), requestCount.Load(), "synthetic checks bypass archive consent")
+	assert.Equal(int64(3), requestCount.Load(), "synthetic checks bypass archive consent")
 }
 
 func TestPersonProviderStoredCheckKeepsSecretOutOfDaemonMetadata(t *testing.T) {

--- a/cmd/msgvault/cmd/person_provider_routing_test.go
+++ b/cmd/msgvault/cmd/person_provider_routing_test.go
@@ -71,6 +71,8 @@ func TestPersonProviderFrontendRoutesExactCommandsAndCredential(t *testing.T) {
 			wantArgs: []string{"person", "provider", "consent", "--semantic-embeddings", "--yes"}},
 		{name: "check", args: []string{"check", "--json"},
 			wantArgs: []string{"person", "provider", "check", "--json"}},
+		{name: "reverify", args: []string{"reverify", "default", "--yes", "--json"},
+			wantArgs: []string{"person", "provider", "reverify", "--json", "--yes", "default"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -142,6 +143,19 @@ func historicalPersonProviderProfile(
 	withCheck bool,
 	withActiveConsent bool,
 ) peoplesweep.ProviderProfile {
+	return historicalPersonProviderProfileWithMutation(
+		t, st, profile, "", nil, withCheck, withActiveConsent)
+}
+
+func historicalPersonProviderProfileWithMutation(
+	t *testing.T,
+	st *store.Store,
+	profile peoplesweep.ProviderProfile,
+	oldProgram string,
+	mutate func(*peoplesweep.ProviderProfile),
+	withCheck bool,
+	withActiveConsent bool,
+) peoplesweep.ProviderProfile {
 	t.Helper()
 	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
 	require.NoError(t, err)
@@ -157,11 +171,23 @@ func historicalPersonProviderProfile(
 		require.NoError(t, err)
 	}
 	historical := profile
-	historical.ProgramFingerprint = strings.Repeat("a", len(profile.ProgramFingerprint))
-	historical.PolicyJSON = bytes.Replace(
-		profile.PolicyJSON, []byte(profile.ProgramFingerprint), []byte(historical.ProgramFingerprint), 1)
+	if mutate != nil {
+		mutate(&historical)
+	}
+	historical.PolicyJSON = testProviderPolicyJSON(t, historical)
+	variantFingerprintDigest := sha256.Sum256(historical.PolicyJSON)
+	historical.Fingerprint = hex.EncodeToString(variantFingerprintDigest[:])
+	if oldProgram == "" {
+		oldProgram = strings.Repeat("a", len(profile.ProgramFingerprint))
+	}
+	historical.ProgramFingerprint = oldProgram
+	historical.PolicyJSON = testProviderPolicyJSON(t, historical)
 	digest := sha256.Sum256(historical.PolicyJSON)
 	historical.Fingerprint = hex.EncodeToString(digest[:])
+	allowedSources, err := json.Marshal(historical.AllowedSources)
+	require.NoError(t, err)
+	disclosedFields, err := json.Marshal(historical.DisclosedPacketFields)
+	require.NoError(t, err)
 	if withCheck {
 		_, err = st.DB().Exec(st.Rebind(`
 			DELETE FROM person_inference_checks WHERE profile_fingerprint = ?`), profile.Fingerprint)
@@ -174,9 +200,25 @@ func historicalPersonProviderProfile(
 	}
 	_, err = st.DB().Exec(st.Rebind(`
 		UPDATE person_inference_profiles
-		SET fingerprint = ?, program_fingerprint = ?, policy_json = ?
-		WHERE fingerprint = ?`), historical.Fingerprint, historical.ProgramFingerprint,
-		string(historical.PolicyJSON), profile.Fingerprint)
+		SET fingerprint = ?, provider_kind = ?, endpoint = ?, model = ?,
+			api_key_env = ?, allow_anonymous = ?, auth_scheme = ?,
+			credential_source = ?, credential_ref = ?, output_mode = ?,
+			token_limit_parameter = ?, reasoning_effort = ?, reasoning_mode = ?,
+			driver_version = ?, retention_posture = ?, training_posture = ?,
+			allowed_sources = ?, source_since = ?, source_until = NULLIF(?, ''),
+			allow_sensitive = ?, execution_boundary = ?, packet_renderer_policy = ?,
+			program_fingerprint = ?, disclosed_packet_fields = ?, policy_json = ?
+		WHERE fingerprint = ?`), historical.Fingerprint, string(historical.Protocol),
+		historical.Endpoint, historical.Model, historical.CredentialRef,
+		historical.Auth == peoplesweep.AuthNone, string(historical.Auth),
+		string(historical.Credential), historical.CredentialRef,
+		string(historical.OutputMode), historical.TokenLimitParameter,
+		historical.ReasoningEffort, historical.ReasoningMode, historical.DriverVersion,
+		historical.RetentionPosture, historical.TrainingPosture, string(allowedSources),
+		historical.SourceSince, historical.SourceUntil, historical.AllowSensitive,
+		historical.ExecutionBoundary, historical.PacketRendererPolicy,
+		historical.ProgramFingerprint, string(disclosedFields), string(historical.PolicyJSON),
+		profile.Fingerprint)
 	require.NoError(t, err)
 	if withCheck {
 		_, err = st.DB().Exec(st.Rebind(`
@@ -193,6 +235,33 @@ func historicalPersonProviderProfile(
 		require.NoError(t, err)
 	}
 	return historical
+}
+
+func testProviderPolicyJSON(
+	t *testing.T,
+	profile peoplesweep.ProviderProfile,
+) json.RawMessage {
+	t.Helper()
+	typeOfProfile := reflect.TypeOf(profile)
+	value := reflect.ValueOf(profile)
+	fields := make([]reflect.StructField, 0, value.NumField()-2)
+	values := make([]reflect.Value, 0, value.NumField()-2)
+	for index := range value.NumField() {
+		field := typeOfProfile.Field(index)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "fingerprint" || name == "" || name == "-" {
+			continue
+		}
+		fields = append(fields, field)
+		values = append(values, value.Field(index))
+	}
+	policy := reflect.New(reflect.StructOf(fields)).Elem()
+	for index, fieldValue := range values {
+		policy.Field(index).Set(fieldValue)
+	}
+	encoded, err := json.Marshal(policy.Interface())
+	require.NoError(t, err)
+	return encoded
 }
 
 func semanticPersonProviderTestConfig() vector.Config {
@@ -319,7 +388,7 @@ func TestPersonProviderStatusReportsStaleProgram(t *testing.T) {
 
 	human, err := executePersonProviderCommand(t, deps, "status", "default")
 	require.NoError(err)
-	assert.Contains(human, "earlier extraction program")
+	assert.Contains(human, "different extraction program")
 	assert.Contains(human, "msgvault person provider reverify <name> --yes")
 	jsonOutput, err := executePersonProviderCommand(t, deps, "status", "default", "--json")
 	require.NoError(err)
@@ -371,6 +440,64 @@ func TestPersonProviderStatusStaleProgramNegativeSpace(t *testing.T) {
 	require.NoError(err)
 	assert.NotContains(output, "stale_program_check")
 	assert.NotContains(output, "stale_program_consent")
+
+	for _, test := range []struct {
+		name   string
+		mutate func(*peoplesweep.ProviderProfile)
+	}{
+		{name: "endpoint", mutate: func(profile *peoplesweep.ProviderProfile) {
+			profile.Endpoint = "https://changed.example/v1"
+		}},
+		{name: "source scope", mutate: func(profile *peoplesweep.ProviderProfile) {
+			profile.AllowedSources = []peoplesweep.SourceClass{peoplesweep.SourceConversationText}
+		}},
+		{name: "renderer", mutate: func(profile *peoplesweep.ProviderProfile) {
+			profile.PacketRendererPolicy = "changed-renderer"
+		}},
+		{name: "disclosed fields", mutate: func(profile *peoplesweep.ProviderProfile) {
+			profile.DisclosedPacketFields = []string{"person_id"}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			st := testutil.NewSQLiteTestStore(t)
+			current, err := personProviderTestConfig().Profile()
+			require.NoError(err)
+			historicalPersonProviderProfileWithMutation(
+				t, st, current, "", test.mutate, true, true)
+			deps := localPersonProviderDeps(personProviderTestConfig(), st, nil)
+			output, err := executePersonProviderCommand(t, deps, "status", "default", "--json")
+			require.NoError(err)
+			assert.NotContains(output, "stale_program_check")
+			assert.NotContains(output, "stale_program_consent")
+		})
+	}
+
+	st = testutil.NewSQLiteTestStore(t)
+	current, err = personProviderTestConfig().Profile()
+	require.NoError(err)
+	historical := historicalPersonProviderProfile(t, st, current, true, true)
+	_, err = st.RevokePersonInferenceConsent(t.Context(), historical.Fingerprint, "cli")
+	require.NoError(err)
+	deps = localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err = executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	var revoked map[string]any
+	require.NoError(json.Unmarshal([]byte(output), &revoked))
+	assert.Equal(true, revoked["stale_program_check"])
+	assert.NotContains(output, "stale_program_consent")
+
+	st = testutil.NewSQLiteTestStore(t)
+	current, err = personProviderTestConfig().Profile()
+	require.NoError(err)
+	historicalPersonProviderProfileWithMutation(
+		t, st, current, strings.Repeat("a", len(current.ProgramFingerprint)), nil, true, true)
+	historicalPersonProviderProfileWithMutation(
+		t, st, current, strings.Repeat("b", len(current.ProgramFingerprint)), nil, true, true)
+	deps = localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err = executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	assert.Contains(output, `"stale_program_check":true`)
+	assert.Contains(output, `"stale_program_consent":true`)
 }
 
 func TestPersonProviderReverifyRequiresConfirmation(t *testing.T) {

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -189,9 +189,6 @@ func historicalPersonProviderProfileWithMutation(
 	if mutate != nil {
 		mutate(&historical)
 	}
-	historical.PolicyJSON = testProviderPolicyJSON(t, historical)
-	variantFingerprintDigest := sha256.Sum256(historical.PolicyJSON)
-	historical.Fingerprint = hex.EncodeToString(variantFingerprintDigest[:])
 	if oldProgram == "" {
 		oldProgram = strings.Repeat("a", len(profile.ProgramFingerprint))
 	}
@@ -401,14 +398,15 @@ func TestPersonProviderStatusReportsStaleProgram(t *testing.T) {
 	historicalPersonProviderProfile(t, st, current, true, true)
 	deps := localPersonProviderDeps(config, st, nil)
 
-	human, err := executePersonProviderCommand(t, deps, "status", "default")
+	human, err := executePersonProviderCommand(t, deps, "status")
 	require.NoError(err)
 	assert.Contains(human, "different extraction program")
-	assert.Contains(human, "msgvault person provider reverify <name> --yes")
-	jsonOutput, err := executePersonProviderCommand(t, deps, "status", "default", "--json")
+	assert.Contains(human, "msgvault person provider reverify default --yes")
+	jsonOutput, err := executePersonProviderCommand(t, deps, "status", "--json")
 	require.NoError(err)
 	var got map[string]any
 	require.NoError(json.Unmarshal([]byte(jsonOutput), &got))
+	assert.Equal("default", got["name"])
 	assert.Equal(true, got["stale_program_check"])
 	assert.Equal(true, got["stale_program_consent"])
 }
@@ -596,7 +594,7 @@ func TestPersonProviderReverifyRunsCheckThenGrantsExactConsent(t *testing.T) {
 		ProviderVersion: profile.DriverVersion, ModelVersion: "current-model-v1",
 	}}
 	deps := localPersonProviderDeps(config, st, checker)
-	output, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes", "--json")
+	output, err := executePersonProviderCommand(t, deps, "reverify", "--yes", "--json")
 	require.NoError(err)
 	var status personProviderStatusOutput
 	require.NoError(json.Unmarshal([]byte(output), &status))

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -133,6 +135,66 @@ func localPersonProviderDeps(
 	}
 }
 
+func historicalPersonProviderProfile(
+	t *testing.T,
+	st *store.Store,
+	profile peoplesweep.ProviderProfile,
+	withCheck bool,
+	withActiveConsent bool,
+) peoplesweep.ProviderProfile {
+	t.Helper()
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(t, err)
+	if withCheck {
+		require.NoError(t, st.RecordPersonInferenceCheck(t.Context(), store.PersonInferenceCheck{
+			ProfileFingerprint: profile.Fingerprint, CheckedAt: time.Now().UTC(),
+			DriverVersion: profile.DriverVersion, OutputMode: profile.OutputMode,
+			ModelVersion: "historical-model-v1",
+		}))
+	}
+	if withActiveConsent {
+		_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+		require.NoError(t, err)
+	}
+	historical := profile
+	historical.ProgramFingerprint = strings.Repeat("a", len(profile.ProgramFingerprint))
+	historical.PolicyJSON = bytes.Replace(
+		profile.PolicyJSON, []byte(profile.ProgramFingerprint), []byte(historical.ProgramFingerprint), 1)
+	digest := sha256.Sum256(historical.PolicyJSON)
+	historical.Fingerprint = hex.EncodeToString(digest[:])
+	if withCheck {
+		_, err = st.DB().Exec(st.Rebind(`
+			DELETE FROM person_inference_checks WHERE profile_fingerprint = ?`), profile.Fingerprint)
+		require.NoError(t, err)
+	}
+	if withActiveConsent {
+		_, err = st.DB().Exec(st.Rebind(`
+			DELETE FROM person_inference_consents WHERE profile_fingerprint = ?`), profile.Fingerprint)
+		require.NoError(t, err)
+	}
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_profiles
+		SET fingerprint = ?, program_fingerprint = ?, policy_json = ?
+		WHERE fingerprint = ?`), historical.Fingerprint, historical.ProgramFingerprint,
+		string(historical.PolicyJSON), profile.Fingerprint)
+	require.NoError(t, err)
+	if withCheck {
+		_, err = st.DB().Exec(st.Rebind(`
+			INSERT INTO person_inference_checks
+				(profile_fingerprint, checked_at, driver_version, output_mode, model_version)
+			VALUES (?, CURRENT_TIMESTAMP, ?, ?, ?)`), historical.Fingerprint,
+			historical.DriverVersion, historical.OutputMode, "historical-model-v1")
+		require.NoError(t, err)
+	}
+	if withActiveConsent {
+		_, err = st.DB().Exec(st.Rebind(`
+			INSERT INTO person_inference_consents (profile_fingerprint, granted_by)
+			VALUES (?, ?)`), historical.Fingerprint, "cli")
+		require.NoError(t, err)
+	}
+	return historical
+}
+
 func semanticPersonProviderTestConfig() vector.Config {
 	return vector.Config{
 		Enabled: true,
@@ -243,6 +305,179 @@ func TestPersonProviderStatusReportsExactPolicyWithoutMutation(t *testing.T) {
 	assert.Equal(profile.Fingerprint, got.Profile.Fingerprint)
 	assert.False(got.Consent.Active)
 	assert.False(got.Consent.ProfileExists)
+}
+
+func TestPersonProviderStatusReportsStaleProgram(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	current, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	historicalPersonProviderProfile(t, st, current, true, true)
+	deps := localPersonProviderDeps(config, st, nil)
+
+	human, err := executePersonProviderCommand(t, deps, "status", "default")
+	require.NoError(err)
+	assert.Contains(human, "earlier extraction program")
+	assert.Contains(human, "msgvault person provider reverify <name> --yes")
+	jsonOutput, err := executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	var got map[string]any
+	require.NoError(json.Unmarshal([]byte(jsonOutput), &got))
+	assert.Equal(true, got["stale_program_check"])
+	assert.Equal(true, got["stale_program_consent"])
+}
+
+func TestPersonProviderStatusStaleProgramNegativeSpace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	changed := personProviderTestConfig()
+	mutateConfiguredPersonProvider(&changed, func(provider *peoplesweep.ProviderConfig) {
+		provider.Model = "different-model"
+	})
+	changedProfile, err := changed.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	historicalPersonProviderProfile(t, st, changedProfile, true, true)
+	deps := localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err := executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	assert.NotContains(output, "stale_program_check")
+	assert.NotContains(output, "stale_program_consent")
+
+	st = testutil.NewSQLiteTestStore(t)
+	current, err := personProviderTestConfig().Profile()
+	require.NoError(err)
+	historicalPersonProviderProfile(t, st, current, false, false)
+	deps = localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err = executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	assert.NotContains(output, "stale_program_check")
+	assert.NotContains(output, "stale_program_consent")
+
+	st = testutil.NewSQLiteTestStore(t)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), current)
+	require.NoError(err)
+	require.NoError(st.RecordPersonInferenceCheck(t.Context(), store.PersonInferenceCheck{
+		ProfileFingerprint: current.Fingerprint, CheckedAt: time.Now().UTC(),
+		DriverVersion: current.DriverVersion, OutputMode: current.OutputMode,
+		ModelVersion: "current-model-v1",
+	}))
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), current.Fingerprint, "cli")
+	require.NoError(err)
+	deps = localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err = executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	assert.NotContains(output, "stale_program_check")
+	assert.NotContains(output, "stale_program_consent")
+}
+
+func TestPersonProviderReverifyRequiresConfirmation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	checker := &fixedPersonProviderChecker{}
+	storeOpens := 0
+	deps := localPersonProviderDeps(config, nil, checker)
+	deps.openStore = func() (personProviderStore, func(), error) {
+		storeOpens++
+		return nil, func() {}, errors.New("store must not open")
+	}
+	output, err := executePersonProviderCommand(t, deps, "reverify", "default")
+	require.ErrorContains(err, "--yes")
+	assert.Contains(output, "People inference provider disclosure")
+	assert.Zero(storeOpens)
+	assert.Zero(checker.calls.Load())
+}
+
+func TestPersonProviderReverifyDoesNotGrantAfterCheckFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), profile)
+	require.NoError(err)
+	require.NoError(st.RecordPersonInferenceCheck(t.Context(), store.PersonInferenceCheck{
+		ProfileFingerprint: profile.Fingerprint, CheckedAt: time.Now().UTC(),
+		DriverVersion: profile.DriverVersion, OutputMode: profile.OutputMode,
+		ModelVersion: "prior-model-v1",
+	}))
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), profile.Fingerprint, "cli")
+	require.NoError(err)
+	checker := &fixedPersonProviderChecker{err: errors.New("synthetic check failed")}
+	deps := localPersonProviderDeps(config, st, checker)
+	_, err = executePersonProviderCommand(t, deps, "reverify", "default", "--yes")
+	require.ErrorContains(err, "synthetic check failed")
+	assert.Equal(int64(1), checker.calls.Load())
+	status, err := st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.True(status.Active)
+	check, err := st.GetPersonInferenceCheck(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	require.NotNil(check)
+	assert.Equal("prior-model-v1", check.ModelVersion)
+}
+
+func TestPersonProviderReverifyRunsCheckThenGrantsExactConsent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	historical := historicalPersonProviderProfile(t, st, profile, true, true)
+	checker := &fixedPersonProviderChecker{response: peoplesweep.StructuredResponse{
+		Output: []byte(`{"ok":true,"secret":"provider-output"}`), ProviderRequestID: "req-reverify",
+		ProviderVersion: profile.DriverVersion, ModelVersion: "current-model-v1",
+	}}
+	deps := localPersonProviderDeps(config, st, checker)
+	output, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes", "--json")
+	require.NoError(err)
+	var status personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(output), &status))
+	assert.Equal(profile.Fingerprint, status.Profile.Fingerprint)
+	assert.True(status.Consent.Active)
+	assert.Equal(int64(1), checker.calls.Load())
+	active, err := st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.True(active)
+	oldActive, err := st.HasActivePersonInferenceConsent(t.Context(), historical.Fingerprint)
+	require.NoError(err)
+	assert.True(oldActive)
+	assert.NotContains(output, "provider-output")
+	firstConsentID := status.Consent.Consent.ID
+	output, err = executePersonProviderCommand(t, deps, "reverify", "default", "--yes", "--json")
+	require.NoError(err)
+	require.NoError(json.Unmarshal([]byte(output), &status))
+	assert.Equal(firstConsentID, status.Consent.Consent.ID)
+	assert.Equal(int64(2), checker.calls.Load())
+}
+
+func TestPersonProviderReverifySelectsDisabledNamedProfile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	config.Enabled = false
+	profileConfig := config
+	profileConfig.Enabled = true
+	profile, err := profileConfig.Profile()
+	require.NoError(err)
+	checker := &fixedPersonProviderChecker{response: peoplesweep.StructuredResponse{
+		Output: []byte(`{"ok":true}`), ProviderVersion: profile.DriverVersion,
+		ModelVersion: "disabled-profile-v1",
+	}}
+	st := testutil.NewSQLiteTestStore(t)
+	deps := localPersonProviderDeps(config, st, checker)
+	output, err := executePersonProviderCommand(t, deps, "reverify", "default", "--yes", "--json")
+	require.NoError(err)
+	var status personProviderStatusOutput
+	require.NoError(json.Unmarshal([]byte(output), &status))
+	assert.Equal(profile.Fingerprint, status.Profile.Fingerprint)
+	assert.True(status.Consent.Active)
+	assert.Equal(int64(1), checker.calls.Load())
 }
 
 func TestPersonProviderConsentDisclosesBeforeConfirmationAndIsIdempotent(t *testing.T) {

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -113,6 +113,7 @@ type fixedPersonProviderChecker struct {
 
 type grantFailingPersonProviderStore struct {
 	personProviderStore
+
 	err error
 }
 
@@ -156,6 +157,7 @@ func historicalPersonProviderProfile(
 	withCheck bool,
 	withActiveConsent bool,
 ) peoplesweep.ProviderProfile {
+	t.Helper()
 	return historicalPersonProviderProfileWithMutation(
 		t, st, profile, "", nil, withCheck, withActiveConsent)
 }

--- a/cmd/msgvault/cmd/person_provider_test.go
+++ b/cmd/msgvault/cmd/person_provider_test.go
@@ -111,6 +111,19 @@ type fixedPersonProviderChecker struct {
 	calls    atomic.Int64
 }
 
+type grantFailingPersonProviderStore struct {
+	personProviderStore
+	err error
+}
+
+func (s *grantFailingPersonProviderStore) GrantPersonInferenceConsent(
+	context.Context,
+	string,
+	string,
+) (*store.PersonInferenceConsent, bool, error) {
+	return nil, false, s.err
+}
+
 func (c *fixedPersonProviderChecker) Check(context.Context) (peoplesweep.StructuredResponse, error) {
 	c.calls.Add(1)
 	return c.response, c.err
@@ -441,6 +454,26 @@ func TestPersonProviderStatusStaleProgramNegativeSpace(t *testing.T) {
 	assert.NotContains(output, "stale_program_check")
 	assert.NotContains(output, "stale_program_consent")
 
+	st = testutil.NewSQLiteTestStore(t)
+	current, err = personProviderTestConfig().Profile()
+	require.NoError(err)
+	historicalPersonProviderProfile(t, st, current, false, true)
+	_, err = st.EnsurePersonInferenceProfile(t.Context(), current)
+	require.NoError(err)
+	require.NoError(st.RecordPersonInferenceCheck(t.Context(), store.PersonInferenceCheck{
+		ProfileFingerprint: current.Fingerprint, CheckedAt: time.Now().UTC(),
+		DriverVersion: current.DriverVersion, OutputMode: current.OutputMode,
+		ModelVersion: "current-model-v1",
+	}))
+	deps = localPersonProviderDeps(personProviderTestConfig(), st, nil)
+	output, err = executePersonProviderCommand(t, deps, "status", "default", "--json")
+	require.NoError(err)
+	var checkPresent map[string]any
+	require.NoError(json.Unmarshal([]byte(output), &checkPresent))
+	_, hasStaleCheck := checkPresent["stale_program_check"]
+	assert.False(hasStaleCheck)
+	assert.Equal(true, checkPresent["stale_program_consent"])
+
 	for _, test := range []struct {
 		name   string
 		mutate func(*peoplesweep.ProviderProfile)
@@ -581,6 +614,33 @@ func TestPersonProviderReverifyRunsCheckThenGrantsExactConsent(t *testing.T) {
 	require.NoError(json.Unmarshal([]byte(output), &status))
 	assert.Equal(firstConsentID, status.Consent.Consent.ID)
 	assert.Equal(int64(2), checker.calls.Load())
+}
+
+func TestPersonProviderReverifyReturnsGrantFailureAfterCheck(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	config := personProviderTestConfig()
+	profile, err := config.Profile()
+	require.NoError(err)
+	st := testutil.NewSQLiteTestStore(t)
+	checker := &fixedPersonProviderChecker{response: peoplesweep.StructuredResponse{
+		ProviderRequestID: "req-reverify", ProviderVersion: profile.DriverVersion,
+		ModelVersion: "current-model-v1",
+	}}
+	grantErr := errors.New("synthetic consent grant failed")
+	wrapped := &grantFailingPersonProviderStore{personProviderStore: st, err: grantErr}
+	deps := localPersonProviderDeps(config, wrapped, checker)
+
+	_, err = executePersonProviderCommand(t, deps, "reverify", "default", "--yes")
+	require.ErrorIs(err, grantErr)
+	assert.Equal(int64(1), checker.calls.Load())
+	check, err := st.GetPersonInferenceCheck(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	require.NotNil(check)
+	assert.Equal("current-model-v1", check.ModelVersion)
+	consent, err := st.GetPersonInferenceConsentStatus(t.Context(), profile.Fingerprint)
+	require.NoError(err)
+	assert.False(consent.Active)
 }
 
 func TestPersonProviderReverifySelectsDisabledNamedProfile(t *testing.T) {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,10 +10,10 @@ All notable changes to msgvault, grouped by release.
 
 - Apply curated person display names to people analytics, search, and exported authors. Add `export-messages --person-id` to select messages through bound participants.
 - Add an opt-in local CSV to PDF conversion path for standalone document indexing. The provider receives generated PDF bytes while the archive retains CSV source identity and conversion provenance.
-
 - Report provider checks and consent recorded for an earlier people extraction
-  program, and add `person provider reverify <name> --yes` to run the synthetic
-  check before granting current exact consent.
+  program, and add `person provider reverify [name] --yes` to run the synthetic
+  check before granting current exact consent. Keep historical profiles readable
+  after program changes so `status --all` and `revoke --all` continue to work.
 
 **Breaking changes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-04
+last_edited: 2026-09-07
 title: Changelog
 description: Release history for msgvault
 ---
@@ -10,6 +10,10 @@ All notable changes to msgvault, grouped by release.
 
 - Apply curated person display names to people analytics, search, and exported authors. Add `export-messages --person-id` to select messages through bound participants.
 - Add an opt-in local CSV to PDF conversion path for standalone document indexing. The provider receives generated PDF bytes while the archive retains CSV source identity and conversion provenance.
+
+- Report provider checks and consent recorded for an earlier people extraction
+  program, and add `person provider reverify <name> --yes` to run the synthetic
+  check before granting current exact consent.
 
 **Breaking changes**
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1497,8 +1497,9 @@ shipped definitions and complete workflow.
 Show the exact people inference provider policy and its check and consent state.
 The JSON output adds `stale_program_check` or `stale_program_consent` when a
 verified historical record matches every policy field except the extraction
-program and supplies a missing current gate. Human output gives the same
-recovery command without provider credentials or response content.
+program and supplies a missing current gate. Human output identifies a
+different extraction program and gives the recovery command without provider
+credentials or response content.
 
 ```bash
 msgvault person provider status [name] [--json]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1492,6 +1492,35 @@ shipped definitions and complete workflow.
 
 ---
 
+## person provider status
+
+Show the exact people inference provider policy and its check and consent state.
+The JSON output adds `stale_program_check` or `stale_program_consent` when a
+verified historical record matches every policy field except the extraction
+program and supplies a missing current gate. Human output gives the same
+recovery command without provider credentials or response content.
+
+```bash
+msgvault person provider status [name] [--json]
+```
+
+## person provider reverify
+
+Run the existing synthetic provider check, then grant consent for the same
+current exact provider profile. The check must succeed before consent is
+granted. The command prints the provider disclosure and asks for confirmation
+unless `--yes` is supplied.
+
+```bash
+msgvault person provider reverify <name> --yes [--json]
+```
+
+`--yes` confirms the disclosure. `--json` returns the final exact check and
+consent status. The named profile can be disabled in configuration, and this
+command still selects it for the operation without enabling scheduled sweeps.
+
+---
+
 ## person provider set
 
 Update the mutable policy fields of an existing named people inference provider

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1495,8 +1495,8 @@ shipped definitions and complete workflow.
 ## person provider status
 
 Show the exact people inference provider policy and its check and consent state.
-The JSON output adds `stale_program_check` or `stale_program_consent` when a
-verified historical record matches every policy field except the extraction
+The JSON output includes the selected profile `name` and adds
+`stale_program_check` or `stale_program_consent` when a verified historical record matches every policy field except the extraction
 program and supplies a missing current gate. Human output identifies a
 different extraction program and gives the recovery command without provider
 credentials or response content.
@@ -1513,12 +1513,13 @@ granted. The command prints the provider disclosure and asks for confirmation
 unless `--yes` is supplied.
 
 ```bash
-msgvault person provider reverify <name> --yes [--json]
+msgvault person provider reverify [name] --yes [--json]
 ```
 
-`--yes` confirms the disclosure. `--json` returns the final exact check and
-consent status. The named profile can be disabled in configuration, and this
-command still selects it for the operation without enabling scheduled sweeps.
+Omit `name` to use the active provider, as with `check` and `consent`.
+`--yes` confirms the disclosure. Human output includes the disclosure even with
+`--yes`; `--json` returns the final exact check and consent status. The named
+profile can be disabled in configuration, and this command still selects it for the operation without enabling scheduled sweeps.
 
 ---
 

--- a/internal/api/cli_allowlist_person_provider_test.go
+++ b/internal/api/cli_allowlist_person_provider_test.go
@@ -50,6 +50,7 @@ func TestCLIRunCommandAllowedPermitsExactPersonProviderCommands(t *testing.T) {
 		}, want: true},
 		{name: "check", args: []string{"person", "provider", "check", "--json"}, want: true},
 		{name: "named check", args: []string{"person", "provider", "check", "alpha", "--json"}, want: true},
+		{name: "named reverify", args: []string{"person", "provider", "reverify", "alpha", "--yes", "--json"}, want: true},
 		{name: "guarded check", args: []string{
 			"person", "provider", "check", "alpha", "--if-fingerprint", strings.Repeat("a", 64),
 		}, want: true},
@@ -69,6 +70,10 @@ func TestCLIRunCommandAllowedPermitsExactPersonProviderCommands(t *testing.T) {
 			"person", "provider", "revoke", "--if-fingerprint", strings.Repeat("a", 64),
 		}},
 		{name: "extra positional smuggling", args: []string{"person", "provider", "check", "alpha", "beta"}},
+		{name: "reverify missing name", args: []string{"person", "provider", "reverify", "--yes"}},
+		{name: "reverify extra positional", args: []string{"person", "provider", "reverify", "alpha", "beta", "--yes"}},
+		{name: "reverify semantic flag", args: []string{"person", "provider", "reverify", "alpha", "--semantic-embeddings", "--yes"}},
+		{name: "reverify credential smuggling", args: []string{"person", "provider", "reverify", "alpha", "--api-key=secret-canary", "--yes"}},
 		{name: "list positional smuggling", args: []string{"person", "provider", "list", "alpha"}},
 		{name: "missing operation", args: []string{"person", "provider"}},
 		{name: "unknown operation", args: []string{"person", "provider", "run"}},

--- a/internal/api/cli_allowlist_person_provider_test.go
+++ b/internal/api/cli_allowlist_person_provider_test.go
@@ -70,7 +70,7 @@ func TestCLIRunCommandAllowedPermitsExactPersonProviderCommands(t *testing.T) {
 			"person", "provider", "revoke", "--if-fingerprint", strings.Repeat("a", 64),
 		}},
 		{name: "extra positional smuggling", args: []string{"person", "provider", "check", "alpha", "beta"}},
-		{name: "reverify missing name", args: []string{"person", "provider", "reverify", "--yes"}},
+		{name: "active reverify", args: []string{"person", "provider", "reverify", "--yes"}, want: true},
 		{name: "reverify extra positional", args: []string{"person", "provider", "reverify", "alpha", "beta", "--yes"}},
 		{name: "reverify semantic flag", args: []string{"person", "provider", "reverify", "alpha", "--semantic-embeddings", "--yes"}},
 		{name: "reverify credential smuggling", args: []string{"person", "provider", "reverify", "alpha", "--api-key=secret-canary", "--yes"}},

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1717,6 +1717,10 @@ func cliRunPersonProviderArgsAllowed(operation string, args []string) bool {
 		maxPositionals = 1
 		boolFlags["json"] = true
 		valueFlags["if-fingerprint"] = true
+	case "reverify":
+		maxPositionals = 1
+		boolFlags["yes"] = true
+		boolFlags["json"] = true
 	default:
 		return false
 	}
@@ -1774,6 +1778,9 @@ func cliRunPersonProviderArgsAllowed(operation string, args []string) bool {
 		return false
 	}
 	if guardedRevoke && positionals != 1 {
+		return false
+	}
+	if operation == "reverify" && positionals != 1 {
 		return false
 	}
 	return true

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1780,9 +1780,6 @@ func cliRunPersonProviderArgsAllowed(operation string, args []string) bool {
 	if guardedRevoke && positionals != 1 {
 		return false
 	}
-	if operation == "reverify" && positionals != 1 {
-		return false
-	}
 	return true
 }
 

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -569,19 +569,70 @@ func (p ProviderProfile) Validate() error {
 	return nil
 }
 
+// ValidateStoredProviderProfile validates an immutable policy without
+// replacing fields that were part of the policy when it was persisted.
+func (p ProviderProfile) ValidateStoredProviderProfile() error {
+	_, err := CanonicalStoredProviderProfile(p)
+	return err
+}
+
+// CanonicalStoredProviderProfile verifies and canonicalizes an immutable
+// policy while preserving its historical program and disclosure fields.
+func CanonicalStoredProviderProfile(p ProviderProfile) (ProviderProfile, error) {
+	provider := providerConfigForProfile(p)
+	if err := (Config{Enabled: true}).validateProvider(provider); err != nil {
+		return ProviderProfile{}, err
+	}
+	switch p.Credential {
+	case CredentialStored:
+		if err := ValidateProviderProfileName(p.CredentialRef); err != nil {
+			return ProviderProfile{}, err
+		}
+	case CredentialNone:
+		if p.CredentialRef != "" {
+			return ProviderProfile{}, errors.New("stored people inference provider profile has an unexpected credential reference")
+		}
+	}
+	if p.ProgramFingerprint == "" {
+		return ProviderProfile{}, errors.New("stored people inference provider profile has no program fingerprint")
+	}
+	if p.PacketRendererPolicy == "" {
+		return ProviderProfile{}, errors.New("stored people inference provider profile has no packet renderer policy")
+	}
+	if len(p.DisclosedPacketFields) == 0 {
+		return ProviderProfile{}, errors.New("stored people inference provider profile has no disclosed packet fields")
+	}
+	canonical := p
+	canonical.Model = strings.TrimSpace(canonical.Model)
+	canonical.ReasoningEffort = strings.TrimSpace(canonical.ReasoningEffort)
+	canonical.RetentionPosture = strings.TrimSpace(canonical.RetentionPosture)
+	canonical.TrainingPosture = strings.TrimSpace(canonical.TrainingPosture)
+	canonical.AllowedSources = slices.Clone(canonical.AllowedSources)
+	slices.Sort(canonical.AllowedSources)
+	canonical.DisclosedPacketFields = slices.Clone(canonical.DisclosedPacketFields)
+	if canonical.Protocol != ProtocolCodexAppServer {
+		endpoint, _, err := validateEndpoint(canonical.Endpoint)
+		if err != nil {
+			return ProviderProfile{}, err
+		}
+		canonical.Endpoint = canonicalEndpoint(endpoint)
+	}
+	policyJSON, err := policyJSONForProviderProfile(canonical)
+	if err != nil {
+		return ProviderProfile{}, fmt.Errorf("encode stored people inference provider policy: %w", err)
+	}
+	digest := sha256.Sum256(policyJSON)
+	if p.Fingerprint != hex.EncodeToString(digest[:]) {
+		return ProviderProfile{}, errors.New("stored people inference provider profile fingerprint does not match policy")
+	}
+	canonical.PolicyJSON = policyJSON
+	return canonical, nil
+}
+
 // CanonicalProviderProfile rebuilds a profile through the validated config path.
 func CanonicalProviderProfile(p ProviderProfile) (ProviderProfile, error) {
 	name := "profile"
-	provider := ProviderConfig{
-		Protocol: p.Protocol, Endpoint: p.Endpoint, Model: p.Model, Auth: p.Auth,
-		Credential: p.Credential, OutputMode: p.OutputMode,
-		TokenLimitParameter: p.TokenLimitParameter, ReasoningEffort: p.ReasoningEffort,
-		ReasoningMode: p.ReasoningMode, DriverVersion: p.DriverVersion,
-		RetentionPosture: p.RetentionPosture, TrainingPosture: p.TrainingPosture,
-		AllowedSources: slices.Clone(p.AllowedSources), SourceSince: p.SourceSince,
-		SourceUntil: p.SourceUntil, AllowSensitive: p.AllowSensitive,
-		ExecutionBoundary: p.ExecutionBoundary, RequestTimeout: time.Second,
-	}
+	provider := providerConfigForProfile(p)
 	switch p.Credential {
 	case CredentialEnv:
 		provider.CredentialEnv = p.CredentialRef
@@ -596,6 +647,23 @@ func CanonicalProviderProfile(p ProviderProfile) (ProviderProfile, error) {
 	}
 	config.ApplyDefaults()
 	return config.Profile()
+}
+
+func providerConfigForProfile(p ProviderProfile) ProviderConfig {
+	provider := ProviderConfig{
+		Protocol: p.Protocol, Endpoint: p.Endpoint, Model: p.Model, Auth: p.Auth,
+		Credential: p.Credential, OutputMode: p.OutputMode,
+		TokenLimitParameter: p.TokenLimitParameter, ReasoningEffort: p.ReasoningEffort,
+		ReasoningMode: p.ReasoningMode, DriverVersion: p.DriverVersion,
+		RetentionPosture: p.RetentionPosture, TrainingPosture: p.TrainingPosture,
+		AllowedSources: slices.Clone(p.AllowedSources), SourceSince: p.SourceSince,
+		SourceUntil: p.SourceUntil, AllowSensitive: p.AllowSensitive,
+		ExecutionBoundary: p.ExecutionBoundary, RequestTimeout: time.Second,
+	}
+	if p.Credential == CredentialEnv {
+		provider.CredentialEnv = p.CredentialRef
+	}
+	return provider
 }
 
 func policyJSONForProviderProfile(profile ProviderProfile) ([]byte, error) {

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -569,13 +569,6 @@ func (p ProviderProfile) Validate() error {
 	return nil
 }
 
-// ValidateStoredProviderProfile validates an immutable policy without
-// replacing fields that were part of the policy when it was persisted.
-func (p ProviderProfile) ValidateStoredProviderProfile() error {
-	_, err := CanonicalStoredProviderProfile(p)
-	return err
-}
-
 // CanonicalStoredProviderProfile verifies and canonicalizes an immutable
 // policy while preserving its historical program and disclosure fields.
 func CanonicalStoredProviderProfile(p ProviderProfile) (ProviderProfile, error) {

--- a/internal/peoplesweep/config.go
+++ b/internal/peoplesweep/config.go
@@ -577,6 +577,7 @@ func CanonicalStoredProviderProfile(p ProviderProfile) (ProviderProfile, error) 
 		return ProviderProfile{}, err
 	}
 	switch p.Credential {
+	case CredentialEnv:
 	case CredentialStored:
 		if err := ValidateProviderProfileName(p.CredentialRef); err != nil {
 			return ProviderProfile{}, err

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -2,6 +2,8 @@ package peoplesweep_test
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"maps"
 	"slices"
@@ -412,6 +414,33 @@ func TestProviderProfileProjectionRoundTrip(t *testing.T) {
 	assert.NotContains(string(profile.PolicyJSON), "credential-value-must-not-persist")
 	assert.NotContains(string(profile.PolicyJSON), "request_timeout")
 	assert.NoError(profile.Validate())
+}
+
+func TestStoredProviderProfilePreservesHistoricalProgramPolicy(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	profile, err := validConfig().Profile()
+	require.NoError(err)
+	oldProgram := strings.Repeat("a", len(profile.ProgramFingerprint))
+	historical := profile
+	historical.ProgramFingerprint = oldProgram
+	historical.PolicyJSON = bytes.Replace(
+		profile.PolicyJSON, []byte(profile.ProgramFingerprint), []byte(oldProgram), 1)
+	digest := sha256.Sum256(historical.PolicyJSON)
+	historical.Fingerprint = hex.EncodeToString(digest[:])
+	require.NoError(historical.ValidateStoredProviderProfile())
+	require.Error(historical.Validate())
+
+	for _, mutate := range []func(*peoplesweep.ProviderProfile){
+		func(p *peoplesweep.ProviderProfile) { p.Model = "changed-model" },
+		func(p *peoplesweep.ProviderProfile) { p.Endpoint = "https://changed.example/v1" },
+		func(p *peoplesweep.ProviderProfile) { p.PacketRendererPolicy = "changed-renderer" },
+		func(p *peoplesweep.ProviderProfile) { p.DisclosedPacketFields = []string{"different"} },
+	} {
+		changed := historical
+		mutate(&changed)
+		assert.Error(changed.ValidateStoredProviderProfile())
+	}
 }
 
 func TestProviderConfigTOMLValuesUseTaggedOptionalFields(t *testing.T) {

--- a/internal/peoplesweep/config_test.go
+++ b/internal/peoplesweep/config_test.go
@@ -428,7 +428,8 @@ func TestStoredProviderProfilePreservesHistoricalProgramPolicy(t *testing.T) {
 		profile.PolicyJSON, []byte(profile.ProgramFingerprint), []byte(oldProgram), 1)
 	digest := sha256.Sum256(historical.PolicyJSON)
 	historical.Fingerprint = hex.EncodeToString(digest[:])
-	require.NoError(historical.ValidateStoredProviderProfile())
+	_, err = peoplesweep.CanonicalStoredProviderProfile(historical)
+	require.NoError(err)
 	require.Error(historical.Validate())
 
 	for _, mutate := range []func(*peoplesweep.ProviderProfile){
@@ -439,7 +440,8 @@ func TestStoredProviderProfilePreservesHistoricalProgramPolicy(t *testing.T) {
 	} {
 		changed := historical
 		mutate(&changed)
-		assert.Error(changed.ValidateStoredProviderProfile())
+		_, err = peoplesweep.CanonicalStoredProviderProfile(changed)
+		assert.Error(err)
 	}
 }
 

--- a/internal/peoplesweep/runner.go
+++ b/internal/peoplesweep/runner.go
@@ -573,7 +573,7 @@ func (r *Runner) requireVerifiedAndConsented(ctx context.Context, fingerprint st
 		return fmt.Errorf("check exact people inference provider verification: %w", err)
 	}
 	if !verified {
-		return errors.New("people inference requires a successful check for the exact provider profile")
+		return errors.New("people inference requires a successful check for the exact provider profile; run msgvault person provider status")
 	}
 	active, err := r.authority.HasActivePersonInferenceConsent(ctx, fingerprint)
 	if err != nil {

--- a/internal/peoplesweep/runner_test.go
+++ b/internal/peoplesweep/runner_test.go
@@ -647,7 +647,7 @@ func TestRunnerFailsClosedBeforeCredentialOrTransport(t *testing.T) {
 		},
 		{
 			name: "missing verification", config: runnerTestConfig(), request: baseRequest,
-			unverified: true, wantVerified: 1, want: "successful check",
+			unverified: true, wantVerified: 1, want: "run msgvault person provider status",
 		},
 		{
 			name: "missing consent", config: runnerTestConfig(), request: baseRequest,

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -256,12 +256,12 @@ func (p *personInferenceProfileProjection) profile() (peoplesweep.ProviderProfil
 		return peoplesweep.ProviderProfile{}, errors.New(
 			"stored people inference profile does not match its immutable policy")
 	}
-	canonical, err := peoplesweep.CanonicalProviderProfile(profile)
+	canonical, err := peoplesweep.CanonicalStoredProviderProfile(profile)
 	if err != nil {
-		return peoplesweep.ProviderProfile{}, err
+		return peoplesweep.ProviderProfile{}, errors.New(
+			"stored people inference profile does not match its immutable policy")
 	}
-	if profile.Fingerprint != canonical.Fingerprint ||
-		!equalJSON(profile.PolicyJSON, canonical.PolicyJSON) {
+	if !equalJSON(profile.PolicyJSON, canonical.PolicyJSON) {
 		return peoplesweep.ProviderProfile{}, errors.New(
 			"stored people inference profile does not match its immutable policy")
 	}

--- a/internal/store/person_inference_consent.go
+++ b/internal/store/person_inference_consent.go
@@ -258,8 +258,7 @@ func (p *personInferenceProfileProjection) profile() (peoplesweep.ProviderProfil
 	}
 	canonical, err := peoplesweep.CanonicalStoredProviderProfile(profile)
 	if err != nil {
-		return peoplesweep.ProviderProfile{}, errors.New(
-			"stored people inference profile does not match its immutable policy")
+		return peoplesweep.ProviderProfile{}, err
 	}
 	if !equalJSON(profile.PolicyJSON, canonical.PolicyJSON) {
 		return peoplesweep.ProviderProfile{}, errors.New(

--- a/internal/store/person_inference_consent_test.go
+++ b/internal/store/person_inference_consent_test.go
@@ -1,8 +1,12 @@
 package store_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -200,6 +204,64 @@ func TestPersonInferenceProfilesCanBeListedAndRevokedWithoutRuntimeConfig(t *tes
 	active, err := st.HasActivePersonInferenceConsent(t.Context(), profile.Fingerprint)
 	require.NoError(err)
 	assert.False(active)
+}
+
+func TestPersonInferenceProfilesCanBeListedAfterProgramChange(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	current := inferenceTestProfile(t)
+	_, err := st.EnsurePersonInferenceProfile(t.Context(), current)
+	require.NoError(err)
+	require.NoError(st.RecordPersonInferenceCheck(t.Context(), store.PersonInferenceCheck{
+		ProfileFingerprint: current.Fingerprint, CheckedAt: time.Now().UTC(),
+		DriverVersion: current.DriverVersion, OutputMode: current.OutputMode,
+		ModelVersion: "test-model-v1",
+	}))
+	_, _, err = st.GrantPersonInferenceConsent(t.Context(), current.Fingerprint, "cli")
+	require.NoError(err)
+	historical := current
+	historical.ProgramFingerprint = strings.Repeat("b", len(current.ProgramFingerprint))
+	historical.PolicyJSON = bytes.Replace(
+		current.PolicyJSON, []byte(current.ProgramFingerprint), []byte(historical.ProgramFingerprint), 1)
+	digest := sha256.Sum256(historical.PolicyJSON)
+	historical.Fingerprint = hex.EncodeToString(digest[:])
+	_, err = st.DB().Exec(st.Rebind(`
+		DELETE FROM person_inference_checks WHERE profile_fingerprint = ?`), current.Fingerprint)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		DELETE FROM person_inference_consents WHERE profile_fingerprint = ?`), current.Fingerprint)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		UPDATE person_inference_profiles
+		SET fingerprint = ?, program_fingerprint = ?, policy_json = ?
+		WHERE fingerprint = ?`),
+		historical.Fingerprint, historical.ProgramFingerprint, string(historical.PolicyJSON), current.Fingerprint)
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_checks
+			(profile_fingerprint, checked_at, driver_version, output_mode, model_version)
+		VALUES (?, CURRENT_TIMESTAMP, ?, ?, ?)`), historical.Fingerprint,
+		historical.DriverVersion, historical.OutputMode, "test-model-v1")
+	require.NoError(err)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO person_inference_consents (profile_fingerprint, granted_by)
+		VALUES (?, ?)`), historical.Fingerprint, "cli")
+	require.NoError(err)
+
+	profiles, err := st.ListPersonInferenceProfiles(t.Context())
+	require.NoError(err)
+	require.Len(profiles, 1)
+	assert.Equal(historical.Fingerprint, profiles[0].Fingerprint)
+	assert.Equal(historical.ProgramFingerprint, profiles[0].ProgramFingerprint)
+	assert.Equal(historical.DisclosedPacketFields, profiles[0].DisclosedPacketFields)
+	assert.JSONEq(string(historical.PolicyJSON), string(profiles[0].PolicyJSON))
+	check, err := st.GetPersonInferenceCheck(t.Context(), historical.Fingerprint)
+	require.NoError(err)
+	require.NotNil(check)
+	consent, err := st.GetPersonInferenceConsentStatus(t.Context(), historical.Fingerprint)
+	require.NoError(err)
+	assert.True(consent.Active)
 }
 
 func TestPersonInferenceProfilesRejectChangedIndexedProjection(t *testing.T) {


### PR DESCRIPTION
People provider upgrades now have an actionable recovery path. `person provider status` identifies checks and consent made stale by an extraction prompt or JSON schema change, includes the selected profile name, and prints a recovery command. Failed sweep verification also points operators to status.

Run `msgvault person provider reverify [name] --yes` to check the current program and grant consent only after the check succeeds. Omitting the name selects the active provider. Human output includes the provider disclosure; `--json` returns the final check and consent state. Program changes still require explicit reapproval because they can change what leaves the archive.

Historical policies remain readable after program changes, fixing `status --all` and `revoke --all` after those upgrades.

Closes #742
