### PR TITLE
feat(imap): create reply drafts

### DIFF
--- a/cmd/msgvault/cmd/daemon_cli_http.go
+++ b/cmd/msgvault/cmd/daemon_cli_http.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.kenn.io/msgvault/internal/api"
 	"go.kenn.io/msgvault/internal/daemonclient"
 )
 
@@ -78,6 +79,9 @@ func runDaemonCLICommandHTTPWithEnv(
 	cwd, err := daemonCLIRunCwd(info, requiresLocalFiles)
 	if err != nil {
 		return err
+	}
+	if api.IsCLIRunDraftReply(args) {
+		cwd = ""
 	}
 
 	runErr := st.RunCLICommand(cmd.Context(), daemonclient.CLIRunRequest{

--- a/cmd/msgvault/cmd/daemon_cli_http.go
+++ b/cmd/msgvault/cmd/daemon_cli_http.go
@@ -84,6 +84,7 @@ func runDaemonCLICommandHTTPWithEnv(
 		cwd = ""
 	}
 
+	draftFailureReported := false
 	runErr := st.RunCLICommand(cmd.Context(), daemonclient.CLIRunRequest{
 		Args: args, Env: env, Cwd: cwd, GrantDecided: grantDecided,
 	}, func(stream, data string) error {
@@ -96,9 +97,14 @@ func runDaemonCLICommandHTTPWithEnv(
 			if _, err := fmt.Fprint(cmd.ErrOrStderr(), data); err != nil {
 				return fmt.Errorf("write CLI stderr: %w", err)
 			}
+			draftFailureReported = api.IsCLIRunDraftReply(args) && data != ""
 		}
 		return nil
 	})
+	if runErr != nil && draftFailureReported {
+		// Draft stderr already contains the failure result or fixed code.
+		cmd.SilenceErrors = true
+	}
 	if runErr != nil && strings.Contains(runErr.Error(), cliSubprocessExitSentinel) {
 		// The daemon subprocess already streamed its real error to our
 		// stderr and exited non-zero. Propagate a non-zero exit without

--- a/cmd/msgvault/cmd/reply_draft.go
+++ b/cmd/msgvault/cmd/reply_draft.go
@@ -1,0 +1,28 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(newDraftReplyCommand())
+}
+
+func newDraftReplyCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "draft-reply <message-id>",
+		Short: "Create an IMAP reply draft from an archived message",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("from") {
+				return usageErr(cmd, errDraftReplyFromRequired)
+			}
+			if !cmd.Flags().Changed("body") {
+				return usageErr(cmd, errDraftReplyBodyRequired)
+			}
+			return runDaemonCLICommandHTTPFromCobra(cmd, args)
+		},
+	}
+	command.Flags().String("from", "", "confirmed source identity for the draft")
+	command.Flags().String("body", "", "reply body")
+	command.Flags().Bool("json", false, "emit one JSON result")
+	return command
+}

--- a/cmd/msgvault/cmd/reply_draft_test.go
+++ b/cmd/msgvault/cmd/reply_draft_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/config"
+)
+
+func TestDraftReplyArgs(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	intent, err := parseDraftReplyArgs([]string{"draft-reply", "42", "--from", "alice@example.com", "--body="})
+	requirements.NoError(err)
+	assertions.Equal(int64(42), intent.MessageID)
+	assertions.Empty(intent.Body)
+	intent, err = parseDraftReplyArgs([]string{"draft-reply", "--verbose", "42", "--log-level", "debug", "--from", "alice@example.com", "--log-sql", "--body", "text", "--log-sql-slow-ms=50"})
+	requirements.NoError(err)
+	assertions.Equal("text", intent.Body)
+	for _, args := range [][]string{
+		{"draft-reply", "42", "--from", "alice@example.com"},
+		{"draft-reply", "42", "--from", "alice@example.com", "--body", "body", "--home", "other"},
+		{"draft-reply", "0", "--from", "alice@example.com", "--body", "body"},
+		{"draft-reply", "42", "--from", "alice@example.com", "--body", "body", "--body", "again"},
+		{"draft-reply", "42", "--from", "alice@example.com", "--body", "body", "--json", "--json"},
+	} {
+		_, err := parseDraftReplyArgs(args)
+		assertions.Error(err)
+	}
+}
+
+func TestDraftReplyArgsRejectsDuplicateJSON(t *testing.T) {
+	requirements := require.New(t)
+	_, err := parseDraftReplyArgs([]string{
+		"draft-reply", "42", "--from", "alice@example.com", "--body", "body", "--json", "--json",
+	})
+	requirements.ErrorContains(err, "invalid_args")
+}
+
+func TestAuthorizeIMAPDraftUsesExactSource(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	policy := []config.IMAPDraftSource{{SourceID: 42, Enabled: true, Mailbox: "Drafts*2026"}}
+	mailbox, err := authorizeIMAPDraft(policy, 42, "imap")
+	requirements.NoError(err)
+	assertions.Equal("Drafts*2026", mailbox)
+	_, err = authorizeIMAPDraft(policy, 41, "imap")
+	requirements.ErrorContains(err, "draft_disabled")
+	_, err = authorizeIMAPDraft(policy, 42, "gmail")
+	requirements.ErrorContains(err, "draft_disabled")
+}

