### PR TITLE
fix(gmail): bound requests and OAuth refresh waits

### DIFF
--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -93,7 +93,13 @@ func (c *Client) Close() error {
 // request makes an HTTP request with rate limiting and retry logic.
 // bodyBytes can be nil for requests without a body.
 func (c *Client) request(ctx context.Context, op Operation, method, path string, bodyBytes []byte) ([]byte, error) {
-	// Share one budget across rate limiting, HTTP I/O and retry backoff.
+	// Quota pauses can exceed the request timeout. Wait using the caller's
+	// context so a previous request's throttle does not exhaust this budget.
+	if err := c.rateLimiter.Acquire(ctx, op); err != nil {
+		return nil, fmt.Errorf("rate limit: %w", err)
+	}
+
+	// Share one budget across HTTP I/O and retry backoff after acquiring tokens.
 	// It bounds the Gmail request path once a token is available; tokens are
 	// fetched beforehand via the contextless TokenSource.Token(), so sources
 	// created by internal/oauth cap every token-endpoint call separately
@@ -105,11 +111,6 @@ func (c *Client) request(ctx context.Context, op Operation, method, path string,
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-
-	// Acquire rate limit tokens
-	if err := c.rateLimiter.Acquire(ctx, op); err != nil {
-		return nil, fmt.Errorf("rate limit: %w", err)
-	}
 
 	reqURL := baseURL + path
 

--- a/internal/gmail/client.go
+++ b/internal/gmail/client.go
@@ -22,9 +22,11 @@ import (
 
 const (
 	baseURL        = "https://gmail.googleapis.com/gmail/v1"
-	maxRetries     = 12  // Covers ~10 minutes of network outages
+	maxRetries     = 12  // Upper bound; the request deadline also limits retries
 	maxBackoff     = 600 // Max backoff in seconds
 	defaultTimeout = 30 * time.Second
+	// Raw MIME includes attachments and needs more time on slow connections.
+	rawRequestTimeout = 5 * time.Minute
 )
 
 // Client implements the Gmail API interface.
@@ -91,6 +93,19 @@ func (c *Client) Close() error {
 // request makes an HTTP request with rate limiting and retry logic.
 // bodyBytes can be nil for requests without a body.
 func (c *Client) request(ctx context.Context, op Operation, method, path string, bodyBytes []byte) ([]byte, error) {
+	// Share one budget across rate limiting, HTTP I/O and retry backoff.
+	// It bounds the Gmail request path once a token is available; tokens are
+	// fetched beforehand via the contextless TokenSource.Token(), so sources
+	// created by internal/oauth cap every token-endpoint call separately
+	// (oauth.refreshHTTPTimeout per call) instead of sharing this deadline.
+	// Any other TokenSource keeps its own refresh behavior.
+	timeout := defaultTimeout
+	if op == OpMessagesGetRaw {
+		timeout = rawRequestTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	// Acquire rate limit tokens
 	if err := c.rateLimiter.Acquire(ctx, op); err != nil {
 		return nil, fmt.Errorf("rate limit: %w", err)

--- a/internal/gmail/client_deadline_test.go
+++ b/internal/gmail/client_deadline_test.go
@@ -84,7 +84,7 @@ func TestGetProfileRetryDeadline(t *testing.T) {
 	}
 }
 
-func TestGetProfileDeadlineIncludesRateLimitWait(t *testing.T) {
+func TestGetProfileCallerDeadlineBoundsRateLimitWait(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)
@@ -99,9 +99,80 @@ func TestGetProfileDeadlineIncludesRateLimitWait(t *testing.T) {
 		start := time.Now()
 		_, err := c.GetProfile(ctx)
 		require.ErrorIs(err, context.DeadlineExceeded)
-		assert.Equal(30*time.Second, time.Since(start))
+		assert.Equal(time.Minute, time.Since(start))
 		assert.Zero(requests)
 	})
+}
+
+func TestGetProfileDeadlineStartsAfterRateLimitWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		var httpStart time.Time
+		c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+			httpStart = time.Now()
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		})
+		c.rateLimiter.Throttle(time.Minute)
+		start := time.Now()
+		_, err := c.GetProfile(context.Background())
+		require.ErrorIs(err, context.DeadlineExceeded)
+		require.False(httpStart.IsZero(), "request must get through the quota wait")
+		assert.GreaterOrEqual(httpStart.Sub(start), time.Minute)
+		assert.Equal(30*time.Second, time.Since(httpStart))
+	})
+}
+
+func TestListMessagesAfterRawFetchQuotaRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		status   int
+		throttle time.Duration
+	}{
+		{"403 quota", http.StatusForbidden, time.Minute},
+		{"429 rate limit", http.StatusTooManyRequests, 30 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				assert := assert.New(t)
+				require := require.New(t)
+				rawRequests := 0
+				c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+					switch r.URL.Path {
+					case "/gmail/v1/users/me/messages/msg-1":
+						rawRequests++
+						if rawRequests == 1 {
+							return deadlineResponse(tc.status,
+								string(NewGmailError(tc.status).WithReason(reasonRateLimitExceeded).Build())), nil
+						}
+						return deadlineResponse(http.StatusOK, `{"id":"msg-1","raw":"dGVzdA"}`), nil
+					case "/gmail/v1/users/me/messages":
+						// A quota wait must leave time for the next page to arrive.
+						select {
+						case <-r.Context().Done():
+							return nil, r.Context().Err()
+						case <-time.After(5 * time.Second):
+						}
+						return deadlineResponse(http.StatusOK, `{"messages":[{"id":"msg-2"}]}`), nil
+					default:
+						return deadlineResponse(http.StatusNotFound, ""), nil
+					}
+				})
+				start := time.Now()
+				message, err := c.GetMessageRaw(context.Background(), "msg-1")
+				require.NoError(err)
+				assert.Equal([]byte("test"), message.Raw)
+
+				page, err := c.ListMessages(context.Background(), "", "")
+				require.NoError(err)
+				require.Len(page.Messages, 1)
+				assert.Equal("msg-2", page.Messages[0].ID)
+				assert.GreaterOrEqual(time.Since(start), tc.throttle+5*time.Second,
+					"preserve the quota pause before fetching the next page")
+			})
+		})
+	}
 }
 
 type deadlineBody struct {

--- a/internal/gmail/client_deadline_test.go
+++ b/internal/gmail/client_deadline_test.go
@@ -1,0 +1,270 @@
+package gmail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// deadlineTransport replaces the external Gmail service, leaving the client's
+// rate limiter, retry loop and context handling intact.
+type deadlineTransport func(*http.Request) (*http.Response, error)
+
+func (f deadlineTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func newDeadlineClient(t *testing.T, transport deadlineTransport) *Client {
+	t.Helper()
+	c := NewClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}))
+	// Install the fake as the base of the production oauth2.Transport instead
+	// of replacing the transport, so the deadline budget is measured across
+	// the real OAuth round trip. The static token never expires, so token
+	// acquisition stays out of the request path; bounding a stalled token
+	// refresh is a separate OAuth concern (TokenSource.Token() is contextless).
+	oauthTransport, ok := c.httpClient.Transport.(*oauth2.Transport)
+	require.True(t, ok, "NewClient must install an oauth2.Transport")
+	oauthTransport.Base = transport
+	return c
+}
+
+func deadlineResponse(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(body))}
+}
+
+func TestGetProfileRetryDeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		callerTimeout, want time.Duration
+	}{
+		{"no caller deadline", 0, 30 * time.Second},
+		{"later caller deadline", time.Minute, 30 * time.Second},
+		{"earlier caller deadline", 5 * time.Second, 5 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				assert := assert.New(t)
+				require := require.New(t)
+				ctx := context.Background()
+				if tc.callerTimeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, tc.callerTimeout)
+					defer cancel()
+				}
+				start := time.Now()
+				requests := 0
+				c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+					requests++
+					deadline, ok := r.Context().Deadline()
+					require.True(ok, "HTTP request needs an overall deadline")
+					assert.Equal(start.Add(tc.want), deadline, "retries must not restart the budget")
+					assert.Equal("Bearer test-token", r.Header.Get("Authorization"),
+						"requests must carry the OAuth token through the production transport")
+					// Even zero jitter cannot exhaust all retries before the deadline.
+					select {
+					case <-r.Context().Done():
+						return nil, r.Context().Err()
+					case <-time.After(3 * time.Second):
+					}
+					return deadlineResponse(http.StatusTooManyRequests, `{"error":{"code":429}}`), nil
+				})
+				profile, err := c.GetProfile(ctx)
+				require.ErrorIs(err, context.DeadlineExceeded)
+				assert.Nil(profile)
+				assert.Equal(tc.want, time.Since(start))
+				assert.Greater(requests, 1, "exercise retries before the deadline")
+			})
+		})
+	}
+}
+
+func TestGetProfileDeadlineIncludesRateLimitWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		requests := 0
+		c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+			requests++
+			return deadlineResponse(http.StatusOK, `{}`), nil
+		})
+		c.rateLimiter.Throttle(2 * time.Minute)
+		start := time.Now()
+		_, err := c.GetProfile(ctx)
+		require.ErrorIs(err, context.DeadlineExceeded)
+		assert.Equal(30*time.Second, time.Since(start))
+		assert.Zero(requests)
+	})
+}
+
+type deadlineBody struct {
+	ctx    context.Context
+	closed bool
+}
+
+func (b *deadlineBody) Read([]byte) (int, error) { <-b.ctx.Done(); return 0, b.ctx.Err() }
+func (b *deadlineBody) Close() error             { b.closed = true; return nil }
+
+func TestGetProfileDeadlineInterruptsHTTP(t *testing.T) {
+	for _, bodyRead := range []bool{false, true} {
+		name := "transport"
+		if bodyRead {
+			name = "body read"
+		}
+		t.Run(name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				assert := assert.New(t)
+				require := require.New(t)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				var body *deadlineBody
+				c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+					if bodyRead {
+						body = &deadlineBody{ctx: r.Context()}
+						return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: body}, nil
+					}
+					<-r.Context().Done()
+					return nil, r.Context().Err()
+				})
+				start := time.Now()
+				_, err := c.GetProfile(ctx)
+				require.ErrorIs(err, context.DeadlineExceeded)
+				assert.Equal(30*time.Second, time.Since(start))
+				if bodyRead {
+					require.NotNil(body)
+					assert.True(body.closed)
+				}
+			})
+		})
+	}
+}
+
+type retrySignalBody struct {
+	io.Reader
+
+	closed chan struct{}
+}
+
+func (b *retrySignalBody) Close() error { b.closed <- struct{}{}; return nil }
+
+func TestGetProfileCancellationInterruptsRetry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		closed := make(chan struct{}, maxRetries+1)
+		c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: make(http.Header), Body: &retrySignalBody{Reader: strings.NewReader(""), closed: closed}}, nil
+		})
+		result := make(chan error, 1)
+		go func() { _, err := c.GetProfile(ctx); result <- err }()
+		<-closed
+		synctest.Wait()
+		start := time.Now()
+		cancel()
+		require.ErrorIs(<-result, context.Canceled)
+		assert.Zero(time.Since(start))
+	})
+}
+
+func TestGetProfileRecoversWithinDeadline(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		requests := 0
+		c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+			requests++
+			if requests == 1 {
+				return deadlineResponse(http.StatusTooManyRequests, ""), nil
+			}
+			return deadlineResponse(http.StatusOK, `{"emailAddress":"user@example.com","historyId":"42"}`), nil
+		})
+		start := time.Now()
+		profile, err := c.GetProfile(context.Background())
+		require.NoError(err)
+		require.NotNil(profile)
+		assert.Equal("user@example.com", profile.EmailAddress)
+		assert.Equal(uint64(42), profile.HistoryID)
+		assert.Equal(2, requests)
+		assert.Less(time.Since(start), 30*time.Second)
+	})
+}
+
+// delayedMessageBody models a raw MIME download whose transfer outlasts a
+// metadata request, while still observing request cancellation.
+type delayedMessageBody struct {
+	io.Reader
+
+	ctx   context.Context
+	delay time.Duration
+}
+
+func (b *delayedMessageBody) Read(p []byte) (int, error) {
+	if b.delay > 0 {
+		select {
+		case <-b.ctx.Done():
+			return 0, b.ctx.Err()
+		case <-time.After(b.delay):
+			b.delay = 0
+		}
+	}
+	return b.Reader.Read(p)
+}
+
+func (b *delayedMessageBody) Close() error { return nil }
+
+func TestGetMessageRawTransferDeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		transfer      time.Duration
+		callerTimeout time.Duration
+		wantElapsed   time.Duration
+		wantError     bool
+	}{
+		{"slow download completes", 2 * time.Minute, 0, 2 * time.Minute, false},
+		{"stalled download is bounded", 6 * time.Minute, 0, 5 * time.Minute, true},
+		{"caller deadline wins", 2 * time.Minute, 5 * time.Second, 5 * time.Second, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				assert := assert.New(t)
+				require := require.New(t)
+				ctx := context.Background()
+				if tc.callerTimeout > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, tc.callerTimeout)
+					defer cancel()
+				}
+				c := newDeadlineClient(t, func(r *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body: &delayedMessageBody{
+							ctx: r.Context(), delay: tc.transfer,
+							Reader: strings.NewReader(`{"id":"msg-1","raw":"dGVzdA"}`),
+						},
+					}, nil
+				})
+				start := time.Now()
+				message, err := c.GetMessageRaw(ctx, "msg-1")
+				if tc.wantError {
+					require.ErrorIs(err, context.DeadlineExceeded)
+					assert.Nil(message)
+				} else {
+					require.NoError(err)
+					require.NotNil(message)
+					assert.Equal([]byte("test"), message.Raw)
+				}
+				assert.Equal(tc.wantElapsed, time.Since(start))
+			})
+		})
+	}
+}

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -255,8 +255,9 @@ func (m *Manager) TokenSource(ctx context.Context, email string) (oauth2.TokenSo
 		return nil, fmt.Errorf("no valid token for %s: %w", email, err)
 	}
 