--- a/cmd/msgvault/cmd/root.go
+++ b/cmd/msgvault/cmd/root.go
@@ -232,6 +232,7 @@ func sanitizeArgs(args []string) []string {
 		"--access-token":   true,
 		"--refresh-token":  true,
 		"--client-secrets": true,
+		"--body":           true,
 	}
 	for _, a := range args {
 		if redactNext {

--- a/cmd/msgvault/cmd/root_test.go
+++ b/cmd/msgvault/cmd/root_test.go
@@ -18,6 +18,10 @@ import (
 	extOAuth2 "golang.org/x/oauth2"
 )
 
+func TestSanitizeArgsDraftBody(t *testing.T) {
+	assert.Equal(t, []string{"draft-reply", "42", "--body", "<redacted>", "--body=<redacted>"}, sanitizeArgs([]string{"draft-reply", "42", "--body", "body-secret-731", "--body=body-secret-731"}))
+}
+
 func TestErrOAuthNotConfigured(t *testing.T) {
 	assert := assert.New(t)
 	err := errOAuthNotConfigured()

--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -26,6 +26,7 @@ import (
 	"go.kenn.io/msgvault/internal/discord"
 	"go.kenn.io/msgvault/internal/gmail"
 	"go.kenn.io/msgvault/internal/granola"
+	imaplib "go.kenn.io/msgvault/internal/imap"
 	"go.kenn.io/msgvault/internal/meetingimport"
 	"go.kenn.io/msgvault/internal/microsoft"
 	"go.kenn.io/msgvault/internal/notionmeetings"
@@ -584,18 +585,21 @@ func runServe(cmd *cobra.Command, args []string) error {
 	sched.Start()
 
 	// Create adapters for the API interfaces
+	refreshCacheAfterWrite := func(_ context.Context, label string) error {
+		// The write is already durable. Keep the refresh independent of the
+		// client, but let daemon shutdown stop it before the store closes.
+		return daemonCacheRefreshError(ctx, rebuildCacheAfterScheduledSync(ctx, label))
+	}
 	meetingImporter := meetingimport.NewImporter(s, meetingimport.Hooks{
 		AfterSourceSetup: func() error {
 			return runPostSourceCreateMigrations(s)
 		},
-		RefreshCache: func(_ context.Context, label string) error {
-			// The import is already durable. Keep the refresh independent of the
-			// client, but let daemon shutdown stop it before the store closes.
-			return daemonCacheRefreshError(ctx, rebuildCacheAfterScheduledSync(ctx, label))
-		},
+		RefreshCache: refreshCacheAfterWrite,
 	}).WithLogger(logger)
 	storeAdapter := &storeAPIAdapter{
 		store:                  s,
+		draftPolicy:            snapshotIMAPDraftPolicy(cfg),
+		draftCacheRefresh:      refreshCacheAfterWrite,
 		attachmentMaintenance:  attachmentMaint,
 		meetingImporter:        meetingImporter,
 		analyticsDir:           cfg.AnalyticsDir(),
@@ -775,6 +779,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func snapshotIMAPDraftPolicy(cfg *config.Config) []config.IMAPDraftSource {
+	if cfg == nil {
+		return nil
+	}
+	return append([]config.IMAPDraftSource(nil), cfg.IMAP.Drafts...)
 }
 
 func reconcileCardDAVSchedulerJob(sched *scheduler.Scheduler, cardDAVConfig config.CardDAVConfig, service api.CardDAVOperations, logger *slog.Logger) error {
@@ -1216,7 +1227,12 @@ func newDaemonIdleTracker(c *config.Config, stop context.CancelFunc) *api.IdleTr
 // Since api.APIMessage, api.StoreStats, etc. are type aliases for store types,
 // the adapter methods are simple pass-throughs with no conversion needed.
 type storeAPIAdapter struct {
-	store                 *store.Store
+	store              *store.Store
+	draftPolicy        []config.IMAPDraftSource
+	draftClientFactory func(context.Context, *store.Source) (*imaplib.Client, error)
+	// draftCacheRefresh rebuilds the analytics cache after a draft is durable,
+	// the same best-effort hook the meeting importer uses.
+	draftCacheRefresh     func(context.Context, string) error
 	attachmentMaintenance *attachmentMaintenance
 	meetingImporter       *meetingimport.Importer
 	// analyticsDir is the daemon's Parquet analytics cache directory, used
@@ -1812,6 +1828,9 @@ func (a *storeAPIAdapter) runCLICommandWithRunner(
 			return nil
 		}
 		return emit(api.CLIRunEvent{Type: stream, Data: data})
+	}
+	if api.IsCLIRunDraftReply(req.Args) {
+		return a.runCLIReplyDraft(ctx, req, emit)
 	}
 	runSubprocess := func(ctx context.Context) error {
 		args := req.Args

--- a/cmd/msgvault/cmd/serve_reply_draft.go
+++ b/cmd/msgvault/cmd/serve_reply_draft.go
@@ -1,0 +1,421 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	imaplib "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+var (
+	errDraftReplyFromRequired = errors.New("--from is required")
+	errDraftReplyBodyRequired = errors.New("--body is required")
+)
+
+const (
+	draftReplyStatusCreated     = "created"
+	draftReplyStatusLocalFailed = "remote_accepted_local_failed"
+)
+
+type draftReplyIntent struct {
+	MessageID int64
+	From      string
+	Body      string
+	JSON      bool
+}
+
+// draftReplyTarget is the archived parent message and the granted source
+// mailbox that will hold the reply.
+type draftReplyTarget struct {
+	parent  *store.APIMessage
+	source  *store.Source
+	mailbox string
+	raw     []byte
+}
+
+type draftReplyOutput struct {
+	Status          string `json:"status"`
+	MessageID       int64  `json:"message_id,omitempty"`
+	OperationRef    string `json:"operation_ref"`
+	RFC822MessageID string `json:"rfc822_message_id"`
+	SourceID        int64  `json:"source_id"`
+	Mailbox         string `json:"mailbox"`
+	UID             uint32 `json:"uid"`
+	UIDValidity     uint32 `json:"uidvalidity"`
+}
+
+// draftReplyError pairs the fixed code a client sees with the cause the
+// daemon logs. Causes must never include flag values or message content.
+func draftReplyError(code string, cause error) error {
+	return &api.CLIRunCodedError{Code: code, Err: cause}
+}
+
+func invalidDraftReplyArgs(format string, args ...any) (draftReplyIntent, error) {
+	return draftReplyIntent{}, draftReplyError("invalid_args", fmt.Errorf(format, args...))
+}
+
+func parseDraftReplyArgs(args []string) (draftReplyIntent, error) {
+	if !api.IsCLIRunDraftReply(args) {
+		return invalidDraftReplyArgs("expected %s as the first argument", api.CLIRunDraftReplyCommand)
+	}
+	var intent draftReplyIntent
+	var positional string
+	var fromSet, bodySet, jsonSet bool
+	rest := args[1:]
+	for len(rest) > 0 {
+		arg := rest[0]
+		rest = rest[1:]
+		nameValue, ok := strings.CutPrefix(arg, "--")
+		if !ok {
+			if positional != "" {
+				return invalidDraftReplyArgs("expected exactly one message ID")
+			}
+			positional = arg
+			continue
+		}
+		name, value, hasValue := strings.Cut(nameValue, "=")
+		switch name {
+		case "from", "body":
+			if !hasValue {
+				if len(rest) == 0 {
+					return invalidDraftReplyArgs("--%s requires a value", name)
+				}
+				value, rest = rest[0], rest[1:]
+			}
+			if (name == "from" && fromSet) || (name == "body" && bodySet) {
+				return invalidDraftReplyArgs("--%s given more than once", name)
+			}
+			if name == "from" {
+				intent.From, fromSet = value, true
+			} else {
+				intent.Body, bodySet = value, true
+			}
+		case "json":
+			if jsonSet {
+				return invalidDraftReplyArgs("--json given more than once")
+			}
+			if hasValue && value != "true" {
+				return invalidDraftReplyArgs("--json accepts no value")
+			}
+			intent.JSON, jsonSet = true, true
+		case "log-level", "verbose", "log-sql", "log-sql-slow-ms":
+			// The client forwards root logging flags to every daemon command.
+			// This route runs in-process on the daemon's logger, so the flag
+			// has nothing to configure. Consume its value and move on.
+			if !hasValue && name != "verbose" && name != "log-sql" && len(rest) > 0 {
+				rest = rest[1:]
+			}
+		default:
+			return invalidDraftReplyArgs("unknown flag --%s", name)
+		}
+	}
+	if !fromSet || intent.From == "" {
+		return invalidDraftReplyArgs("--from is required")
+	}
+	if !bodySet {
+		return invalidDraftReplyArgs("--body is required")
+	}
+	id, err := strconv.ParseInt(positional, 10, 64)
+	if err != nil || id <= 0 {
+		return invalidDraftReplyArgs("message ID must be a positive integer")
+	}
+	intent.MessageID = id
+	return intent, nil
+}
+
+func marshalDraftReplyOutput(output draftReplyOutput) []byte {
+	data, err := json.Marshal(output)
+	if err != nil {
+		return []byte("{\"status\":\"output_encoding_failed\"}")
+	}
+	return data
+}
+
+func authorizeIMAPDraft(policy []config.IMAPDraftSource, sourceID int64, sourceType string) (string, error) {
+	if sourceType != "imap" {
+		return "", draftReplyError("draft_disabled", fmt.Errorf("source %d is a %q source, not imap", sourceID, sourceType))
+	}
+	for _, grant := range policy {
+		if grant.SourceID == sourceID && grant.Enabled {
+			if err := imaplib.ValidateDraftMailbox(grant.Mailbox); err != nil {
+				return "", draftReplyError("invalid_mailbox", fmt.Errorf("[[imap.drafts]] grant for source %d: %w", sourceID, err))
+			}
+			return grant.Mailbox, nil
+		}
+	}
+	return "", draftReplyError("draft_disabled", fmt.Errorf("source %d has no enabled [[imap.drafts]] grant", sourceID))
+}
+
+func hasConfirmedSourceIdentity(identities []store.AccountIdentity, address string) bool {
+	for _, identity := range identities {
+		if !identity.ConfirmedAt.IsZero() && store.EqualIdentifier(identity.Address, address) {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *storeAPIAdapter) runCLIReplyDraft(
+	ctx context.Context,
+	req api.CLIRunRequest,
+	emit func(api.CLIRunEvent) error,
+) error {
+	if len(req.Env) != 0 || req.Cwd != "" {
+		return draftReplyError("invalid_args", errors.New("draft-reply accepts no environment or working directory"))
+	}
+	intent, err := parseDraftReplyArgs(req.Args)
+	if err != nil {
+		return err
+	}
+	target, err := a.resolveDraftReplyTarget(ctx, intent)
+	if err != nil {
+		return err
+	}
+	reply, err := imaplib.BuildReply(target.raw, intent.From, intent.Body, time.Now(), "")
+	if err != nil {
+		return draftReplyError("invalid_reply_metadata", err)
+	}
+	if len(reply.Parsed.From) != 1 || len(reply.Parsed.To) == 0 {
+		return draftReplyError("invalid_reply_metadata", errors.New("composed reply needs one From and at least one To address"))
+	}
+	messageIDValue := mime.NormalizeMessageID(reply.Parsed.MessageID)
+	if messageIDValue == "" {
+		return draftReplyError("invalid_reply_metadata", errors.New("composed reply has no usable Message-ID"))
+	}
+	messageIDValue = "<" + messageIDValue + ">"
+
+	// Hold the source's sync lock from APPEND through local publication so a
+	// concurrent sync cannot reconcile a stale mailbox snapshot over the draft.
+	execution, err := a.store.AcquireSyncExecutionContext(ctx, target.source.ID)
+	if err != nil {
+		if errors.Is(err, store.ErrSyncAlreadyActive) {
+			return draftReplyError("sync_active", fmt.Errorf("source %d: %w", target.source.ID, err))
+		}
+		return draftReplyError("sync_lock_failed", fmt.Errorf("source %d: %w", target.source.ID, err))
+	}
+	defer func() { _ = execution.Release() }()
+
+	receipt, err := a.appendDraftReply(ctx, target, reply.Raw, emit)
+	if err != nil {
+		return err
+	}
+	receiptModel := store.IMAPDraftReceipt{
+		SourceID: target.source.ID, Mailbox: target.mailbox,
+		UIDValidity: receipt.UIDValidity, UID: receipt.UID,
+	}
+	result := draftReplyOutput{
+		Status:          draftReplyStatusCreated,
+		OperationRef:    draftOperationRef(receiptModel),
+		RFC822MessageID: messageIDValue,
+		SourceID:        target.source.ID,
+		Mailbox:         target.mailbox,
+		UID:             receipt.UID,
+		UIDValidity:     receipt.UIDValidity,
+	}
+	localID, err := a.store.PersistIMAPDraftContext(ctx, receiptModel, draftReplyParticipants(reply.Parsed), func(ids []int64) *store.MessagePersistData {
+		return draftReplyPersistData(target, reply, receiptModel, messageIDValue, ids)
+	})
+	if err != nil {
+		result.Status = draftReplyStatusLocalFailed
+		_ = emitDraftReplyOutput(emit, cliStreamStderr, intent.JSON, result)
+		return draftReplyError(draftReplyStatusLocalFailed, err)
+	}
+	result.MessageID = localID
+	if err := emitDraftReplyOutput(emit, cliStreamStdout, intent.JSON, result); err != nil {
+		return draftReplyError("output_failed", err)
+	}
+	// The draft is durable and reported. Free the source for syncs before the
+	// cache rebuild, which can take a while and needs no lock.
+	if err := execution.Release(); err != nil {
+		logger.Error("release source after draft", "source_id", target.source.ID, "error", err)
+	}
+	a.refreshDraftCache(ctx, target.source)
+	return nil
+}
+
+// refreshDraftCache runs the daemon's best-effort analytics rebuild once the
+// draft is durable, so aggregate views include it before the next sync. A
+// failure is logged and never changes the result the client already received.
+func (a *storeAPIAdapter) refreshDraftCache(ctx context.Context, source *store.Source) {
+	if a.draftCacheRefresh == nil {
+		return
+	}
+	if err := a.draftCacheRefresh(ctx, source.Identifier); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		logger.Error("draft analytics cache refresh failed", "source_id", source.ID, "error", err)
+	}
+}
+
+// resolveDraftReplyTarget loads the parent, checks the operator grant, and
+// confirms the sender identity. It runs before the sync lock is taken so a
+// denied request never blocks a sync.
+func (a *storeAPIAdapter) resolveDraftReplyTarget(ctx context.Context, intent draftReplyIntent) (draftReplyTarget, error) {
+	parent, err := a.store.GetMessageContext(ctx, intent.MessageID)
+	if err != nil {
+		return draftReplyTarget{}, draftReplyError("invalid_parent", fmt.Errorf("load message %d: %w", intent.MessageID, err))
+	}
+	source, err := a.store.GetSourceByIDContext(ctx, parent.SourceID)
+	if err != nil {
+		return draftReplyTarget{}, draftReplyError("invalid_source", fmt.Errorf("load source %d: %w", parent.SourceID, err))
+	}
+	mailbox, err := authorizeIMAPDraft(a.draftPolicy, source.ID, source.SourceType)
+	if err != nil {
+		return draftReplyTarget{}, err
+	}
+	if !source.SyncConfig.Valid {
+		return draftReplyTarget{}, draftReplyError("invalid_source", fmt.Errorf("source %d has no sync config", source.ID))
+	}
+	imapConfig, err := imaplib.ConfigFromJSON(source.SyncConfig.String)
+	if err != nil {
+		return draftReplyTarget{}, draftReplyError("invalid_source", fmt.Errorf("source %d sync config: %w", source.ID, err))
+	}
+	if imapConfig.Identifier() != source.Identifier {
+		return draftReplyTarget{}, draftReplyError("invalid_source", fmt.Errorf("source %d sync config identifier does not match the source", source.ID))
+	}
+	raw, err := a.store.GetMessageRawContext(ctx, parent.ID)
+	if err != nil {
+		return draftReplyTarget{}, draftReplyError("invalid_parent", fmt.Errorf("load raw MIME for message %d: %w", parent.ID, err))
+	}
+	identities, err := a.store.ListAccountIdentitiesContext(ctx, source.ID)
+	if err != nil {
+		return draftReplyTarget{}, draftReplyError("invalid_from", fmt.Errorf("list identities for source %d: %w", source.ID, err))
+	}
+	if !hasConfirmedSourceIdentity(identities, intent.From) {
+		return draftReplyTarget{}, draftReplyError("invalid_from", fmt.Errorf("--from is not a confirmed identity on source %d", source.ID))
+	}
+	return draftReplyTarget{parent: parent, source: source, mailbox: mailbox, raw: raw}, nil
+}
+
+func defaultDraftClientFactory(ctx context.Context, source *store.Source) (*imaplib.Client, error) {
+	client, err := buildAPIClient(ctx, source, oauthManagerCache(), nil)
+	if err != nil {
+		return nil, err
+	}
+	imapClient, ok := client.(*imaplib.Client)
+	if !ok {
+		return nil, fmt.Errorf("source %d did not produce an IMAP client", source.ID)
+	}
+	return imapClient, nil
+}
+
+// appendDraftReply sends the single APPEND. Any failure after this point
+// leaves a state the operator must inspect before retrying.
+func (a *storeAPIAdapter) appendDraftReply(
+	ctx context.Context,
+	target draftReplyTarget,
+	raw []byte,
+	emit func(api.CLIRunEvent) error,
+) (imaplib.DraftAppendResult, error) {
+	clientFactory := a.draftClientFactory
+	if clientFactory == nil {
+		clientFactory = defaultDraftClientFactory
+	}
+	client, err := clientFactory(ctx, target.source)
+	if err != nil {
+		return imaplib.DraftAppendResult{}, draftReplyError("invalid_source", fmt.Errorf("build IMAP client for source %d: %w", target.source.ID, err))
+	}
+	defer func() { _ = client.Close() }()
+	receipt, err := client.AppendDraft(ctx, target.mailbox, raw)
+	if err != nil {
+		if emit != nil {
+			_ = emit(api.CLIRunEvent{Type: cliStreamStderr, Data: receipt.Code + "\n"})
+		}
+		if appendErr, ok := errors.AsType[*imaplib.DraftAppendError](err); ok {
+			err = appendErr.Err
+		}
+		return receipt, draftReplyError(receipt.Code, err)
+	}
+	return receipt, nil
+}
+
+func draftReplyParticipants(parsed *mime.Message) []store.ParticipantPersistData {
+	participants := make([]store.ParticipantPersistData, 0, len(parsed.From)+len(parsed.To))
+	for _, address := range append(append([]mime.Address(nil), parsed.From...), parsed.To...) {
+		participants = append(participants, store.ParticipantPersistData{
+			EmailAddress: address.Email,
+			DisplayName:  address.Name,
+			Domain:       address.Domain,
+		})
+	}
+	return participants
+}
+
+// draftReplyPersistData builds the local row set for the accepted draft. ids
+// holds the participant IDs in From-then-To order.
+func draftReplyPersistData(
+	target draftReplyTarget,
+	reply imaplib.ReplyDraft,
+	receipt store.IMAPDraftReceipt,
+	messageIDValue string,
+	ids []int64,
+) *store.MessagePersistData {
+	parsed := reply.Parsed
+	fromCount := len(parsed.From)
+	toAddresses := make([]string, len(parsed.To))
+	for i, address := range parsed.To {
+		toAddresses[i] = address.Email
+	}
+	conversationKey := target.parent.SourceConversationID
+	if conversationKey == "" {
+		conversationKey = fmt.Sprintf("draft-reply-%d", target.parent.ID)
+	}
+	return &store.MessagePersistData{
+		Message: &store.Message{
+			SourceID:        target.source.ID,
+			SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+			RFC822MessageID: sql.NullString{String: messageIDValue, Valid: true},
+			MessageType:     "email", IsFromMe: true, IdentityDerivedIsFromMe: true,
+			SenderID:         sql.NullInt64{Int64: ids[0], Valid: true},
+			ReplyToMessageID: sql.NullInt64{Int64: target.parent.ID, Valid: true},
+			Subject:          sql.NullString{String: parsed.Subject, Valid: parsed.Subject != ""},
+			Snippet:          sql.NullString{String: strings.TrimSpace(parsed.BodyText), Valid: parsed.BodyText != ""},
+			SentAt:           sql.NullTime{Time: parsed.Date, Valid: !parsed.Date.IsZero()},
+			InternalDate:     sql.NullTime{Time: parsed.Date, Valid: !parsed.Date.IsZero()},
+			SizeEstimate:     int64(len(reply.Raw)), ArchivedAt: time.Now(),
+		},
+		Conversation: &store.ConversationPersistData{
+			SourceConversationID: conversationKey,
+			ConversationType:     "email_thread", Title: parsed.Subject,
+		},
+		BodyText: sql.NullString{String: parsed.BodyText, Valid: true},
+		RawMIME:  reply.Raw, RawFormat: "mime",
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: ids[:fromCount], EmailAddresses: []string{parsed.From[0].Email}},
+			{Type: "to", ParticipantIDs: ids[fromCount:], EmailAddresses: toAddresses},
+		},
+		FTS: &store.FTSDoc{Subject: parsed.Subject, Body: parsed.BodyText, FromAddr: parsed.From[0].Email, ToAddrs: strings.Join(toAddresses, " ")},
+	}
+}
+
+func emitDraftReplyOutput(emit func(api.CLIRunEvent) error, stream string, asJSON bool, result draftReplyOutput) error {
+	if emit == nil {
+		return nil
+	}
+	var text string
+	switch {
+	case asJSON:
+		text = string(marshalDraftReplyOutput(result)) + "\n"
+	case result.Status == draftReplyStatusCreated:
+		text = fmt.Sprintf("created draft message %d (%s|%d|%d), operation %s\n",
+			result.MessageID, result.Mailbox, result.UIDValidity, result.UID, result.OperationRef)
+	default:
+		text = fmt.Sprintf("remote accepted; local persistence failed, inspect operation %s\n", result.OperationRef)
+	}
+	return emit(api.CLIRunEvent{Type: stream, Data: text})
+}
+
+func draftOperationRef(receipt store.IMAPDraftReceipt) string {
+	return fmt.Sprintf("%d:%s|%d:%d", receipt.SourceID, receipt.Mailbox, receipt.UIDValidity, receipt.UID)
+}

--- a/cmd/msgvault/cmd/serve_reply_draft_test.go
+++ b/cmd/msgvault/cmd/serve_reply_draft_test.go
@@ -1,0 +1,390 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	emersionimap "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	imaplib "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestDraftReplyPolicyStates(t *testing.T) {
+	cases := []struct {
+		name    string
+		policy  []config.IMAPDraftSource
+		source  int64
+		typ     string
+		mailbox string
+		code    string
+	}{
+		{name: "disabled", policy: []config.IMAPDraftSource{{SourceID: 42, Mailbox: "Drafts"}}, source: 42, typ: "imap", code: "draft_disabled"},
+		{name: "wrong source", policy: []config.IMAPDraftSource{{SourceID: 42, Enabled: true, Mailbox: "Drafts"}}, source: 41, typ: "imap", code: "draft_disabled"},
+		{name: "wrong provider", policy: []config.IMAPDraftSource{{SourceID: 42, Enabled: true, Mailbox: "Drafts"}}, source: 42, typ: "gmail", code: "draft_disabled"},
+		{name: "blank mailbox", policy: []config.IMAPDraftSource{{SourceID: 42, Enabled: true, Mailbox: " "}}, source: 42, typ: "imap", code: "invalid_mailbox"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			mailbox, err := authorizeIMAPDraft(tc.policy, tc.source, tc.typ)
+			requirements.Error(err)
+			assertions.Empty(mailbox)
+			assertions.Equal(tc.code, err.Error())
+			coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+			requirements.True(ok)
+			assertions.Error(coded.Err)
+		})
+	}
+}
+
+func TestRunCLIReplyDraftUsesTypedRoute(t *testing.T) {
+	run := false
+	adapter := &storeAPIAdapter{}
+	err := adapter.runCLICommandWithRunner(context.Background(), api.CLIRunRequest{
+		Args: []string{"draft-reply"},
+	}, nil, func(context.Context, []string, map[string]string, string, func(string, string) error) error {
+		run = true
+		return nil
+	})
+	require.ErrorContains(t, err, "invalid_args")
+	assert.False(t, run)
+}
+
+func TestDraftPolicySnapshotRequiresDaemonRestart(t *testing.T) {
+	cfg := config.Config{IMAP: config.IMAPConfig{Drafts: []config.IMAPDraftSource{{SourceID: 42, Enabled: true, Mailbox: "Drafts"}}}}
+	snapshot := snapshotIMAPDraftPolicy(&cfg)
+	cfg.IMAP.Drafts[0].Enabled = false
+	assert.True(t, snapshot[0].Enabled)
+}
+
+func TestConfirmedSourceIdentityRejectsMismatch(t *testing.T) {
+	identities := []store.AccountIdentity{{Address: "user@example.com", ConfirmedAt: time.Now()}}
+	assert.False(t, hasConfirmedSourceIdentity(identities, "other@example.com"))
+	assert.True(t, hasConfirmedSourceIdentity(identities, "USER@example.com"))
+}
+
+// draftReplyFixture is one archived IMAP parent message on a source backed by
+// an in-memory IMAP server that advertises UIDPLUS.
+type draftReplyFixture struct {
+	store    *store.Store
+	source   *store.Source
+	parentID int64
+	config   *imaplib.Config
+	// refreshed records every analytics cache refresh label the route requested.
+	refreshed *[]string
+}
+
+func newDraftReplyFixture(t *testing.T) draftReplyFixture {
+	t.Helper()
+	addr, _ := testutil.StartIMAPMemServerForDrafts(t, testutil.IMAPDraftServerOptions{
+		MessagesPerMailbox: map[string]int{"Drafts": 0},
+		Caps:               emersionimap.CapSet{emersionimap.CapIMAP4rev1: {}, emersionimap.CapUIDPlus: {}},
+	})
+	host, portText, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	imapConfig := &imaplib.Config{Host: host, Port: port, Username: testutil.IMAPTestUsername}
+
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", imapConfig.Identifier())
+	require.NoError(t, err)
+	configJSON, err := imapConfig.ToJSON()
+	require.NoError(t, err)
+	// Request-side draft settings smuggled into the source JSON must be ignored.
+	configJSON = strings.TrimSuffix(configJSON, "}") + `,"draft_enabled":false,"drafts_mailbox":"AttackerMailbox"}`
+	require.NoError(t, st.UpdateSourceSyncConfig(source.ID, configJSON))
+	require.NoError(t, st.AddAccountIdentity(source.ID, testutil.IMAPTestUsername, "manual"))
+	conversationID, err := st.EnsureConversation(source.ID, "thread-666", "Question")
+	require.NoError(t, err)
+	senderID, err := st.EnsureParticipant("sender@example.com", "Sender", "example.com")
+	require.NoError(t, err)
+	ownerID, err := st.EnsureParticipant(testutil.IMAPTestUsername, "", "example.com")
+	require.NoError(t, err)
+	parentRaw := []byte("From: Sender <sender@example.com>\r\n" +
+		"To: " + testutil.IMAPTestUsername + "\r\n" +
+		"Subject: Question\r\n" +
+		"Message-ID: <parent@example.com>\r\n\r\n" +
+		"Parent body\r\n")
+	parentID, err := st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			SourceID: source.ID, SourceMessageID: "INBOX|9",
+			ConversationID: conversationID, RFC822MessageID: sql.NullString{String: "parent@example.com", Valid: true},
+			MessageType: store.MessageTypeEmail, SenderID: sql.NullInt64{Int64: senderID, Valid: true},
+			Subject:      sql.NullString{String: "Question", Valid: true},
+			SentAt:       sql.NullTime{Time: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), Valid: true},
+			SizeEstimate: int64(len(parentRaw)),
+		},
+		BodyText: sql.NullString{String: "Parent body", Valid: true}, RawMIME: parentRaw,
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: []int64{senderID}, EmailAddresses: []string{"sender@example.com"}},
+			{Type: "to", ParticipantIDs: []int64{ownerID}, EmailAddresses: []string{testutil.IMAPTestUsername}},
+		},
+	})
+	require.NoError(t, err)
+	return draftReplyFixture{store: st, source: source, parentID: parentID, config: imapConfig, refreshed: new([]string)}
+}
+
+func (f draftReplyFixture) grantedAdapter() *storeAPIAdapter {
+	return &storeAPIAdapter{
+		store:       f.store,
+		draftPolicy: []config.IMAPDraftSource{{SourceID: f.source.ID, Enabled: true, Mailbox: "Drafts"}},
+		draftClientFactory: func(context.Context, *store.Source) (*imaplib.Client, error) {
+			return imaplib.NewClient(f.config, testutil.IMAPTestPassword), nil
+		},
+		draftCacheRefresh: func(ctx context.Context, label string) error {
+			// The refresh must run with the source lock already released.
+			execution, err := f.store.AcquireSyncExecutionContext(ctx, f.source.ID)
+			if err != nil {
+				return fmt.Errorf("source still locked during cache refresh: %w", err)
+			}
+			*f.refreshed = append(*f.refreshed, label)
+			return execution.Release()
+		},
+	}
+}
+
+func (f draftReplyFixture) run(t *testing.T, adapter *storeAPIAdapter, flags ...string) ([]api.CLIRunEvent, error) {
+	t.Helper()
+	args := append([]string{"draft-reply", strconv.FormatInt(f.parentID, 10), "--from", testutil.IMAPTestUsername}, flags...)
+	var events []api.CLIRunEvent
+	err := adapter.runCLIReplyDraft(t.Context(), api.CLIRunRequest{Args: args}, func(event api.CLIRunEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	return events, err
+}
+
+func TestRunCLIReplyDraftPublishesRemoteAndLocalRows(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newDraftReplyFixture(t)
+	adapter := fixture.grantedAdapter()
+
+	events, err := fixture.run(t, adapter, "--body", "reply body", "--json")
+	requirements.NoError(err)
+	requirements.Len(events, 1)
+	var result map[string]any
+	requirements.NoError(json.Unmarshal([]byte(events[0].Data), &result))
+	assertions.Equal("created", result["status"])
+	assertions.Equal("Drafts", result["mailbox"])
+	assertions.Contains(result["operation_ref"], fmt.Sprintf("%d:Drafts|", fixture.source.ID))
+	assertions.NotContains(events[0].Data, "reply body")
+	assertions.Equal([]string{fixture.source.Identifier}, *fixture.refreshed)
+
+	events, err = fixture.run(t, adapter, "--log-level=debug", "--verbose", "--body", "second body", "--log-sql-slow-ms", "50")
+	requirements.NoError(err)
+	requirements.Len(events, 1)
+	assertions.Len(*fixture.refreshed, 2)
+	var latestUIDValidity, latestUID uint32
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`
+		SELECT uidvalidity, uid FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? ORDER BY uid DESC LIMIT 1
+	`), fixture.source.ID, "Drafts").Scan(&latestUIDValidity, &latestUID))
+	assertions.Contains(events[0].Data, fmt.Sprintf("Drafts|%d|%d", latestUIDValidity, latestUID))
+	assertions.Contains(events[0].Data, fmt.Sprintf("operation %d:Drafts|%d:%d", fixture.source.ID, latestUIDValidity, latestUID))
+
+	var localID int64
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`
+		SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?
+	`), fixture.source.ID, "Drafts|1").Scan(&localID))
+	assertions.NotZero(localID)
+	var replyTo sql.NullInt64
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT reply_to_message_id FROM messages WHERE id = ?`), localID).Scan(&replyTo))
+	assertions.Equal(fixture.parentID, replyTo.Int64)
+	assertions.True(replyTo.Valid)
+	var rfc822MessageID string
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT rfc822_message_id FROM messages WHERE id = ?`), localID).Scan(&rfc822MessageID))
+	assertions.True(strings.HasPrefix(rfc822MessageID, "<"))
+	assertions.True(strings.HasSuffix(rfc822MessageID, ">"))
+	var membershipCount, cursorCount int
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT COUNT(*) FROM imap_message_memberships WHERE message_id = ?`), localID).Scan(&membershipCount))
+	var membershipMailbox, membershipFlags string
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT mailbox, flags FROM imap_message_memberships WHERE message_id = ?`), localID).Scan(&membershipMailbox, &membershipFlags))
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT COUNT(*) FROM imap_folder_state WHERE source_id = ?`), fixture.source.ID).Scan(&cursorCount))
+	assertions.Equal(1, membershipCount)
+	assertions.Equal("Drafts", membershipMailbox)
+	assertions.Equal(`["\\Draft"]`, membershipFlags)
+	assertions.Zero(cursorCount)
+	raw, err := fixture.store.GetMessageRaw(localID)
+	requirements.NoError(err)
+	assertions.Contains(string(raw), "In-Reply-To: <parent@example.com>")
+	assertions.Contains(string(raw), "reply body")
+}
+
+func TestRunCLIReplyDraftDeniesBeforeConnecting(t *testing.T) {
+	fixture := newDraftReplyFixture(t)
+	refuseConnect := func(context.Context, *store.Source) (*imaplib.Client, error) {
+		return nil, errors.New("denied requests must not open an IMAP connection")
+	}
+	cases := []struct {
+		name    string
+		adapter *storeAPIAdapter
+		flags   []string
+		code    string
+		cause   string
+	}{
+		{
+			name:    "no grant",
+			adapter: &storeAPIAdapter{store: fixture.store, draftClientFactory: refuseConnect},
+			flags:   []string{"--body", "reply body"},
+			code:    "draft_disabled",
+			cause:   "no enabled [[imap.drafts]] grant",
+		},
+		{
+			name: "duplicate from flag",
+			adapter: &storeAPIAdapter{
+				store:              fixture.store,
+				draftPolicy:        []config.IMAPDraftSource{{SourceID: fixture.source.ID, Enabled: true, Mailbox: "Drafts"}},
+				draftClientFactory: refuseConnect,
+			},
+			flags: []string{"--from", "other@example.com", "--body", "reply body"},
+			code:  "invalid_args",
+			cause: "--from given more than once",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			events, err := fixture.run(t, tc.adapter, tc.flags...)
+			requirements.Error(err)
+			assertions.Empty(events)
+			assertions.Equal(tc.code, err.Error())
+			coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+			requirements.True(ok)
+			requirements.ErrorContains(coded.Err, tc.cause)
+		})
+	}
+
+	t.Run("unconfirmed identity", func(t *testing.T) {
+		adapter := &storeAPIAdapter{
+			store:              fixture.store,
+			draftPolicy:        []config.IMAPDraftSource{{SourceID: fixture.source.ID, Enabled: true, Mailbox: "Drafts"}},
+			draftClientFactory: refuseConnect,
+		}
+		var events []api.CLIRunEvent
+		err := adapter.runCLIReplyDraft(t.Context(), api.CLIRunRequest{
+			Args: []string{"draft-reply", strconv.FormatInt(fixture.parentID, 10), "--from", "other@example.com", "--body", "reply body"},
+		}, func(event api.CLIRunEvent) error {
+			events = append(events, event)
+			return nil
+		})
+		requirements := require.New(t)
+		assertions := assert.New(t)
+		requirements.Error(err)
+		assertions.Empty(events)
+		assertions.Equal("invalid_from", err.Error())
+		coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+		requirements.True(ok)
+		requirements.ErrorContains(coded.Err, "not a confirmed identity")
+		assertions.NotContains(coded.Err.Error(), "other@example.com")
+	})
+}
+
+func TestRunCLIReplyDraftRefusesWhileSourceSyncs(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newDraftReplyFixture(t)
+	execution, err := fixture.store.AcquireSyncExecutionContext(t.Context(), fixture.source.ID)
+	requirements.NoError(err)
+	defer func() { _ = execution.Release() }()
+	adapter := fixture.grantedAdapter()
+	adapter.draftClientFactory = func(context.Context, *store.Source) (*imaplib.Client, error) {
+		return nil, errors.New("a request refused for an active sync must not open an IMAP connection")
+	}
+
+	events, err := fixture.run(t, adapter, "--body", "reply body")
+	requirements.Error(err)
+	assertions.Empty(events)
+	assertions.Equal("sync_active", err.Error())
+	coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+	requirements.True(ok)
+	requirements.ErrorIs(coded.Err, store.ErrSyncAlreadyActive)
+	assertions.NotContains(coded.Err.Error(), "reply body")
+}
+
+func TestRunCLIReplyDraftReportsLocalPersistenceFailure(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	fixture := newDraftReplyFixture(t)
+	// Occupy the provider key the first APPEND into the empty mailbox will
+	// receive, so the remote accepts the draft but local publication conflicts.
+	conversationID, err := fixture.store.EnsureConversation(fixture.source.ID, "thread-stale", "Stale")
+	requirements.NoError(err)
+	_, err = fixture.store.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			SourceID: fixture.source.ID, SourceMessageID: "Drafts|1", ConversationID: conversationID,
+			MessageType: store.MessageTypeEmail, Subject: sql.NullString{String: "Stale", Valid: true},
+		},
+		BodyText: sql.NullString{String: "stale", Valid: true}, RawMIME: []byte("Subject: Stale\r\n\r\nstale\r\n"),
+	})
+	requirements.NoError(err)
+
+	events, err := fixture.run(t, fixture.grantedAdapter(), "--body", "reply body", "--json")
+	requirements.Error(err)
+	assertions.Equal("remote_accepted_local_failed", err.Error())
+	coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+	requirements.True(ok)
+	requirements.ErrorContains(coded.Err, "source_key_conflict")
+	requirements.Len(events, 1)
+	assertions.Equal(cliStreamStderr, events[0].Type)
+	var result map[string]any
+	requirements.NoError(json.Unmarshal([]byte(events[0].Data), &result))
+	assertions.Equal("remote_accepted_local_failed", result["status"])
+	assertions.Equal(fmt.Sprintf("%d:Drafts|%v:%v", fixture.source.ID, result["uidvalidity"], result["uid"]), result["operation_ref"])
+	assertions.NotContains(events[0].Data, "reply body")
+	var membershipCount int
+	requirements.NoError(fixture.store.DB().QueryRow(fixture.store.Rebind(`SELECT COUNT(*) FROM imap_message_memberships WHERE source_id = ?`), fixture.source.ID).Scan(&membershipCount))
+	assertions.Zero(membershipCount)
+	assertions.Empty(*fixture.refreshed)
+}
+
+func TestAppendDraftReplyRetainsFailureCause(t *testing.T) {
+	addr, _ := testutil.StartIMAPMemServerForDrafts(t, testutil.IMAPDraftServerOptions{
+		MessagesPerMailbox: map[string]int{"Drafts": 0},
+		Caps:               emersionimap.CapSet{emersionimap.CapIMAP4rev1: {}},
+	})
+	host, portText, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portText)
+	require.NoError(t, err)
+	adapter := &storeAPIAdapter{
+		draftClientFactory: func(context.Context, *store.Source) (*imaplib.Client, error) {
+			return imaplib.NewClient(&imaplib.Config{Host: host, Port: port, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword), nil
+		},
+	}
+	for _, tc := range []struct{ name, mailbox, code, cause string }{
+		{"missing UIDPLUS", "Drafts", "uidplus_required", "IMAP server does not advertise UIDPLUS"},
+		{"invalid mailbox", "", "invalid_mailbox", "mailbox must be nonblank"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+			var events []api.CLIRunEvent
+			_, err := adapter.appendDraftReply(t.Context(), draftReplyTarget{source: &store.Source{}, mailbox: tc.mailbox}, []byte("Subject: Reply\r\n\r\nreply body\r\n"), func(event api.CLIRunEvent) error {
+				events = append(events, event)
+				return nil
+			})
+			requirements.EqualError(err, tc.code)
+			coded, ok := errors.AsType[*api.CLIRunCodedError](err)
+			requirements.True(ok)
+			requirements.EqualError(coded.Err, tc.cause)
+			assertions.Equal([]api.CLIRunEvent{{Type: cliStreamStderr, Data: tc.code + "\n"}}, events)
+		})
+	}
+}

--- a/cmd/msgvault/cmd/serve_reply_draft_test.go
+++ b/cmd/msgvault/cmd/serve_reply_draft_test.go
@@ -1,18 +1,22 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
+	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	emersionimap "github.com/emersion/go-imap/v2"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/msgvault/internal/api"
@@ -386,5 +390,75 @@ func TestAppendDraftReplyRetainsFailureCause(t *testing.T) {
 			requirements.EqualError(coded.Err, tc.cause)
 			assertions.Equal([]api.CLIRunEvent{{Type: cliStreamStderr, Data: tc.code + "\n"}}, events)
 		})
+	}
+}
+
+func TestDraftReplyCLIFailureOutput(t *testing.T) {
+	for _, failure := range []string{"local persistence", "APPEND rejected", "no result"} {
+		for _, asJSON := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/json=%t", failure, asJSON), func(t *testing.T) {
+				requirements := require.New(t)
+				assertions := assert.New(t)
+				fixture := newDraftReplyFixture(t)
+				adapter := fixture.grantedAdapter()
+				switch failure {
+				case "local persistence":
+					// The remote accepts UID 1, but the archive already owns its key.
+					conversationID, err := fixture.store.EnsureConversation(fixture.source.ID, "stale", "Stale")
+					requirements.NoError(err)
+					_, err = fixture.store.PersistMessage(&store.MessagePersistData{
+						Message: &store.Message{
+							SourceID: fixture.source.ID, SourceMessageID: "Drafts|1",
+							ConversationID: conversationID,
+							MessageType:    store.MessageTypeEmail,
+						},
+						BodyText: sql.NullString{String: "stale", Valid: true},
+						RawMIME:  []byte("Subject: Stale\r\n\r\nstale\r\n"),
+					})
+					requirements.NoError(err)
+				case "APPEND rejected":
+					adapter.draftPolicy[0].Mailbox = "Missing"
+				case "no result":
+					adapter.draftPolicy = nil
+				}
+				server := httptest.NewServer(api.NewServerWithOptions(api.ServerOptions{
+					Config: &config.Config{HomeDir: t.TempDir()},
+					Store:  adapter,
+					Logger: slog.New(slog.DiscardHandler),
+				}).Router())
+				t.Cleanup(server.Close)
+				configureRemoteDaemonForTest(t, server.URL)
+				root := &cobra.Command{Use: "msgvault"}
+				root.AddCommand(newDraftReplyCommand())
+				silenceUsageInRunE(root)
+				var stdout, stderr bytes.Buffer
+				root.SetOut(&stdout)
+				root.SetErr(&stderr)
+				args := []string{"draft-reply", strconv.FormatInt(fixture.parentID, 10), "--from", testutil.IMAPTestUsername, "--body", "reply body"}
+				if asJSON {
+					args = append(args, "--json")
+				}
+				root.SetArgs(args)
+				requirements.Error(root.ExecuteContext(t.Context()))
+				assertions.Empty(stdout.String())
+				assertions.Len(strings.Split(strings.TrimSpace(stderr.String()), "\n"), 1, stderr.String())
+				switch failure {
+				case "local persistence":
+					if asJSON {
+						var result draftReplyOutput
+						requirements.NoError(json.Unmarshal(stderr.Bytes(), &result), stderr.String())
+						assertions.Equal(draftReplyStatusLocalFailed, result.Status)
+						assertions.NotEmpty(result.OperationRef)
+					} else {
+						assertions.Contains(stderr.String(), "remote accepted; local persistence failed, inspect operation ")
+					}
+				case "APPEND rejected":
+					assertions.Equal("append_rejected\n", stderr.String())
+				case "no result":
+					assertions.Contains(stderr.String(), "Error:")
+					assertions.Contains(stderr.String(), "draft_disabled")
+				}
+			})
+		}
 	}
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -158,6 +158,7 @@ and [MCP](usage/chat.md).
 ### Sync, imports, and maintenance
 
 - Fix WhatsApp Apple imports silently skipping URL messages (type 7) with non-empty text.
+- Add `draft-reply`, an opt-in IMAP reply draft path: the daemon composes a plain-text reply with the parent's threading headers, appends it with UIDPLUS to the granted mailbox, and stores the message and its receipt locally in one transaction. msgvault never sends mail.
 - Sync Notion AI Meeting Notes with available transcripts, verified attendees,
   changed-note refresh, and bounded late-transcript retries.
 - Import Slackdump directories/ZIPs and MailMate-style `.mailbox` trees of EML

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -116,7 +116,45 @@ It tests the connection before saving credentials.
 
 Credentials are stored in `tokens/imap_<hash>.json` with restricted file permissions (0600). Use app-specific passwords when your provider supports them.
 
+---
+
 After adding an account, sync it with `msgvault sync-full`. IMAP accounts use the same `sync` and `sync-full` commands as Gmail. See [Setup Guide](/docs/setup/#add-an-imap-account) for a walkthrough.
+
+---
+
+## draft-reply
+
+Create one reply draft from an archived IMAP message. The daemon requires a
+confirmed `--from` identity and an operator grant in `[[imap.drafts]]`.
+
+```bash
+msgvault draft-reply <message-id> --from <address> --body <text>
+msgvault draft-reply <message-id> --from <address> --body= --json
+```
+
+The daemon appends the composed message to the configured literal mailbox with
+the `\Draft` flag, then stores the local message and its `(mailbox, uidvalidity,
+uid)` receipt. The server must advertise UIDPLUS. An accepted APPEND without a
+receipt returns `accepted_unidentified`, and a lost connection returns
+`remote_unknown`; inspect the mailbox before retrying either result. A request
+made while that source is syncing returns `sync_active`; retry after the sync
+finishes.
+
+Configure the grant by editing the daemon host's `config.toml`, then restart
+the daemon:
+
+```toml
+[[imap.drafts]]
+source_id = 42
+enabled = true
+mailbox = "Drafts"
+```
+
+Requests, Settings, source JSON, environment variables, and client config do
+not grant access or change the mailbox. The grant is per source, not per
+caller: any client that can reach the daemon can create drafts on it. A later sync reconciles the saved
+membership when the mailbox's UIDVALIDITY changes. Draft creation never moves
+an IMAP cursor.
 
 ---
 

--- a/docs/usage/imap.md
+++ b/docs/usage/imap.md
@@ -178,3 +178,29 @@ msgvault sync-full you@example.com --noresume
 
 Leave out folder filters for a complete account scan. `repair-labels` cannot
 recover memberships that the archive has never observed.
+
+## Reply drafts
+
+An operator can grant draft creation for one IMAP source in the daemon host's
+TOML file:
+
+```toml
+[[imap.drafts]]
+source_id = 42
+enabled = true
+mailbox = "Drafts"
+```
+
+Restart the daemon after changing the grant. The grant applies to the source,
+not to the caller: any client that can reach the daemon can create drafts on a
+granted source. The `draft-reply` command accepts
+one archived message ID, one confirmed `--from` identity, and `--body`. The
+daemon composes a plain-text reply with the parent message's threading headers,
+then sends one IMAP `APPEND` to the literal mailbox with `\Draft`. The source
+must advertise UIDPLUS. An empty body is valid when supplied as `--body=`.
+
+The daemon stores the accepted message and its mailbox, UIDVALIDITY, and UID in
+one local transaction. It leaves `imap_folder_state` unchanged. A later sync
+owns cursor advancement and reconciles the membership after a UIDVALIDITY
+change, including a reused UID that identifies different mail. An uncertain
+APPEND requires mailbox inspection before another request.

--- a/internal/api/cli_allowlist_drafts_test.go
+++ b/internal/api/cli_allowlist_drafts_test.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCLIRunDraftAllowlist(t *testing.T) {
+	assert.True(t, cliRunCommandAllowed([]string{"draft-reply", "42", "--from=alice@example.com", "--body=body"}))
+	assert.False(t, cliRunCommandAllowed([]string{"configure-imap-drafts"}))
+	assert.False(t, cliRunCommandAllowed([]string{"draft-reply"}))
+}

--- a/internal/api/cli_handlers.go
+++ b/internal/api/cli_handlers.go
@@ -1324,7 +1324,11 @@ func (s *Server) handleCLIRun(w http.ResponseWriter, r *http.Request) {
 
 	writeEvent := newCLINDJSONEventWriter[CLIRunEvent](w)
 	if err := runner.RunCLICommand(r.Context(), req, writeEvent); err != nil {
-		s.logger.Error("failed to run CLI command", "args", req.Args, "error", err)
+		if coded, ok := errors.AsType[*CLIRunCodedError](err); ok {
+			s.logger.Error("failed to run CLI command", "command", req.Args[0], "error_code", coded.Code, "cause", coded.Err)
+		} else {
+			s.logger.Error("failed to run CLI command", "args", req.Args, "error", err)
+		}
 		if writeErr := writeEvent(CLIRunEvent{Type: cliStreamEventTypeError, Error: err.Error()}); writeErr != nil {
 			s.logger.Error("failed to stream CLI run error event", "error", writeErr)
 		}
@@ -1336,6 +1340,9 @@ func (s *Server) handleCLIRun(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) cliRunEnvAllowedForCommand(args []string, name string) bool {
+	if IsCLIRunDraftReply(args) {
+		return false
+	}
 	if len(args) >= 3 && args[0] == cliRunPersonCommand {
 		providerCall := args[1] == "provider" && args[2] == "check"
 		sweepCall := args[1] == "sweep" && args[2] == "run"
@@ -1573,6 +1580,9 @@ const cliRunPersonCommand = "person"
 func cliRunCommandAllowed(args []string) bool {
 	if len(args) == 0 {
 		return false
+	}
+	if IsCLIRunDraftReply(args) {
+		return len(args) >= 2
 	}
 	if args[0] == "backup" {
 		return len(args) >= 2 && args[1] == "create"

--- a/internal/api/cli_run_draft.go
+++ b/internal/api/cli_run_draft.go
@@ -1,0 +1,22 @@
+package api
+
+// CLIRunDraftReplyCommand names the daemon CLI command that the daemon runs
+// in-process instead of spawning a subprocess.
+const CLIRunDraftReplyCommand = "draft-reply"
+
+// IsCLIRunDraftReply reports whether args invoke the in-process draft-reply
+// route.
+func IsCLIRunDraftReply(args []string) bool {
+	return len(args) > 0 && args[0] == CLIRunDraftReplyCommand
+}
+
+// CLIRunCodedError carries a fixed code for the client and the underlying
+// cause for the daemon log. Clients only ever see Code.
+type CLIRunCodedError struct {
+	Code string
+	Err  error
+}
+
+func (e *CLIRunCodedError) Error() string { return e.Code }
+
+func (e *CLIRunCodedError) Unwrap() error { return e.Err }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/BurntSushi/toml"
 	"github.com/robfig/cron/v3"
@@ -440,10 +441,24 @@ type Config struct {
 	People         PeopleConfig                    `toml:"people"`
 	Teams          TeamsConfig                     `toml:"teams"`
 	Deletion       DeletionConfig                  `toml:"deletion"`
+	IMAP           IMAPConfig                      `toml:"imap"`
 
 	// Computed paths (not from config file)
 	HomeDir    string `toml:"-"`
 	configPath string // resolved path to the loaded config file
+}
+
+// IMAPConfig contains operator-owned settings for IMAP mutations.
+type IMAPConfig struct {
+	Drafts []IMAPDraftSource `toml:"drafts"`
+}
+
+// IMAPDraftSource grants one source permission to create a draft in a literal
+// mailbox. The daemon copies this grant at startup.
+type IMAPDraftSource struct {
+	SourceID int64  `toml:"source_id"`
+	Enabled  bool   `toml:"enabled"`
+	Mailbox  string `toml:"mailbox"`
 }
 
 // DeletionConfig records durable operator consent for remote deletion.
@@ -819,8 +834,14 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 		if key.String() == "carddav.password" {
 			return nil, errors.New("[carddav] password is not allowed in config; store it in tokens/carddav.json")
 		}
+		if strings.HasPrefix(key.String(), "imap.drafts.") {
+			return nil, fmt.Errorf("unknown IMAP draft config key %q", key.String())
+		}
 	}
 	if err := cfg.validateFastmailSources(fastmailSourceIDConfigured(content)); err != nil {
+		return nil, err
+	}
+	if err := cfg.validateIMAPDraftSources(content); err != nil {
 		return nil, err
 	}
 
@@ -916,6 +937,38 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	}
 
 	return cfg, nil
+}
+
+func (c *Config) validateIMAPDraftSources(content []byte) error {
+	var raw struct {
+		IMAP struct {
+			Drafts []struct {
+				SourceID *int64 `toml:"source_id"`
+			} `toml:"drafts"`
+		} `toml:"imap"`
+	}
+	_, _ = toml.Decode(string(content), &raw)
+	seen := make(map[int64]struct{}, len(c.IMAP.Drafts))
+	for i := range c.IMAP.Drafts {
+		draft := &c.IMAP.Drafts[i]
+		if i >= len(raw.IMAP.Drafts) || raw.IMAP.Drafts[i].SourceID == nil {
+			return fmt.Errorf("[[imap.drafts]] entry %d: source_id is required", i+1)
+		}
+		if draft.SourceID <= 0 {
+			return fmt.Errorf("[[imap.drafts]] entry %d: source_id must be positive", i+1)
+		}
+		if _, ok := seen[draft.SourceID]; ok {
+			return fmt.Errorf("[[imap.drafts]] entry %d: duplicate source_id selector %d", i+1, draft.SourceID)
+		}
+		seen[draft.SourceID] = struct{}{}
+		if !utf8.ValidString(draft.Mailbox) || strings.TrimSpace(draft.Mailbox) == "" {
+			return fmt.Errorf("[[imap.drafts]] entry %d: mailbox must be nonblank UTF-8", i+1)
+		}
+		if strings.ContainsAny(draft.Mailbox, "\x00\r\n") {
+			return fmt.Errorf("[[imap.drafts]] entry %d: mailbox contains control characters", i+1)
+		}
+	}
+	return nil
 }
 
 func fastmailSourceIDConfigured(content []byte) []bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,39 @@ enabled = true
 	assert.NotContains(encoded.String(), "password")
 }
 
+func TestIMAPDraftConfig(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	path := filepath.Join(t.TempDir(), "config.toml")
+	content := "[[imap.drafts]]\nsource_id = 42\nenabled = true\nmailbox = \"Drafts*2026\"\n"
+	requirements.NoError(os.WriteFile(path, []byte(content), 0o600))
+	t.Log("[[imap.drafts]] enabled source_id=42 mailbox=Drafts*2026")
+	cfg, err := Load(path, "")
+	requirements.NoError(err)
+	requirements.Len(cfg.IMAP.Drafts, 1)
+	assertions.Equal(int64(42), cfg.IMAP.Drafts[0].SourceID)
+	assertions.True(cfg.IMAP.Drafts[0].Enabled)
+	assertions.Equal("Drafts*2026", cfg.IMAP.Drafts[0].Mailbox)
+	requirements.NoError(cfg.Save())
+	reloaded, err := Load(path, "")
+	requirements.NoError(err)
+	requirements.Len(reloaded.IMAP.Drafts, 1)
+	assertions.Equal("Drafts*2026", reloaded.IMAP.Drafts[0].Mailbox)
+	t.Log("config Save/load round-trip kept enabled=true mailbox=Drafts*2026")
+
+	for _, invalid := range []string{
+		"[[imap.drafts]]\nsource_id = 0\nenabled = true\nmailbox = \"Drafts\"\n",
+		"[[imap.drafts]]\nsource_id = 42\nenabled = true\nmailbox = \"\"\n",
+		"[[imap.drafts]]\nsource_id = 42\nenabled = true\nmailbox = \"Drafts\"\n[[imap.drafts]]\nsource_id = 42\nenabled = false\nmailbox = \"Drafts\"\n",
+		"[[imap.drafts]]\nsource_id = 42\nenabled = true\nmailbox = \"Drafts\"\nextra = true\n",
+	} {
+		requirements.NoError(os.WriteFile(path, []byte(invalid), 0o600))
+		_, err := Load(path, "")
+		requirements.Error(err)
+	}
+	t.Log("invalid [[imap.drafts]] entries reject bad source_id, mailbox, duplicate source_id, and unknown keys")
+}
+
 func TestCardDAVConfigRejectsPasswordField(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.toml")
 	require.NoError(t, os.WriteFile(path, []byte(`[carddav]

--- a/internal/imap/draft.go
+++ b/internal/imap/draft.go
@@ -1,0 +1,145 @@
+package imap
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"unicode/utf8"
+
+	imaplib "github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+const (
+	DraftStateCreated              = "created"
+	DraftStateAcceptedUnidentified = "accepted_unidentified"
+	DraftStateRejected             = "rejected"
+	DraftStateRemoteUnknown        = "remote_unknown"
+	DraftStateCancelled            = "cancelled"
+)
+
+// DraftAppendResult records the provider outcome without retaining provider
+// text in callers' error paths.
+type DraftAppendResult struct {
+	State       string
+	UID         uint32
+	UIDValidity uint32
+	Code        string
+}
+
+// DraftAppendError carries a fixed reconciliation code.
+type DraftAppendError struct {
+	State string
+	Code  string
+	Err   error
+}
+
+func (e *DraftAppendError) Error() string { return e.Code }
+func (e *DraftAppendError) Unwrap() error { return e.Err }
+
+// ValidateDraftMailbox validates a configured literal mailbox name.
+func ValidateDraftMailbox(mailbox string) error {
+	if strings.TrimSpace(mailbox) == "" {
+		return errors.New("mailbox must be nonblank")
+	}
+	if strings.ContainsAny(mailbox, "\x00\r\n") {
+		return errors.New("mailbox contains control characters")
+	}
+	if !utf8.ValidString(mailbox) {
+		return errors.New("mailbox must be valid UTF-8")
+	}
+	return nil
+}
+
+// AppendDraft sends one authenticated APPEND. It never selects, creates, or
+// retries the mailbox operation.
+func (c *Client) AppendDraft(ctx context.Context, mailbox string, raw []byte) (DraftAppendResult, error) {
+	if err := ValidateDraftMailbox(mailbox); err != nil {
+		return DraftAppendResult{State: DraftStateRejected, Code: "invalid_mailbox"}, err
+	}
+	if len(raw) == 0 {
+		return DraftAppendResult{State: DraftStateRejected, Code: "invalid_message"}, errors.New("draft message is empty")
+	}
+	if err := ctx.Err(); err != nil {
+		return DraftAppendResult{State: DraftStateCancelled, Code: "cancelled"}, err
+	}
+	var result DraftAppendResult
+	err := c.withConn(ctx, func(conn *imapclient.Client) error {
+		if !conn.Caps().Has(imaplib.CapUIDPlus) {
+			result = DraftAppendResult{State: DraftStateRejected, Code: "uidplus_required"}
+			return &DraftAppendError{State: result.State, Code: result.Code, Err: errors.New("IMAP server does not advertise UIDPLUS")}
+		}
+		if err := ctx.Err(); err != nil {
+			result = DraftAppendResult{State: DraftStateCancelled, Code: "cancelled"}
+			return err
+		}
+		command := conn.Append(mailbox, int64(len(raw)), &imaplib.AppendOptions{
+			Flags: []imaplib.Flag{imaplib.FlagDraft},
+		})
+		finished := make(chan struct{})
+		var data *imaplib.AppendData
+		var appendErr error
+		go func() {
+			var written int64
+			written, appendErr = io.Copy(command, bytes.NewReader(raw))
+			if appendErr == nil && written != int64(len(raw)) {
+				appendErr = io.ErrShortWrite
+			}
+			if appendErr == nil {
+				appendErr = command.Close()
+			}
+			if appendErr == nil {
+				data, appendErr = command.Wait()
+			}
+			close(finished)
+		}()
+		select {
+		case <-finished:
+		case <-ctx.Done():
+			_ = conn.Close()
+			<-finished
+			result = DraftAppendResult{State: DraftStateRemoteUnknown, Code: "remote_unknown"}
+			return &DraftAppendError{State: result.State, Code: result.Code, Err: io.ErrUnexpectedEOF}
+		}
+		if appendErr != nil {
+			if isNetworkError(appendErr) {
+				result = DraftAppendResult{State: DraftStateRemoteUnknown, Code: "remote_unknown"}
+				return fmt.Errorf("append draft transport: %w", appendErr)
+			}
+			var statusErr *imaplib.Error
+			if errors.As(appendErr, &statusErr) &&
+				(statusErr.Type == imaplib.StatusResponseTypeNo || statusErr.Type == imaplib.StatusResponseTypeBad) {
+				result = DraftAppendResult{State: DraftStateRejected, Code: "append_rejected"}
+				return &DraftAppendError{State: result.State, Code: result.Code, Err: errors.New(result.Code)}
+			}
+			result = DraftAppendResult{State: DraftStateRemoteUnknown, Code: "remote_unknown"}
+			return &DraftAppendError{State: result.State, Code: result.Code, Err: appendErr}
+		}
+		if data == nil || data.UID == 0 || data.UIDValidity == 0 {
+			result = DraftAppendResult{State: DraftStateAcceptedUnidentified, Code: "accepted_unidentified"}
+			return &DraftAppendError{State: result.State, Code: result.Code, Err: errors.New(result.Code)}
+		}
+		result = DraftAppendResult{
+			State: DraftStateCreated, Code: "append_uidplus",
+			UID: uint32(data.UID), UIDValidity: data.UIDValidity,
+		}
+		return nil
+	})
+	if err != nil {
+		if appendErr, ok := errors.AsType[*DraftAppendError](err); ok {
+			return result, appendErr
+		}
+		if ctx.Err() != nil {
+			result = DraftAppendResult{State: DraftStateCancelled, Code: "cancelled"}
+			return result, &DraftAppendError{State: result.State, Code: result.Code, Err: ctx.Err()}
+		}
+		if result.State == "" {
+			result = DraftAppendResult{State: DraftStateRejected, Code: "connection_failed"}
+		}
+		return result, &DraftAppendError{State: result.State, Code: result.Code, Err: err}
+	}
+	return result, nil
+}