-	// Create a token source that auto-refreshes
-	ts := m.config.TokenSource(ctx, &tf.Token)
+	// Create a token source that auto-refreshes. The creation context
+	// bounds the token-endpoint client used by every later refresh.
+	ts := m.config.TokenSource(withRefreshHTTPClient(ctx), &tf.Token)
 
 	// Save refreshed token if it changed
 	newToken, err := ts.Token()
@@ -303,7 +304,7 @@ func (m *Manager) ForceRefresh(ctx context.Context, email string) error {
 	// A token without an access token is never Valid, so the token source
 	// must hit the token endpoint with the refresh grant.
 	stale := &oauth2.Token{RefreshToken: tf.RefreshToken}
-	newToken, err := m.config.TokenSource(ctx, stale).Token()
+	newToken, err := m.config.TokenSource(withRefreshHTTPClient(ctx), stale).Token()
 	if err != nil {
 		return fmt.Errorf("refresh token: %w", err)
 	}
@@ -662,6 +663,36 @@ func (m *Manager) browserFlow(
 
 const resolveTimeout = 10 * time.Second
 
+// refreshHTTPTimeout caps each token-endpoint HTTP call (refresh grant or
+// service-account JWT exchange) made by token sources this package creates.
+// oauth2 sources take their HTTP client from the creation context, and later
+// refreshes run through the contextless TokenSource.Token() — invoked by
+// oauth2.Transport before dispatching an API request — so a stalled token
+// endpoint can only be bounded inside that client. The cap applies per call:
+// when x/oauth2 does not know the endpoint's auth style it retries once with
+// the other style, so one Token() performs at most two bounded calls. It is
+// independent of any caller's request deadline.
+const refreshHTTPTimeout = 30 * time.Second
+
+// withRefreshHTTPClient returns ctx carrying a token-endpoint client whose
+// Timeout is capped at refreshHTTPTimeout. The client already in ctx — or
+// http.DefaultClient, oauth2's fallback — is shallow-copied so Transport,
+// Jar and CheckRedirect are preserved and the original is never mutated; a
+// client whose Timeout is already refreshHTTPTimeout or less is kept as is.
+// The context's cancellation chain is untouched.
+func withRefreshHTTPClient(ctx context.Context) context.Context {
+	base := http.DefaultClient
+	if c, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		base = c
+	}
+	if base.Timeout > 0 && base.Timeout <= refreshHTTPTimeout {
+		return ctx
+	}
+	capped := *base
+	capped.Timeout = refreshHTTPTimeout
+	return context.WithValue(ctx, oauth2.HTTPClient, &capped)
+}
+
 // resolveTokenEmail calls a Google profile endpoint to confirm that
 // the token belongs to an account matching the expected email.
 // Returns the canonical Google account email when available,
@@ -675,7 +706,7 @@ func (m *Manager) resolveTokenEmail(
 	if m.profileURL != "" {
 		endpoint.url = m.profileURL
 	}
-	ts := m.config.TokenSource(ctx, token)
+	ts := m.config.TokenSource(withRefreshHTTPClient(ctx), token)
 	return fetchTokenProfileEmailFromEndpoint(ctx, ts, endpoint, email, tokenProfileErrorOAuth)
 }
 

--- a/internal/oauth/refresh_bound_test.go
+++ b/internal/oauth/refresh_bound_test.go
@@ -1,0 +1,390 @@
+package oauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// stubTransport is an inert RoundTripper for tests that never dial anything.
+type stubTransport struct{}
+
+func (stubTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+	}, nil
+}
+
+// stubJar is an inert cookie jar used to prove shallow copies preserve it.
+type stubJar struct{}
+
+func (stubJar) SetCookies(*url.URL, []*http.Cookie) {}
+func (stubJar) Cookies(*url.URL) []*http.Cookie     { return nil }
+
+// The helper copies the caller's (or oauth2's default) client instead of
+// mutating it, and never widens an existing timeout.
+func TestWithRefreshHTTPClientCapsTimeout(t *testing.T) {
+	t.Run("default client is copied and capped", func(t *testing.T) {
+		assert := assert.New(t)
+
+		ctx := withRefreshHTTPClient(context.Background())
+
+		got, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+		require.True(t, ok, "context must carry a client")
+		assert.Equal(refreshHTTPTimeout, got.Timeout, "capped timeout")
+		assert.Equal(http.DefaultClient.Transport, got.Transport, "customized default transport preserved")
+		assert.Equal(http.DefaultClient.Jar, got.Jar, "default jar preserved")
+		assert.NotSame(http.DefaultClient, got, "global client must not be reused or mutated")
+		assert.Zero(http.DefaultClient.Timeout, "http.DefaultClient must stay untouched")
+	})
+
+	t.Run("zero timeout is capped, settings preserved", func(t *testing.T) {
+		assert := assert.New(t)
+
+		transport := &stubTransport{}
+		checkRedirect := func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+		caller := &http.Client{
+			Transport:     transport,
+			Jar:           stubJar{},
+			CheckRedirect: checkRedirect,
+		}
+
+		ctx := withRefreshHTTPClient(context.WithValue(context.Background(), oauth2.HTTPClient, caller))
+
+		got, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+		require.True(t, ok, "context must carry a client")
+		assert.Equal(refreshHTTPTimeout, got.Timeout, "zero timeout capped")
+		assert.Same(transport, got.Transport, "caller transport preserved")
+		assert.Equal(caller.Jar, got.Jar, "caller jar preserved")
+		assert.Equal(
+			reflect.ValueOf(caller.CheckRedirect).Pointer(),
+			reflect.ValueOf(got.CheckRedirect).Pointer(),
+			"caller redirect policy preserved")
+		assert.NotSame(caller, got, "caller client must not be mutated")
+		assert.Zero(caller.Timeout, "caller timeout unchanged")
+	})
+
+	t.Run("long timeout is capped", func(t *testing.T) {
+		caller := &http.Client{Timeout: 2 * time.Hour}
+
+		ctx := withRefreshHTTPClient(context.WithValue(context.Background(), oauth2.HTTPClient, caller))
+
+		got, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+		require.True(t, ok, "context must carry a client")
+		assert.Equal(t, refreshHTTPTimeout, got.Timeout, "long timeout capped")
+		assert.Equal(t, 2*time.Hour, caller.Timeout, "caller timeout unchanged")
+	})
+
+	t.Run("short timeout is kept as is", func(t *testing.T) {
+		caller := &http.Client{Timeout: 5 * time.Second}
+
+		ctx := withRefreshHTTPClient(context.WithValue(context.Background(), oauth2.HTTPClient, caller))
+
+		got, ok := ctx.Value(oauth2.HTTPClient).(*http.Client)
+		require.True(t, ok, "context must carry a client")
+		assert.Same(t, caller, got, "already-bounded client is not replaced")
+	})
+
+	t.Run("earlier cancellation is preserved", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		derived := withRefreshHTTPClient(parent)
+		cancel()
+		assert.ErrorIs(t, derived.Err(), context.Canceled,
+			"the derived context must honor the caller's cancellation")
+	})
+}
+
+// stalledTokenTransport imitates a token endpoint that accepts the request
+// and never responds: each round trip blocks until its request context is
+// canceled, then surfaces the cancellation — the exact mechanism
+// http.Client.Timeout uses to stop a stalled call.
+type stalledTokenTransport struct {
+	served chan *http.Request
+}
+
+func newStalledTokenTransport() *stalledTokenTransport {
+	return &stalledTokenTransport{served: make(chan *http.Request, 4)}
+}
+
+func (s *stalledTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case s.served <- req:
+	default:
+	}
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+// tokenSourceForLaterRefresh builds a Manager token source whose stored
+// access token is valid at creation (so creation performs no token-endpoint
+// I/O) and then advances virtual time past its expiry. The returned source is
+// the one oauth2.Transport would later drive through the contextless
+// TokenSource.Token() — the exact path of the reported hang.
+func tokenSourceForLaterRefresh(ctx context.Context, t *testing.T) oauth2.TokenSource {
+	t.Helper()
+
+	mgr := setupTestManager(t, Scopes)
+	mgr.config.Endpoint = oauth2.Endpoint{TokenURL: "https://token.example.test/token"}
+	writeTokenFile(t, mgr, "user@example.com", oauth2.Token{
+		AccessToken:  "cached-access",
+		RefreshToken: "refresh-1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}, Scopes)
+
+	ts, err := mgr.TokenSource(ctx, "user@example.com")
+	require.NoError(t, err, "TokenSource with valid cached token")
+
+	time.Sleep(90 * time.Minute) // virtual clock: expire the cached access token
+	return ts
+}
+
+// A token endpoint that never responds must not block a later Token() on an
+// already-created source. The refresh runs through real http.Client timeout
+// machinery over the production constant in virtual time; with the fix
+// removed the bubble deadlocks and synctest fails the test.
+func TestTokenSourceLaterRefreshBoundsStalledTokenEndpoint(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+
+		stall := newStalledTokenTransport()
+		// Zero timeout: the cap must come from the production path.
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient,
+			&http.Client{Transport: stall})
+
+		ts := tokenSourceForLaterRefresh(ctx, t)
+
+		start := time.Now()
+		_, err := ts.Token()
+		require.Error(err, "later refresh must surface the stalled endpoint")
+		require.ErrorContains(err, "context deadline exceeded",
+			"the unblock must come from the capped HTTP client")
+
+		// x/oauth2 does not know this endpoint's auth style, so it probes
+		// twice; each probe is individually capped at the production bound.
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(elapsed, 2*refreshHTTPTimeout,
+			"both auth-style probes must run to their own bound")
+		assert.Less(elapsed, 2*refreshHTTPTimeout+time.Second,
+			"each probe must stop at the production bound")
+		assert.Len(stall.served, 2, "one request per auth-style probe")
+	})
+}
+
+// The cap lowers the ceiling, never the floor: a caller client already
+// bounded tighter than the package cap keeps its own (virtual) timeout.
+func TestTokenSourceLaterRefreshKeepsShorterCallerTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+
+		stall := newStalledTokenTransport()
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient,
+			&http.Client{Timeout: 5 * time.Second, Transport: stall})
+
+		ts := tokenSourceForLaterRefresh(ctx, t)
+
+		start := time.Now()
+		_, err := ts.Token()
+		require.Error(err, "later refresh must surface the stalled endpoint")
+		require.ErrorContains(err, "context deadline exceeded",
+			"the unblock must come from the caller's own timeout")
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(elapsed, 5*time.Second,
+			"the caller's timeout is honored")
+		assert.Less(elapsed, refreshHTTPTimeout,
+			"a shorter caller timeout must not be widened to the package cap")
+	})
+}
+
+// serveThenStallTransport answers token exchanges until told to stall, after
+// which it behaves like stalledTokenTransport.
+type serveThenStallTransport struct {
+	served chan *http.Request
+	stall  atomic.Bool
+}
+
+func newServeThenStallTransport() *serveThenStallTransport {
+	return &serveThenStallTransport{served: make(chan *http.Request, 4)}
+}
+
+func (s *serveThenStallTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case s.served <- req:
+	default:
+	}
+	if s.stall.Load() {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"access_token":"sa-access","token_type":"Bearer","expires_in":3600}`)),
+		Request: req,
+	}, nil
+}
+
+// The service-account JWT exchange goes through the same capped client: the
+// first Token() mints a token normally, and a later Token() on the
+// already-created source after that token expires must surface a stalled
+// token endpoint. The JWT flow is a single round trip per Token(), so one
+// bounded call must suffice.
+func TestServiceAccountTokenSourceBoundsLaterRefresh(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+
+		transport := newServeThenStallTransport()
+		// Zero timeout: the cap must come from the production path.
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient,
+			&http.Client{Transport: transport})
+
+		keyPath := filepath.Join(t.TempDir(), "service-account.json")
+		writeServiceAccountKeyWithTokenURI(t, keyPath, 0600, "https://token.example.test/token")
+		saMgr, err := NewServiceAccountManager(keyPath, Scopes)
+		require.NoError(err, "NewServiceAccountManager")
+
+		ts, err := saMgr.TokenSource(ctx, "user@example.com")
+		require.NoError(err, "TokenSource")
+
+		token, err := ts.Token()
+		require.NoError(err, "first JWT exchange must succeed against a serving endpoint")
+		assert.Equal("sa-access", token.AccessToken, "minted access token")
+		assert.Len(transport.served, 1, "one serving round trip")
+
+		transport.stall.Store(true)
+		time.Sleep(90 * time.Minute) // virtual clock: expire the minted token
+
+		start := time.Now()
+		_, err = ts.Token()
+		require.Error(err, "later JWT exchange must surface the stalled endpoint")
+		require.ErrorContains(err, "context deadline exceeded",
+			"the unblock must come from the capped HTTP client")
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(elapsed, refreshHTTPTimeout,
+			"the later JWT exchange must run to the production bound")
+		assert.Less(elapsed, 2*refreshHTTPTimeout,
+			"the JWT exchange is a single capped round trip")
+		assert.Len(transport.served, 2, "exactly one stalled round trip after expiry")
+	})
+}
+
+// The ordinary refresh path keeps working against a real token endpoint:
+// an expired stored token is redeemed through the bounded default client
+// and the refreshed token is persisted.
+func TestTokenSourceRefreshesExpiredTokenThroughBoundedClient(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		assert.NoError(r.ParseForm())
+		assert.Equal("refresh_token", r.FormValue("grant_type"))
+		assert.Equal("refresh-1", r.FormValue("refresh_token"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer srv.Close()
+
+	mgr := setupTestManager(t, Scopes)
+	mgr.config.Endpoint = oauth2.Endpoint{TokenURL: srv.URL}
+	writeTokenFile(t, mgr, "user@example.com", oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "refresh-1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Minute),
+	}, Scopes)
+
+	ts, err := mgr.TokenSource(context.Background(), "user@example.com")
+	require.NoError(err, "TokenSource should refresh the expired token")
+
+	token, err := ts.Token()
+	require.NoError(err, "Token")
+	assert.Equal("new-access", token.AccessToken, "refreshed access token")
+	assert.Equal("refresh-1", token.RefreshToken, "refresh token must survive the round trip")
+
+	tf, err := mgr.loadTokenFile("user@example.com")
+	require.NoError(err, "loadTokenFile")
+	assert.Equal("new-access", tf.AccessToken, "refreshed token should be persisted")
+	assert.Equal("refresh-1", tf.RefreshToken, "stored refresh token should be preserved")
+	assert.Equal(Scopes, tf.Scopes, "stored scopes should be preserved")
+}
+
+// servingTokenTransport records each request it serves and answers with a
+// fixed token response, proving which client handled the refresh.
+type servingTokenTransport struct {
+	served chan *http.Request
+}
+
+func (s *servingTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	select {
+	case s.served <- req:
+	default:
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"access_token":"caller-access","token_type":"Bearer","expires_in":3600}`)),
+		Request: req,
+	}, nil
+}
+
+// A caller who supplies an oauth2.HTTPClient keeps their client: the refresh
+// is served by that client's transport (the token URL is unroutable, so the
+// package default could never serve it) with the refresh grant intact.
+func TestTokenSourcePreservesCallerSuppliedHTTPClient(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	transport := &servingTokenTransport{served: make(chan *http.Request, 2)}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient,
+		&http.Client{Transport: transport})
+
+	mgr := setupTestManager(t, Scopes)
+	mgr.config.Endpoint = oauth2.Endpoint{TokenURL: "https://token.invalid/token"}
+	writeTokenFile(t, mgr, "user@example.com", oauth2.Token{
+		AccessToken:  "expired-access",
+		RefreshToken: "refresh-1",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(-time.Minute),
+	}, Scopes)
+
+	ts, err := mgr.TokenSource(ctx, "user@example.com")
+	require.NoError(err, "caller-supplied client must handle the refresh")
+
+	token, err := ts.Token()
+	require.NoError(err, "Token")
+	assert.Equal("caller-access", token.AccessToken, "refreshed access token")
+
+	select {
+	case req := <-transport.served:
+		body, err := io.ReadAll(req.Body)
+		require.NoError(err, "read refresh request body")
+		form, err := url.ParseQuery(string(body))
+		require.NoError(err, "parse refresh request body")
+		assert.Equal("refresh_token", form.Get("grant_type"))
+		assert.Equal("refresh-1", form.Get("refresh_token"))
+	default:
+		require.Fail("caller client never saw the refresh",
+			"refresh was not routed to the caller-supplied client")
+	}
+}