--- a/internal/imap/draft_test.go
+++ b/internal/imap/draft_test.go
@@ -1,0 +1,102 @@
+package imap
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	emersionimap "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestAppendDraft(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServerForDrafts(t, testutil.IMAPDraftServerOptions{
+		MessagesPerMailbox: map[string]int{"Drafts*2026": 0},
+		Caps:               emersionimap.CapSet{emersionimap.CapIMAP4rev1: {}, emersionimap.CapUIDPlus: {}},
+	})
+	host, port, err := net.SplitHostPort(addr)
+	requirements.NoError(err)
+	portNumber, err := strconv.Atoi(port)
+	requirements.NoError(err)
+	client := NewClient(&Config{Host: host, Port: portNumber, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword)
+	t.Cleanup(func() { _ = client.Close() })
+	result, err := client.AppendDraft(t.Context(), "Drafts*2026", []byte("From: alice@example.com\r\n\r\nbody\r\n"))
+	requirements.NoError(err)
+	assertions.Equal(DraftStateCreated, result.State)
+	assertions.Positive(result.UID)
+	assertions.Positive(result.UIDValidity)
+}
+
+func TestAppendDraftRequiresUIDPlus(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServerForDrafts(t, testutil.IMAPDraftServerOptions{
+		MessagesPerMailbox: map[string]int{"Drafts": 0},
+		Caps:               emersionimap.CapSet{emersionimap.CapIMAP4rev1: {}},
+	})
+	host, port, err := net.SplitHostPort(addr)
+	requirements.NoError(err)
+	portNumber, err := strconv.Atoi(port)
+	requirements.NoError(err)
+	client := NewClient(&Config{Host: host, Port: portNumber, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword)
+	t.Cleanup(func() { _ = client.Close() })
+	result, err := client.AppendDraft(t.Context(), "Drafts", []byte("From: alice@example.com\r\n\r\nbody\r\n"))
+	requirements.Error(err)
+	assertions.Equal("uidplus_required", result.Code)
+}
+
+func TestAppendDraftAcceptedWithoutReceipt(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	addr, _ := testutil.StartIMAPMemServerForDrafts(t, testutil.IMAPDraftServerOptions{
+		MessagesPerMailbox: map[string]int{"Drafts": 0},
+		Caps:               emersionimap.CapSet{emersionimap.CapIMAP4rev1: {}, emersionimap.CapUIDPlus: {}},
+		ReceiptlessAppend:  true,
+	})
+	host, port, err := net.SplitHostPort(addr)
+	requirements.NoError(err)
+	portNumber, err := strconv.Atoi(port)
+	requirements.NoError(err)
+	client := NewClient(&Config{Host: host, Port: portNumber, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword)
+	t.Cleanup(func() { _ = client.Close() })
+	result, err := client.AppendDraft(t.Context(), "Drafts", []byte("From: alice@example.com\r\n\r\nbody\r\n"))
+	requirements.Error(err)
+	assertions.Equal("accepted_unidentified", result.Code)
+}
+
+func TestAppendDraftCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	client := NewClient(&Config{Host: "127.0.0.1", Port: 1, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword)
+	result, err := client.AppendDraft(ctx, "Drafts", []byte("From: alice@example.com\r\n\r\nbody\r\n"))
+	require.Error(t, err)
+	assert.Equal(t, "cancelled", result.Code)
+}
+
+func TestAppendDraftConnectionFailureIsRejected(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	client := NewClient(&Config{Host: "127.0.0.1", Port: 1, Username: testutil.IMAPTestUsername}, testutil.IMAPTestPassword)
+	result, err := client.AppendDraft(ctx, "Drafts", []byte("From: alice@example.com\r\n\r\nbody\r\n"))
+	requirements.Error(err)
+	assertions.Equal(DraftStateRejected, result.State)
+	assertions.Equal("connection_failed", result.Code)
+	assertions.Equal("connection_failed", err.Error())
+}
+
+func TestValidateDraftMailbox(t *testing.T) {
+	for _, value := range []string{"Drafts*2026", " mailbox "} {
+		require.NoError(t, ValidateDraftMailbox(value))
+	}
+	for _, value := range []string{"", "  ", "Drafts\r\nX: bad"} {
+		require.Error(t, ValidateDraftMailbox(value))
+	}
+}

--- a/internal/imap/reply.go
+++ b/internal/imap/reply.go
@@ -1,0 +1,332 @@
+package imap
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	stdmime "mime"
+	"mime/quotedprintable"
+	"net/mail"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	msgmime "go.kenn.io/msgvault/internal/mime"
+)
+
+// ReplyDraft is the composed RFC822 message and its parsed representation.
+type ReplyDraft struct {
+	Raw    []byte
+	Parsed *msgmime.Message
+}
+
+// BuildReply composes a single plain-text reply from an archived message.
+func BuildReply(parentRaw []byte, from, body string, now time.Time, messageID string) (ReplyDraft, error) {
+	if !utf8.ValidString(from) || strings.ContainsAny(from, "\r\n") {
+		return ReplyDraft{}, errors.New("invalid reply From address")
+	}
+	fromAddress, err := parseOneAddress(from)
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("invalid reply From address: %w", err)
+	}
+	if !utf8.ValidString(body) || strings.ContainsAny(body, "\x00") {
+		return ReplyDraft{}, errors.New("invalid reply body")
+	}
+
+	parent, err := mail.ReadMessage(bytes.NewReader(parentRaw))
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("read parent headers: %w", err)
+	}
+	if err := validateSingletonHeaders(parent.Header); err != nil {
+		return ReplyDraft{}, err
+	}
+	replyTo := parent.Header.Get("Reply-To")
+	if replyTo == "" {
+		replyTo = parent.Header.Get("From")
+	}
+	addresses, err := mail.ParseAddressList(replyTo)
+	if err != nil || len(addresses) == 0 {
+		return ReplyDraft{}, errors.New("parent has invalid From or Reply-To")
+	}
+	for _, address := range addresses {
+		if err := validateAddress(address); err != nil {
+			return ReplyDraft{}, fmt.Errorf("parent has invalid reply address: %w", err)
+		}
+	}
+
+	if messageID == "" {
+		messageID, err = newReplyMessageID()
+		if err != nil {
+			return ReplyDraft{}, err
+		}
+	}
+	messageID, err = normalizeWireMessageID(messageID)
+	if err != nil {
+		return ReplyDraft{}, err
+	}
+	parentIDs, err := parseMessageIDHeader(parent.Header.Get("Message-ID"))
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("invalid parent Message-ID: %w", err)
+	}
+	if len(parentIDs) > 1 {
+		return ReplyDraft{}, errors.New("invalid parent Message-ID: more than one ID")
+	}
+	inReplyTo, err := parseMessageIDHeader(parent.Header.Get("In-Reply-To"))
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("invalid parent In-Reply-To: %w", err)
+	}
+	references, err := parseMessageIDHeader(parent.Header.Get("References"))
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("invalid parent References: %w", err)
+	}
+	if len(references) == 0 {
+		references = inReplyTo
+	}
+	var parentID string
+	if len(parentIDs) == 1 {
+		parentID = parentIDs[0]
+		references = append(references, parentID)
+	}
+
+	subject := normalizeReplySubject(decodeHeader(parent.Header.Get("Subject")))
+	fromValue := fromAddress.String()
+	toValue := formatAddresses(addresses)
+	if !validHeaderValue(subject) || !validHeaderValue(fromValue) || !validHeaderValue(toValue) {
+		return ReplyDraft{}, errors.New("invalid reply header")
+	}
+	var raw bytes.Buffer
+	writeHeader := func(name, value string) {
+		_, _ = fmt.Fprintf(&raw, "%s: %s\r\n", name, value)
+	}
+	writeHeader("Date", now.UTC().Format(time.RFC1123Z))
+	writeHeader("From", fromValue)
+	writeHeader("To", toValue)
+	if subject != "" {
+		if !isASCII(subject) {
+			subject = stdmime.QEncoding.Encode("UTF-8", subject)
+		}
+		writeHeader("Subject", subject)
+	}
+	writeHeader("Message-ID", "<"+messageID+">")
+	if parentID != "" {
+		writeHeader("In-Reply-To", "<"+parentID+">")
+	}
+	if len(references) > 0 {
+		writeFoldedHeader(&raw, "References", formatMessageIDs(references))
+	}
+	writeHeader("MIME-Version", "1.0")
+	writeHeader("Content-Type", `text/plain; charset="utf-8"`)
+	writeHeader("Content-Transfer-Encoding", "quoted-printable")
+	raw.WriteString("\r\n")
+	qp := quotedprintable.NewWriter(&raw)
+	if _, err := io.WriteString(qp, body); err != nil {
+		return ReplyDraft{}, fmt.Errorf("encode reply body: %w", err)
+	}
+	if err := qp.Close(); err != nil {
+		return ReplyDraft{}, fmt.Errorf("close reply body: %w", err)
+	}
+
+	parsed, err := msgmime.Parse(raw.Bytes())
+	if err != nil {
+		return ReplyDraft{}, fmt.Errorf("parse composed reply: %w", err)
+	}
+	return ReplyDraft{Raw: raw.Bytes(), Parsed: parsed}, nil
+}
+
+func newReplyMessageID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate reply Message-ID: %w", err)
+	}
+	return hex.EncodeToString(raw[:]) + "@msgvault.local", nil
+}
+
+func parseOneAddress(value string) (*mail.Address, error) {
+	addresses, err := mail.ParseAddressList(value)
+	if err != nil || len(addresses) != 1 {
+		return nil, errors.New("expected exactly one address")
+	}
+	if err := validateAddress(addresses[0]); err != nil {
+		return nil, err
+	}
+	return addresses[0], nil
+}
+
+func validateAddress(address *mail.Address) error {
+	if address == nil || address.Address == "" || strings.ContainsAny(address.Address, "\r\n") || !utf8.ValidString(address.Address) {
+		return errors.New("address is empty or malformed")
+	}
+	if _, err := mail.ParseAddress(address.String()); err != nil {
+		return fmt.Errorf("parse address: %w", err)
+	}
+	return nil
+}
+
+func validHeaderValue(value string) bool {
+	if !utf8.ValidString(value) {
+		return false
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func decodeHeader(value string) string {
+	decoded, err := new(stdmime.WordDecoder).DecodeHeader(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func validateSingletonHeaders(header mail.Header) error {
+	for _, name := range []string{"From", "Reply-To", "Message-ID", "In-Reply-To", "References", "Subject"} {
+		if len(headerValues(header, name)) > 1 {
+			return fmt.Errorf("parent contains duplicate %s headers", name)
+		}
+	}
+	return nil
+}
+
+func headerValues(header mail.Header, name string) []string {
+	var values []string
+	for key, entries := range header {
+		if strings.EqualFold(key, name) {
+			values = append(values, entries...)
+		}
+	}
+	return values
+}
+
+// normalizeWireMessageID accepts one message ID with or without angle
+// brackets and returns it bare.
+func normalizeWireMessageID(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) < 3 || value[0] != '<' || value[len(value)-1] != '>' {
+		if strings.Contains(value, "<") || strings.Contains(value, ">") {
+			return "", errors.New("malformed angle brackets")
+		}
+		value = "<" + value + ">"
+	}
+	return validBareMessageID(value[1 : len(value)-1])
+}
+
+func validBareMessageID(inner string) (string, error) {
+	if inner == "" || strings.ContainsAny(inner, "\r\n<> \t()") || !utf8.ValidString(inner) {
+		return "", errors.New("malformed Message-ID")
+	}
+	return inner, nil
+}
+
+// parseMessageIDHeader returns every message ID in a Message-ID, In-Reply-To,
+// or References header value, bare and in order. RFC 5322 comments in
+// parentheses are skipped, including nested and escaped ones. A bare token
+// without angle brackets is accepted as one ID, as older mail software emits
+// them. Any other text is an error.
+func parseMessageIDHeader(value string) ([]string, error) {
+	var ids []string
+	depth := 0
+	for i := 0; i < len(value); i++ {
+		c := value[i]
+		switch {
+		case depth > 0:
+			switch c {
+			case '\\':
+				i++
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+		case c == '(':
+			depth++
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n':
+		case c == '<':
+			end := strings.IndexByte(value[i:], '>')
+			if end < 0 {
+				return nil, errors.New("unterminated angle bracket")
+			}
+			id, err := validBareMessageID(value[i+1 : i+end])
+			if err != nil {
+				return nil, err
+			}
+			ids = append(ids, id)
+			i += end
+		case c == ')' || c == '>':
+			return nil, errors.New("malformed angle brackets")
+		default:
+			end := strings.IndexAny(value[i:], " \t\r\n(<")
+			if end < 0 {
+				end = len(value) - i
+			}
+			id, err := validBareMessageID(value[i : i+end])
+			if err != nil {
+				return nil, err
+			}
+			ids = append(ids, id)
+			i += end - 1
+		}
+	}
+	if depth != 0 {
+		return nil, errors.New("unterminated comment")
+	}
+	return ids, nil
+}
+
+func normalizeReplySubject(subject string) string {
+	subject = strings.TrimSpace(subject)
+	for len(subject) >= 3 && strings.EqualFold(subject[:3], "re:") {
+		subject = strings.TrimSpace(subject[3:])
+	}
+	if subject == "" {
+		return "Re:"
+	}
+	return "Re: " + subject
+}
+
+func isASCII(value string) bool {
+	for i := range len(value) {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+func formatAddresses(addresses []*mail.Address) string {
+	values := make([]string, len(addresses))
+	for i, address := range addresses {
+		values[i] = address.String()
+	}
+	return strings.Join(values, ", ")
+}
+
+func formatMessageIDs(ids []string) string {
+	values := make([]string, len(ids))
+	for i, id := range ids {
+		values[i] = "<" + id + ">"
+	}
+	return strings.Join(values, " ")
+}
+
+func writeFoldedHeader(raw *bytes.Buffer, name, value string) {
+	const width = 78
+	line := name + ": "
+	for token := range strings.FieldsSeq(value) {
+		if len(line)+len(token)+1 > width && line != name+": " {
+			raw.WriteString(line + "\r\n")
+			line = " "
+		}
+		if line != " " && !strings.HasSuffix(line, " ") {
+			line += " "
+		}
+		line += token
+	}
+	raw.WriteString(line + "\r\n")
+}

--- a/internal/imap/reply_test.go
+++ b/internal/imap/reply_test.go
@@ -1,0 +1,108 @@
+package imap
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildReply(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	parent := "From: Test User <user@example.com>\r\n" +
+		"To: alice@example.com\r\n" +
+		"Reply-To: Test User <user@example.com>\r\n" +
+		"Subject: Re: Café notes\r\n" +
+		"Message-ID: <parent@example.com>\r\n" +
+		"References: <root@example.com>\r\n" +
+		"\r\nparent body\r\n"
+	draft, err := BuildReply([]byte(parent), "alice@example.com", "body-secret-731\nsecond line", time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC), "reply@example.com")
+	requirements.NoError(err)
+	t.Log(`reply composition accepts --body= and emits full References plus CRLF text/plain MIME`)
+	assertions.Contains(string(draft.Raw), "In-Reply-To: <parent@example.com>")
+	assertions.Contains(string(draft.Raw), "References: <root@example.com> <parent@example.com>")
+	assertions.Contains(string(draft.Raw), "Subject: =?UTF-8?")
+	assertions.Contains(string(draft.Raw), "Content-Transfer-Encoding: quoted-printable")
+	assertions.Equal("Re: Café notes", draft.Parsed.Subject)
+	assertions.Equal("body-secret-731\nsecond line", strings.TrimSpace(strings.ReplaceAll(draft.Parsed.BodyText, "\r\n", "\n")))
+}
+
+func TestBuildReplyRejectsInvalidParentHeaders(t *testing.T) {
+	for _, parent := range []string{
+		"From: user@example.com\r\nFrom: alice@example.com\r\n\r\nbody",
+		"From: user@example.com\r\nMessage-ID: broken <id>\r\n\r\nbody",
+	} {
+		_, err := BuildReply([]byte(parent), "alice@example.com", "body", time.Now(), "reply@example.com")
+		require.Error(t, err)
+	}
+}
+
+func TestBuildReplyDoesNotCopyParentInjectedHeaders(t *testing.T) {
+	parent := "From: user@example.com\r\n" +
+		"Subject: safe\r\n" +
+		"Bcc: attacker@example.com\r\n" +
+		"Message-ID: <parent@example.com>\r\n\r\nbody"
+	draft, err := BuildReply([]byte(parent), "alice@example.com", "body", time.Now(), "reply@example.com")
+	require.NoError(t, err)
+	assert.NotContains(t, string(draft.Raw), "Bcc:")
+}
+
+func TestBuildReplyDecodesEncodedParentSubject(t *testing.T) {
+	parent := "From: user@example.com\r\n" +
+		"Subject: =?UTF-8?Q?Caf=C3=A9_notes?=\r\n" +
+		"Message-ID: <parent@example.com>\r\n\r\nbody"
+	draft, err := BuildReply([]byte(parent), "alice@example.com", "body", time.Now(), "reply@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "Re: Café notes", draft.Parsed.Subject)
+	assert.Contains(t, string(draft.Raw), "Subject: =?UTF-8?")
+}
+
+func TestBuildReplyParsesCommentedThreadingHeaders(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	parent := "From: user@example.com\r\n" +
+		"Message-ID: <parent@example.com> (sent by test)\r\n" +
+		"References: <root@example.com> (nested (comment)) <mid@example.com>\r\n" +
+		"\r\nbody"
+	draft, err := BuildReply([]byte(parent), "alice@example.com", "body", time.Now(), "reply@example.com")
+	requirements.NoError(err)
+	raw := string(draft.Raw)
+	assertions.Contains(raw, "In-Reply-To: <parent@example.com>\r\n")
+	assertions.Contains(raw, "References: <root@example.com> <mid@example.com> <parent@example.com>\r\n")
+	assertions.NotContains(raw, "comment")
+
+	parent = "From: user@example.com\r\n" +
+		"Message-ID: <parent@example.com>\r\n" +
+		"In-Reply-To: <a@example.com> <b@example.com>\r\n" +
+		"\r\nbody"
+	draft, err = BuildReply([]byte(parent), "alice@example.com", "body", time.Now(), "reply@example.com")
+	requirements.NoError(err)
+	assertions.Contains(string(draft.Raw), "References: <a@example.com> <b@example.com> <parent@example.com>\r\n")
+
+	for _, bad := range []string{
+		"From: user@example.com\r\nMessage-ID: <one@example.com> <two@example.com>\r\n\r\nbody",
+		"From: user@example.com\r\nMessage-ID: <parent@example.com> (unterminated\r\n\r\nbody",
+		"From: user@example.com\r\nReferences: <root@example.com\r\n\r\nbody",
+	} {
+		_, err := BuildReply([]byte(bad), "alice@example.com", "body", time.Now(), "reply@example.com")
+		assertions.Error(err)
+	}
+}
+
+func TestParseMessageIDHeader(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	ids, err := parseMessageIDHeader(" <a@example.com>(c)<b@example.com> bare@example.com (x \\) y) ")
+	requirements.NoError(err)
+	assertions.Equal([]string{"a@example.com", "b@example.com", "bare@example.com"}, ids)
+	ids, err = parseMessageIDHeader("")
+	requirements.NoError(err)
+	assertions.Empty(ids)
+	for _, bad := range []string{"<>", "<a b@example.com>", "a) b", "<a@example.com>>", "(open"} {
+		_, err := parseMessageIDHeader(bad)
+		assertions.Error(err, bad)
+	}
+}

--- a/internal/store/imap_drafts.go
+++ b/internal/store/imap_drafts.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const imapDraftFlagsJSON = `["\\Draft"]`
+
+// IMAPDraftReceipt identifies the provider message created by APPEND.
+type IMAPDraftReceipt struct {
+	SourceID    int64
+	Mailbox     string
+	UIDValidity uint32
+	UID         uint32
+}
+
+// PersistIMAPDraftContext commits the local message snapshot and its exact
+// mailbox membership in one transaction. It never changes sync cursors.
+func (s *Store) PersistIMAPDraftContext(
+	ctx context.Context,
+	receipt IMAPDraftReceipt,
+	participants []ParticipantPersistData,
+	build func([]int64) *MessagePersistData,
+) (int64, error) {
+	if receipt.SourceID <= 0 || strings.TrimSpace(receipt.Mailbox) == "" || receipt.UID == 0 || receipt.UIDValidity == 0 {
+		return 0, errors.New("invalid IMAP draft receipt")
+	}
+	if build == nil {
+		return 0, errors.New("persist IMAP draft requires a message builder")
+	}
+	var messageID int64
+	before := func(ctx context.Context, tx *loggedTx) error {
+		var sourceType string
+		if err := tx.QueryRowContext(ctx, `SELECT source_type FROM sources WHERE id = ?`, receipt.SourceID).Scan(&sourceType); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.New("invalid_source")
+			}
+			return fmt.Errorf("read IMAP draft source: %w", err)
+		}
+		if sourceType != "imap" {
+			return errors.New("invalid_source")
+		}
+		var existing int64
+		err := tx.QueryRowContext(ctx, `
+			SELECT message_id FROM imap_message_memberships
+			WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+		`, receipt.SourceID, receipt.Mailbox, receipt.UIDValidity, receipt.UID).Scan(&existing)
+		if err == nil {
+			return errors.New("source_key_conflict")
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("check IMAP draft membership: %w", err)
+		}
+		err = tx.QueryRowContext(ctx, `
+			SELECT id FROM messages
+			WHERE source_id = ? AND source_message_id = ?
+		`, receipt.SourceID, IMAPDraftSourceMessageID(receipt)).Scan(&existing)
+		if err == nil {
+			return errors.New("source_key_conflict")
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("check IMAP draft source key: %w", err)
+		}
+		return nil
+	}
+	prepare := func(ctx context.Context, _ *loggedTx, data *MessagePersistData) (*MessagePersistData, error) {
+		if data == nil || data.Message == nil {
+			return nil, errors.New("persist IMAP draft requires a message")
+		}
+		if data.Message.SourceID != receipt.SourceID || data.Message.SourceMessageID != IMAPDraftSourceMessageID(receipt) {
+			return nil, errors.New("source_key_conflict")
+		}
+		if data.MIMEAttachmentReplacement != nil {
+			return nil, errors.New("IMAP drafts cannot contain attachments")
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+	after := func(ctx context.Context, tx *loggedTx, _ *MessagePersistData, id int64) error {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO imap_message_memberships
+				(source_id, mailbox, uidvalidity, uid, message_id, flags, updated_at)
+			VALUES (?, ?, ?, ?, ?, %s, %s)
+		`, s.dialect.JSONBindExpr(), s.dialect.Now()), receipt.SourceID, receipt.Mailbox, receipt.UIDValidity, receipt.UID, id, imapDraftFlagsJSON); err != nil {
+			return fmt.Errorf("persist IMAP draft membership: %w", err)
+		}
+		labelID, err := ensureIMAPMailboxLabel(ctx, tx, receipt.SourceID, receipt.Mailbox)
+		if err != nil {
+			return err
+		}
+		if err := replaceMessageLabelsTx(boundQuerier{ctx: ctx, q: tx}, id, []int64{labelID}); err != nil {
+			return fmt.Errorf("persist IMAP draft label: %w", err)
+		}
+		messageID = id
+		return nil
+	}
+	if _, err := s.persistMessageWithParticipantsTransaction(ctx, before, participants, build, prepare, after); err != nil {
+		return 0, err
+	}
+	return messageID, nil
+}
+
+// IMAPDraftSourceMessageID returns the composite provider key used by sync.
+func IMAPDraftSourceMessageID(receipt IMAPDraftReceipt) string {
+	return fmt.Sprintf("%s|%d", receipt.Mailbox, receipt.UID)
+}

--- a/internal/store/imap_drafts.go
+++ b/internal/store/imap_drafts.go
@@ -55,6 +55,18 @@ func (s *Store) PersistIMAPDraftContext(
 		if !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("check IMAP draft membership: %w", err)
 		}
+		// A new epoch can reuse an archived UID. Preserve the old message under
+		// sync's invalidated key; sync still owns membership retirement and cursors.
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE messages SET source_message_id = 'msgvault-invalidated:' || CAST(id AS TEXT)
+			WHERE source_id = ? AND source_message_id = ? AND EXISTS (
+				SELECT 1 FROM imap_message_memberships
+				WHERE message_id = messages.id AND source_id = messages.source_id
+				  AND mailbox = ? AND uid = ? AND uidvalidity <> ?
+			)
+		`, receipt.SourceID, IMAPDraftSourceMessageID(receipt), receipt.Mailbox, receipt.UID, receipt.UIDValidity); err != nil {
+			return fmt.Errorf("invalidate previous IMAP draft source key: %w", err)
+		}
 		err = tx.QueryRowContext(ctx, `
 			SELECT id FROM messages
 			WHERE source_id = ? AND source_message_id = ?

--- a/internal/store/imap_drafts_test.go
+++ b/internal/store/imap_drafts_test.go
@@ -1,0 +1,88 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestPersistIMAPDraft(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "imap://alice@host:143")
+	requirements.NoError(err)
+	initialStates := []store.IMAPFolderState{
+		{Mailbox: "INBOX", UIDValidity: 101, UIDNext: 900, HighestModSeq: 1 << 40},
+		{Mailbox: "Drafts*2026", UIDValidity: 6, UIDNext: 41, HighestModSeq: 1 << 41},
+		{Mailbox: "Archive", UIDValidity: 8, UIDNext: 77, HighestModSeq: 1 << 42},
+	}
+	requirements.NoError(st.UpsertIMAPFolderStates(source.ID, initialStates))
+	conversationID, err := st.EnsureConversation(source.ID, "thread-666", "Thread")
+	requirements.NoError(err)
+	receipt := store.IMAPDraftReceipt{SourceID: source.ID, Mailbox: "Drafts*2026", UIDValidity: 7, UID: 42}
+	build := func(ids []int64) *store.MessagePersistData {
+		return &store.MessagePersistData{
+			Message: &store.Message{
+				SourceID: source.ID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+				ConversationID: conversationID, MessageType: store.MessageTypeEmail,
+				SenderID:        sql.NullInt64{Int64: ids[0], Valid: true},
+				RFC822MessageID: sql.NullString{String: "draft-42@example.com", Valid: true},
+				Subject:         sql.NullString{String: "Re: Thread", Valid: true},
+				ArchivedAt:      time.Now(), SizeEstimate: 10,
+			},
+			BodyText: sql.NullString{String: "draft body", Valid: true},
+			RawMIME:  []byte("From: alice@example.com\r\n\r\n draft body\r\n"),
+			Recipients: []store.RecipientSet{
+				{Type: "from", ParticipantIDs: []int64{ids[0]}, EmailAddresses: []string{"alice@example.com"}},
+				{Type: "to", ParticipantIDs: []int64{ids[1]}, EmailAddresses: []string{"user@example.com"}},
+			},
+		}
+	}
+	id, err := st.PersistIMAPDraftContext(context.Background(), receipt, []store.ParticipantPersistData{
+		{EmailAddress: "alice@example.com", Domain: "example.com"},
+		{EmailAddress: "user@example.com", Domain: "example.com"},
+	}, build)
+	requirements.NoError(err)
+	assertions.Positive(id)
+	var membershipCount, cursorCount int
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM imap_message_memberships WHERE message_id = ?`), id).Scan(&membershipCount))
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM imap_folder_state WHERE source_id = ?`), source.ID).Scan(&cursorCount))
+	assertions.Equal(1, membershipCount)
+	assertions.Equal(len(initialStates), cursorCount)
+	states, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	assertions.ElementsMatch(initialStates, states)
+	raw, err := st.GetMessageRaw(id)
+	requirements.NoError(err)
+	assertions.Contains(string(raw), "draft body")
+	requirements.NoError(st.ApplyIMAPMailboxDeltas(source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts*2026",
+		State:   store.IMAPFolderState{Mailbox: "Drafts*2026", UIDValidity: 7, UIDNext: 43, HighestModSeq: 11},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Drafts*2026", UIDValidity: 7, UID: 42,
+			SourceMessageID: store.IMAPDraftSourceMessageID(receipt), Flags: []string{"\\Draft"},
+		}},
+	}}))
+	var reconciledID int64
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), source.ID, receipt.Mailbox, receipt.UIDValidity, receipt.UID).Scan(&reconciledID))
+	assertions.Equal(id, reconciledID)
+
+	_, err = st.PersistIMAPDraftContext(context.Background(), receipt, nil, build)
+	requirements.ErrorContains(err, "source_key_conflict")
+	receipt.UIDValidity++
+	_, err = st.PersistIMAPDraftContext(context.Background(), receipt, nil, build)
+	requirements.ErrorContains(err, "source_key_conflict")
+	var messageCount int
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ? AND source_message_id = ?`), source.ID, store.IMAPDraftSourceMessageID(receipt)).Scan(&messageCount))
+	assertions.Equal(1, messageCount)
+}

--- a/internal/store/imap_drafts_test.go
+++ b/internal/store/imap_drafts_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ func TestPersistIMAPDraft(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
 	st := testutil.NewTestStore(t)
-	source, err := st.GetOrCreateSource("imap", "imap://alice@host:143")
+	source, err := st.GetOrCreateSource("imap", "imap://alice@example.com:143")
 	requirements.NoError(err)
 	initialStates := []store.IMAPFolderState{
 		{Mailbox: "INBOX", UIDValidity: 101, UIDNext: 900, HighestModSeq: 1 << 40},
@@ -33,28 +34,29 @@ func TestPersistIMAPDraft(t *testing.T) {
 				SourceID: source.ID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
 				ConversationID: conversationID, MessageType: store.MessageTypeEmail,
 				SenderID:        sql.NullInt64{Int64: ids[0], Valid: true},
-				RFC822MessageID: sql.NullString{String: "draft-42@example.com", Valid: true},
+				RFC822MessageID: sql.NullString{String: fmt.Sprintf("draft-%d@example.com", receipt.UIDValidity), Valid: true},
 				Subject:         sql.NullString{String: "Re: Thread", Valid: true},
 				ArchivedAt:      time.Now(), SizeEstimate: 10,
 			},
 			BodyText: sql.NullString{String: "draft body", Valid: true},
-			RawMIME:  []byte("From: alice@example.com\r\n\r\n draft body\r\n"),
+			RawMIME:  fmt.Appendf(nil, "From: alice@example.com\r\n\r\n draft body epoch %d\r\n", receipt.UIDValidity),
 			Recipients: []store.RecipientSet{
 				{Type: "from", ParticipantIDs: []int64{ids[0]}, EmailAddresses: []string{"alice@example.com"}},
 				{Type: "to", ParticipantIDs: []int64{ids[1]}, EmailAddresses: []string{"user@example.com"}},
 			},
 		}
 	}
-	id, err := st.PersistIMAPDraftContext(context.Background(), receipt, []store.ParticipantPersistData{
+	participants := []store.ParticipantPersistData{
 		{EmailAddress: "alice@example.com", Domain: "example.com"},
 		{EmailAddress: "user@example.com", Domain: "example.com"},
-	}, build)
+	}
+	id, err := st.PersistIMAPDraftContext(context.Background(), receipt, participants, build)
 	requirements.NoError(err)
 	assertions.Positive(id)
-	var membershipCount, cursorCount int
-	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM imap_message_memberships WHERE message_id = ?`), id).Scan(&membershipCount))
+	var draftMembershipCount, cursorCount int
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM imap_message_memberships WHERE message_id = ?`), id).Scan(&draftMembershipCount))
 	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM imap_folder_state WHERE source_id = ?`), source.ID).Scan(&cursorCount))
-	assertions.Equal(1, membershipCount)
+	assertions.Equal(1, draftMembershipCount)
 	assertions.Equal(len(initialStates), cursorCount)
 	states, err := st.GetIMAPFolderStates(source.ID)
 	requirements.NoError(err)
@@ -79,9 +81,48 @@ func TestPersistIMAPDraft(t *testing.T) {
 
 	_, err = st.PersistIMAPDraftContext(context.Background(), receipt, nil, build)
 	requirements.ErrorContains(err, "source_key_conflict")
+	states, err = st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
 	receipt.UIDValidity++
-	_, err = st.PersistIMAPDraftContext(context.Background(), receipt, nil, build)
-	requirements.ErrorContains(err, "source_key_conflict")
+	// A failed insert must also roll back the old message's rekey.
+	_, err = st.PersistIMAPDraftContext(context.Background(), receipt, nil, func([]int64) *store.MessagePersistData { return nil })
+	requirements.ErrorContains(err, "persist message requires a message")
+	oldSourceID, err := st.GetMessageSourceID(id)
+	requirements.NoError(err)
+	assertions.Equal(store.IMAPDraftSourceMessageID(receipt), oldSourceID)
+
+	newID, err := st.PersistIMAPDraftContext(context.Background(), receipt, participants, build)
+	requirements.NoError(err)
+	assertions.NotEqual(id, newID)
+	oldRaw, err := st.GetMessageRaw(id)
+	requirements.NoError(err)
+	assertions.Equal(raw, oldRaw)
+	newRaw, err := st.GetMessageRaw(newID)
+	requirements.NoError(err)
+	assertions.Contains(string(newRaw), "draft body epoch 8")
+	oldSourceID, err = st.GetMessageSourceID(id)
+	requirements.NoError(err)
+	assertions.Equal(fmt.Sprintf("msgvault-invalidated:%d", id), oldSourceID)
+	unchangedStates, err := st.GetIMAPFolderStates(source.ID)
+	requirements.NoError(err)
+	assertions.ElementsMatch(states, unchangedStates)
+	requirements.NoError(st.DB().QueryRow(st.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), source.ID, receipt.Mailbox, receipt.UIDValidity, receipt.UID).Scan(&reconciledID))
+	assertions.Equal(newID, reconciledID)
+
+	// The next sync retires the old epoch without replacing the new draft.
+	requirements.NoError(st.ApplyIMAPMailboxDeltas(source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: receipt.Mailbox, Reset: true,
+		State: store.IMAPFolderState{Mailbox: receipt.Mailbox, UIDValidity: receipt.UIDValidity, UIDNext: receipt.UID + 1},
+		Memberships: []store.IMAPMembershipObservation{{
+			UID: receipt.UID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt), Flags: []string{"\\Draft"},
+		}},
+	}}))
+	assertions.True(messageTombstoned(t, st, id))
+	assertions.False(messageTombstoned(t, st, newID))
+	assertions.Equal(1, membershipCount(t, st, source.ID))
 	var messageCount int
 	requirements.NoError(st.DB().QueryRow(st.Rebind(`SELECT COUNT(*) FROM messages WHERE source_id = ? AND source_message_id = ?`), source.ID, store.IMAPDraftSourceMessageID(receipt)).Scan(&messageCount))
 	assertions.Equal(1, messageCount)

--- a/internal/store/messages.go
+++ b/internal/store/messages.go
@@ -387,18 +387,19 @@ type ConversationPersistData struct {
 
 // Message represents a message in the database.
 type Message struct {
-	ID              int64
-	ConversationID  int64
-	SourceID        int64
-	SourceMessageID string
-	RFC822MessageID sql.NullString // RFC822 Message-ID header for cross-mailbox dedup
-	ListID          sql.NullString // RFC 2919 List-Id header for email list membership
-	MessageType     string         // "email"
-	SentAt          sql.NullTime
-	ReceivedAt      sql.NullTime
-	InternalDate    sql.NullTime
-	SenderID        sql.NullInt64
-	IsFromMe        bool
+	ID               int64
+	ConversationID   int64
+	SourceID         int64
+	SourceMessageID  string
+	RFC822MessageID  sql.NullString // RFC822 Message-ID header for cross-mailbox dedup
+	ListID           sql.NullString // RFC 2919 List-Id header for email list membership
+	MessageType      string         // "email"
+	SentAt           sql.NullTime
+	ReceivedAt       sql.NullTime
+	InternalDate     sql.NullTime
+	SenderID         sql.NullInt64
+	ReplyToMessageID sql.NullInt64
+	IsFromMe         bool
 	// IdentityDerivedIsFromMe reports that IsFromMe came from a confirmed
 	// account identity rather than a source-native sent-by-me signal.
 	IdentityDerivedIsFromMe bool
@@ -1127,11 +1128,12 @@ func upsertMessageSQL(now string) string {
 		conversation_id, source_id, source_message_id,
 		rfc822_message_id, list_id, message_type,
 		sent_at, received_at, internal_date, sender_id,
+		reply_to_message_id,
 		is_from_me, source_is_from_me, identity_is_from_me,
 		subject, snippet, size_estimate,
 		has_attachments, attachment_count, archived_at
 	)
-	SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+	SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 	       (source_is_from_me OR identity_is_from_me),
 	       source_is_from_me, identity_is_from_me,
 	       ?, ?, ?, ?, ?, %s
@@ -1252,6 +1254,7 @@ func upsertMessageWith(q querier, d Dialect, msg *Message) (int64, error) {
 		msg.ConversationID, msg.SourceID, msg.SourceMessageID,
 		msg.RFC822MessageID, msg.ListID, msg.MessageType,
 		msg.SentAt, msg.ReceivedAt, msg.InternalDate, msg.SenderID,
+		msg.ReplyToMessageID,
 		msg.Subject, msg.Snippet, msg.SizeEstimate,
 		msg.HasAttachments, msg.AttachmentCount,
 	}
@@ -1519,12 +1522,17 @@ var ErrInvalidMessageRaw = errors.New("invalid message raw data")
 
 // GetMessageRaw retrieves and decompresses the raw MIME data for a message.
 func (s *Store) GetMessageRaw(messageID int64) ([]byte, error) {
+	return s.GetMessageRawContext(context.Background(), messageID)
+}
+
+// GetMessageRawContext retrieves raw MIME using the caller's request context.
+func (s *Store) GetMessageRawContext(ctx context.Context, messageID int64) ([]byte, error) {
 	var compressed []byte
 	var compression sql.NullString
 
-	err := s.db.QueryRow(`
+	err := s.db.QueryRowContext(ctx, s.Rebind(`
 		SELECT raw_data, compression FROM message_raw WHERE message_id = ?
-	`, messageID).Scan(&compressed, &compression)
+	`), messageID).Scan(&compressed, &compression)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -50,6 +50,18 @@ type statusErrorSession struct {
 	mailbox string
 }
 
+type receiptlessAppendSession struct {
+	imapserver.Session
+}
+
+func (s *receiptlessAppendSession) Append(mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error) {
+	_, err := s.Session.Append(mailbox, r, options)
+	if err != nil {
+		return nil, fmt.Errorf("append IMAP memory message: %w", err)
+	}
+	return nil, nil //nolint:nilnil // IMAP success without APPENDUID.
+}
+
 func (s *statusErrorSession) Status(
 	mailbox string,
 	options *imap.StatusOptions,
@@ -388,6 +400,24 @@ func StartIMAPMemServer(t *testing.T, messagesPerMailbox map[string]int) (string
 	return startIMAPMemServer(t, messagesPerMailbox, nil, "", 0, "", nil)
 }
 
+// IMAPDraftServerOptions controls the capabilities exposed by a draft test
+// server.
+type IMAPDraftServerOptions struct {
+	MessagesPerMailbox map[string]int
+	Caps               imap.CapSet
+	ReceiptlessAppend  bool
+}
+
+// StartIMAPMemServerForDrafts starts the in-memory server with explicit
+// capabilities so APPEND and UIDPLUS paths can be tested together.
+func StartIMAPMemServerForDrafts(t *testing.T, opts IMAPDraftServerOptions) (string, *imapmemserver.User) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	user := serveIMAPMemServerWithCaps(t, ln, opts.MessagesPerMailbox, nil, "", 0, "", nil, nil, opts.Caps, opts.ReceiptlessAppend)
+	return ln.Addr().String(), user
+}
+
 // ServeIMAPMemServer serves an in-memory IMAP server on the caller-supplied
 // listener and returns the user handle for later mutation.
 func ServeIMAPMemServer(
@@ -480,6 +510,23 @@ func serveIMAPMemServer(
 	startTLSConfig *tls.Config,
 ) *imapmemserver.User {
 	t.Helper()
+	return serveIMAPMemServerWithCaps(t, ln, messagesPerMailbox, specialUse, selectErrorMailbox, selectErrorCount, statusErrorMailbox, missingUID, startTLSConfig, nil, false)
+}
+
+func serveIMAPMemServerWithCaps(
+	t *testing.T,
+	ln net.Listener,
+	messagesPerMailbox map[string]int,
+	specialUse map[string][]imap.MailboxAttr,
+	selectErrorMailbox string,
+	selectErrorCount int,
+	statusErrorMailbox string,
+	missingUID *missingUIDConfig,
+	startTLSConfig *tls.Config,
+	caps imap.CapSet,
+	receiptlessAppend bool,
+) *imapmemserver.User {
+	t.Helper()
 	user := imapmemserver.NewUser(IMAPTestUsername, IMAPTestPassword)
 	mailboxes := make([]string, 0, len(messagesPerMailbox))
 	for mailbox, count := range messagesPerMailbox {
@@ -494,6 +541,7 @@ func serveIMAPMemServer(
 	memServer.AddUser(user)
 
 	server := imapserver.New(&imapserver.Options{
+		Caps: caps,
 		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
 			var session imapserver.Session
 			session = memServer.NewSession()
@@ -519,6 +567,9 @@ func serveIMAPMemServer(
 			}
 			if missingUID != nil {
 				session = &missingUIDSession{Session: session, config: missingUID}
+			}
+			if receiptlessAppend {
+				session = &receiptlessAppendSession{Session: session}
 			}
 			return session, nil, nil
 		},


### PR DESCRIPTION
Users can create a plain-text reply draft from an archived IMAP message with `msgvault draft-reply <message-id> --from <address> --body <text>`. This preserves the archived message's threading context, including `In-Reply-To`, `References`, recipients, and a normalized `Re:` subject. msgvault appends the draft to the configured IMAP mailbox with the `\Draft` flag and stores it in the local archive, so users can retrieve it at once and review or send it from their mail client. msgvault never sends mail.

Draft creation stays off unless users enable the matching source in the daemon startup config with `[[imap.drafts]]`, `enabled = true`, and a literal `mailbox`. The daemon reads that grant at startup, rejects request-side config, environment, and working-directory overrides, and requires `UIDPLUS` so the remote mailbox, `UIDVALIDITY`, and `UID` identify the draft. An IMAP acceptance without a receipt, an uncertain transport result, or a local persistence failure produces a state users can reconcile before retrying. msgvault never retries `APPEND` automatically.

This PR handles one plain-text reply for one archived message on one IMAP source. It doesn't add SMTP sending, draft editing or deletion, forwarding, reply-all, attachments, other providers, REST, or MCP.

Refs #666, slice 1