--- a/internal/oauth/serviceaccount.go
+++ b/internal/oauth/serviceaccount.go
@@ -62,5 +62,7 @@ func (m *ServiceAccountManager) TokenSource(ctx context.Context, email string) (
 		return nil, fmt.Errorf("parse service account key: %w", err)
 	}
 	conf.Subject = email
-	return conf.TokenSource(ctx), nil
+	// The creation context carries a bounded token-endpoint client so the
+	// JWT exchange cannot stall the caller forever.
+	return conf.TokenSource(withRefreshHTTPClient(ctx)), nil
 }

--- a/internal/oauth/serviceaccount_test.go
+++ b/internal/oauth/serviceaccount_test.go
@@ -17,6 +17,13 @@ import (
 
 func writeServiceAccountKey(t *testing.T, path string, perm os.FileMode) {
 	t.Helper()
+	writeServiceAccountKeyWithTokenURI(t, path, perm, "https://oauth2.googleapis.com/token")
+}
+
+// writeServiceAccountKeyWithTokenURI writes a service-account key whose
+// token_uri the test controls, so the JWT exchange targets a known endpoint.
+func writeServiceAccountKeyWithTokenURI(t *testing.T, path string, perm os.FileMode, tokenURI string) {
+	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err, "GenerateKey")
@@ -34,7 +41,7 @@ func writeServiceAccountKey(t *testing.T, path string, perm os.FileMode) {
 		"private_key":    string(pemKey),
 		"client_email":   "svc@test-project.iam.gserviceaccount.com",
 		"client_id":      "123456789",
-		"token_uri":      "https://oauth2.googleapis.com/token",
+		"token_uri":      tokenURI,
 	})
 	require.NoError(t, err, "Marshal")
 	require.NoError(t, os.WriteFile(path, data, perm), "WriteFile")


### PR DESCRIPTION
Gmail profile and metadata calls now share a 30-second deadline across HTTP calls and retry backoff, preventing repeated 429 responses from delaying scheduled work for many minutes. Raw message downloads get five minutes. Earlier caller deadlines and cancellation still apply.

The request budget starts after the shared rate limiter grants tokens. Quota pauses of 30 or 60 seconds remain subject to the caller’s context, allowing full sync to wait and fetch the next page after a quota response. The new request timeout does not cap that initial wait, and retries do not restart the budget.

Google OAuth token sources cap each token-endpoint HTTP call at 30 seconds, including service-account exchanges and later refreshes. Shorter timeouts and custom HTTP settings are preserved without mutating the supplied client. This cap is independent of the Gmail request deadline; authentication-style detection can make two calls. Other Google clients using these token managers receive the same cap. Externally supplied token sources retain their own refresh behavior.

No configuration changes are required. This addresses the request and refresh timeout portion of #803. Preserving Gmail quota error reasons and honoring or reporting `Retry-After` remain follow-up work.

Refs #803
