### PR TITLE
fix(imap): refresh edited outgoing copies after relocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,11 +395,19 @@ jobs:
         include:
           - name: cli
             package: ./cmd/msgvault/cmd
+            # Windows SQLite I/O makes this package's aggregate shard duration
+            # exceed one hour: the passing shard alone ran 406 tests in 3373.8s
+            # (~56m) and the next shard timed out at 60m while still actively
+            # executing schema setup (no deadlock; tests kept progressing).
+            # Give only this package the larger per-shard budget.
+            timeout: 120m
           - name: sync-vector-embed
             package: ./internal/sync
             package2: ./internal/vector/embed
+            timeout: 60m
           - name: vector-sqlite
             package: ./internal/vector/sqlitevec
+            timeout: 60m
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -428,7 +436,7 @@ jobs:
               -Package $package `
               -ShardCount 4 `
               -Tags "fts5 sqlite_vec" `
-              -Timeout 60m
+              -Timeout ${{ matrix.timeout }}
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/cmd/msgvault/cmd/imap_folder_state_sync_test.go
+++ b/cmd/msgvault/cmd/imap_folder_state_sync_test.go
@@ -333,8 +333,6 @@ func TestIMAPFolderStateOptions_ForceRescanRetainsStatesAndEnumerates(t *testing
 	require.NoError(first.Close())
 
 	opts := imapFolderStateOptions(st, src, true)
-	require.Len(opts, 3,
-		"--noresume needs saved identity and alias state plus forced enumeration")
 
 	second := listedIMAPClient(t, addr, opts...)
 	ctx, cancel := context.WithTimeout(

--- a/cmd/msgvault/cmd/imap_qresync_integration_test.go
+++ b/cmd/msgvault/cmd/imap_qresync_integration_test.go
@@ -25,11 +25,16 @@ import (
 )
 
 type scriptedRFC7162Message struct {
-	UID       imapapi.UID
-	MessageID string
-	Subject   string
-	Flags     []imapapi.Flag
-	ModSeq    uint64
+	UID        imapapi.UID
+	MessageID  string
+	Subject    string
+	Body       string
+	MissingRaw bool
+	Flags      []imapapi.Flag
+	ModSeq     uint64
+	// Raw overrides the synthesized message bytes verbatim (already CRLF
+	// encoded) so tests can vary recipients, attachments, and HTML.
+	Raw string
 }
 
 type scriptedRFC7162Mailbox struct {
@@ -405,6 +410,10 @@ func writeScriptedRFC7162Fetch(
 				sequence, uid, formatScriptedRFC7162Flags(message.Flags), modSeq, len(body), body)
 			continue
 		}
+		if message.MissingRaw {
+			_, _ = fmt.Fprintf(w, "* %d FETCH (UID %d FLAGS (%s))\r\n", sequence, uid, formatScriptedRFC7162Flags(message.Flags))
+			continue
+		}
 		raw := scriptedRFC7162RawMessage(message)
 		_, _ = fmt.Fprintf(w,
 			"* %d FETCH (UID %d FLAGS (%s)%s INTERNALDATE \"01-Jan-2024 00:00:00 +0000\" RFC822.SIZE %d BODY[] {%d}\r\n%s)\r\n",
@@ -413,6 +422,9 @@ func writeScriptedRFC7162Fetch(
 }
 
 func scriptedRFC7162RawMessage(message scriptedRFC7162Message) string {
+	if message.Raw != "" {
+		return message.Raw
+	}
 	subject := message.Subject
 	if subject == "" {
 		subject = "Synthetic message"
@@ -421,9 +433,13 @@ func scriptedRFC7162RawMessage(message scriptedRFC7162Message) string {
 	if message.MessageID != "" {
 		messageIDHeader = fmt.Sprintf("Message-ID: <%s>\r\n", message.MessageID)
 	}
+	body := message.Body
+	if body == "" {
+		body = "Synthetic body."
+	}
 	return fmt.Sprintf(
-		"From: sender@example.test\r\nTo: recipient@example.test\r\nDate: Mon, 1 Jan 2024 00:00:00 +0000\r\n%sSubject: %s\r\n\r\nSynthetic body.\r\n",
-		messageIDHeader, subject)
+		"From: sender@example.test\r\nTo: recipient@example.test\r\nDate: Mon, 1 Jan 2024 00:00:00 +0000\r\n%sSubject: %s\r\n\r\n%s\r\n",
+		messageIDHeader, subject, body)
 }
 
 func newScriptedRFC7162Client(

--- a/cmd/msgvault/cmd/imap_relocation_integration_test.go
+++ b/cmd/msgvault/cmd/imap_relocation_integration_test.go
@@ -2645,3 +2645,71 @@ func TestIMAPRelocationRetainsOutgoingPrecedence(t *testing.T) {
 		})
 	}
 }
+
+// An unchanged Sent membership must still supply the final content when a
+// lost Drafts canonical also has an All Mail survivor in the changed set.
+func TestIMAPRelocationUnchangedSentOutranksChangedAll(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	f := newRelocationFixture(t)
+	rawSent := []byte(scriptedRFC7162RawMessage(f.sent))
+	rfc822 := "<" + f.sent.MessageID + ">"
+	// Keep the legacy draft snapshot and all three prior memberships. The
+	// next incremental sync loses Drafts and sees only an All Mail flag change.
+	require.NoError(f.st.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "Drafts",
+			State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 77, UIDNext: 2, HighestModSeq: 1},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Drafts", UIDValidity: 77, UID: 1, SourceMessageID: "Drafts|1",
+				RFC822MessageID: rfc822, Flags: []string{"\\Draft"},
+			}},
+		},
+		{
+			Mailbox: "Sent",
+			State:   store.IMAPFolderState{Mailbox: "Sent", UIDValidity: 88, UIDNext: 2, HighestModSeq: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Sent", UIDValidity: 88, UID: 1, SourceMessageID: "Sent|1",
+				RFC822MessageID: rfc822, RawSHA256: sha256.Sum256(rawSent), RawSize: int64(len(rawSent)), Flags: []string{"\\Seen"},
+			}},
+		},
+		{
+			Mailbox: "All Mail",
+			State:   store.IMAPFolderState{Mailbox: "All Mail", UIDValidity: 99, UIDNext: 2, HighestModSeq: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "All Mail", UIDValidity: 99, UID: 1, SourceMessageID: "All Mail|1",
+				RFC822MessageID: rfc822, RawSHA256: sha256.Sum256(rawSent), RawSize: int64(len(rawSent)), Flags: []string{"\\Seen"},
+			}},
+		},
+	}))
+	require.Len(queryScriptedRFC7162Memberships(t, f.st, f.source.ID), 3)
+	before, err := f.st.GetMessage(f.id)
+	require.NoError(err)
+	require.Equal("Drafts|1", before.SourceMessageID)
+	require.Contains(before.BodyText, f.draft.Body)
+	changed := f.sent
+	changed.Flags = []imapapi.Flag{imapapi.FlagSeen, imapapi.FlagFlagged}
+	f.final.Mailboxes = append(f.final.Mailboxes, scriptedRFC7162Mailbox{
+		Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll},
+		UIDValidity: 99, UIDNext: 2, HighestModSeq: 3,
+		ChangedUIDs: []imapapi.UID{1}, Messages: []scriptedRFC7162Message{changed},
+	})
+	for range 2 {
+		f.server.setSnapshot(f.final)
+		client, err := f.sync(t)
+		require.NoError(err)
+		require.NoError(client.Close())
+		after, err := f.st.GetMessage(f.id)
+		require.NoError(err)
+		assert.Contains(after.BodyText, f.sent.Body)
+		assert.NotContains(after.BodyText, f.draft.Body)
+		raw, err := f.st.GetMessageRaw(f.id)
+		require.NoError(err)
+		assert.Equal(rawSent, raw)
+		_, total, err := f.st.SearchMessagesQuery(&search.Query{TextTerms: []string{f.draft.Body}}, 0, 10)
+		require.NoError(err)
+		assert.Zero(total, "the obsolete draft must leave the search index")
+		f.final.Mailboxes[0].VanishedUIDs = nil
+		f.final.Mailboxes[2].ChangedUIDs = nil
+	}
+}

--- a/cmd/msgvault/cmd/imap_relocation_integration_test.go
+++ b/cmd/msgvault/cmd/imap_relocation_integration_test.go
@@ -2540,8 +2540,10 @@ func TestIMAPRelocationSentContentSurvivesAllAdoption(t *testing.T) {
 	draft.Body = "draftobsoleteword"
 	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
 	sent.Body = "sentfinalword"
+	// The mirror starts with the draft bytes so Sent supplies an edited
+	// snapshot and becomes canonical before its later disappearance.
 	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
-		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{sent}},
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
 		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
 		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{sent}},
 	}}
@@ -2711,5 +2713,148 @@ func TestIMAPRelocationUnchangedSentOutranksChangedAll(t *testing.T) {
 		assert.Zero(total, "the obsolete draft must leave the search index")
 		f.final.Mailboxes[0].VanishedUIDs = nil
 		f.final.Mailboxes[2].ChangedUIDs = nil
+	}
+}
+
+func TestIMAPRelocationMalformedSentAdvancesFolderStates(t *testing.T) {
+	for _, legacy := range []bool{false, true} {
+		t.Run(fmt.Sprintf("persisted-membership=%t", legacy), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			draft := newScriptedRFC7162Message(1, "malformed-relocation@example.test", imapapi.FlagDraft)
+			draft.Body = "validdraftword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Raw = "From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: Invalid final\r\nMessage-ID: <" + draft.MessageID + ">\r\nMIME-Version: 1.0\r\nContent-Type: multipart mixed; boundary=outer\r\n\r\n--outer\r\nContent-Type: text/plain\r\n\r\nfinalword\r\n--outer--\r\n"
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				scriptedRFC7162Inbox(55, 1, 1),
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://malformed-relocation@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+			if legacy {
+				seedLegacyDraftsCanonicalWithSentMembership(t, st, source, []byte(sent.Raw), "<"+draft.MessageID+">")
+			}
+			edited := baseline.clone()
+			edited.Mailboxes[1].Messages = nil
+			edited.Mailboxes[1].HighestModSeq = 3
+			edited.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+			edited.Mailboxes[2].UIDNext = 2
+			edited.Mailboxes[2].HighestModSeq = 2
+			if !legacy {
+				edited.Mailboxes[2].ChangedUIDs = []imapapi.UID{1}
+			}
+			for n := 1; n <= 3; n++ {
+				inbox := newScriptedRFC7162Message(imapapi.UID(n), fmt.Sprintf("new-inbox-%d@example.test", n), imapapi.FlagSeen)
+				inbox.Body = fmt.Sprintf("inboxword%d", n)
+				edited.Mailboxes[0].Messages = append(edited.Mailboxes[0].Messages, inbox)
+				edited.Mailboxes[0].UIDNext = uint32(n + 1)
+				edited.Mailboxes[0].HighestModSeq = uint64(n + 1)
+				edited.Mailboxes[0].ChangedUIDs = append(edited.Mailboxes[0].ChangedUIDs, imapapi.UID(n))
+				server.setSnapshot(edited)
+				summary, err := runScriptedRelocationSyncSummary(t, st, identifier, addr)
+				require.NoError(err)
+				require.NotNil(summary)
+				assert.Zero(summary.Errors)
+				assert.Equal(int64(1), summary.MessagesAdded)
+				inboxID, err := st.GetMessageIDByRFC822ID(source.ID, "<"+inbox.MessageID+">")
+				require.NoError(err)
+				assert.Positive(inboxID)
+				target, err := st.GetMessage(id)
+				require.NoError(err)
+				assert.Equal("Sent|1", target.SourceMessageID)
+				assert.Contains(target.BodyText, "MIME parsing failed")
+				assert.NotContains(target.BodyText, draft.Body)
+				raw, err := st.GetMessageRaw(id)
+				require.NoError(err)
+				assert.Equal(sent.Raw, string(raw))
+				afterStates, err := st.GetIMAPFolderStates(source.ID)
+				require.NoError(err)
+				require.Len(afterStates, 3)
+				for _, state := range afterStates {
+					if state.Mailbox == "INBOX" {
+						assert.Equal(uint32(n+1), state.UIDNext)
+						assert.Equal(uint64(n+1), state.HighestModSeq)
+					}
+				}
+				edited.Mailboxes[1].VanishedUIDs = nil
+				edited.Mailboxes[2].ChangedUIDs = nil
+			}
+		})
+	}
+}
+
+func TestIMAPIdenticalSentKeepsPreferredLocation(t *testing.T) {
+	for _, withSent := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sent=%v", withSent), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			msg := newScriptedRFC7162Message(1, "identical-outgoing@example.test", imapapi.FlagSeen)
+			msg.Body = "finalsentword"
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{msg}},
+			}}
+			if withSent {
+				baseline.Mailboxes = append(baseline.Mailboxes, scriptedRFC7162Mailbox{
+					Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{msg},
+				})
+			}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://identical-outgoing@example.test"
+			summary, err := runScriptedRelocationSyncSummary(t, st, identifier, addr)
+			require.NoError(err)
+			assert.Zero(summary.Errors)
+			assert.Equal(int64(1), summary.MessagesAdded)
+			assert.Zero(summary.MessagesUpdated, "identical content must not trigger relocation persistence")
+			source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+			require.NoError(err)
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+msg.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal("All Mail|1", message.SourceMessageID)
+			if !withSent {
+				metadata, err := st.GetMessageMetadata(id)
+				require.NoError(err)
+				assert.False(metadata.Valid, "untrusted origin does not need a metadata write")
+				return
+			}
+			for range 2 {
+				client, err := runScriptedRelocationResync(t, st, identifier, addr)
+				require.NoError(err)
+				require.NoError(client.Close())
+				message, err = st.GetMessage(id)
+				require.NoError(err)
+				assert.Equal("All Mail|1", message.SourceMessageID)
+				assert.Contains(message.BodyText, msg.Body)
+			}
+			// The identical Sent copy must still establish content precedence:
+			// losing both locations cannot let a stale draft replace the final bytes.
+			draft := newScriptedRFC7162Message(1, msg.MessageID, imapapi.FlagDraft)
+			draft.Body = "staledraftword"
+			server.setSnapshot(scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+			}})
+			client, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(client.Close())
+			message, err = st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal("Drafts|1", message.SourceMessageID)
+			assert.Contains(message.BodyText, msg.Body)
+			assert.NotContains(message.BodyText, draft.Body)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(msg), string(raw))
+		})
 	}
 }

--- a/cmd/msgvault/cmd/imap_relocation_integration_test.go
+++ b/cmd/msgvault/cmd/imap_relocation_integration_test.go
@@ -2350,6 +2350,30 @@ func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
 			assert.NotContains(message.BodyText, draft.Body)
 			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
 			assert.Equal(1, count)
+
+			// Losing the Sent copy must only relocate the archive to Drafts,
+			// not replace its final content with the surviving stale draft.
+			require.Equal(sentMailbox.Name+"|1", message.SourceMessageID)
+			require.Len(queryScriptedRFC7162Memberships(t, st, source.ID), 2)
+			edited.Mailboxes[1].Messages = nil
+			edited.Mailboxes[1].HighestModSeq = 3
+			edited.Mailboxes[1].ChangedUIDs = nil
+			edited.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+			for range 2 {
+				server.setSnapshot(edited)
+				client, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+				require.NoError(err)
+				require.NoError(client.Close())
+				message, err = st.GetMessage(id)
+				require.NoError(err)
+				assert.Equal("Drafts|1", message.SourceMessageID)
+				assert.Contains(message.BodyText, sent.Body)
+				assert.NotContains(message.BodyText, draft.Body)
+				raw, err = st.GetMessageRaw(id)
+				require.NoError(err)
+				assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+				edited.Mailboxes[1].VanishedUIDs = nil
+			}
 		})
 	}
 }

--- a/cmd/msgvault/cmd/imap_relocation_integration_test.go
+++ b/cmd/msgvault/cmd/imap_relocation_integration_test.go
@@ -1094,7 +1094,6 @@ func TestIMAPRelocationAmbiguousRoleDeniesRefresh(t *testing.T) {
 // full rescan, matching the CLI's --noresume production wiring.
 func runScriptedRelocationResync(
 	t *testing.T, st *store.Store, identifier, addr string,
-	mod func(*msgsync.Options),
 ) (*imap.Client, error) {
 	t.Helper()
 	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
@@ -1103,9 +1102,6 @@ func runScriptedRelocationResync(
 	options := msgsync.DefaultOptions()
 	options.SourceType = sourceTypeIMAP
 	options.NoResume = true
-	if mod != nil {
-		mod(options)
-	}
 	summary, err := newMessageSyncer(client, st, options).
 		WithLogger(slog.New(slog.DiscardHandler)).
 		Full(t.Context(), identifier)
@@ -1177,7 +1173,7 @@ func TestIMAPRelocationRescanOrderingKeepsEditedSent(t *testing.T) {
 
 	// Force-full rescan with every copy present: durable memberships route
 	// each copy through alias label refresh, so nothing is re-ingested.
-	rescan, err := runScriptedRelocationResync(t, st, identifier, addr, nil)
+	rescan, err := runScriptedRelocationResync(t, st, identifier, addr)
 	require.NoError(err)
 	require.NoError(rescan.Close())
 	assert.NotContains(server.commandsFor(3), "BODY.PEEK[]",
@@ -1235,7 +1231,7 @@ func TestIMAPRelocationRescanOrderingKeepsEditedSent(t *testing.T) {
 	requireEditedSent("draft flag change")
 
 	// Final force-full rescan with every copy present, then a no-op sync.
-	finalRescan, err := runScriptedRelocationResync(t, st, identifier, addr, nil)
+	finalRescan, err := runScriptedRelocationResync(t, st, identifier, addr)
 	require.NoError(err)
 	require.NoError(finalRescan.Close())
 	requireEditedSent("final force-full rescan")
@@ -2263,7 +2259,7 @@ func TestIMAPRelocationConfiguredDraftsRoleNotSent(t *testing.T) {
 // placements never gain that precedence, and a later stale Drafts copy must
 // not downgrade the refreshed snapshot.
 func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
-	for _, mode := range []string{"qresync", "full enumeration", "configured localized sent"} {
+	for _, mode := range []string{"qresync", "full enumeration", "configured localized sent", "removed sent mailbox", "removed sent mailbox full enumeration"} {
 		t.Run(mode, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
@@ -2305,7 +2301,7 @@ func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
 			require.Contains(stale.BodyText, draft.Body, "the archived snapshot starts as the draft")
 
 			edited := baseline.clone()
-			if mode == "full enumeration" {
+			if mode == "full enumeration" || mode == "removed sent mailbox full enumeration" {
 				edited.Capabilities = "IMAP4rev1 SPECIAL-USE"
 			}
 			edited.Mailboxes[1].HighestModSeq = 2
@@ -2359,6 +2355,10 @@ func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
 			edited.Mailboxes[1].HighestModSeq = 3
 			edited.Mailboxes[1].ChangedUIDs = nil
 			edited.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+			removeMailbox := mode == "removed sent mailbox" || mode == "removed sent mailbox full enumeration"
+			if removeMailbox {
+				edited.Mailboxes = edited.Mailboxes[:1]
+			}
 			for range 2 {
 				server.setSnapshot(edited)
 				client, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
@@ -2372,7 +2372,9 @@ func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
 				raw, err = st.GetMessageRaw(id)
 				require.NoError(err)
 				assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
-				edited.Mailboxes[1].VanishedUIDs = nil
+				if !removeMailbox {
+					edited.Mailboxes[1].VanishedUIDs = nil
+				}
 			}
 		})
 	}
@@ -2527,6 +2529,119 @@ func TestIMAPRelocationDualSentDraftsRoleDenied(t *testing.T) {
 			raw, err := st.GetMessageRaw(id)
 			require.NoError(err)
 			assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+		})
+	}
+}
+
+func TestIMAPRelocationSentContentSurvivesAllAdoption(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "survivors@example.test", imapapi.FlagDraft)
+	draft.Body = "draftobsoleteword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{sent}},
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{sent}},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://survivors@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+sent.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+	before, err := st.GetMessage(id)
+	require.NoError(err)
+	require.Equal("Sent|1", before.SourceMessageID)
+	require.Contains(before.BodyText, sent.Body)
+	require.Len(queryScriptedRFC7162Memberships(t, st, source.ID), 3)
+	final := baseline.clone()
+	final.Mailboxes[2].Messages = nil
+	final.Mailboxes[2].HighestModSeq = 3
+	final.Mailboxes[2].VanishedUIDs = []imapapi.UID{1}
+	for range 2 {
+		server.setSnapshot(final)
+		client, err := runScriptedRelocationResync(t, st, identifier, addr)
+		require.NoError(err)
+		require.NoError(client.Close())
+		after, err := st.GetMessage(id)
+		require.NoError(err)
+		assert.Contains(after.BodyText, sent.Body)
+		assert.NotContains(after.BodyText, draft.Body)
+		assert.Equal("All Mail|1", after.SourceMessageID)
+		raw, err := st.GetMessageRaw(id)
+		require.NoError(err)
+		assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+		final.Mailboxes[2].VanishedUIDs = nil
+	}
+}
+
+// Keep the existing placement policy for archives without origin metadata,
+// and continue refreshing a Sent survivor when the original Sent copy is gone.
+func TestIMAPRelocationRetainsOutgoingPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		survivorRole    imapapi.MailboxAttr
+		missingMetadata bool
+		removeCanonical bool
+		wantRefresh     bool
+	}{
+		{name: "sent survivor refreshes", survivorRole: imapapi.MailboxAttrSent, removeCanonical: true, wantRefresh: true},
+		{name: "existing sent without metadata", survivorRole: imapapi.MailboxAttrDrafts, missingMetadata: true},
+		{name: "lost sent without metadata", survivorRole: imapapi.MailboxAttrDrafts, missingMetadata: true, removeCanonical: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			original := newScriptedRFC7162Message(1, "outgoing-precedence@example.test", imapapi.FlagSeen)
+			original.Body = "originalsentword"
+			survivor := original
+			survivor.Body = "survivingcopyword"
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{original}},
+				{Name: "Survivor", Attrs: []imapapi.MailboxAttr{tc.survivorRole}, UIDValidity: 77, UIDNext: 1, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://outgoing-precedence@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+original.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+			if tc.missingMetadata {
+				_, err := st.DB().Exec(st.Rebind("UPDATE messages SET metadata = NULL WHERE id = ?"), id)
+				require.NoError(err)
+			}
+			next := baseline.clone()
+			next.Mailboxes[1].Messages = []scriptedRFC7162Message{survivor}
+			next.Mailboxes[1].UIDNext = 2
+			next.Mailboxes[1].HighestModSeq = 2
+			wantSource := "Sent|1"
+			if tc.removeCanonical {
+				next.Mailboxes[0].Messages = nil
+				next.Mailboxes[0].HighestModSeq = 2
+				next.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+				wantSource = "Survivor|1"
+			}
+			server.setSnapshot(next)
+			second, err := runScriptedRelocationResync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal(wantSource, message.SourceMessageID)
+			want := original
+			if tc.wantRefresh {
+				want = survivor
+			}
+			assert.Contains(message.BodyText, want.Body)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(want), string(raw))
 		})
 	}
 }

--- a/cmd/msgvault/cmd/imap_relocation_integration_test.go
+++ b/cmd/msgvault/cmd/imap_relocation_integration_test.go
@@ -1,0 +1,2508 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	msgsync "go.kenn.io/msgvault/internal/sync"
+
+	imapapi "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type relocationFixture struct {
+	st          *store.Store
+	source      *store.Source
+	addr        string
+	server      *scriptedRFC7162Server
+	id          int64
+	draft, sent scriptedRFC7162Message
+	final       scriptedRFC7162Snapshot
+}
+
+func newRelocationFixture(t *testing.T) relocationFixture {
+	t.Helper()
+	draft := newScriptedRFC7162Message(1, "overlap-relocation@example.test", imapapi.FlagDraft)
+	draft.Body = "draftobsoleteword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://overlap-relocation@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(t, first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(t, err)
+	require.Positive(t, id)
+	// Legacy persisted-state fixture: this suite exercises forced
+	// relocation of a lost Drafts canonical, which now coexists with
+	// Sent-over-Drafts overlap refresh. Seed the pre-precedence archive
+	// state — stale Drafts canonical and snapshot plus a saved Sent
+	// membership and both cursors — through the real topology helper, so
+	// every recovery case below still starts from a lost canonical holding
+	// the old draft body. The overlap behavior itself is covered separately
+	// by TestIMAPRelocationSentOutranksStaleDraftsCanonical.
+	overlap := baseline.clone()
+	overlap.Mailboxes[1].UIDNext = 2
+	overlap.Mailboxes[1].HighestModSeq = 2
+	overlap.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+	overlap.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	seedLegacyDraftsCanonicalWithSentMembership(
+		t, st, source, []byte(scriptedRFC7162RawMessage(sent)), "<"+draft.MessageID+">")
+	body, err := st.GetMessageBodyText(id)
+	require.NoError(t, err)
+	require.Contains(t, body, draft.Body,
+		"the legacy fixture keeps the stale draft snapshot under the Drafts canonical")
+	require.Len(t, queryScriptedRFC7162Memberships(t, st, source.ID), 2)
+	final := overlap.clone()
+	final.Mailboxes[0].Messages = nil
+	final.Mailboxes[0].HighestModSeq = 3
+	final.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	final.Mailboxes[1].ChangedUIDs = nil
+	return relocationFixture{st: st, source: source, addr: addr, server: server, id: id, draft: draft, sent: sent, final: final}
+}
+
+func (f relocationFixture) sync(t *testing.T, extra ...imap.Option) (*imap.Client, error) {
+	t.Helper()
+	opts := append(imapFolderStateOptions(f.st, f.source, false), extra...)
+	client := newScriptedRFC7162Client(t, f.addr, opts...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	summary, err := newMessageSyncer(client, f.st, options).WithLogger(slog.New(slog.DiscardHandler)).FullWithFinalizer(
+		t.Context(), f.source, func(summary *gmail.SyncSummary) error {
+			return saveIMAPFolderStates(t.Context(), f.st, f.source, client, summary, options.Limit)
+		})
+	if err == nil && summary.Errors != 0 {
+		err = fmt.Errorf("relocation sync completed with %d errors", summary.Errors)
+	}
+	return client, err
+}
+
+func (f relocationFixture) assertSent(t *testing.T, otherMemberships ...string) {
+	t.Helper()
+	assert := assert.New(t)
+	require := require.New(t)
+	body, err := f.st.GetMessageBodyText(f.id)
+	require.NoError(err)
+	assert.Contains(body, f.sent.Body)
+	assert.NotContains(body, f.draft.Body)
+	raw, err := f.st.GetMessageRaw(f.id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(f.sent), string(raw))
+	message, err := f.st.GetMessage(f.id)
+	require.NoError(err)
+	assert.Equal("Sent|1", message.SourceMessageID)
+	assert.ElementsMatch([]string{"Sent"}, message.Labels)
+	assert.ElementsMatch(append([]string{"Sent|1|[\"\\\\Seen\"]"}, otherMemberships...), queryScriptedRFC7162Memberships(t, f.st, f.source.ID))
+	results, total, err := f.st.SearchMessagesQuery(&search.Query{TextTerms: []string{f.sent.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(f.id, results[0].ID)
+	_, total, err = f.st.SearchMessagesQuery(&search.Query{TextTerms: []string{f.draft.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total)
+}
+
+func TestIMAPRelocationAfterOverlapVANISHED(t *testing.T) {
+	for _, mode := range []string{"VANISHED", "disappeared mailbox", "new epoch", "fallback", "changed alias"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			f := newRelocationFixture(t)
+			switch mode {
+			case "disappeared mailbox":
+				f.final.Mailboxes = f.final.Mailboxes[1:]
+			case "new epoch":
+				f.final.Mailboxes[0].UIDValidity = 99
+			case "fallback":
+				f.final.Capabilities = "IMAP4rev1 SPECIAL-USE"
+			case "changed alias":
+				f.final.Mailboxes[1].HighestModSeq = 3
+				f.final.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+			}
+			f.server.setSnapshot(f.final)
+			third, err := f.sync(t)
+			require.NoError(err)
+			require.NoError(third.Close())
+			f.assertSent(t)
+			if mode == "VANISHED" {
+				assert.NotRegexp(`UID SEARCH UID \d+:\*`, f.server.commandsFor(2))
+				assert.Contains(f.server.commandsFor(2), "BODY.PEEK",
+					"the forced loader fetches the unchanged Sent survivor")
+			}
+			states, err := f.st.GetIMAPFolderStates(f.source.ID)
+			require.NoError(err)
+			require.Len(states, len(f.final.Mailboxes))
+			for i, state := range states {
+				assert.Equal(f.final.Mailboxes[i].HighestModSeq, state.HighestModSeq)
+				assert.Equal(f.final.Mailboxes[i].UIDValidity, state.UIDValidity)
+			}
+			if mode == "VANISHED" {
+				f.final.Mailboxes[0].VanishedUIDs = nil
+				f.server.setSnapshot(f.final)
+				fourth, err := f.sync(t, imap.WithRelocationCandidateLoader(func(context.Context, []string) ([]imap.RelocationCandidate, error) {
+					return nil, errors.New("unchanged sync must not load candidates")
+				}))
+				require.NoError(err)
+				require.NoError(fourth.Close())
+				assert.NotContains(f.server.commandsFor(3), "BODY.PEEK[]")
+			}
+		})
+	}
+}
+
+func TestIMAPRelocationFailureKeepsSnapshotAndCursorsRetryable(t *testing.T) {
+	for _, failure := range []string{"candidate query", "raw identity", "raw body", "source collision", "target guard"} {
+		t.Run(failure, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			f := newRelocationFixture(t)
+			beforeStates, err := f.st.GetIMAPFolderStates(f.source.ID)
+			require.NoError(err)
+			beforeMemberships := queryScriptedRFC7162Memberships(t, f.st, f.source.ID)
+			beforeRaw, err := f.st.GetMessageRaw(f.id)
+			require.NoError(err)
+			failed := f.final.clone()
+			var extra []imap.Option
+			var collisionID int64
+			switch failure {
+			case "candidate query":
+				extra = append(extra, imap.WithRelocationCandidateLoader(func(context.Context, []string) ([]imap.RelocationCandidate, error) {
+					return nil, errors.New("candidate query failure")
+				}))
+			case "raw identity":
+				failed.Mailboxes[1].Messages[0].MessageID = "different@example.test"
+			case "raw body":
+				failed.Mailboxes[1].Messages[0].MissingRaw = true
+			case "source collision":
+				conv, err := f.st.EnsureConversation(f.source.ID, "collision-thread", "Collision")
+				require.NoError(err)
+				collisionID, err = f.st.UpsertMessage(&store.Message{SourceID: f.source.ID, ConversationID: conv, SourceMessageID: "Sent|1", MessageType: "email"})
+				require.NoError(err)
+			case "target guard":
+				extra = append(extra, imap.WithRelocationCandidateLoader(func(ctx context.Context, lost []string) ([]imap.RelocationCandidate, error) {
+					candidates, err := f.st.GetIMAPRelocationCandidatesContext(ctx, f.source.ID, lost)
+					if err != nil {
+						return nil, err
+					}
+					var result []imap.RelocationCandidate
+					for _, c := range candidates {
+						result = append(result, imap.RelocationCandidate{Target: gmail.MessageRelocationTarget{
+							InternalID: c.ID + 1000, SourceID: c.SourceID, SourceMessageID: c.SourceMessageID, RFC822MessageID: c.RFC822MessageID,
+						}, Mailbox: c.Mailbox, UIDValidity: c.UIDValidity, UID: c.UID})
+					}
+					return result, nil
+				}))
+			}
+			f.server.setSnapshot(failed)
+			client, err := f.sync(t, extra...)
+			require.Error(err)
+			require.NoError(client.Close())
+			afterStates, err := f.st.GetIMAPFolderStates(f.source.ID)
+			require.NoError(err)
+			assert.Equal(beforeStates, afterStates)
+			assert.Equal(beforeMemberships, queryScriptedRFC7162Memberships(t, f.st, f.source.ID))
+			raw, err := f.st.GetMessageRaw(f.id)
+			require.NoError(err)
+			assert.Equal(beforeRaw, raw)
+			message, err := f.st.GetMessage(f.id)
+			require.NoError(err)
+			assert.Equal("Drafts|1", message.SourceMessageID)
+			assert.Contains(message.Labels, "Drafts")
+			if collisionID != 0 {
+				_, err := f.st.DB().Exec(f.st.Rebind("DELETE FROM messages WHERE id = ?"), collisionID)
+				require.NoError(err)
+			}
+			f.server.setSnapshot(f.final)
+			retry, err := f.sync(t)
+			require.NoError(err)
+			require.NoError(retry.Close())
+			f.assertSent(t)
+		})
+	}
+}
+
+// A reset can reuse the lost canonical composite ID in the same listing as
+// its forced replacement. Ordinary routing must not invalidate the retained
+// target before relocation, including when the relocation needs another run.
+func TestIMAPRelocationBeforeReusedUIDRouting(t *testing.T) {
+	for _, failure := range []string{"none", "raw body", "raw identity", "source collision"} {
+		t.Run(failure, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			f := newRelocationFixture(t)
+			unrelated := newScriptedRFC7162Message(1, "unrelated-new-epoch@example.test", imapapi.FlagDraft)
+			unrelated.Body = "unrelatedreplacementword"
+			f.final.Mailboxes[0].UIDValidity = 99
+			f.final.Mailboxes[0].HighestModSeq = 1
+			f.final.Mailboxes[0].VanishedUIDs = nil
+			f.final.Mailboxes[0].Messages = []scriptedRFC7162Message{unrelated}
+			beforeStates, err := f.st.GetIMAPFolderStates(f.source.ID)
+			require.NoError(err)
+			beforeMemberships := queryScriptedRFC7162Memberships(t, f.st, f.source.ID)
+			before, err := f.st.GetMessage(f.id)
+			require.NoError(err)
+			beforeRaw, err := f.st.GetMessageRaw(f.id)
+			require.NoError(err)
+			failed := f.final.clone()
+			var collisionID int64
+			switch failure {
+			case "raw body":
+				failed.Mailboxes[1].Messages[0].MissingRaw = true
+			case "raw identity":
+				failed.Mailboxes[1].Messages[0].MessageID = "different-survivor@example.test"
+			case "source collision":
+				conv, err := f.st.EnsureConversation(f.source.ID, "collision-thread", "Collision")
+				require.NoError(err)
+				collisionID, err = f.st.UpsertMessage(&store.Message{SourceID: f.source.ID, ConversationID: conv, SourceMessageID: "Sent|1", MessageType: "email"})
+				require.NoError(err)
+			}
+			f.server.setSnapshot(failed)
+			client, syncErr := f.sync(t)
+			require.NoError(client.Close())
+			if failure == "none" {
+				require.NoError(syncErr)
+			} else {
+				require.Error(syncErr)
+				afterStates, err := f.st.GetIMAPFolderStates(f.source.ID)
+				require.NoError(err)
+				assert.Equal(beforeStates, afterStates)
+				assert.Equal(beforeMemberships, queryScriptedRFC7162Memberships(t, f.st, f.source.ID))
+				after, err := f.st.GetMessage(f.id)
+				require.NoError(err)
+				assert.Equal(before.SourceMessageID, after.SourceMessageID, "failed relocation must retain the key used to discover its retry")
+				assert.Equal(before.BodyText, after.BodyText)
+				assert.Equal(before.Labels, after.Labels)
+				raw, err := f.st.GetMessageRaw(f.id)
+				require.NoError(err)
+				assert.Equal(beforeRaw, raw)
+				results, total, err := f.st.SearchMessagesQuery(&search.Query{TextTerms: []string{f.draft.Body}}, 0, 10)
+				require.NoError(err)
+				assert.Equal(int64(1), total)
+				require.Len(results, 1)
+				assert.Equal(f.id, results[0].ID)
+				unrelatedID, err := f.st.GetMessageIDByRFC822ID(f.source.ID, "<"+unrelated.MessageID+">")
+				require.NoError(err)
+				assert.Zero(unrelatedID, "ordinary routing waits for forced relocation to succeed")
+				if collisionID != 0 {
+					_, err := f.st.DB().Exec(f.st.Rebind("DELETE FROM messages WHERE id = ?"), collisionID)
+					require.NoError(err)
+				}
+				f.server.setSnapshot(f.final)
+				retry, err := f.sync(t)
+				require.NoError(err)
+				require.NoError(retry.Close())
+			}
+			f.assertSent(t, "Drafts|1|[\"\\\\Draft\"]")
+			unrelatedID, err := f.st.GetMessageIDByRFC822ID(f.source.ID, "<"+unrelated.MessageID+">")
+			require.NoError(err)
+			require.Positive(unrelatedID)
+			assert.NotEqual(f.id, unrelatedID)
+			message, err := f.st.GetMessage(unrelatedID)
+			require.NoError(err)
+			assert.Equal("Drafts|1", message.SourceMessageID)
+			assert.Contains(message.BodyText, unrelated.Body)
+			assert.ElementsMatch([]string{"Drafts"}, message.Labels)
+			raw, err := f.st.GetMessageRaw(unrelatedID)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(unrelated), string(raw))
+			results, total, err := f.st.SearchMessagesQuery(&search.Query{TextTerms: []string{unrelated.Body}}, 0, 10)
+			require.NoError(err)
+			assert.Equal(int64(1), total)
+			require.Len(results, 1)
+			assert.Equal(unrelatedID, results[0].ID)
+			var count int
+			require.NoError(f.st.DB().QueryRow(f.st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), f.source.ID).Scan(&count))
+			assert.Equal(2, count, "no invalidated stale archive row is stranded")
+			states, err := f.st.GetIMAPFolderStates(f.source.ID)
+			require.NoError(err)
+			require.Len(states, 2)
+			for i, state := range states {
+				assert.Equal(f.final.Mailboxes[i].UIDValidity, state.UIDValidity)
+				assert.Equal(f.final.Mailboxes[i].HighestModSeq, state.HighestModSeq)
+			}
+			known, err := f.st.GetIMAPKnownUIDs(f.source.ID)
+			require.NoError(err)
+			assert.Equal(map[string][]uint32{"Drafts": {1}, "Sent": {1}}, known)
+			noop, err := f.sync(t, imap.WithRelocationCandidateLoader(func(context.Context, []string) ([]imap.RelocationCandidate, error) {
+				return nil, errors.New("unchanged sync must not load candidates")
+			}))
+			require.NoError(err)
+			require.NoError(noop.Close())
+			connection := 4
+			if failure != "none" {
+				connection++
+			}
+			assert.NotContains(f.server.commandsFor(connection), "BODY.PEEK[]")
+		})
+	}
+}
+
+// A UIDVALIDITY change that reuses the same UID keeps the composite source ID.
+// The surviving copy at that unchanged key must refresh the archived snapshot
+// through identity routing without a same-key relocation, and a reused UID
+// holding a different message must never replace the archived original.
+func TestIMAPRelocationUIDValidityChangeSameUIDSurvivor(t *testing.T) {
+	for _, mode := range []string{"edited survivor", "reused by different message"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			draft := newScriptedRFC7162Message(1, "uidvalidity-survivor@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			survivor := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			survivor.Body = "editedfinalword"
+			unrelated := newScriptedRFC7162Message(1, "uidvalidity-unrelated@example.test", imapapi.FlagSeen)
+			unrelated.Body = "unrelatedreplacementword"
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://uidvalidity-survivor@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+
+			reset := baseline.clone()
+			reset.Mailboxes[0].UIDValidity = 99
+			reset.Mailboxes[0].HighestModSeq = 2
+			reset.Mailboxes[0].ChangedUIDs = []imapapi.UID{1}
+			if mode == "edited survivor" {
+				reset.Mailboxes[0].Messages = []scriptedRFC7162Message{survivor}
+			} else {
+				reset.Mailboxes[0].Messages = []scriptedRFC7162Message{unrelated}
+			}
+			server.setSnapshot(reset)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err, "unchanged composite key after an epoch change must not strand the sync")
+			require.NoError(second.Close())
+
+			states, err := st.GetIMAPFolderStates(source.ID)
+			require.NoError(err)
+			require.Len(states, 1)
+			assert.Equal(uint32(99), states[0].UIDValidity)
+			known, err := st.GetIMAPKnownUIDs(source.ID)
+			require.NoError(err)
+			assert.Equal(map[string][]uint32{"Drafts": {1}}, known)
+
+			if mode == "edited survivor" {
+				message, err := st.GetMessage(id)
+				require.NoError(err)
+				assert.Equal("Drafts|1", message.SourceMessageID)
+				assert.Contains(message.BodyText, survivor.Body)
+				assert.NotContains(message.BodyText, draft.Body)
+				assert.ElementsMatch([]string{"Drafts"}, message.Labels)
+				assert.ElementsMatch([]string{"Drafts|1|[\"\\\\Seen\"]"}, queryScriptedRFC7162Memberships(t, st, source.ID))
+				var count int
+				require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+				assert.Equal(1, count)
+			} else {
+				message, err := st.GetMessage(id)
+				require.NoError(err)
+				assert.Contains(message.BodyText, draft.Body, "a reused UID holding a different message must not replace the archived original")
+				raw, err := st.GetMessageRaw(id)
+				require.NoError(err)
+				assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+				var deleted int
+				require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ? AND deleted_from_source_at IS NOT NULL"), source.ID).Scan(&deleted))
+				assert.Equal(1, deleted, "the superseded original is retired, not rewritten")
+				unrelatedID, err := st.GetMessageIDByRFC822ID(source.ID, "<"+unrelated.MessageID+">")
+				require.NoError(err)
+				require.Positive(unrelatedID)
+				unrelatedMessage, err := st.GetMessage(unrelatedID)
+				require.NoError(err)
+				assert.Equal("Drafts|1", unrelatedMessage.SourceMessageID)
+				assert.Contains(unrelatedMessage.BodyText, unrelated.Body)
+				assert.ElementsMatch([]string{"Drafts"}, unrelatedMessage.Labels)
+			}
+
+			server.setSnapshot(reset)
+			third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(third.Close())
+			var count int
+			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+			if mode == "edited survivor" {
+				assert.Equal(1, count)
+				message, err := st.GetMessage(id)
+				require.NoError(err)
+				assert.Contains(message.BodyText, survivor.Body)
+			} else {
+				assert.Equal(2, count)
+			}
+		})
+	}
+}
+
+// A saved membership that already carries the current epoch while the saved
+// folder state is older makes the relocation listing offer the unchanged
+// composite key itself. The listing must skip that candidate: persistence
+// requires the key to change, and ordinary identity routing already refreshes
+// the snapshot, so forcing it would fail every retry without progress.
+func TestIMAPRelocationSkipsSameCompositeForcedCandidate(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "same-composite-candidate@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	survivor := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	survivor.Body = "editedfinalword"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://same-composite-candidate@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+	_, err = st.DB().Exec(st.Rebind(`
+		INSERT INTO imap_message_memberships (source_id, mailbox, uidvalidity, uid, message_id, flags, updated_at)
+		SELECT source_id, mailbox, 99, uid, message_id, flags, updated_at
+		FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = 'Drafts' AND uidvalidity = 77 AND uid = 1
+	`), source.ID)
+	require.NoError(err)
+
+	reset := baseline.clone()
+	reset.Mailboxes[0].UIDValidity = 99
+	reset.Mailboxes[0].HighestModSeq = 2
+	reset.Mailboxes[0].ChangedUIDs = []imapapi.UID{1}
+	reset.Mailboxes[0].Messages = []scriptedRFC7162Message{survivor}
+	server.setSnapshot(reset)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err, "a same-composite forced candidate must fall back to identity routing")
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Drafts|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, survivor.Body)
+	assert.NotContains(message.BodyText, draft.Body)
+	assert.ElementsMatch([]string{"Drafts"}, message.Labels)
+	assert.ElementsMatch([]string{"Drafts|1|[\"\\\\Seen\"]"}, queryScriptedRFC7162Memberships(t, st, source.ID))
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	require.Len(states, 1)
+	assert.Equal(uint32(99), states[0].UIDValidity)
+	known, err := st.GetIMAPKnownUIDs(source.ID)
+	require.NoError(err)
+	assert.Equal(map[string][]uint32{"Drafts": {1}}, known)
+
+	third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(third.Close())
+	assert.NotContains(server.commandsFor(3), "BODY.PEEK[]")
+}
+
+// A forged RFC822 Message-ID on an incoming message must not replace an
+// archived snapshot. Content refresh is authorized only by provider-controlled
+// placement evidence (server-advertised \Sent or \Drafts special use), which
+// external senders cannot produce; every other adoption keeps the canonical
+// snapshot and only rekeys the location, matching pre-relocation behavior.
+func TestIMAPRelocationForgedSurvivorPreservesSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = config.NewDefaultConfig()
+	cfg.Sync.ArchiveRemoteImages = true
+	victim := newScriptedRFC7162Message(1, "forged-survivor@example.test", imapapi.FlagSeen)
+	victim.Body = "victimoriginalword"
+	victim.Raw = scriptedOutgoingRaw(
+		victim.MessageID, "Original subject",
+		"victim-to@example.test", "victim-cc@example.test",
+		"victimoriginalword", "<p>victimoriginalword</p>",
+		"victim.bin", "victim attachment bytes")
+	forger := newScriptedRFC7162Message(2, victim.MessageID, imapapi.FlagSeen)
+	forger.Body = "forgedreplacementword"
+	forger.Raw = scriptedOutgoingRaw(
+		victim.MessageID, "Forged replacement",
+		"forger-to@example.test", "forger-cc@example.test",
+		"forgedreplacementword",
+		"<p>forgedreplacementword <img src=\"http://images.example/forged-chart\"></p>",
+		"forger.bin", "forged attachment bytes")
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 2, 1, victim),
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://forged-survivor@example.test"
+	attachDir := t.TempDir()
+	run := func(snapshot scriptedRFC7162Snapshot) error {
+		server.setSnapshot(snapshot)
+		client, _, err := runScriptedRelocationSync(t, st, identifier, addr, func(o *msgsync.Options) {
+			o.AttachmentsDir = attachDir
+		})
+		if closeErr := client.Close(); err == nil {
+			err = closeErr
+		}
+		return err
+	}
+	first, source, err := runScriptedRelocationSync(t, st, identifier, addr, func(o *msgsync.Options) {
+		o.AttachmentsDir = attachDir
+	})
+	require.NoError(err)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+victim.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+	before, err := st.GetMessage(id)
+	require.NoError(err)
+	require.Len(before.Attachments, 1)
+	assert.Equal("victim.bin", before.Attachments[0].Filename)
+
+	replaced := baseline.clone()
+	replaced.Mailboxes[0].HighestModSeq = 2
+	replaced.Mailboxes[0].UIDNext = 3
+	replaced.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	replaced.Mailboxes[0].ChangedUIDs = []imapapi.UID{2}
+	replaced.Mailboxes[0].Messages = []scriptedRFC7162Message{forger}
+	require.NoError(run(replaced))
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("INBOX|2", message.SourceMessageID, "the forged survivor still rekeys the location")
+	assert.Contains(message.BodyText, victim.Body, "the archived body must survive a forged Message-ID")
+	assert.NotContains(message.BodyText, forger.Body)
+	assert.NotEqual("Forged replacement", message.Subject)
+	assert.Equal([]string{"victim-to@example.test"}, message.To,
+		"forged recipients must not overwrite the archived recipient")
+	assert.Equal([]string{"victim-cc@example.test"}, message.Cc)
+	assert.Equal(before.FromEmail, message.FromEmail)
+	require.Len(message.Attachments, 1)
+	assert.Equal("victim.bin", message.Attachments[0].Filename,
+		"the forged attachment must not replace or join the archived one")
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(victim.Raw, string(raw))
+	assert.ElementsMatch([]string{"INBOX"}, message.Labels)
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{victim.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{forger.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "forged content must not reach the search index")
+	refs, err := st.MessageRemoteImages(id)
+	require.NoError(err)
+	assert.Empty(refs, "rejected forged bytes must not trigger remote-image processing")
+
+	require.NoError(run(replaced))
+	message, err = st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, victim.Body)
+	assert.Equal("INBOX|2", message.SourceMessageID)
+	refs, err = st.MessageRemoteImages(id)
+	require.NoError(err)
+	assert.Empty(refs)
+}
+
+// A forged copy mirrored into the server's \All mailbox must not replace the
+// archived snapshot even though the original still exists and the copy is at
+// the preferred canonical location: \All placement holds received mail too,
+// so it is not provider-authored evidence.
+func TestIMAPPreferredAllMailForgedCopyPreservesSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	victim := newScriptedRFC7162Message(1, "forged-all-mail@example.test", imapapi.FlagSeen)
+	victim.Body = "victimoriginalword"
+	forger := newScriptedRFC7162Message(1, victim.MessageID, imapapi.FlagSeen)
+	forger.Body = "forgedreplacementword"
+	forger.Subject = "Forged replacement"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(66, 2, 1, victim),
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 77, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://forged-all-mail@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+victim.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	mirrored := baseline.clone()
+	mirrored.Mailboxes[0].HighestModSeq = 2
+	mirrored.Mailboxes[0].UIDNext = 3
+	mirrored.Mailboxes[0].ChangedUIDs = []imapapi.UID{2}
+	mirrored.Mailboxes[0].Messages = []scriptedRFC7162Message{victim, forgerWithUID(forger, 2)}
+	mirrored.Mailboxes[1].HighestModSeq = 2
+	mirrored.Mailboxes[1].UIDNext = 2
+	mirrored.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	mirrored.Mailboxes[1].Messages = []scriptedRFC7162Message{forger}
+	server.setSnapshot(mirrored)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("All Mail|1", message.SourceMessageID, "preferred adoption still rekeys the canonical location")
+	assert.Contains(message.BodyText, victim.Body, "the archived body must survive a forged preferred copy")
+	assert.NotContains(message.BodyText, forger.Body)
+	assert.NotEqual(forger.Subject, message.Subject)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(victim), string(raw))
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{victim.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{forger.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "forged content must not reach the search index")
+
+	third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(third.Close())
+	message, err = st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, victim.Body)
+	assert.Equal("All Mail|1", message.SourceMessageID)
+}
+
+// A membership previously bound to the archived row through a forged
+// Message-ID must not let forced recovery replace the snapshot when the
+// original location vanishes: the surviving location holds received mail, not
+// provider-authored placement.
+func TestIMAPRelocationForgedMembershipPreservesSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	victim := newScriptedRFC7162Message(1, "forged-membership@example.test", imapapi.FlagSeen)
+	victim.Body = "victimoriginalword"
+	forger := newScriptedRFC7162Message(2, victim.MessageID, imapapi.FlagSeen)
+	forger.Body = "forgedreplacementword"
+	forger.Subject = "Forged replacement"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 2, 1, victim),
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://forged-membership@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+victim.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	overlap := baseline.clone()
+	overlap.Mailboxes[0].HighestModSeq = 2
+	overlap.Mailboxes[0].UIDNext = 3
+	overlap.Mailboxes[0].ChangedUIDs = []imapapi.UID{2}
+	overlap.Mailboxes[0].Messages = []scriptedRFC7162Message{victim, forger}
+	server.setSnapshot(overlap)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err, "the overlapping forged copy must not disturb the archive")
+	require.NoError(second.Close())
+	memberships := queryScriptedRFC7162Memberships(t, st, source.ID)
+	assert.ElementsMatch([]string{"INBOX|1|[\"\\\\Seen\"]", "INBOX|2|[\"\\\\Seen\"]"}, memberships,
+		"the overlap sync binds the forged copy's membership to the archived row")
+
+	vanished := overlap.clone()
+	vanished.Mailboxes[0].HighestModSeq = 3
+	vanished.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	vanished.Mailboxes[0].ChangedUIDs = nil
+	vanished.Mailboxes[0].Messages = []scriptedRFC7162Message{forger}
+	server.setSnapshot(vanished)
+	third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(third.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("INBOX|2", message.SourceMessageID, "forced recovery still rekeys to the surviving location")
+	assert.Contains(message.BodyText, victim.Body, "forced recovery must not adopt forged content")
+	assert.NotContains(message.BodyText, forger.Body)
+	assert.NotEqual(forger.Subject, message.Subject)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(victim), string(raw))
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{victim.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{forger.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "forged content must not reach the search index")
+}
+
+// Without advertised \Sent or \Drafts special use there is no defensible
+// provider evidence for an edited survivor, so even a genuine draft-to-sent
+// edit keeps the archived snapshot and only rekeys the location. Mailbox
+// names alone are never trusted.
+func TestIMAPRelocationWithoutSpecialUsePreservesEditedSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "no-special-use@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "editedfinalword"
+	sent.Subject = "Edited final"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "Drafts", UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", UIDValidity: 88, UIDNext: 2, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://no-special-use@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	edited := baseline.clone()
+	edited.Mailboxes[0].HighestModSeq = 2
+	edited.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[0].Messages = nil
+	edited.Mailboxes[1].HighestModSeq = 2
+	edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(edited)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Sent|1", message.SourceMessageID, "the surviving location is still adopted")
+	assert.Contains(message.BodyText, draft.Body, "unadvertised placement keeps the archived snapshot")
+	assert.NotContains(message.BodyText, sent.Body)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+	assert.ElementsMatch([]string{"Sent"}, message.Labels)
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+}
+
+func forgerWithUID(message scriptedRFC7162Message, uid imapapi.UID) scriptedRFC7162Message {
+	message.UID = uid
+	return message
+}
+
+// runScriptedRelocationSync mirrors runScriptedRFC7162Sync with an options
+// modifier, so relocation tests can exercise production wiring with an
+// attachments directory or remote-image fetcher configured.
+func runScriptedRelocationSync(
+	t *testing.T, st *store.Store, identifier, addr string,
+	mod func(*msgsync.Options),
+) (*imap.Client, *store.Source, error) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+	require.NoError(t, err)
+	client := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	if mod != nil {
+		mod(options)
+	}
+	summary, err := newMessageSyncer(client, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	if err != nil {
+		return client, source, err
+	}
+	if summary.Errors != 0 {
+		return client, source, fmt.Errorf(
+			"scripted IMAP sync completed with %d errors", summary.Errors)
+	}
+	return client, source, saveIMAPFolderStates(
+		context.Background(), st, source, client, summary, options.Limit)
+}
+
+func scriptedOutgoingRaw(
+	messageID, subject, to, cc, textBody, htmlBody, attachmentName, attachmentBytes string,
+) string {
+	headers := fmt.Sprintf(
+		"From: account-owner@example.test\r\nTo: %s\r\nCc: %s\r\nSubject: %s\r\n"+
+			"Date: Mon, 1 Jan 2024 00:00:00 +0000\r\nMessage-ID: <%s>\r\n"+
+			"MIME-Version: 1.0\r\n", to, cc, subject, messageID)
+	alternative := fmt.Sprintf(
+		"--outmix\r\nContent-Type: multipart/alternative; boundary=outalt\r\n\r\n"+
+			"--outalt\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s\r\n"+
+			"--outalt\r\nContent-Type: text/html; charset=utf-8\r\n\r\n%s\r\n"+
+			"--outalt--\r\n", textBody, htmlBody)
+	if attachmentName == "" {
+		return headers + "Content-Type: multipart/alternative; boundary=outalt\r\n\r\n" +
+			fmt.Sprintf("--outalt\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s\r\n"+
+				"--outalt\r\nContent-Type: text/html; charset=utf-8\r\n\r\n%s\r\n--outalt--\r\n",
+				textBody, htmlBody)
+	}
+	return headers + "Content-Type: multipart/mixed; boundary=outmix\r\n\r\n" +
+		alternative +
+		fmt.Sprintf("--outmix\r\nContent-Type: application/octet-stream; name=%q\r\n"+
+			"Content-Disposition: attachment; filename=%q\r\n\r\n%s\r\n--outmix--\r\n",
+			attachmentName, attachmentName, attachmentBytes)
+}
+
+// The reported topology: advertised \Drafts, \Sent, and \All all exist. An
+// untrusted \All mirror must not strand the genuine edited Sent copy — the
+// trusted outgoing placement refreshes the snapshot even after the mirror took
+// the canonical key, both when the draft disappears directly and when an
+// overlap sync adopts the mirror first.
+func TestIMAPRelocationDraftsSentAllMailTopology(t *testing.T) {
+	for _, mode := range []string{"direct disappearance", "overlap then disappearance"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			draft := newScriptedRFC7162Message(1, "all-mail-topology@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Body = "sentfinalword"
+			sent.Subject = "Sent final"
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				// All Mail listed first so its mirror is ingested before Sent.
+				{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 1, HighestModSeq: 1},
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://all-mail-topology@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+
+			edited := baseline.clone()
+			edited.Mailboxes[0].HighestModSeq = 2
+			edited.Mailboxes[0].UIDNext = 2
+			edited.Mailboxes[0].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[0].Messages = []scriptedRFC7162Message{sent}
+			edited.Mailboxes[1].HighestModSeq = 2
+			edited.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[1].Messages = nil
+			edited.Mailboxes[2].HighestModSeq = 2
+			edited.Mailboxes[2].UIDNext = 2
+			edited.Mailboxes[2].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+			if mode == "overlap then disappearance" {
+				edited.Mailboxes[1].VanishedUIDs = nil
+				edited.Mailboxes[1].Messages = []scriptedRFC7162Message{draft}
+			}
+			server.setSnapshot(edited)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Contains(message.BodyText, sent.Body,
+				"the trusted Sent copy must refresh the snapshot despite the All Mail mirror")
+			assert.NotContains(message.BodyText, draft.Body)
+			assert.Equal("Sent final", message.Subject)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+			var count int
+			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+			assert.Equal(1, count)
+			results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+			require.NoError(err)
+			assert.Equal(int64(1), total)
+			require.Len(results, 1)
+			assert.Equal(id, results[0].ID)
+			_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+			require.NoError(err)
+			assert.Zero(total)
+
+			final := edited.clone()
+			if mode == "overlap then disappearance" {
+				final.Mailboxes[1].HighestModSeq = 3
+				final.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+				final.Mailboxes[1].Messages = nil
+			}
+			server.setSnapshot(final)
+			third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(third.Close())
+			message, err = st.GetMessage(id)
+			require.NoError(err)
+			assert.Contains(message.BodyText, sent.Body)
+			assert.NotContains(message.BodyText, draft.Body)
+			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+			assert.Equal(1, count)
+			assert.ElementsMatch([]string{"Sent", "All Mail"}, message.Labels)
+
+			server.setSnapshot(final)
+			forth, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(forth.Close())
+			assert.NotContains(server.commandsFor(4), "BODY.PEEK[]")
+		})
+	}
+}
+
+// Servers without RFC 6154 role discovery — the reported provider uses a
+// localized Sent folder — stay deny-by-default, but the explicit
+// trusted_imap_sent_mailboxes configuration restores the edited-copy
+// refresh through the same production wiring.
+func TestIMAPRelocationConfiguredTrustedOutgoingMailbox(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	const identifier = "imap://configured-trust@example.test"
+	cfg = config.NewDefaultConfig()
+	cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+		identifier: {"Gesendete Elemente"},
+	}
+
+	draft := newScriptedRFC7162Message(1, "configured-trust@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	sent.Subject = "Sent final"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "Entw&APw-rfe", UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Gesendete Elemente", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	edited := baseline.clone()
+	edited.Mailboxes[0].HighestModSeq = 2
+	edited.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[0].Messages = nil
+	edited.Mailboxes[1].HighestModSeq = 2
+	edited.Mailboxes[1].UIDNext = 2
+	edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(edited)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Gesendete Elemente|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, sent.Body, "the configured trust restores the edited-copy refresh")
+	assert.NotContains(message.BodyText, draft.Body)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+	assert.ElementsMatch([]string{"Gesendete Elemente"}, message.Labels)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+}
+
+// A mailbox whose advertised role is ambiguous — Sent combined with All, Junk,
+// Trash, or INBOX — carries no outgoing-placement assumption, so an edited
+// survivor there keeps the archived snapshot.
+func TestIMAPRelocationAmbiguousRoleDeniesRefresh(t *testing.T) {
+	for _, extra := range []string{"All", "Junk", "Trash", "InboxName"} {
+		t.Run(extra, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			draft := newScriptedRFC7162Message(1, "ambiguous-role@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Body = "sentfinalword"
+			survivorAttrs := []imapapi.MailboxAttr{imapapi.MailboxAttrSent, imapapi.MailboxAttrAll}
+			survivorName := "Sent"
+			switch extra {
+			case "Junk":
+				survivorAttrs = []imapapi.MailboxAttr{imapapi.MailboxAttrSent, imapapi.MailboxAttrJunk}
+			case "Trash":
+				survivorAttrs = []imapapi.MailboxAttr{imapapi.MailboxAttrSent, imapapi.MailboxAttrTrash}
+			case "InboxName":
+				survivorName = "INBOX"
+			}
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				{Name: survivorName, Attrs: survivorAttrs, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://ambiguous-role@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+
+			edited := baseline.clone()
+			edited.Mailboxes[0].HighestModSeq = 2
+			edited.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[0].Messages = nil
+			edited.Mailboxes[1].HighestModSeq = 2
+			edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+			server.setSnapshot(edited)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal(survivorName+"|1", message.SourceMessageID, "the location is still adopted")
+			assert.Contains(message.BodyText, draft.Body, "an ambiguous advertised role denies the refresh")
+			assert.NotContains(message.BodyText, sent.Body)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+		})
+	}
+}
+
+// runScriptedRelocationResync mirrors runScriptedRelocationSync with a forced
+// full rescan, matching the CLI's --noresume production wiring.
+func runScriptedRelocationResync(
+	t *testing.T, st *store.Store, identifier, addr string,
+	mod func(*msgsync.Options),
+) (*imap.Client, error) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+	require.NoError(t, err)
+	client := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source, true)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	if mod != nil {
+		mod(options)
+	}
+	summary, err := newMessageSyncer(client, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	if err != nil {
+		return client, err
+	}
+	if summary.Errors != 0 {
+		return client, fmt.Errorf(
+			"scripted IMAP resync completed with %d errors", summary.Errors)
+	}
+	return client, saveIMAPFolderStates(
+		context.Background(), st, source, client, summary, options.Limit)
+}
+
+// Force-full rescans and realistic mailbox rebuilds — including an All Mail
+// epoch rebuild, a stale-Draft resurrection, a flag change, and repeated
+// rescans — must keep the archived edited-Sent snapshot: alias and dedup
+// suppression route unchanged copies through label refresh, and no adoption
+// path may overwrite the sent body, raw MIME, or search content with the
+// stale draft. Canonical placement follows the normal adoption rules and is
+// not pinned here. Every stage runs through completed production syncs.
+func TestIMAPRelocationRescanOrderingKeepsEditedSent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "rescan-ordering@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	sent.Subject = "Sent final"
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 1, HighestModSeq: 1},
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://rescan-ordering@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	requireEditedSent := func(stage string) {
+		message, err := st.GetMessage(id)
+		require.NoError(err)
+		assert.Contains(message.BodyText, sent.Body, stage)
+		assert.NotContains(message.BodyText, draft.Body, stage)
+	}
+
+	// Overlap: the edited Sent copy and its All mirror appear while the
+	// draft remains. The production sync establishes the edited-Sent
+	// snapshot (mirror preferred adoption first, then the trusted Sent
+	// refresh) that every rescan stage below must keep.
+	overlap := baseline.clone()
+	overlap.Mailboxes[0].HighestModSeq = 2
+	overlap.Mailboxes[0].UIDNext = 2
+	overlap.Mailboxes[0].ChangedUIDs = []imapapi.UID{1}
+	overlap.Mailboxes[0].Messages = []scriptedRFC7162Message{sent}
+	overlap.Mailboxes[2].HighestModSeq = 2
+	overlap.Mailboxes[2].UIDNext = 2
+	overlap.Mailboxes[2].ChangedUIDs = []imapapi.UID{1}
+	overlap.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(overlap)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+	requireEditedSent("overlap establishes the edited Sent snapshot")
+
+	// Force-full rescan with every copy present: durable memberships route
+	// each copy through alias label refresh, so nothing is re-ingested.
+	rescan, err := runScriptedRelocationResync(t, st, identifier, addr, nil)
+	require.NoError(err)
+	require.NoError(rescan.Close())
+	assert.NotContains(server.commandsFor(3), "BODY.PEEK[]",
+		"a force-full rescan with saved memberships must not refetch copies")
+
+	// The draft vanishes while the sent copy and its mirror remain: the
+	// edited snapshot must survive whatever location recovery adopts.
+	vanished := overlap.clone()
+	vanished.Mailboxes[1].HighestModSeq = 2
+	vanished.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+	vanished.Mailboxes[1].Messages = nil
+	server.setSnapshot(vanished)
+	forced, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(forced.Close())
+	requireEditedSent("forced recovery after the draft vanished")
+
+	// Realistic All Mail rebuild (new UIDVALIDITY epoch) while Sent is
+	// unchanged: the edited snapshot must survive the location change.
+	allMailRebuilt := vanished.clone()
+	allMailRebuilt.Mailboxes[0].UIDValidity = 100
+	allMailRebuilt.Mailboxes[0].HighestModSeq = 1
+	allMailRebuilt.Mailboxes[0].ChangedUIDs = nil
+	server.setSnapshot(allMailRebuilt)
+	mirror, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(mirror.Close())
+	requireEditedSent("All Mail epoch rebuild")
+
+	// Realistic Drafts rebuild that resurrects the stale draft: it must not
+	// downgrade the snapshot while the trusted Sent copy remains valid.
+	draftsRebuilt := allMailRebuilt.clone()
+	draftsRebuilt.Mailboxes[1].UIDValidity = 78
+	draftsRebuilt.Mailboxes[1].HighestModSeq = 1
+	draftsRebuilt.Mailboxes[1].VanishedUIDs = nil
+	draftsRebuilt.Mailboxes[1].Messages = []scriptedRFC7162Message{draft}
+	server.setSnapshot(draftsRebuilt)
+	stale, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(stale.Close())
+	requireEditedSent("stale Draft resurrection")
+
+	// Incremental flag change on the resurrected draft is an ordinary label
+	// refresh and must not touch the snapshot.
+	flagged := draftsRebuilt.clone()
+	flaggedDraft := draft
+	flaggedDraft.Flags = []imapapi.Flag{imapapi.FlagSeen}
+	flagged.Mailboxes[1].HighestModSeq = 2
+	flagged.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	flagged.Mailboxes[1].Messages = []scriptedRFC7162Message{flaggedDraft}
+	server.setSnapshot(flagged)
+	flagSync, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(flagSync.Close())
+	requireEditedSent("draft flag change")
+
+	// Final force-full rescan with every copy present, then a no-op sync.
+	finalRescan, err := runScriptedRelocationResync(t, st, identifier, addr, nil)
+	require.NoError(err)
+	require.NoError(finalRescan.Close())
+	requireEditedSent("final force-full rescan")
+	server.setSnapshot(flagged)
+	noop, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(noop.Close())
+	requireEditedSent("final no-op sync")
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Sent final", message.Subject)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total)
+}
+
+// Explicit trusted_imap_sent_mailboxes configuration must not override a
+// conflicting advertised role or the INBOX name: those placements are denied
+// exactly as when they are advertised without configuration.
+func TestIMAPRelocationConfiguredConflictDenied(t *testing.T) {
+	for _, mode := range []string{"sent-plus-all", "all-only", "inbox"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			savedCfg := cfg
+			t.Cleanup(func() { cfg = savedCfg })
+			cfg = config.NewDefaultConfig()
+
+			draft := newScriptedRFC7162Message(1, "configured-conflict@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Body = "sentfinalword"
+			survivorName := "Sent"
+			survivorAttrs := []imapapi.MailboxAttr{imapapi.MailboxAttrSent, imapapi.MailboxAttrAll}
+			switch mode {
+			case "all-only":
+				survivorName = "Mirror"
+				survivorAttrs = []imapapi.MailboxAttr{imapapi.MailboxAttrAll}
+			case "inbox":
+				survivorName = "INBOX"
+				survivorAttrs = nil
+			}
+			const identifier = "imap://configured-conflict@example.test"
+			cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+				identifier: {survivorName},
+			}
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				{Name: survivorName, Attrs: survivorAttrs, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+
+			edited := baseline.clone()
+			edited.Mailboxes[0].HighestModSeq = 2
+			edited.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[0].Messages = nil
+			edited.Mailboxes[1].HighestModSeq = 2
+			edited.Mailboxes[1].UIDNext = 2
+			edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+			server.setSnapshot(edited)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal(survivorName+"|1", message.SourceMessageID, "the location is still adopted")
+			assert.Contains(message.BodyText, draft.Body,
+				"a configured name must not override a conflicting advertised role or INBOX")
+			assert.NotContains(message.BodyText, sent.Body)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+		})
+	}
+}
+
+// runScriptedRelocationSyncSummary mirrors runScriptedRelocationSync but
+// returns the raw Full result, so tests can distinguish a completed run that
+// reports per-item errors from an aborted one.
+func runScriptedRelocationSyncSummary(
+	t *testing.T, st *store.Store, identifier, addr string,
+) (*gmail.SyncSummary, error) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+	require.NoError(t, err)
+	client := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	summary, err := newMessageSyncer(client, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	if err != nil {
+		return summary, err
+	}
+	return summary, saveIMAPFolderStates(
+		context.Background(), st, source, client, summary, options.Limit)
+}
+
+// A persistently failing relocation target must not starve unrelated mail:
+// the failure stays a retryable per-item error, the guarded row keeps its
+// snapshot and old composite key, reused keys and later-page duplicates are
+// deferred rather than merged, the run reports errors so topology is not
+// published, and a later successful retry completes both the relocation and
+// the held work.
+func TestIMAPRelocationPersistentFailureKeepsUnrelatedMailFlowing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "liveness-target@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	sent.Subject = "Sent final"
+	unrelated := func(uid imapapi.UID, n int) scriptedRFC7162Message {
+		message := newScriptedRFC7162Message(uid, fmt.Sprintf("unrelated-%d@example.test", n), imapapi.FlagSeen)
+		message.Body = fmt.Sprintf("unrelatedbody%d", n)
+		return message
+	}
+	reusedKey := newScriptedRFC7162Message(1, "reused-key-holder@example.test", imapapi.FlagSeen)
+	reusedKey.Body = "reusedkeyholderword"
+	duplicate := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	duplicate.Body = "duplicatecopyword"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 1, 1),
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://liveness-target@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	// Overlap: the sent copy appears while the draft remains, and ten
+	// unrelated INBOX messages arrive.
+	// Legacy persisted-state precondition: the row keeps its stale Drafts
+	// canonical and snapshot while a saved Sent membership exists, seeded
+	// through the real topology helper (see the shared relocation fixture),
+	// so the failing phase exercises the forced relocation loader. The
+	// unrelated INBOX mail has been present since the first sync.
+	overlap := baseline.clone()
+	overlap.Mailboxes[2].HighestModSeq = 2
+	overlap.Mailboxes[2].UIDNext = 2
+	overlap.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(overlap)
+	seedLegacyDraftsCanonicalWithSentMembership(
+		t, st, source, []byte(scriptedRFC7162RawMessage(sent)), "<"+draft.MessageID+">")
+	before, err := st.GetMessage(id)
+	require.NoError(err)
+	beforeStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	beforeMemberships := queryScriptedRFC7162Memberships(t, st, source.ID)
+	beforeRaw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+
+	// Persistent failure: the draft's mailbox moves to a new epoch whose
+	// UID 1 holds an unrelated message (the old composite is reused), the
+	// survivor cannot be fetched, two new unrelated messages and a
+	// later-page duplicate of the guarded identity arrive.
+	failing := overlap.clone()
+	failing.Mailboxes[0].UIDNext = 13
+	failing.Mailboxes[0].HighestModSeq = 3
+	failing.Mailboxes[0].ChangedUIDs = []imapapi.UID{11, 12}
+	failing.Mailboxes[0].Messages = append([]scriptedRFC7162Message(nil), overlap.Mailboxes[0].Messages...)
+	failing.Mailboxes[0].Messages = append(failing.Mailboxes[0].Messages, unrelated(11, 11), unrelated(12, 12))
+	failing.Mailboxes[1].UIDValidity = 99
+	failing.Mailboxes[1].HighestModSeq = 1
+	failing.Mailboxes[1].VanishedUIDs = nil
+	failing.Mailboxes[1].Messages = []scriptedRFC7162Message{reusedKey}
+	unfetchable := sent
+	unfetchable.MissingRaw = true
+	failing.Mailboxes[2].Messages = []scriptedRFC7162Message{unfetchable}
+	failing.Mailboxes = append(failing.Mailboxes, scriptedRFC7162Mailbox{
+		Name: "ZFolder", UIDValidity: 22, UIDNext: 2, HighestModSeq: 2,
+		ChangedUIDs: []imapapi.UID{1}, Messages: []scriptedRFC7162Message{duplicate},
+	})
+	server.setSnapshot(failing)
+
+	runFailing := func() *gmail.SyncSummary {
+		summary, fullErr := runScriptedRelocationSyncSummary(t, st, identifier, addr)
+		require.NoError(fullErr, "a per-item relocation failure must complete the run, not abort it")
+		require.Positive(summary.Errors)
+		return summary
+	}
+	summary := runFailing()
+	assert.Equal(int64(2), summary.MessagesAdded,
+		"unrelated new mail must ingest while the relocation target fails")
+
+	after, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(before.SourceMessageID, after.SourceMessageID, "the guarded row keeps its old composite key")
+	assert.Equal(before.BodyText, after.BodyText)
+	assert.Equal(before.Labels, after.Labels)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(beforeRaw, raw)
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID)
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "the unfetchable survivor's content must not reach the index")
+	for _, held := range []string{"reused-key-holder@example.test", "liveness-target@example.test"} {
+		heldID, err := st.GetMessageIDByRFC822ID(source.ID, "<"+held+">")
+		require.NoError(err)
+		if held == "reused-key-holder@example.test" {
+			assert.Zero(heldID, "the reused composite key stays deferred while its target fails")
+		} else {
+			assert.Equal(id, heldID)
+		}
+	}
+	_, duplicateHits, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{"duplicatecopyword"}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(duplicateHits, "a later-page duplicate must not mutate or join the guarded row")
+	afterStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	assert.Equal(beforeStates, afterStates, "a run reporting errors must not publish folder state")
+	assert.Equal(beforeMemberships, queryScriptedRFC7162Memberships(t, st, source.ID))
+
+	// A repeated completed attempt behaves identically.
+	runFailing()
+	after, err = st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(before.SourceMessageID, after.SourceMessageID)
+	assert.Equal(before.BodyText, after.BodyText)
+
+	// Recovery: the survivor becomes fetchable; relocation, the held reused
+	// key, and folder publication all complete.
+	recovered := failing.clone()
+	recovered.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	recovered.Mailboxes[2].HighestModSeq = 3
+	server.setSnapshot(recovered)
+	fixed, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(fixed.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Sent|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, sent.Body)
+	assert.NotContains(message.BodyText, draft.Body)
+	raw, err = st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+	reusedID, err := st.GetMessageIDByRFC822ID(source.ID, "<reused-key-holder@example.test>")
+	require.NoError(err)
+	require.Positive(reusedID, "the held reused-key message archives after recovery")
+	reusedMessage, err := st.GetMessage(reusedID)
+	require.NoError(err)
+	assert.Equal("Drafts|1", reusedMessage.SourceMessageID)
+	assert.Contains(reusedMessage.BodyText, reusedKey.Body)
+	assert.NotEqual(id, reusedID, "the held message archives as its own row")
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	require.Len(states, 4)
+	byMailbox := map[string]uint32{}
+	for _, state := range states {
+		byMailbox[state.Mailbox] = state.UIDValidity
+	}
+	assert.Equal(uint32(99), byMailbox["Drafts"], "folder state advances after the successful retry")
+	known, err := st.GetIMAPKnownUIDs(source.ID)
+	require.NoError(err)
+	assert.Equal([]uint32{1}, known["Sent"])
+}
+
+// cancelOnSecondListIMAP surfaces a context cancellation on the second
+// ListMessages call, after the first page's checkpoint has been saved.
+type cancelOnSecondListIMAP struct {
+	*imap.Client
+
+	calls int
+}
+
+func (c *cancelOnSecondListIMAP) ListMessages(
+	ctx context.Context, query, pageToken string,
+) (*gmail.MessageListResponse, error) {
+	c.calls++
+	if c.calls == 2 {
+		return nil, fmt.Errorf("list messages: %w", context.Canceled)
+	}
+	return c.Client.ListMessages(ctx, query, pageToken)
+}
+
+// An interrupted run that deferred a relocation target must not resume past
+// it: the saved cursor stays empty, the next attempt is a fresh replan whose
+// forced target runs before ordinary routing, and the reused old composite
+// on that first page is deferred rather than consumed.
+func TestIMAPRelocationDeferredTargetInterruptedRunRestart(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "interrupted-target@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	reusedKey := newScriptedRFC7162Message(1, "interrupted-reused@example.test", imapapi.FlagSeen)
+	reusedKey.Body = "reusedkeyholderword"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 1, 1),
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://interrupted-target@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	// Legacy persisted-state precondition: stale Drafts canonical and
+	// snapshot with a saved Sent membership, seeded through the real
+	// topology helper so the interrupted run exercises forced relocation.
+	overlap := baseline.clone()
+	overlap.Mailboxes[2].HighestModSeq = 2
+	overlap.Mailboxes[2].UIDNext = 2
+	overlap.Mailboxes[2].ChangedUIDs = []imapapi.UID{1}
+	overlap.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(overlap)
+	seedLegacyDraftsCanonicalWithSentMembership(
+		t, st, source, []byte(scriptedRFC7162RawMessage(sent)), "<"+draft.MessageID+">")
+	before, err := st.GetMessage(id)
+	require.NoError(err)
+	beforeStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+
+	// Failing snapshot: reused old composite, unfetchable survivor, and
+	// enough INBOX mail to force a second page.
+	failing := overlap.clone()
+	// The IMAP client lists in pages of 100, so the reused composite lands
+	// on the second page and only a fresh full replan reaches it.
+	inbox := []scriptedRFC7162Message{}
+	for n := 1; n <= 105; n++ {
+		message := newScriptedRFC7162Message(imapapi.UID(n),
+			fmt.Sprintf("interrupted-fill-%d@example.test", n), imapapi.FlagSeen)
+		message.Body = fmt.Sprintf("fillerbody%d", n)
+		inbox = append(inbox, message)
+	}
+	failing.Mailboxes[0].UIDNext = 106
+	failing.Mailboxes[0].HighestModSeq = 2
+	failing.Mailboxes[0].ChangedUIDs = nil
+	for uid := 1; uid <= 105; uid++ {
+		failing.Mailboxes[0].ChangedUIDs = append(failing.Mailboxes[0].ChangedUIDs, imapapi.UID(uid))
+	}
+	failing.Mailboxes[0].Messages = inbox
+	failing.Mailboxes[1].UIDValidity = 99
+	failing.Mailboxes[1].HighestModSeq = 1
+	failing.Mailboxes[1].VanishedUIDs = nil
+	failing.Mailboxes[1].Messages = []scriptedRFC7162Message{reusedKey}
+	unfetchable := sent
+	unfetchable.MissingRaw = true
+	failing.Mailboxes[2].Messages = []scriptedRFC7162Message{unfetchable}
+	server.setSnapshot(failing)
+
+	// Interrupt after the first page: the forced target defers, page one
+	// completes, then the listing is canceled mid-run.
+	source2, err := st.GetSourceByIdentifier(identifier)
+	require.NoError(err)
+	interrupted := &cancelOnSecondListIMAP{Client: newScriptedRFC7162Client(
+		t, addr, imapFolderStateOptions(st, source2, false)...)}
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	_, err = newMessageSyncer(interrupted, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	require.ErrorIs(err, context.Canceled)
+	require.NoError(interrupted.Close())
+
+	run, err := st.GetLatestSync(source.ID)
+	require.NoError(err)
+	assert.Equal(store.SyncStatusFailed, run.Status)
+	assert.False(run.CursorBefore.Valid && run.CursorBefore.String != "",
+		"the saved cursor must stay empty so the deferred target cannot be resumed past")
+
+	// The next attempt must be a fresh replan even with resume enabled: the
+	// forced target re-runs ahead of ordinary routing, the reused composite
+	// is deferred, and the guarded row is untouched.
+	resumableOptions := msgsync.DefaultOptions()
+	resumableOptions.SourceType = sourceTypeIMAP
+	resumable := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source2, false)...)
+	summary, err := newMessageSyncer(resumable, st, resumableOptions).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	require.NoError(err, "the retry attempt completes with per-item errors")
+	require.NoError(resumable.Close())
+	assert.False(summary.WasResumed, "an empty saved cursor must force a fresh replan, not a resume")
+	assert.Positive(summary.Errors)
+	after, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(before.SourceMessageID, after.SourceMessageID,
+		"protection is rebuilt before ordinary routing on the fresh replan")
+	assert.Equal(before.BodyText, after.BodyText)
+	reusedID, err := st.GetMessageIDByRFC822ID(source.ID, "<interrupted-reused@example.test>")
+	require.NoError(err)
+	assert.Zero(reusedID, "the reused old composite stays deferred across the restart")
+	afterStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	assert.Equal(beforeStates, afterStates)
+
+	// Recovery completes the relocation and publishes topology on the fresh
+	// successful retry.
+	recovered := failing.clone()
+	recovered.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	recovered.Mailboxes[2].HighestModSeq = 3
+	server.setSnapshot(recovered)
+	fixed, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(fixed.Close())
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("Sent|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, sent.Body)
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	require.Len(states, 3)
+	byMailbox := map[string]uint32{}
+	for _, state := range states {
+		byMailbox[state.Mailbox] = state.UIDValidity
+	}
+	assert.Equal(uint32(99), byMailbox["Drafts"], "the fresh successful retry publishes folder state")
+}
+
+// A saved All Mail alias whose preferred label-validation/rekey route runs
+// while the selected All Mail candidate persistently fails must not consume
+// the failed target's old archive key: that key is what rediscovers the
+// candidate on the next attempt. The client's own listing picks the canonical
+// All Mail representative and the relocation selector picks the target; the
+// flag-changed alias appears on a later page through ordinary routing.
+func TestIMAPRelocationFailedTargetAliasDoesNotConsumeOldKey(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "alias-target@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	mirror := func(uid imapapi.UID) scriptedRFC7162Message {
+		message := newScriptedRFC7162Message(uid, draft.MessageID, imapapi.FlagSeen)
+		message.Body = "draftmirrorword"
+		return message
+	}
+	filler := func(n int) scriptedRFC7162Message {
+		message := newScriptedRFC7162Message(imapapi.UID(n),
+			fmt.Sprintf("alias-fill-%d@example.test", n), imapapi.FlagSeen)
+		message.Body = fmt.Sprintf("fillerbody%d", n)
+		return message
+	}
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 1, 1),
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 44, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://alias-target@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	// Binding sync: three All Mail mirrors and filler INBOX mail appear.
+	// The client's listing selects one mirror as the canonical All Mail
+	// representative; the others are stubbed and saved as memberships.
+	binding := baseline.clone()
+	binding.Mailboxes[0].UIDNext = 104
+	binding.Mailboxes[0].HighestModSeq = 2
+	binding.Mailboxes[0].ChangedUIDs = nil
+	for uid := 1; uid <= 103; uid++ {
+		binding.Mailboxes[0].ChangedUIDs = append(binding.Mailboxes[0].ChangedUIDs, imapapi.UID(uid))
+		binding.Mailboxes[0].Messages = append(binding.Mailboxes[0].Messages, filler(uid))
+	}
+	binding.Mailboxes[2].UIDNext = 4
+	binding.Mailboxes[2].HighestModSeq = 2
+	binding.Mailboxes[2].ChangedUIDs = []imapapi.UID{1, 2, 3}
+	binding.Mailboxes[2].Messages = []scriptedRFC7162Message{mirror(1), mirror(2), mirror(3)}
+	server.setSnapshot(binding)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+	bound, err := st.GetMessage(id)
+	require.NoError(err)
+	canonicalKey := bound.SourceMessageID
+	require.Regexp("^All Mail\\|\\d$", canonicalKey,
+		"preferred adoption takes an All Mail canonical key")
+	canonicalUID := int(canonicalKey[len("All Mail|")] - '0')
+	var others []int
+	for uid := 1; uid <= 3; uid++ {
+		if uid != canonicalUID {
+			others = append(others, uid)
+		}
+	}
+	require.Len(others, 2)
+	beforeStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+
+	// Failing sync: the canonical mirror vanishes, the selector's candidate
+	// cannot be fetched, the remaining alias only changes flags, and two new
+	// unrelated messages arrive. Enough filler keeps the flag-changed alias
+	// on the second page.
+	failing := binding.clone()
+	failing.Mailboxes[0].UIDNext = 106
+	failing.Mailboxes[0].HighestModSeq = 3
+	failing.Mailboxes[0].ChangedUIDs = []imapapi.UID{104, 105}
+	failing.Mailboxes[0].Messages = append([]scriptedRFC7162Message(nil), binding.Mailboxes[0].Messages...)
+	for _, n := range []int{104, 105} {
+		message := newScriptedRFC7162Message(imapapi.UID(n),
+			fmt.Sprintf("alias-new-%d@example.test", n), imapapi.FlagSeen)
+		message.Body = fmt.Sprintf("newbody%d", n)
+		failing.Mailboxes[0].Messages = append(failing.Mailboxes[0].Messages, message)
+	}
+	unreadable := mirror(imapapi.UID(others[0]))
+	unreadable.MissingRaw = true
+	flagged := mirror(imapapi.UID(others[1]))
+	flagged.Flags = []imapapi.Flag{imapapi.FlagSeen, imapapi.FlagFlagged}
+	failing.Mailboxes[2].HighestModSeq = 3
+	failing.Mailboxes[2].VanishedUIDs = []imapapi.UID{imapapi.UID(canonicalUID)}
+	failing.Mailboxes[2].ChangedUIDs = []imapapi.UID{imapapi.UID(others[1])}
+	failing.Mailboxes[2].Messages = []scriptedRFC7162Message{unreadable, flagged}
+	server.setSnapshot(failing)
+
+	summary, fullErr := runScriptedRelocationSyncSummary(t, st, identifier, addr)
+	require.NoError(fullErr, "the failing candidate defers instead of aborting the run")
+	require.Positive(summary.Errors)
+	assert.Equal(int64(2), summary.MessagesAdded, "unrelated new mail still ingests")
+
+	after, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(canonicalKey, after.SourceMessageID,
+		"the flag-changed alias's preferred rekey must not consume the failed target's old key")
+	assert.Contains(after.BodyText, draft.Body)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+	afterStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	assert.Equal(beforeStates, afterStates, "a run reporting errors publishes no folder state")
+
+	// A repeated failing attempt stays stable.
+	summary, fullErr = runScriptedRelocationSyncSummary(t, st, identifier, addr)
+	require.NoError(fullErr)
+	require.Positive(summary.Errors)
+	after, err = st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal(canonicalKey, after.SourceMessageID)
+
+	// Recovery: the candidate becomes fetchable; relocation and publication
+	// complete on the fresh successful attempt.
+	recovered := failing.clone()
+	recovered.Mailboxes[2].Messages = []scriptedRFC7162Message{mirror(imapapi.UID(others[0])), flagged}
+	recovered.Mailboxes[2].HighestModSeq = 4
+	server.setSnapshot(recovered)
+	fixed, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(fixed.Close())
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, draft.Body,
+		"the untrusted All Mail relocation rekeys without replacing content")
+	_, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	require.Len(states, 3)
+}
+
+// immediateLabelScriptedIMAP runs the production client with authoritative
+// label reconciliation enabled, so the untrusted forced adoption executes
+// its label step in the same call as the rekey.
+type immediateLabelScriptedIMAP struct {
+	*imap.Client
+}
+
+func (*immediateLabelScriptedIMAP) DefersAuthoritativeLabelReconciliation() bool {
+	return false
+}
+
+// An untrusted forced adoption whose label reconciliation fails late must
+// keep the old composite key and the guarded row untouched: rekey and labels
+// commit in one guarded transaction, leaving the failed target retryable.
+func TestIMAPRelocationUntrustedAdoptionKeepsOldKeyOnLabelFailure(t *testing.T) {
+	testutil.SkipIfPostgres(t, "uses a SQLite trigger to fail the label write")
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "atomic-forced@example.test", imapapi.FlagSeen)
+	draft.Body = "survivorbodyword"
+	survivor := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	survivor.Body = "survivorbodyword"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "OldBox", UIDValidity: 66, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "NewBox", UIDValidity: 77, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://atomic-forced@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	// Overlap binds the untrusted survivor's membership.
+	overlap := baseline.clone()
+	overlap.Mailboxes[1].HighestModSeq = 2
+	overlap.Mailboxes[1].UIDNext = 2
+	overlap.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	overlap.Mailboxes[1].Messages = []scriptedRFC7162Message{survivor}
+	server.setSnapshot(overlap)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+	before, err := st.GetMessage(id)
+	require.NoError(err)
+	require.Equal("OldBox|1", before.SourceMessageID)
+	beforeStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+
+	// The canonical mailbox rebuilds (new epoch), making the untrusted
+	// survivor the forced target. Label writes for the guarded row fail.
+	failing := overlap.clone()
+	failing.Mailboxes[0].UIDValidity = 67
+	failing.Mailboxes[0].HighestModSeq = 1
+	failing.Mailboxes[0].Messages = nil
+	server.setSnapshot(failing)
+	_, triggerErr := st.DB().Exec(fmt.Sprintf(`
+		CREATE TRIGGER fail_forced_labels_insert
+		BEFORE INSERT ON message_labels
+		WHEN NEW.message_id = %d
+		BEGIN
+			SELECT RAISE(ABORT, 'forced label write unavailable');
+		END`, id))
+	require.NoError(triggerErr)
+	_, triggerErr = st.DB().Exec(fmt.Sprintf(`
+		CREATE TRIGGER fail_forced_labels_delete
+		BEFORE DELETE ON message_labels
+		WHEN OLD.message_id = %d
+		BEGIN
+			SELECT RAISE(ABORT, 'forced label write unavailable');
+		END`, id))
+	require.NoError(triggerErr)
+	t.Cleanup(func() {
+		_, _ = st.DB().Exec(`DROP TRIGGER IF EXISTS fail_forced_labels_insert`)
+		_, _ = st.DB().Exec(`DROP TRIGGER IF EXISTS fail_forced_labels_delete`)
+	})
+
+	runImmediate := func() (*gmail.SyncSummary, error) {
+		src, srcErr := st.GetSourceByIdentifier(identifier)
+		require.NoError(srcErr)
+		client := &immediateLabelScriptedIMAP{Client: newScriptedRFC7162Client(
+			t, addr, imapFolderStateOptions(st, src, false)...)}
+		options := msgsync.DefaultOptions()
+		options.SourceType = sourceTypeIMAP
+		options.NoResume = true
+		summary, err := newMessageSyncer(client, st, options).
+			WithLogger(slog.New(slog.DiscardHandler)).
+			Full(t.Context(), identifier)
+		if closeErr := client.Close(); err == nil {
+			err = closeErr
+		}
+		return summary, err
+	}
+	summary, fullErr := runImmediate()
+	require.NoError(fullErr, "the failed adoption defers instead of aborting the run")
+	require.Positive(summary.Errors)
+
+	after, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("OldBox|1", after.SourceMessageID,
+		"a failed untrusted adoption must not consume the old composite key")
+	assert.Equal(before.Labels, after.Labels)
+	assert.Contains(after.BodyText, draft.Body)
+	afterStates, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	assert.Equal(beforeStates, afterStates, "a run reporting errors publishes no folder state")
+
+	// Removing the fault lets the retry adopt the untrusted location with
+	// reconciled labels and publish topology.
+	_, err = st.DB().Exec(`DROP TRIGGER fail_forced_labels_insert`)
+	require.NoError(err)
+	_, err = st.DB().Exec(`DROP TRIGGER fail_forced_labels_delete`)
+	require.NoError(err)
+	fixed, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(fixed.Close())
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Equal("NewBox|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, draft.Body)
+	states, err := st.GetIMAPFolderStates(source.ID)
+	require.NoError(err)
+	require.Len(states, 2)
+}
+
+// A full-enumeration run (initial archive, rescan, or QRESYNC-ineligible
+// fallback) fetches the untrusted All mirror before the trusted Sent copy.
+// The cross-copy RFC822 dedup must not turn that trusted copy into a
+// raw-less stub: the stale archived draft snapshot then never refreshes even
+// though the run held the only trusted copy it needs.
+func TestIMAPRelocationFullEnumerationRefreshesEditedSent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	draft := newScriptedRFC7162Message(1, "full-enum-refresh@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	sent.Subject = "Sent final"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 1, HighestModSeq: 1},
+		{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	const identifier = "imap://full-enum-refresh@example.test"
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+	stale, err := st.GetMessage(id)
+	require.NoError(err)
+	require.Contains(stale.BodyText, draft.Body, "the archived snapshot starts as the draft")
+
+	// The draft vanishes while the edited Sent copy and its All mirror
+	// appear. QRESYNC is unavailable, so the run enumerates fully and the
+	// All mirror is fetched ahead of the trusted Sent copy.
+	edited := baseline.clone()
+	edited.Capabilities = "IMAP4rev1 SPECIAL-USE"
+	edited.Mailboxes[0].HighestModSeq = 2
+	edited.Mailboxes[0].UIDNext = 2
+	edited.Mailboxes[0].Messages = []scriptedRFC7162Message{sent}
+	edited.Mailboxes[1].HighestModSeq = 2
+	edited.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[1].Messages = nil
+	edited.Mailboxes[2].HighestModSeq = 2
+	edited.Mailboxes[2].UIDNext = 2
+	edited.Mailboxes[2].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(edited)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, sent.Body,
+		"the trusted Sent copy must refresh the stale draft snapshot in a full-enumeration run")
+	assert.NotContains(message.BodyText, draft.Body)
+	assert.Equal("Sent final", message.Subject)
+	raw, err := st.GetMessageRaw(id)
+	require.NoError(err)
+	assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+	var count int
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count, "the duplicate copies collapse into one row")
+	results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(id, results[0].ID, "the internal ID is retained")
+	_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "the stale draft body leaves the search index")
+
+	server.setSnapshot(edited)
+	third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(third.Close())
+	message, err = st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, sent.Body)
+	assert.NotContains(message.BodyText, draft.Body)
+	require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+	assert.Equal(1, count)
+}
+
+// runScriptedSourceSync runs a full production sync for one IMAP source
+// against its own scripted server under the current global configuration.
+func runScriptedSourceSync(
+	t *testing.T, st *store.Store, identifier, addr string,
+	mod func(*msgsync.Options),
+) (*imap.Client, *store.Source, error) {
+	t.Helper()
+	source, err := st.GetOrCreateSource(sourceTypeIMAP, identifier)
+	require.NoError(t, err)
+	client := newScriptedRFC7162Client(t, addr, imapFolderStateOptions(st, source, false)...)
+	options := msgsync.DefaultOptions()
+	options.SourceType = sourceTypeIMAP
+	options.NoResume = true
+	if mod != nil {
+		mod(options)
+	}
+	summary, err := newMessageSyncer(client, st, options).
+		WithLogger(slog.New(slog.DiscardHandler)).
+		Full(t.Context(), identifier)
+	if err != nil {
+		return client, source, err
+	}
+	if summary.Errors != 0 {
+		return client, source, fmt.Errorf(
+			"scripted IMAP sync completed with %d errors", summary.Errors)
+	}
+	return client, source, saveIMAPFolderStates(
+		context.Background(), st, source, client, summary, options.Limit)
+}
+
+// Sent-folder trust is scoped to the exact IMAP source identifier: two
+// accounts with the same localized folder name, only one of them configured,
+// must behave differently. The configured account refreshes an edited
+// outgoing copy even in a full-enumeration run with a mirror fetched first;
+// the unconfigured account's same-named folder cannot replace an archived
+// snapshot, its raw MIME, participants, attachments, or search content, and
+// rejected bytes never reach remote-image processing.
+func TestIMAPRelocationSentTrustIsSourceScoped(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = config.NewDefaultConfig()
+	cfg.Sync.ArchiveRemoteImages = true
+	const identifierA = "imap://scoped-a@example.test"
+	const identifierB = "imap://scoped-b@example.test"
+	cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+		identifierA: {"Gesendete Elemente"},
+	}
+
+	// Source A: configured localized Sent folder, no advertised roles. The
+	// run enumerates fully (no QRESYNC), so the untrusted mirror is fetched
+	// before the configured Sent copy.
+	draftA := newScriptedRFC7162Message(1, "scoped-a@example.test", imapapi.FlagDraft)
+	draftA.Body = "draftaword"
+	sentA := newScriptedRFC7162Message(1, draftA.MessageID, imapapi.FlagSeen)
+	sentA.Body = "sentafinalword"
+	baselineA := scriptedRFC7162Snapshot{Capabilities: "IMAP4rev1 SPECIAL-USE", Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "Alles", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 1, HighestModSeq: 1},
+		{Name: "Entw&APw-rfe", UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draftA}},
+		{Name: "Gesendete Elemente", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addrA, serverA := startScriptedRFC7162Server(t, baselineA)
+	stA := testutil.NewTestStore(t)
+	withAttachments := func(o *msgsync.Options) { o.AttachmentsDir = t.TempDir() }
+	firstA, sourceA, err := runScriptedSourceSync(t, stA, identifierA, addrA, withAttachments)
+	require.NoError(err)
+	require.NoError(firstA.Close())
+	idA, err := stA.GetMessageIDByRFC822ID(sourceA.ID, "<"+draftA.MessageID+">")
+	require.NoError(err)
+	require.Positive(idA)
+
+	editedA := baselineA.clone()
+	editedA.Mailboxes[0].HighestModSeq = 2
+	editedA.Mailboxes[0].UIDNext = 2
+	editedA.Mailboxes[0].Messages = []scriptedRFC7162Message{sentA}
+	editedA.Mailboxes[1].HighestModSeq = 2
+	editedA.Mailboxes[1].VanishedUIDs = []imapapi.UID{1}
+	editedA.Mailboxes[1].Messages = nil
+	editedA.Mailboxes[2].HighestModSeq = 2
+	editedA.Mailboxes[2].UIDNext = 2
+	editedA.Mailboxes[2].Messages = []scriptedRFC7162Message{sentA}
+	serverA.setSnapshot(editedA)
+	secondA, _, err := runScriptedSourceSync(t, stA, identifierA, addrA, withAttachments)
+	require.NoError(err)
+	require.NoError(secondA.Close())
+	messageA, err := stA.GetMessage(idA)
+	require.NoError(err)
+	assert.Contains(messageA.BodyText, sentA.Body,
+		"the configured source refreshes the edited copy despite the mirror-first full enumeration")
+	assert.NotContains(messageA.BodyText, draftA.Body)
+
+	// Source B: same folder name, no configuration. A forged Message-ID
+	// survivor there must not replace the archived snapshot.
+	victimB := newScriptedRFC7162Message(1, "scoped-b@example.test", imapapi.FlagSeen)
+	victimB.Body = "victimbword"
+	victimB.Raw = scriptedOutgoingRaw(
+		victimB.MessageID, "Original B",
+		"victim-to@example.test", "victim-cc@example.test",
+		"victimbword", "<p>victimbword</p>",
+		"victimb.bin", "victim b attachment bytes")
+	forgerB := newScriptedRFC7162Message(2, victimB.MessageID, imapapi.FlagSeen)
+	forgerB.Raw = scriptedOutgoingRaw(
+		victimB.MessageID, "Forged B",
+		"forger-to@example.test", "forger-cc@example.test",
+		"forgerbword",
+		"<p>forgerbword <img src=\"http://images.example/forger-b\"></p>",
+		"forgerb.bin", "forger b attachment bytes")
+	baselineB := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		scriptedRFC7162Inbox(55, 2, 1, victimB),
+		{Name: "Gesendete Elemente", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addrB, serverB := startScriptedRFC7162Server(t, baselineB)
+	stB := testutil.NewTestStore(t)
+	firstB, sourceB, err := runScriptedSourceSync(t, stB, identifierB, addrB, withAttachments)
+	require.NoError(err)
+	require.NoError(firstB.Close())
+	idB, err := stB.GetMessageIDByRFC822ID(sourceB.ID, "<"+victimB.MessageID+">")
+	require.NoError(err)
+	require.Positive(idB)
+	beforeB, err := stB.GetMessage(idB)
+	require.NoError(err)
+	require.Len(beforeB.Attachments, 1)
+
+	replacedB := baselineB.clone()
+	replacedB.Mailboxes[0].HighestModSeq = 2
+	replacedB.Mailboxes[0].UIDNext = 3
+	replacedB.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+	replacedB.Mailboxes[0].Messages = nil
+	replacedB.Mailboxes[1].HighestModSeq = 2
+	replacedB.Mailboxes[1].UIDNext = 3
+	replacedB.Mailboxes[1].ChangedUIDs = []imapapi.UID{2}
+	replacedB.Mailboxes[1].Messages = []scriptedRFC7162Message{forgerB}
+	serverB.setSnapshot(replacedB)
+	secondB, _, err := runScriptedSourceSync(t, stB, identifierB, addrB, withAttachments)
+	require.NoError(err)
+	require.NoError(secondB.Close())
+
+	messageB, err := stB.GetMessage(idB)
+	require.NoError(err)
+	assert.Equal("Gesendete Elemente|2", messageB.SourceMessageID,
+		"the surviving location in the same-named folder is still adopted")
+	assert.Contains(messageB.BodyText, victimB.Body,
+		"the unconfigured source's same-named folder cannot replace the snapshot")
+	assert.NotContains(messageB.BodyText, "forgerbword")
+	assert.Equal([]string{"victim-to@example.test"}, messageB.To)
+	assert.Equal([]string{"victim-cc@example.test"}, messageB.Cc)
+	require.Len(messageB.Attachments, 1)
+	assert.Equal("victimb.bin", messageB.Attachments[0].Filename)
+	rawB, err := stB.GetMessageRaw(idB)
+	require.NoError(err)
+	assert.Equal(victimB.Raw, string(rawB))
+	_, hitsB, err := stB.SearchMessagesQuery(&search.Query{TextTerms: []string{"forgerbword"}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(hitsB, "forged content must not reach the search index")
+	refsB, err := stB.MessageRemoteImages(idB)
+	require.NoError(err)
+	assert.Empty(refsB,
+		"rejected bytes must not create remote-image references; the no-HTTP-request guarantee is covered by the sync-level counter test")
+}
+
+// A configured name the server itself advertises as \Drafts keeps its Drafts
+// meaning: explicit configuration cannot turn a Drafts folder into the
+// account's Sent folder and grant its duplicate copies the trusted dedup
+// bypass that would let a stale draft downgrade a fresh snapshot.
+func TestIMAPRelocationConfiguredDraftsRoleNotSent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = config.NewDefaultConfig()
+	const identifier = "imap://configured-drafts@example.test"
+	cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+		identifier: {"My Drafts"},
+	}
+
+	sent := newScriptedRFC7162Message(1, "configured-drafts@example.test", imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	staleDraft := newScriptedRFC7162Message(1, sent.MessageID, imapapi.FlagDraft)
+	staleDraft.Body = "draftoriginalword"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: "IMAP4rev1 SPECIAL-USE", Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "All Mail", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrAll}, UIDValidity: 99, UIDNext: 1, HighestModSeq: 1},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{sent}},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+sent.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	// The All mirror is fetched first in the full enumeration; the stale
+	// draft copy in the configured-but-advertised-Drafts mailbox arrives
+	// second and must stay a dedup stub.
+	failing := baseline.clone()
+	failing.Mailboxes[0].HighestModSeq = 2
+	failing.Mailboxes[0].UIDNext = 2
+	failing.Mailboxes[0].Messages = []scriptedRFC7162Message{sent}
+	failing.Mailboxes = append(failing.Mailboxes, scriptedRFC7162Mailbox{
+		Name: "My Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts},
+		UIDValidity: 66, UIDNext: 2, HighestModSeq: 2, ChangedUIDs: []imapapi.UID{1},
+		Messages: []scriptedRFC7162Message{staleDraft},
+	})
+	server.setSnapshot(failing)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, sent.Body,
+		"a configured Drafts-role name must not gain the Sent dedup bypass")
+	assert.NotContains(message.BodyText, staleDraft.Body)
+}
+
+// An edited Sent copy must refresh a stale archived Drafts snapshot even
+// while the old Drafts copy still exists and remains canonical: Sent
+// placement outranks Drafts placement for content precedence. Received
+// placements never gain that precedence, and a later stale Drafts copy must
+// not downgrade the refreshed snapshot.
+func TestIMAPRelocationSentOutranksStaleDraftsCanonical(t *testing.T) {
+	for _, mode := range []string{"qresync", "full enumeration", "configured localized sent"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			savedCfg := cfg
+			t.Cleanup(func() { cfg = savedCfg })
+			cfg = config.NewDefaultConfig()
+			draft := newScriptedRFC7162Message(1, "sent-precedence@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Body = "sentfinalword"
+			sent.Subject = "Sent final"
+			sentMailbox := scriptedRFC7162Mailbox{
+				Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent},
+				UIDValidity: 88, UIDNext: 1, HighestModSeq: 1,
+			}
+			if mode == "configured localized sent" {
+				sentMailbox = scriptedRFC7162Mailbox{
+					Name: "Gesendete Elemente", UIDValidity: 88, UIDNext: 1, HighestModSeq: 1,
+				}
+				const identifier = "imap://sent-precedence@example.test"
+				cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+					identifier: {"Gesendete Elemente"},
+				}
+			}
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				sentMailbox,
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			const identifier = "imap://sent-precedence@example.test"
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+			stale, err := st.GetMessage(id)
+			require.NoError(err)
+			require.Contains(stale.BodyText, draft.Body, "the archived snapshot starts as the draft")
+
+			edited := baseline.clone()
+			if mode == "full enumeration" {
+				edited.Capabilities = "IMAP4rev1 SPECIAL-USE"
+			}
+			edited.Mailboxes[1].HighestModSeq = 2
+			edited.Mailboxes[1].UIDNext = 2
+			edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+			server.setSnapshot(edited)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Contains(message.BodyText, sent.Body,
+				"the edited Sent copy must refresh the stale draft while Drafts remains")
+			assert.NotContains(message.BodyText, draft.Body)
+			assert.Equal("Sent final", message.Subject)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(sent), string(raw))
+			var count int
+			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+			assert.Equal(1, count)
+			results, total, err := st.SearchMessagesQuery(&search.Query{TextTerms: []string{sent.Body}}, 0, 10)
+			require.NoError(err)
+			assert.Equal(int64(1), total)
+			require.Len(results, 1)
+			assert.Equal(id, results[0].ID)
+			_, total, err = st.SearchMessagesQuery(&search.Query{TextTerms: []string{draft.Body}}, 0, 10)
+			require.NoError(err)
+			assert.Zero(total, "the stale draft body leaves the search index")
+
+			// A repeated run must not let the surviving stale Drafts copy
+			// downgrade the refreshed snapshot.
+			server.setSnapshot(edited)
+			third, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(third.Close())
+			message, err = st.GetMessage(id)
+			require.NoError(err)
+			assert.Contains(message.BodyText, sent.Body)
+			assert.NotContains(message.BodyText, draft.Body)
+			require.NoError(st.DB().QueryRow(st.Rebind("SELECT COUNT(*) FROM messages WHERE source_id = ?"), source.ID).Scan(&count))
+			assert.Equal(1, count)
+		})
+	}
+}
+
+// An advertised \Drafts role outranks explicit Sent configuration: a
+// mistakenly configured Drafts canonical is still recognized as Drafts and
+// yields to a genuine Sent copy, while never itself gaining the Sent
+// placement's dedup bypass.
+func TestIMAPRelocationConfiguredDraftsCanonicalStillYieldsToSent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	savedCfg := cfg
+	t.Cleanup(func() { cfg = savedCfg })
+	cfg = config.NewDefaultConfig()
+	const identifier = "imap://configured-drafts-canonical@example.test"
+	cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+		identifier: {"My Drafts"},
+	}
+
+	draft := newScriptedRFC7162Message(1, "configured-drafts-canonical@example.test", imapapi.FlagDraft)
+	draft.Body = "draftoriginalword"
+	sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+	sent.Body = "sentfinalword"
+	sent.Subject = "Sent final"
+
+	baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+		{Name: "My Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 66, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+		{Name: "Sent", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+	}}
+	addr, server := startScriptedRFC7162Server(t, baseline)
+	st := testutil.NewTestStore(t)
+	first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(first.Close())
+	id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+	require.NoError(err)
+	require.Positive(id)
+
+	edited := baseline.clone()
+	edited.Mailboxes[1].HighestModSeq = 2
+	edited.Mailboxes[1].UIDNext = 2
+	edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+	edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+	server.setSnapshot(edited)
+	second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+	require.NoError(err)
+	require.NoError(second.Close())
+
+	message, err := st.GetMessage(id)
+	require.NoError(err)
+	assert.Contains(message.BodyText, sent.Body,
+		"an advertised \\Drafts canonical yields to a genuine Sent copy despite the mistaken configuration")
+	assert.NotContains(message.BodyText, draft.Body)
+}
+
+// seedLegacyDraftsCanonicalWithSentMembership persists the archive state that
+// predates Sent-over-Drafts overlap refresh through the real production
+// topology helper: the row keeps its stale Drafts canonical and snapshot while
+// a saved Sent membership and both mailbox cursors exist, so a later sync
+// rediscovers the Sent survivor through the forced relocation loader. Real
+// membership and folder-state persistence keep the recovery path identical to
+// a legacy archive's.
+func seedLegacyDraftsCanonicalWithSentMembership(
+	t *testing.T,
+	st *store.Store,
+	source *store.Source,
+	sentRaw []byte,
+	rfc822 string,
+) {
+	t.Helper()
+	require.NoError(t, st.ApplyIMAPMailboxDeltas(source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "Drafts",
+			State: store.IMAPFolderState{
+				Mailbox: "Drafts", UIDValidity: 77, UIDNext: 2, HighestModSeq: 1,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Drafts", UIDValidity: 77, UID: 1,
+				SourceMessageID: "Drafts|1", RFC822MessageID: rfc822,
+				Flags: []string{"\\Draft"},
+			}},
+		},
+		{
+			Mailbox: "Sent",
+			State: store.IMAPFolderState{
+				Mailbox: "Sent", UIDValidity: 88, UIDNext: 2, HighestModSeq: 2,
+			},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Sent", UIDValidity: 88, UID: 1,
+				SourceMessageID: "Sent|1", RFC822MessageID: rfc822,
+				RawSHA256: sha256.Sum256(sentRaw),
+				RawSize:   int64(len(sentRaw)),
+				Flags:     []string{"\\Seen"},
+			}},
+		},
+	}))
+}
+
+// A mailbox the server advertises with BOTH \Sent and \Drafts is ambiguous:
+// it must neither authorize snapshot replacement nor gain the Sent placement
+// precedence or dedup bypass, including when the account lists it explicitly.
+func TestIMAPRelocationDualSentDraftsRoleDenied(t *testing.T) {
+	for _, mode := range []string{"advertised", "advertised and configured"} {
+		t.Run(mode, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			savedCfg := cfg
+			t.Cleanup(func() { cfg = savedCfg })
+			cfg = config.NewDefaultConfig()
+			draft := newScriptedRFC7162Message(1, "dual-role@example.test", imapapi.FlagDraft)
+			draft.Body = "draftoriginalword"
+			sent := newScriptedRFC7162Message(1, draft.MessageID, imapapi.FlagSeen)
+			sent.Body = "sentfinalword"
+			const identifier = "imap://dual-role@example.test"
+			if mode == "advertised and configured" {
+				cfg.Sync.TrustedIMAPSentMailboxes = map[string][]string{
+					identifier: {"Outgoing"},
+				}
+			}
+			baseline := scriptedRFC7162Snapshot{Capabilities: scriptedRFC7162Capabilities(), Mailboxes: []scriptedRFC7162Mailbox{
+				{Name: "Drafts", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrDrafts}, UIDValidity: 77, UIDNext: 2, HighestModSeq: 1, Messages: []scriptedRFC7162Message{draft}},
+				{Name: "Outgoing", Attrs: []imapapi.MailboxAttr{imapapi.MailboxAttrSent, imapapi.MailboxAttrDrafts}, UIDValidity: 88, UIDNext: 1, HighestModSeq: 1},
+			}}
+			addr, server := startScriptedRFC7162Server(t, baseline)
+			st := testutil.NewTestStore(t)
+			first, source := requireScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(first.Close())
+			id, err := st.GetMessageIDByRFC822ID(source.ID, "<"+draft.MessageID+">")
+			require.NoError(err)
+			require.Positive(id)
+
+			edited := baseline.clone()
+			edited.Mailboxes[0].HighestModSeq = 2
+			edited.Mailboxes[0].VanishedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[0].Messages = nil
+			edited.Mailboxes[1].HighestModSeq = 2
+			edited.Mailboxes[1].UIDNext = 2
+			edited.Mailboxes[1].ChangedUIDs = []imapapi.UID{1}
+			edited.Mailboxes[1].Messages = []scriptedRFC7162Message{sent}
+			server.setSnapshot(edited)
+			second, _, err := runScriptedRFC7162Sync(t, st, identifier, addr)
+			require.NoError(err)
+			require.NoError(second.Close())
+
+			message, err := st.GetMessage(id)
+			require.NoError(err)
+			assert.Equal("Outgoing|1", message.SourceMessageID,
+				"the surviving location in the ambiguous mailbox is still adopted")
+			assert.Contains(message.BodyText, draft.Body,
+				"an ambiguous \\Sent+\\Drafts advertisement must not authorize snapshot replacement")
+			assert.NotContains(message.BodyText, sent.Body)
+			raw, err := st.GetMessageRaw(id)
+			require.NoError(err)
+			assert.Equal(scriptedRFC7162RawMessage(draft), string(raw))
+		})
+	}
+}

--- a/cmd/msgvault/cmd/syncfull.go
+++ b/cmd/msgvault/cmd/syncfull.go
@@ -341,6 +341,19 @@ func buildAPIClient(ctx context.Context, src *store.Source, getOAuthMgr func(str
 	}
 }
 
+// configuredTrustedSentMailboxes exposes the explicit Sent-folder trust
+// configured for exactly this IMAP source, keyed by its identifier (the
+// ACCOUNT value printed by `msgvault list-accounts`). Trust never crosses
+// accounts: another source with a same-named mailbox gets no entry. Nil-safe
+// because several command tests run without a loaded global config; a
+// missing entry means no explicit trust.
+func configuredTrustedSentMailboxes(identifier string) []string {
+	if cfg == nil {
+		return nil
+	}
+	return cfg.Sync.TrustedIMAPSentMailboxes[identifier]
+}
+
 // loadIMAPFolderStates returns the saved per-mailbox states in the map
 // form the IMAP client consumes.
 func loadIMAPFolderStates(s *store.Store, sourceID int64) (map[string]imaplib.FolderState, error) {
@@ -385,7 +398,26 @@ func imapFolderStateOptions(
 	opts = append(opts, imaplib.WithSourceMessageAliasLoader(
 		func(mailbox string, uids []uint32) (map[string]string, error) {
 			return s.GetIMAPSourceMessageAliases(src.ID, mailbox, uids)
-		}))
+		}), imaplib.WithRelocationCandidateLoader(
+		func(ctx context.Context, lost []string) ([]imaplib.RelocationCandidate, error) {
+			candidates, err := s.GetIMAPRelocationCandidatesContext(ctx, src.ID, lost)
+			if err != nil {
+				return nil, err
+			}
+			result := make([]imaplib.RelocationCandidate, 0, len(candidates))
+			for _, candidate := range candidates {
+				result = append(result, imaplib.RelocationCandidate{
+					Target: gmail.MessageRelocationTarget{
+						InternalID: candidate.ID, SourceID: candidate.SourceID,
+						SourceMessageID: candidate.SourceMessageID,
+						RFC822MessageID: candidate.RFC822MessageID,
+					},
+					Mailbox: candidate.Mailbox, UIDValidity: candidate.UIDValidity, UID: candidate.UID,
+				})
+			}
+			return result, nil
+		}),
+		imaplib.WithTrustedSentMailboxes(configuredTrustedSentMailboxes(src.Identifier)))
 	if forceRescan {
 		opts = append(opts, imaplib.WithForceFullEnumeration())
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-09-08"
+last_edited: "2026-09-09"
 title: Configuration
 description: Configuration file reference, environment variables, and file locations.
 ---
@@ -466,6 +466,7 @@ Use `msgvault logs` to view and tail log files from the selected local or remote
 |---|---|---|
 | `rate_limit_qps` | `5` | Gmail API requests per second |
 | `archive_remote_images` | `false` | Download remote email images during Gmail/IMAP sync and EML, EMLX, MBOX, and PST imports |
+| `trusted_imap_sent_mailboxes` | `{}` | Per-IMAP-account Sent-folder names (keyed by the ACCOUNT identifier from `msgvault list-accounts`) that enable edited-copy snapshot refresh for servers without advertised special-use roles |
 
 Remote image archiving is **off by default**. Enabling it contacts
 sender-controlled servers and can activate tracking pixels or disclose the
@@ -474,6 +475,38 @@ It applies to new ingestion; existing mail needs an explicit backfill.
 
 See [remote email images](usage/remote-images.md) for the opt-in workflow,
 supported formats, download limits, and effect on attachment counts.
+
+`trusted_imap_sent_mailboxes` names each IMAP account's Sent folder for
+servers — such as some Exchange/Outlook accounts — whose (possibly localized)
+Sent folder advertises no RFC 6154 `\Sent` special-use role. A survivor copy in
+that unadvertised folder never replaces the archived snapshot by default:
+the sync adopts the surviving location but keeps the previously archived
+body, raw MIME, recipients, and attachments, because a sender can forge any
+RFC822 `Message-ID`. Placement the server does advertise — an unambiguous
+`\Sent` or `\Drafts` role — remains trusted automatically regardless of
+this setting. Naming a mailbox here states that it is that account's Sent
+folder and holds only mail the account itself authored, which re-enables
+refreshing the archived snapshot from an edited copy found there.
+
+The mapping is keyed by the exact source identifier — copy the `ACCOUNT`
+value printed by `msgvault list-accounts` (for example
+`imaps://user@example.com@imap.example.com:993`), not the email or display
+name. Trust never crosses accounts: a same-named mailbox in another synced
+account stays untrusted, and an account with no entry has no explicit trust.
+
+```toml
+[sync]
+trusted_imap_sent_mailboxes = { "imaps://user@example.com@imap.example.com:993" = ["Gesendete Elemente"] }
+```
+
+This is an explicit trust assumption, not evidence: filters or IMAP rules
+that file received mail into the listed mailbox would let that mail replace
+an archived snapshot under the same Message-ID. Advertised unambiguous
+`\Sent` and `\Drafts` placement is trusted automatically, and a mailbox
+that carries `\All`, `\Junk`, or `\Trash` roles, or INBOX, is never
+trusted — not even when listed here explicitly. A configured name the server
+itself advertises as `\Drafts` keeps its Drafts meaning: explicit
+configuration cannot turn a Drafts folder into the account's Sent folder.
 
 ### `[server]`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -648,6 +648,16 @@ type SyncConfig struct {
 	// ArchiveRemoteImages opts into sender-controlled HTTP requests, which
 	// can activate tracking pixels. Unset is deliberately false.
 	ArchiveRemoteImages bool `toml:"archive_remote_images"`
+	// TrustedIMAPSentMailboxes maps an exact IMAP source identifier (the
+	// ACCOUNT value printed by `msgvault list-accounts`, e.g.
+	// "imaps://user@example.com@imap.example.com:993") to that source's
+	// Sent-folder mailbox names, for servers whose (possibly localized) Sent
+	// folder advertises no RFC 6154 \Sent role. The mapping is per source:
+	// a same-named mailbox in another account never gains trust. Each entry
+	// is an explicit trust assumption, not evidence. Untrusted-by-default:
+	// a missing entry leaves snapshot refresh authorized only by
+	// unambiguous advertised \Sent or \Drafts placement.
+	TrustedIMAPSentMailboxes map[string][]string `toml:"trusted_imap_sent_mailboxes"`
 }
 
 // DefaultHome returns the default msgvault home directory.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2154,3 +2154,30 @@ capabilities_file = "manifests/voyage.json"
 	assert.Equal(filepath.Join(tmpDir, "manifests/voyage.json"),
 		cfg.Vector.Multimodal.CapabilitiesFile)
 }
+
+func TestLoadTrustedIMAPSentMailboxesPerSource(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	content := `[sync]
+trusted_imap_sent_mailboxes = { "imaps://alice@example.com@imap.example.com:993" = ["Gesendete Elemente", "Sent Items"] }
+`
+	require.NoError(os.WriteFile(configPath, []byte(content), 0o600))
+
+	cfg, err := Load(configPath, "")
+	require.NoError(err)
+	require.Len(cfg.Sync.TrustedIMAPSentMailboxes, 1)
+	assert.Equal(
+		[]string{"Gesendete Elemente", "Sent Items"},
+		cfg.Sync.TrustedIMAPSentMailboxes["imaps://alice@example.com@imap.example.com:993"])
+	assert.Empty(
+		cfg.Sync.TrustedIMAPSentMailboxes["imaps://bob@example.com@imap.example.com:993"],
+		"a same-named mailbox in another account gains no trust")
+
+	emptyPath := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(os.WriteFile(emptyPath, []byte(""), 0o600))
+	cfg, err = Load(emptyPath, "")
+	require.NoError(err)
+	assert.Empty(cfg.Sync.TrustedIMAPSentMailboxes,
+		"unconfigured archives carry no explicit Sent-folder trust")
+}

--- a/internal/gmail/api.go
+++ b/internal/gmail/api.go
@@ -168,3 +168,13 @@ type HistoryLabelChange struct {
 	Message  MessageID
 	LabelIDs []string
 }
+
+// MessageRelocationTarget retains the archived identity selected for adopting
+// a fetched snapshot after its previous IMAP location disappears.
+type MessageRelocationTarget struct {
+	InternalID         int64
+	SourceID           int64
+	SourceMessageID    string // Expected old archived composite ID.
+	RFC822MessageID    string
+	NewSourceMessageID string
+}

--- a/internal/imap/batch_fetch.go
+++ b/internal/imap/batch_fetch.go
@@ -16,6 +16,7 @@ import (
 	gomessage "github.com/emersion/go-message"
 	gomail "github.com/emersion/go-message/mail"
 	gmailapi "go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/mime"
 )
 
 var errIMAPRawBodyMissing = errors.New("IMAP fetch result did not include raw body")
@@ -149,6 +150,18 @@ func (c *Client) applyFetchResults(
 		// skip, not a fetch error.
 		msgID := compositeID(mailbox, msgBuf.UID)
 		rfc822MessageID := rawMIMEMessageID(rawMIME)
+		target, forced := c.relocationTargets[msgID]
+		if state, observed := c.observedFolderStates[mailbox]; forced &&
+			(!observed || c.selectedUIDValidity != state.UIDValidity) {
+			results[idx].Message = nil
+			results[idx].Err = fmt.Errorf("IMAP relocation candidate %q changed mailbox epoch", msgID)
+			continue
+		}
+		if forced && mime.NormalizeMessageID(rfc822MessageID) != target.RFC822MessageID {
+			results[idx].Message = nil
+			results[idx].Err = fmt.Errorf("IMAP relocation candidate %q changed RFC822 identity", msgID)
+			continue
+		}
 		canonicalSourceMessageID := ""
 		var rawSHA256 [32]byte
 		if rfc822MessageID == "" && c.preferredRawSourceIDs != nil {
@@ -176,6 +189,9 @@ func (c *Client) applyFetchResults(
 				}
 			}
 		}
+		if forced {
+			canonicalSourceMessageID = msgID
+		}
 		c.recordMembershipLocked(
 			mailbox, msgBuf.UID, canonicalSourceMessageID, rfc822MessageID,
 			rawSHA256, msgBuf.RFC822Size, msgBuf.Flags)
@@ -184,14 +200,31 @@ func (c *Client) applyFetchResults(
 			results[idx].Err = nil
 			continue
 		}
-		if c.seenRFC822IDs != nil &&
+		if !forced && c.seenRFC822IDs != nil &&
 			rfc822MessageID != "" {
 			if c.seenRFC822IDs[rfc822MessageID] {
-				results[idx].Message = &gmailapi.RawMessage{ID: msgID}
-				results[idx].Err = nil
-				continue
+				// A duplicate copy in Sent placement still gets its full
+				// raw — once per identity per run — because that copy may
+				// be the one that must refresh a stale archived snapshot;
+				// an untrusted mirror fetched first must not consume the
+				// only trusted refresh opportunity. Drafts-placement and
+				// further duplicates keep stubbing: a resurrected stale
+				// draft must not overwrite an already-fresh snapshot, and
+				// one row plus the preferred source-key behavior are
+				// preserved.
+				if !c.isSentPlacementMailboxLocked(mailbox) ||
+					c.seenTrustedRFC822IDs[rfc822MessageID] {
+					results[idx].Message = &gmailapi.RawMessage{ID: msgID}
+					results[idx].Err = nil
+					continue
+				}
+				c.seenTrustedRFC822IDs[rfc822MessageID] = true
+			} else {
+				c.seenRFC822IDs[rfc822MessageID] = true
+				if c.isSentPlacementMailboxLocked(mailbox) {
+					c.seenTrustedRFC822IDs[rfc822MessageID] = true
+				}
 			}
-			c.seenRFC822IDs[rfc822MessageID] = true
 		}
 
 		// Merge labels from other mailboxes via the label map built during
@@ -882,6 +915,113 @@ func (c *Client) IsPreferredSourceMessageID(messageID string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.allMailFolder != "" && mailbox == c.allMailFolder
+}
+
+// IsSentPlacementMailbox reports whether the mailbox this composite source
+// ID names is a Sent placement: unambiguously advertised \Sent, or
+// explicitly configured as this source's Sent folder. The shared
+// conflicting-role denial applies, and a mailbox advertised as both \Sent
+// and \Drafts is ambiguous and never a Sent placement.
+func (c *Client) IsSentPlacementMailbox(messageID string) bool {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isSentPlacementMailboxLocked(mailbox)
+}
+
+// IsDraftsPlacementMailbox reports whether the mailbox this composite source
+// ID names is a Drafts placement and nothing stronger: unambiguously
+// advertised \Drafts and not a Sent placement. An advertised \Drafts role
+// keeps its Drafts meaning even when the account also lists the mailbox in
+// its Sent-folder configuration — advertised roles outrank explicit
+// configuration — so configuration cannot suppress the Sent-over-Drafts
+// precedence for such a canonical. The predicate never identifies a
+// destination that could itself authorize a snapshot replacement.
+func (c *Client) IsDraftsPlacementMailbox(messageID string) bool {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isDraftsPlacementMailboxLocked(mailbox)
+}
+
+// isDraftsPlacementMailboxLocked is the lock-holding form of
+// IsDraftsPlacementMailbox.
+func (c *Client) isDraftsPlacementMailboxLocked(mailbox string) bool {
+	if c.conflictingRoleMailboxes[mailbox] {
+		return false
+	}
+	return c.advertisedDraftsMailboxes[mailbox] &&
+		!c.advertisedSentMailboxes[mailbox]
+}
+
+// IsTrustedOutgoingMailbox reports whether the mailbox this composite source
+// ID names is trusted to hold only mail the account itself authored, either
+// because the authenticated LIST response advertised an unambiguous \Sent or
+// \Drafts special-use role for it, or because the user explicitly configured
+// it for servers without role discovery. This is an explicit trust assumption,
+// not an authorship proof: RFC 6154 roles advise intent, and user filters or
+// client APPEND/COPY can place other mail there. It is still the narrow
+// evidence that authorizes replacing an archived snapshot from that placement,
+// because a sender-controlled RFC822 Message-ID alone never does. Mailbox
+// names alone are never trusted from the server response, and absent
+// advertisement without explicit configuration denies.
+func (c *Client) IsTrustedOutgoingMailbox(messageID string) bool {
+	mailbox, _, err := parseCompositeID(messageID)
+	if err != nil {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.isTrustedOutgoingMailboxLocked(mailbox)
+}
+
+// isSentPlacementMailbox reports whether a mailbox name is a Sent
+// placement: unambiguously advertised \Sent, or explicitly configured as
+// this source's Sent folder (the configuration exists for localized Sent
+// folders without role discovery). The shared conflicting-role denial
+// applies to both sources of Sent semantics, and an advertised \Drafts role
+// outranks explicit configuration: a configured name the server calls
+// Drafts is not a Sent placement, so it cannot gain the trusted dedup
+// bypass. Caller must hold mu.
+func (c *Client) isSentPlacementMailboxLocked(mailbox string) bool {
+	if c.conflictingRoleMailboxes[mailbox] {
+		return false
+	}
+	if c.advertisedSentMailboxes[mailbox] {
+		return true
+	}
+	if c.configuredSentMailboxes[mailbox] {
+		return !c.advertisedDraftsMailboxes[mailbox]
+	}
+	return false
+}
+
+// isTrustedOutgoingMailbox reports whether a mailbox name carries trusted
+// outgoing placement. Caller must hold mu. Explicit trust is honored only
+// where the server's own advertisement does not contradict it: a mailbox the
+// authenticated LIST response shows carrying a received-mail role (\All,
+// \Junk, \Trash) or the INBOX name is never trusted, even when named
+// explicitly. A mailbox the response shows without those roles is honored;
+// one not yet seen is honored until discovery observes a conflict.
+func (c *Client) isTrustedOutgoingMailboxLocked(mailbox string) bool {
+	if strings.EqualFold(mailbox, "INBOX") {
+		// Delivery lands in INBOX; it is never trusted, even before
+		// discovery has observed the LIST response.
+		return false
+	}
+	if c.conflictingRoleMailboxes[mailbox] {
+		return false
+	}
+	return c.trustedOutgoingMailboxes[mailbox] || c.advertisedOutgoingMailboxes[mailbox]
 }
 
 // DefersAuthoritativeLabelReconciliation reports that complete IMAP mailbox

--- a/internal/imap/client.go
+++ b/internal/imap/client.go
@@ -28,6 +28,30 @@ func WithLogger(logger *slog.Logger) Option {
 	return func(c *Client) { c.logger = logger }
 }
 
+// WithTrustedSentMailboxes names this source's Sent-folder mailboxes the
+// user explicitly configured, for servers whose (possibly localized) Sent
+// folder advertises no RFC 6154 \Sent role. This is an opt-in trust
+// assumption for servers without role discovery, not provider evidence: it
+// extends snapshot-refresh authorization to these mailboxes exactly like an
+// unambiguous advertised \Sent role. The configuration is derived from the
+// per-source sync configuration by the caller and is never cleared by
+// connection rediscovery.
+func WithTrustedSentMailboxes(names []string) Option {
+	return func(c *Client) {
+		if len(names) == 0 {
+			return
+		}
+		trusted := make(map[string]bool, len(names))
+		for _, name := range names {
+			if name = strings.TrimSpace(name); name != "" {
+				trusted[name] = true
+			}
+		}
+		c.trustedOutgoingMailboxes = trusted
+		c.configuredSentMailboxes = trusted
+	}
+}
+
 // WithTokenSource sets a callback that provides OAuth2 access tokens
 // for XOAUTH2 SASL authentication. Required when Config.AuthMethod is AuthXOAuth2.
 func WithTokenSource(fn func(ctx context.Context) (string, error)) Option {
@@ -83,24 +107,34 @@ type Client struct {
 	tokenSource func(ctx context.Context) (string, error) // XOAUTH2 token callback
 	logger      *slog.Logger
 
-	mu                    sync.Mutex
-	conn                  *imapclient.Client
-	selectedMailbox       string               // currently selected mailbox
-	selectedUIDValidity   uint32               // UIDVALIDITY from the last SELECT
-	selectedNumMessages   uint32               // EXISTS count from the last SELECT
-	mailboxCache          []string             // cached list of selectable mailboxes
-	messageListCache      []gmailapi.MessageID // full message ID list, built once per session
-	trashMailbox          string               // cached trash mailbox name
-	junkMailbox           string               // cached junk/spam mailbox name
-	allMailFolder         string               // mailbox with \All attribute (empty if not detected)
-	msgIDToLabels         map[string][]string  // RFC822 Message-ID → mailbox memberships
-	seenRFC822IDs         map[string]bool      // dedup overlapping mailbox copies
-	preferredRawSourceIDs map[[32]byte]string  // raw digest → canonical \All source ID
-	sourceMessageAliases  map[string]string    // mailbox UID source ID → durable canonical source ID
-	activeSourceAliases   map[string]string    // aliases validated by this session's QRESYNC SELECTs
-	labelMapComplete      bool                 // latest listing collected every mailbox membership
-	since                 time.Time            // IMAP SINCE date filter (zero = no filter)
-	before                time.Time            // IMAP BEFORE date filter (zero = no filter)
+	mu                          sync.Mutex
+	conn                        *imapclient.Client
+	selectedMailbox             string               // currently selected mailbox
+	selectedUIDValidity         uint32               // UIDVALIDITY from the last SELECT
+	selectedNumMessages         uint32               // EXISTS count from the last SELECT
+	mailboxCache                []string             // cached list of selectable mailboxes
+	messageListCache            []gmailapi.MessageID // full message ID list, built once per session
+	trashMailbox                string               // cached trash mailbox name
+	junkMailbox                 string               // cached junk/spam mailbox name
+	allMailFolder               string               // mailbox with \All attribute (empty if not detected)
+	advertisedOutgoingMailboxes map[string]bool      // unambiguous LIST-advertised \Sent or \Drafts placement
+	advertisedSentMailboxes     map[string]bool      // unambiguous LIST-advertised \Sent placement
+	advertisedDraftsMailboxes   map[string]bool      // unambiguous LIST-advertised \Drafts placement
+	conflictingRoleMailboxes    map[string]bool      // LIST-advertised \All/\Junk/\Trash roles, or INBOX
+	trustedOutgoingMailboxes    map[string]bool      // explicit user-configured outgoing mailboxes
+	configuredSentMailboxes     map[string]bool      // explicit per-source Sent-folder configuration (never cleared)
+	msgIDToLabels               map[string][]string  // RFC822 Message-ID → mailbox memberships
+	seenRFC822IDs               map[string]bool      // dedup overlapping mailbox copies
+	seenTrustedRFC822IDs        map[string]bool      // identities already carried by a trusted full raw this run
+	preferredRawSourceIDs       map[[32]byte]string  // raw digest → canonical \All source ID
+	sourceMessageAliases        map[string]string    // mailbox UID source ID → durable canonical source ID
+	activeSourceAliases         map[string]string    // aliases validated by this session's QRESYNC SELECTs
+	labelMapComplete            bool                 // latest listing collected every mailbox membership
+	since                       time.Time            // IMAP SINCE date filter (zero = no filter)
+	before                      time.Time            // IMAP BEFORE date filter (zero = no filter)
+
+	relocationCandidateLoader func(context.Context, []string) ([]RelocationCandidate, error)
+	relocationTargets         map[string]gmailapi.MessageRelocationTarget
 
 	// aliasLoader resolves durable aliases for the mailbox UIDs a listing
 	// actually touches. Nil when the caller keeps no durable state.
@@ -572,6 +606,50 @@ func (c *Client) listMailboxesLocked() ([]string, error) {
 			continue
 		}
 		names = append(names, item.Mailbox)
+		// Received-mail roles deny outgoing trust regardless of how the
+		// mailbox is advertised or configured. RFC 6154 roles describe
+		// intended use, not authorship proof, so this records every LIST
+		// entry carrying \All, \Junk, or \Trash — independently of any
+		// \Sent or \Drafts role — a mailbox advertised with BOTH \Sent
+		// and \Drafts (the roles conflict, so the entry is ambiguous), and
+		// the INBOX name, where placement carries no outgoing assumption at
+		// all. The evidence always comes from the authenticated LIST
+		// response, never the mailbox name alone; the trust predicate
+		// additionally rejects INBOX before discovery has run.
+		if strings.EqualFold(item.Mailbox, "INBOX") ||
+			hasAttr(item.Attrs, imap.MailboxAttrAll) ||
+			hasAttr(item.Attrs, imap.MailboxAttrJunk) ||
+			hasAttr(item.Attrs, imap.MailboxAttrTrash) ||
+			(hasAttr(item.Attrs, imap.MailboxAttrSent) &&
+				hasAttr(item.Attrs, imap.MailboxAttrDrafts)) {
+			if c.conflictingRoleMailboxes == nil {
+				c.conflictingRoleMailboxes = map[string]bool{}
+			}
+			c.conflictingRoleMailboxes[item.Mailbox] = true
+		}
+		if hasAttr(item.Attrs, imap.MailboxAttrSent) || hasAttr(item.Attrs, imap.MailboxAttrDrafts) {
+			// An unambiguous \Sent or \Drafts advertisement is the narrow
+			// trust assumption that authorizes refreshing an archived
+			// snapshot from that placement.
+			if !c.conflictingRoleMailboxes[item.Mailbox] {
+				if c.advertisedOutgoingMailboxes == nil {
+					c.advertisedOutgoingMailboxes = map[string]bool{}
+				}
+				c.advertisedOutgoingMailboxes[item.Mailbox] = true
+				if hasAttr(item.Attrs, imap.MailboxAttrSent) {
+					if c.advertisedSentMailboxes == nil {
+						c.advertisedSentMailboxes = map[string]bool{}
+					}
+					c.advertisedSentMailboxes[item.Mailbox] = true
+				}
+				if hasAttr(item.Attrs, imap.MailboxAttrDrafts) {
+					if c.advertisedDraftsMailboxes == nil {
+						c.advertisedDraftsMailboxes = map[string]bool{}
+					}
+					c.advertisedDraftsMailboxes[item.Mailbox] = true
+				}
+			}
+		}
 		if c.trashMailbox == "" && hasAttr(item.Attrs, imap.MailboxAttrTrash) {
 			c.trashMailbox = item.Mailbox
 		}
@@ -629,6 +707,10 @@ func (c *Client) clearMailboxDiscoveryLocked() {
 	c.trashMailbox = ""
 	c.junkMailbox = ""
 	c.allMailFolder = ""
+	c.advertisedOutgoingMailboxes = nil
+	c.advertisedSentMailboxes = nil
+	c.advertisedDraftsMailboxes = nil
+	c.conflictingRoleMailboxes = nil
 }
 
 // enumerateMailboxSearchCriteria always constrains the search with an
@@ -1095,6 +1177,8 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 	// this listing additive rather than authoritative.
 	c.labelMapComplete = false
 	c.seenRFC822IDs = nil
+	c.seenTrustedRFC822IDs = nil
+	c.relocationTargets = nil
 	c.preferredRawSourceIDs = nil
 	c.activeSourceAliases = nil
 	c.observedMailboxDeltas = nil
@@ -1171,7 +1255,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 		requireQresync := !c.forceFullEnumeration &&
 			!c.labelsSnapshotFilteredLocked() &&
 			len(c.priorFolderStates) > 0
-		handled, deltaErr := c.tryBuildQresyncMessageList(ctx, allMailboxes, folderStatuses)
+		qresyncMessages, handled, deltaErr := c.tryBuildQresyncMessageList(ctx, allMailboxes, folderStatuses)
 		switch {
 		case deltaErr != nil:
 			// A failed attempt has already issued ENABLE and CONDSTORE SELECTs
@@ -1202,7 +1286,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			c.logger.Info("QRESYNC unavailable, enumerating fully")
 			qresyncFallback = true
 		case handled:
-			return nil
+			return c.finalizeMessageListLocked(ctx, allMailboxes, qresyncMessages)
 		}
 	}
 	if trackFolders && !c.labelsSnapshotFilteredLocked() {
@@ -1258,6 +1342,7 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			// A complete membership map lets the first raw result carry every
 			// mailbox label before overlapping copies become dedup stubs.
 			c.seenRFC822IDs = make(map[string]bool)
+			c.seenTrustedRFC822IDs = make(map[string]bool)
 		}
 	}
 
@@ -1452,10 +1537,9 @@ func (c *Client) buildMessageListCache(ctx context.Context) error {
 			"unchanged", unchangedFolders, "total", len(listMailboxes))
 	}
 
-	c.messageListCache = messages
 	c.activeSourceAliases = activeSourceAliases
 	c.labelMapComplete = labelMapComplete && enumerationComplete
-	return nil
+	return c.finalizeMessageListLocked(ctx, allMailboxes, messages)
 }
 
 // deltasCoverMailboxes reports whether every current mailbox appears in the

--- a/internal/imap/client_folderstate_test.go
+++ b/internal/imap/client_folderstate_test.go
@@ -1287,3 +1287,20 @@ func TestSourceMessageAliasLoaderRequestsOnlyListedUIDs(t *testing.T) {
 	assert.True(ok)
 	assert.Equal("[Gmail]/All Mail|9", canonical)
 }
+
+// Explicit Sent-folder configuration must survive connection rediscovery:
+// the configured set is persistent per source, and only advertised roles are
+// re-derived from the LIST response.
+func TestConfiguredSentPlacementSurvivesDiscoveryReset(t *testing.T) {
+	client := NewClient(&Config{Host: "imap.example.test", Port: 993}, "password",
+		WithTrustedSentMailboxes([]string{"Gesendete Elemente"}))
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	require.True(t, client.isSentPlacementMailboxLocked("Gesendete Elemente"))
+
+	client.clearMailboxDiscoveryLocked()
+	assert.True(t, client.isSentPlacementMailboxLocked("Gesendete Elemente"),
+		"rediscovery must not discard the per-source Sent configuration")
+	assert.False(t, client.isSentPlacementMailboxLocked("INBOX"))
+}

--- a/internal/imap/qresync.go
+++ b/internal/imap/qresync.go
@@ -94,21 +94,21 @@ func (c *Client) tryBuildQresyncMessageList(
 	ctx context.Context,
 	mailboxes []string,
 	statuses map[string]FolderState,
-) (bool, error) {
+) ([]gmailapi.MessageID, bool, error) {
 	if c.forceFullEnumeration || c.labelsSnapshotFilteredLocked() || len(mailboxes) == 0 ||
 		len(statuses) != len(mailboxes) || !c.qresyncBaselinePresent(mailboxes) {
-		return false, nil
+		return nil, false, nil
 	}
 
 	for _, mailbox := range mailboxes {
 		prior, priorOK := c.priorFolderStates[mailbox]
 		current, currentOK := statuses[mailbox]
 		if !priorOK || !currentOK || !c.qresyncEligible(prior, current) {
-			return false, nil
+			return nil, false, nil
 		}
 	}
 	if !c.enableQresync() {
-		return false, nil
+		return nil, false, nil
 	}
 
 	c.observedFolderStates = make(map[string]FolderState, len(mailboxes))
@@ -121,13 +121,13 @@ func (c *Client) tryBuildQresyncMessageList(
 	}
 	for i, mailbox := range mailboxes {
 		if err := ctx.Err(); err != nil {
-			return false, err
+			return nil, false, err
 		}
 		prior := c.priorFolderStates[mailbox]
 		var delta MailboxDelta
 		delta, err := c.collectQresyncMailbox(ctx, mailbox, prior)
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 		if len(delta.ChangedUIDs) == 0 && len(delta.VanishedUIDs) == 0 {
 			unchanged++
@@ -147,10 +147,9 @@ func (c *Client) tryBuildQresyncMessageList(
 			c.listProgress(i+1, len(mailboxes), mailbox, len(messages), unchanged)
 		}
 	}
-	c.messageListCache = messages
 	c.activeSourceAliases = activeSourceAliases
 	c.labelMapComplete = true
-	return true, nil
+	return messages, true, nil
 }
 
 func (c *Client) collectQresyncMailbox(

--- a/internal/imap/relocation.go
+++ b/internal/imap/relocation.go
@@ -1,0 +1,153 @@
+package imap
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	imap "github.com/emersion/go-imap/v2"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/mime"
+)
+
+// RelocationCandidate binds a saved membership to its archived canonical row.
+// The saved epoch must still be present before the client can adopt it.
+type RelocationCandidate struct {
+	Target      gmail.MessageRelocationTarget
+	Mailbox     string
+	UIDValidity uint32
+	UID         uint32
+}
+
+// WithRelocationCandidateLoader resolves alternatives only for canonical
+// source IDs lost from a complete, authoritative mailbox snapshot.
+func WithRelocationCandidateLoader(load func(context.Context, []string) ([]RelocationCandidate, error)) Option {
+	return func(c *Client) { c.relocationCandidateLoader = load }
+}
+
+// MessageRelocationTarget reports a target selected by this listing. Consumers
+// must retain this exact guard through alias lookup and ingestion.
+func (c *Client) MessageRelocationTarget(sourceMessageID string) (gmail.MessageRelocationTarget, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	target, ok := c.relocationTargets[sourceMessageID]
+	return target, ok
+}
+
+// finalizeMessageListLocked is shared by QRESYNC and full enumeration. No
+// listing is exposed if selecting a required replacement fails.
+func (c *Client) finalizeMessageListLocked(ctx context.Context, mailboxes []string, messages []gmail.MessageID) error {
+	if err := c.addRelocationMessagesLocked(ctx, mailboxes, &messages); err != nil {
+		c.messageListCache = nil
+		c.relocationTargets = nil
+		c.labelMapComplete = false
+		c.observedFolderStates = nil
+		c.observedMailboxDeltas = nil
+		c.clearFolderAcknowledgements()
+		return err
+	}
+	c.messageListCache = append([]gmail.MessageID{}, messages...)
+	return nil
+}
+
+func (c *Client) addRelocationMessagesLocked(ctx context.Context, mailboxes []string, messages *[]gmail.MessageID) error {
+	if c.relocationCandidateLoader == nil || !c.labelMapComplete ||
+		!c.since.IsZero() || !c.before.IsZero() || c.labelsSnapshotFilteredLocked() ||
+		c.observedMailboxDeltas == nil || !deltasCoverMailboxes(mailboxes, c.observedMailboxDeltas) {
+		return nil
+	}
+	current := make(map[string]FolderState, len(c.observedMailboxDeltas))
+	present := make(map[string]map[uint32]bool, len(c.observedMailboxDeltas))
+	for _, delta := range c.observedMailboxDeltas {
+		current[delta.Mailbox] = delta.State
+		uids := make(map[uint32]bool, len(delta.State.KnownUIDs))
+		for _, uid := range delta.State.KnownUIDs {
+			uids[uid] = true
+		}
+		present[delta.Mailbox] = uids
+	}
+	var lost []string
+	for mailbox, prior := range c.priorFolderStates {
+		state, exists := current[mailbox]
+		for _, uid := range prior.KnownUIDs {
+			if !exists || state.UIDValidity != prior.UIDValidity || !present[mailbox][uid] {
+				lost = append(lost, compositeID(mailbox, imap.UID(uid)))
+			}
+		}
+	}
+	if len(lost) == 0 {
+		return nil
+	}
+	slices.Sort(lost)
+	lost = slices.Compact(lost)
+	candidates, err := c.relocationCandidateLoader(ctx, lost)
+	if err != nil {
+		return fmt.Errorf("load IMAP relocation candidates: %w", err)
+	}
+	// Prefer advertised All-Mail, then a stable mailbox/UID ordering. Internal
+	// IDs break ties without reselecting a row by its RFC822 identity.
+	slices.SortFunc(candidates, func(a, b RelocationCandidate) int {
+		if a.Mailbox != b.Mailbox {
+			if a.Mailbox == c.allMailFolder {
+				return -1
+			}
+			if b.Mailbox == c.allMailFolder {
+				return 1
+			}
+			return cmp.Compare(a.Mailbox, b.Mailbox)
+		}
+		if n := cmp.Compare(a.UID, b.UID); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Target.InternalID, b.Target.InternalID)
+	})
+	listed := make(map[string]bool, len(*messages))
+	for _, message := range *messages {
+		listed[message.ID] = true
+	}
+	selected := make(map[int64]bool)
+	c.relocationTargets = make(map[string]gmail.MessageRelocationTarget)
+	var forced []gmail.MessageID
+	for _, candidate := range candidates {
+		target := candidate.Target
+		state, exists := current[candidate.Mailbox]
+		if selected[target.InternalID] || !exists || candidate.UIDValidity != state.UIDValidity ||
+			!present[candidate.Mailbox][candidate.UID] {
+			continue
+		}
+		if _, lostTarget := slices.BinarySearch(lost, target.SourceMessageID); !lostTarget {
+			continue
+		}
+		target.RFC822MessageID = mime.NormalizeMessageID(target.RFC822MessageID)
+		if target.RFC822MessageID == "" {
+			continue
+		}
+		target.NewSourceMessageID = compositeID(candidate.Mailbox, imap.UID(candidate.UID))
+		if target.SourceMessageID == target.NewSourceMessageID {
+			// Relocation must change the composite key: persistence rejects an
+			// unchanged source ID, and a survivor at the unchanged key is
+			// refreshed by ordinary identity routing (mailbox-epoch and
+			// UID-reuse checks). Only a membership epoch inconsistent with the
+			// saved folder state can offer the same key here; skipping it keeps
+			// that state on the self-healing path instead of failing every retry.
+			continue
+		}
+		if other, exists := c.relocationTargets[target.NewSourceMessageID]; exists && other.InternalID != target.InternalID {
+			return fmt.Errorf("IMAP relocation candidate %q has multiple archived targets", target.NewSourceMessageID)
+		}
+		c.relocationTargets[target.NewSourceMessageID] = target
+		selected[target.InternalID] = true
+		forced = append(forced, gmail.MessageID{ID: target.NewSourceMessageID})
+		if !listed[target.NewSourceMessageID] {
+			c.trackFolderMessages(candidate.Mailbox, state, []imap.UID{imap.UID(candidate.UID)})
+		}
+	}
+	for _, message := range *messages {
+		if _, selected := c.relocationTargets[message.ID]; !selected {
+			forced = append(forced, message)
+		}
+	}
+	*messages = forced
+	return nil
+}

--- a/internal/imap/relocation.go
+++ b/internal/imap/relocation.go
@@ -85,10 +85,20 @@ func (c *Client) addRelocationMessagesLocked(ctx context.Context, mailboxes []st
 	if err != nil {
 		return fmt.Errorf("load IMAP relocation candidates: %w", err)
 	}
-	// Prefer advertised All-Mail, then a stable mailbox/UID ordering. Internal
-	// IDs break ties without reselecting a row by its RFC822 identity.
+	// Recover content from trusted Sent before choosing an All-Mail mirror:
+	// only one candidate is forced, and an unchanged Sent copy may otherwise
+	// never be fetched. Other candidates retain All-Mail preference followed
+	// by stable mailbox/UID ordering. Internal IDs break ties.
 	slices.SortFunc(candidates, func(a, b RelocationCandidate) int {
 		if a.Mailbox != b.Mailbox {
+			aSent := c.isSentPlacementMailboxLocked(a.Mailbox) && c.isTrustedOutgoingMailboxLocked(a.Mailbox)
+			bSent := c.isSentPlacementMailboxLocked(b.Mailbox) && c.isTrustedOutgoingMailboxLocked(b.Mailbox)
+			if aSent != bSent {
+				if aSent {
+					return -1
+				}
+				return 1
+			}
 			if a.Mailbox == c.allMailFolder {
 				return -1
 			}

--- a/internal/imap/relocation_test.go
+++ b/internal/imap/relocation_test.go
@@ -1,0 +1,145 @@
+package imap
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	imapapi "github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/gmail"
+)
+
+func TestRelocationPlanUsesCurrentMembershipEpochAndExactTarget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	target := gmail.MessageRelocationTarget{InternalID: 12, SourceID: 3, SourceMessageID: "Drafts|1", RFC822MessageID: "<same@example.test>"}
+	c := &Client{config: &Config{},
+		labelMapComplete: true, allMailFolder: "Everything",
+		priorFolderStates: map[string]FolderState{
+			"Drafts":  {UIDValidity: 77, KnownUIDs: []uint32{1, 2}},
+			"Reset":   {UIDValidity: 50, KnownUIDs: []uint32{7}},
+			"Deleted": {UIDValidity: 40, KnownUIDs: []uint32{9}},
+		},
+		observedMailboxDeltas: []MailboxDelta{
+			{Mailbox: "Drafts", State: FolderState{UIDValidity: 77, KnownUIDs: []uint32{2}}},
+			{Mailbox: "Reset", State: FolderState{UIDValidity: 51, KnownUIDs: []uint32{7}}},
+			{Mailbox: "Archive", State: FolderState{UIDValidity: 88, KnownUIDs: []uint32{1}}},
+			{Mailbox: "Everything", State: FolderState{UIDValidity: 99, KnownUIDs: []uint32{4, 8}}},
+		},
+	}
+	c.relocationCandidateLoader = func(_ context.Context, lost []string) ([]RelocationCandidate, error) {
+		assert.Equal([]string{"Deleted|9", "Drafts|1", "Reset|7"}, lost)
+		return []RelocationCandidate{
+			{Target: target, Mailbox: "Drafts", UIDValidity: 77, UID: 1},
+			{Target: target, Mailbox: "Everything", UIDValidity: 98, UID: 1},
+			{Target: target, Mailbox: "Archive", UIDValidity: 88, UID: 1},
+			{Target: target, Mailbox: "Everything", UIDValidity: 99, UID: 8},
+			{Target: target, Mailbox: "Everything", UIDValidity: 99, UID: 4},
+		}, nil
+	}
+	err := c.finalizeMessageListLocked(t.Context(), []string{"Drafts", "Reset", "Archive", "Everything"}, []gmail.MessageID{{ID: "Archive|1"}, {ID: "Everything|4"}})
+	require.NoError(err)
+	assert.Equal([]gmail.MessageID{{ID: "Everything|4"}, {ID: "Archive|1"}}, c.messageListCache)
+	selected, ok := c.MessageRelocationTarget("Everything|4")
+	require.True(ok)
+	target.RFC822MessageID = "same@example.test"
+	target.NewSourceMessageID = "Everything|4"
+	assert.Equal(target, selected)
+}
+
+func TestRelocationPlanRejectsStaleAndUnknownIdentities(t *testing.T) {
+	for _, candidate := range []RelocationCandidate{
+		{Target: gmail.MessageRelocationTarget{InternalID: 1, SourceID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "same@example.test"}, Mailbox: "Sent", UIDValidity: 87, UID: 1},
+		{Target: gmail.MessageRelocationTarget{InternalID: 1, SourceID: 1, SourceMessageID: "Drafts|1"}, Mailbox: "Sent", UIDValidity: 88, UID: 1},
+	} {
+		c := &Client{config: &Config{}, labelMapComplete: true,
+			priorFolderStates:     map[string]FolderState{"Drafts": {UIDValidity: 77, KnownUIDs: []uint32{1}}},
+			observedMailboxDeltas: []MailboxDelta{{Mailbox: "Sent", State: FolderState{UIDValidity: 88, KnownUIDs: []uint32{1}}}},
+			relocationCandidateLoader: func(context.Context, []string) ([]RelocationCandidate, error) {
+				return []RelocationCandidate{candidate}, nil
+			},
+		}
+		require.NoError(t, c.finalizeMessageListLocked(t.Context(), []string{"Sent"}, nil))
+		assert.Empty(t, c.messageListCache)
+		assert.Empty(t, c.relocationTargets)
+	}
+}
+
+func TestRelocationLoaderFailureClearsListingAndAllowsRetry(t *testing.T) {
+	assert := assert.New(t)
+	c := &Client{config: &Config{}, labelMapComplete: true,
+		priorFolderStates:     map[string]FolderState{"Drafts": {UIDValidity: 77, KnownUIDs: []uint32{1}}},
+		observedMailboxDeltas: []MailboxDelta{},
+		messageListCache:      []gmail.MessageID{{ID: "stale|1"}},
+		relocationCandidateLoader: func(context.Context, []string) ([]RelocationCandidate, error) {
+			return nil, errors.New("database unavailable")
+		},
+	}
+	require.ErrorContains(t, c.finalizeMessageListLocked(t.Context(), nil, nil), "database unavailable")
+	assert.Nil(c.messageListCache)
+	assert.Nil(c.relocationTargets)
+	assert.Nil(c.observedMailboxDeltas)
+	assert.False(c.labelMapComplete)
+}
+
+func TestRelocationPlanRequiresAuthoritativeCoverage(t *testing.T) {
+	for _, mode := range []string{"incomplete labels", "missing mailbox delta", "filtered"} {
+		t.Run(mode, func(t *testing.T) {
+			c := &Client{config: &Config{}, labelMapComplete: true,
+				priorFolderStates:     map[string]FolderState{"Drafts": {UIDValidity: 77, KnownUIDs: []uint32{1}}},
+				observedMailboxDeltas: []MailboxDelta{{Mailbox: "Sent", State: FolderState{UIDValidity: 88, KnownUIDs: []uint32{1}}}},
+				relocationCandidateLoader: func(context.Context, []string) ([]RelocationCandidate, error) {
+					return nil, errors.New("must not infer losses")
+				},
+			}
+			mailboxes := []string{"Sent"}
+			switch mode {
+			case "incomplete labels":
+				c.labelMapComplete = false
+			case "missing mailbox delta":
+				mailboxes = append(mailboxes, "Drafts")
+			case "filtered":
+				c.folderFilterInclude = []string{"Sent"}
+			}
+			require.NoError(t, c.finalizeMessageListLocked(t.Context(), mailboxes, []gmail.MessageID{{ID: "Sent|1"}}))
+			assert.Empty(t, c.relocationTargets)
+		})
+	}
+}
+
+func TestRelocationRawFetchRejectsEpochChangeAndBypassesDedup(t *testing.T) {
+	for _, epoch := range []uint32{88, 99} {
+		t.Run(strconv.FormatUint(uint64(epoch), 10), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			c := &Client{
+				selectedUIDValidity:  epoch,
+				observedFolderStates: map[string]FolderState{"Sent": {UIDValidity: 88, KnownUIDs: []uint32{1}}},
+				relocationTargets:    map[string]gmail.MessageRelocationTarget{"Sent|1": {InternalID: 12, SourceID: 3, SourceMessageID: "Drafts|1", RFC822MessageID: "same@example.test", NewSourceMessageID: "Sent|1"}},
+				seenRFC822IDs:        map[string]bool{"same@example.test": true},
+				activeSourceAliases:  map[string]string{"Sent|1": "Drafts|1"},
+			}
+			raw := []byte("Message-ID: <same@example.test>\r\n\r\nfinalword\r\n")
+			results := newRawBatchResults([]string{"Sent|1"})
+			c.applyFetchResults(results, map[imapapi.UID]int{1: 0}, "Sent", []batchFetchItem{{idx: 0, uid: 1}}, []*imapclient.FetchMessageBuffer{{
+				UID: 1, BodySection: []imapclient.FetchBodySectionBuffer{{Bytes: raw}},
+			}})
+			if epoch == 99 {
+				require.Error(results[0].Err)
+				require.NotErrorIs(results[0].Err, gmail.ErrMessageGone)
+				assert.Nil(results[0].Message)
+				assert.Empty(c.ObservedMemberships())
+			} else {
+				require.NoError(results[0].Err)
+				require.NotNil(results[0].Message)
+				assert.Equal(raw, results[0].Message.Raw)
+				require.Len(c.ObservedMemberships(), 1)
+				assert.Equal("Sent|1", c.ObservedMemberships()[0].CanonicalSourceMessageID)
+			}
+		})
+	}
+}

--- a/internal/store/imap_relocation.go
+++ b/internal/store/imap_relocation.go
@@ -1,0 +1,190 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/msgvault/internal/mime"
+)
+
+// PersistIMAPRelocationWithParticipantsContext atomically adopts a fetched
+// IMAP snapshot under a new source message ID while preserving the guarded
+// archive row's internal ID.
+func (s *Store) PersistIMAPRelocationWithParticipantsContext(
+	ctx context.Context,
+	expected MessageIdentityGuard,
+	participants []ParticipantPersistData,
+	build func(participantIDs []int64) *MessagePersistData,
+	replaceLabels bool,
+) (int64, error) {
+	if build == nil {
+		return 0, errors.New("persist IMAP relocation requires a participant builder")
+	}
+	if s.syncGeneration == nil {
+		return 0, errors.New("persist IMAP relocation requires a sync generation")
+	}
+	if err := s.requireSyncSource(expected.SourceID); err != nil {
+		return 0, err
+	}
+
+	var expectedRFC822MessageID string
+	beforeParticipants := func(ctx context.Context, tx *loggedTx) error {
+		var actual MessageIdentityGuard
+		var sourceType string
+		var storedRFC822MessageID sql.NullString
+		err := tx.QueryRowContext(ctx, `
+			SELECT m.id, m.source_id, m.source_message_id,
+			       m.rfc822_message_id, s.source_type
+			FROM messages m
+			JOIN sources s ON s.id = m.source_id
+			WHERE m.id = ?`+s.dialect.SelectForUpdate(), expected.ID,
+		).Scan(
+			&actual.ID, &actual.SourceID, &actual.SourceMessageID,
+			&storedRFC822MessageID, &sourceType,
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("IMAP relocation identity guard mismatch: target id %d not found", expected.ID)
+		}
+		if err != nil {
+			return fmt.Errorf("read IMAP relocation identity guard: %w", err)
+		}
+		if actual != expected {
+			return fmt.Errorf(
+				"IMAP relocation identity guard mismatch: expected (%d, %d, %q), found (%d, %d, %q)",
+				expected.ID, expected.SourceID, expected.SourceMessageID,
+				actual.ID, actual.SourceID, actual.SourceMessageID,
+			)
+		}
+		if sourceType != "imap" {
+			return fmt.Errorf("IMAP relocation requires an IMAP source, found %q", sourceType)
+		}
+		expectedRFC822MessageID = mime.NormalizeMessageID(storedRFC822MessageID.String)
+		if !storedRFC822MessageID.Valid || expectedRFC822MessageID == "" {
+			return errors.New("IMAP relocation target requires an RFC822 Message-ID")
+		}
+		return nil
+	}
+
+	var preserveLabels bool
+	prepare := func(
+		ctx context.Context, tx *loggedTx, data *MessagePersistData,
+	) (*MessagePersistData, error) {
+		if data == nil || data.Message == nil {
+			return nil, errors.New("persist IMAP relocation requires a message")
+		}
+		if data.Message.SourceID != expected.SourceID {
+			return nil, fmt.Errorf(
+				"IMAP relocation snapshot source mismatch: expected %d, got %d",
+				expected.SourceID, data.Message.SourceID,
+			)
+		}
+		if data.Message.SourceMessageID == "" {
+			return nil, errors.New("IMAP relocation snapshot requires a source message ID")
+		}
+		if data.Message.SourceMessageID == expected.SourceMessageID {
+			return nil, errors.New("IMAP relocation snapshot source message ID must change")
+		}
+		actualRFC822MessageID := mime.NormalizeMessageID(data.Message.RFC822MessageID.String)
+		if !data.Message.RFC822MessageID.Valid || actualRFC822MessageID == "" ||
+			actualRFC822MessageID != expectedRFC822MessageID {
+			return nil, fmt.Errorf(
+				"IMAP relocation RFC822 identity mismatch: expected %q, got %q",
+				expectedRFC822MessageID, actualRFC822MessageID,
+			)
+		}
+		if len(data.RawMIME) == 0 {
+			return nil, errors.New("IMAP relocation snapshot requires raw MIME")
+		}
+		if data.FTS == nil {
+			return nil, errors.New("IMAP relocation snapshot requires FTS content")
+		}
+		if data.MIMEAttachmentReplacement == nil {
+			return nil, errors.New("IMAP relocation snapshot requires MIME attachment replacement")
+		}
+		if err := validateIMAPRelocationRecipients(data.Recipients); err != nil {
+			return nil, err
+		}
+
+		result, err := tx.ExecContext(ctx, `
+			UPDATE messages
+			SET source_message_id = ?
+			WHERE id = ? AND source_id = ? AND source_message_id = ?
+		`, data.Message.SourceMessageID, expected.ID, expected.SourceID, expected.SourceMessageID)
+		if err != nil {
+			return nil, fmt.Errorf("rekey IMAP relocation target: %w", err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return nil, fmt.Errorf("inspect IMAP relocation rekey: %w", err)
+		}
+		if rowsAffected != 1 {
+			return nil, fmt.Errorf(
+				"IMAP relocation identity guard mismatch: rekey affected %d rows", rowsAffected,
+			)
+		}
+
+		preserveLabels = data.PreserveLabels
+		prepared := *data
+		message := *data.Message
+		prepared.Message = &message
+		prepared.PreserveLabels = true
+		return &prepared, nil
+	}
+
+	afterPersist := func(
+		ctx context.Context, tx *loggedTx, data *MessagePersistData, messageID int64,
+	) error {
+		if messageID != expected.ID {
+			return fmt.Errorf(
+				"IMAP relocation identity guard mismatch: persistence returned id %d, expected %d",
+				messageID, expected.ID,
+			)
+		}
+		q := boundQuerier{ctx: ctx, q: tx}
+		if err := s.replaceMIMEAttachmentsWith(q, messageID, data.MIMEAttachmentReplacement); err != nil {
+			return fmt.Errorf("replace IMAP relocation attachments: %w", err)
+		}
+		if err := recomputeMessageAttachmentStatsWith(q, messageID); err != nil {
+			return fmt.Errorf("recompute IMAP relocation attachment stats: %w", err)
+		}
+		if !preserveLabels {
+			if _, err := s.reconcileMessageLabelsTxContext(
+				ctx, tx, messageID, data.LabelIDs, replaceLabels,
+			); err != nil {
+				return fmt.Errorf("reconcile IMAP relocation labels: %w", err)
+			}
+		}
+		return nil
+	}
+
+	return s.persistMessageWithParticipantsTransaction(
+		ctx, beforeParticipants, participants, build, prepare, afterPersist,
+	)
+}
+
+func validateIMAPRelocationRecipients(recipients []RecipientSet) error {
+	required := map[string]int{
+		"from": 0,
+		"to":   0,
+		"cc":   0,
+		"bcc":  0,
+	}
+	for _, recipient := range recipients {
+		count, ok := required[recipient.Type]
+		if !ok {
+			return fmt.Errorf("IMAP relocation snapshot has unexpected recipient role %q", recipient.Type)
+		}
+		required[recipient.Type] = count + 1
+	}
+	for _, role := range []string{"from", "to", "cc", "bcc"} {
+		if required[role] != 1 {
+			return fmt.Errorf(
+				"IMAP relocation snapshot requires exactly one %s recipient set, got %d",
+				role, required[role],
+			)
+		}
+	}
+	return nil
+}

--- a/internal/store/imap_relocation_candidates.go
+++ b/internal/store/imap_relocation_candidates.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// IMAPRelocationCandidate binds a saved mailbox membership to the exact
+// archived row whose canonical source location disappeared.
+type IMAPRelocationCandidate struct {
+	MessageIdentityGuard
+
+	RFC822MessageID string
+	Mailbox         string
+	UIDValidity     uint32
+	UID             uint32
+}
+
+// GetIMAPRelocationCandidatesContext reads only the requested canonical rows
+// and their saved memberships. The caller validates membership epochs against
+// the current authoritative mailbox topology before fetching a replacement.
+func (s *Store) GetIMAPRelocationCandidatesContext(ctx context.Context, sourceID int64, lostSourceMessageIDs []string) ([]IMAPRelocationCandidate, error) {
+	keys := slices.Clone(lostSourceMessageIDs)
+	slices.Sort(keys)
+	keys = slices.Compact(keys)
+	var candidates []IMAPRelocationCandidate
+	for chunk := range slices.Chunk(keys, aliasUIDChunkSize) {
+		found, err := s.readIMAPRelocationCandidates(ctx, sourceID, chunk)
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, found...)
+	}
+	slices.SortFunc(candidates, func(a, b IMAPRelocationCandidate) int {
+		if n := cmp.Compare(a.ID, b.ID); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.Mailbox, b.Mailbox); n != 0 {
+			return n
+		}
+		if n := cmp.Compare(a.UIDValidity, b.UIDValidity); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.UID, b.UID)
+	})
+	return candidates, nil
+}
+
+func (s *Store) readIMAPRelocationCandidates(ctx context.Context, sourceID int64, keys []string) ([]IMAPRelocationCandidate, error) {
+	args := make([]any, 0, len(keys)+1)
+	args = append(args, sourceID)
+	for _, key := range keys {
+		args = append(args, key)
+	}
+	rows, err := s.db.QueryContext(ctx, `
+ SELECT m.id, m.source_id, m.source_message_id, m.rfc822_message_id,
+        membership.mailbox, membership.uidvalidity, membership.uid
+ FROM messages m
+ JOIN imap_message_memberships membership
+   ON membership.message_id = m.id AND membership.source_id = m.source_id
+ WHERE m.source_id = ? AND m.source_message_id IN (?`+strings.Repeat(",?", len(keys)-1)+`)
+   AND m.rfc822_message_id IS NOT NULL AND m.rfc822_message_id <> ''`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query IMAP relocation candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var candidates []IMAPRelocationCandidate
+	for rows.Next() {
+		var candidate IMAPRelocationCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.SourceID, &candidate.SourceMessageID, &candidate.RFC822MessageID, &candidate.Mailbox, &candidate.UIDValidity, &candidate.UID); err != nil {
+			return nil, fmt.Errorf("scan IMAP relocation candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate IMAP relocation candidates: %w", err)
+	}
+	return candidates, nil
+}

--- a/internal/store/imap_relocation_candidates_test.go
+++ b/internal/store/imap_relocation_candidates_test.go
@@ -1,0 +1,69 @@
+package store_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func TestIMAPRelocationCandidates(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	var sourceID, targetID int64
+	for i := range 2 {
+		source, err := st.GetOrCreateSource("imap", fmt.Sprintf("candidate-%d@example.test", i))
+		require.NoError(err)
+		conv, err := st.EnsureConversation(source.ID, "thread", "thread")
+		require.NoError(err)
+		id, err := st.UpsertMessage(&store.Message{ConversationID: conv, SourceID: source.ID, SourceMessageID: "Drafts|1", RFC822MessageID: sql.NullString{String: "same@example.test", Valid: true}, MessageType: "email"})
+		require.NoError(err)
+		if i == 0 {
+			sourceID, targetID = source.ID, id
+		}
+		for _, mailbox := range []string{"Drafts", "Sent", "Archive"} {
+			_, err = st.DB().Exec(st.Rebind(`INSERT INTO imap_message_memberships (source_id, mailbox, uidvalidity, uid, message_id, flags) VALUES (?, ?, ?, ?, ?, ?)`), source.ID, mailbox, 77+i, 1, id, "[]")
+			require.NoError(err)
+		}
+	}
+	conv, err := st.EnsureConversation(sourceID, "other-thread", "Other")
+	require.NoError(err)
+	for _, sourceMessageID := range []string{"Drafts|2", "Drafts|3"} {
+		rfc822 := sql.NullString{String: "unrequested@example.test", Valid: sourceMessageID == "Drafts|2"}
+		id, err := st.UpsertMessage(&store.Message{ConversationID: conv, SourceID: sourceID, SourceMessageID: sourceMessageID, RFC822MessageID: rfc822, MessageType: "email"})
+		require.NoError(err)
+		_, err = st.DB().Exec(st.Rebind(`INSERT INTO imap_message_memberships (source_id, mailbox, uidvalidity, uid, message_id, flags) VALUES (?, ?, ?, ?, ?, ?)`), sourceID, sourceMessageID, 77, 1, id, "[]")
+		require.NoError(err)
+	}
+	unidentified, err := st.GetIMAPRelocationCandidatesContext(t.Context(), sourceID, []string{"Drafts|3"})
+	require.NoError(err)
+	assert.Empty(unidentified)
+	got, err := st.GetIMAPRelocationCandidatesContext(t.Context(), sourceID, []string{"Drafts|1"})
+	require.NoError(err)
+	require.Len(got, 3)
+	for _, candidate := range got {
+		assert.Equal(store.MessageIdentityGuard{ID: targetID, SourceID: sourceID, SourceMessageID: "Drafts|1"}, candidate.MessageIdentityGuard)
+		assert.Equal("same@example.test", candidate.RFC822MessageID)
+		assert.Equal(uint32(77), candidate.UIDValidity)
+		assert.Equal(uint32(1), candidate.UID)
+	}
+	assert.Equal("Archive", got[0].Mailbox)
+	assert.Equal("Drafts", got[1].Mailbox)
+	assert.Equal("Sent", got[2].Mailbox)
+	empty, err := st.GetIMAPRelocationCandidatesContext(t.Context(), sourceID, nil)
+	require.NoError(err)
+	assert.Empty(empty)
+	keys := make([]string, 1901)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("absent|%d", i)
+	}
+	keys[1900] = "Drafts|1"
+	chunked, err := st.GetIMAPRelocationCandidatesContext(t.Context(), sourceID, keys)
+	require.NoError(err)
+	assert.Equal(got, chunked)
+}

--- a/internal/store/imap_relocation_test.go
+++ b/internal/store/imap_relocation_test.go
@@ -1,0 +1,562 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+type imapRelocationFixture struct {
+	Store          *store.Store
+	Scoped         *store.Store
+	SourceID       int64
+	ConversationID int64
+	TargetID       int64
+	Guard          store.MessageIdentityGuard
+	OldLabelID     int64
+	SentLabelID    int64
+	SyncID         int64
+}
+
+func seedIMAPRelocationFixture(t *testing.T) imapRelocationFixture {
+	t.Helper()
+	return seedRelocationFixtureWithSourceType(t, "imap")
+}
+
+func seedRelocationFixtureWithSourceType(
+	t *testing.T, sourceType string,
+) imapRelocationFixture {
+	t.Helper()
+	require := require.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource(sourceType, "imap-relocation@example.test")
+	require.NoError(err)
+	conversationID, err := st.EnsureConversation(
+		source.ID, "imap-relocation-thread", "Draft conversation")
+	require.NoError(err)
+	oldLabelID, err := st.EnsureLabel(source.ID, "DRAFT", "Drafts", "system")
+	require.NoError(err)
+	sentLabelID, err := st.EnsureLabel(source.ID, "SENT", "Sent", "system")
+	require.NoError(err)
+
+	targetID, err := st.PersistMessageWithParticipantsContext(
+		t.Context(),
+		[]store.ParticipantPersistData{
+			{EmailAddress: "draft-author@example.test", DisplayName: "Draft Author", Domain: "example.test"},
+			{EmailAddress: "draft-to@example.test", DisplayName: "Draft To", Domain: "example.test"},
+			{EmailAddress: "draft-cc@example.test", DisplayName: "Draft Cc", Domain: "example.test"},
+			{EmailAddress: "draft-bcc@example.test", DisplayName: "Draft Bcc", Domain: "example.test"},
+		},
+		func(participantIDs []int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					ConversationID:  conversationID,
+					SourceID:        source.ID,
+					SourceMessageID: "Drafts|1",
+					RFC822MessageID: sql.NullString{String: "<relocation@example.test>", Valid: true},
+					MessageType:     "email",
+					SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+					Subject:         sql.NullString{String: "Draft subject", Valid: true},
+					Snippet:         sql.NullString{String: "Draft snippet", Valid: true},
+					SizeEstimate:    101,
+				},
+				BodyText: sql.NullString{String: "draftword", Valid: true},
+				BodyHTML: sql.NullString{String: "<p>draftword</p>", Valid: true},
+				RawMIME:  []byte("literal draft MIME"),
+				Recipients: []store.RecipientSet{
+					{Type: "from", ParticipantIDs: participantIDs[0:1], DisplayNames: []string{"Draft Author"}, EmailAddresses: []string{"draft-author@example.test"}},
+					{Type: "to", ParticipantIDs: participantIDs[1:2], DisplayNames: []string{"Draft To"}, EmailAddresses: []string{"draft-to@example.test"}},
+					{Type: "cc", ParticipantIDs: participantIDs[2:3], DisplayNames: []string{"Draft Cc"}, EmailAddresses: []string{"draft-cc@example.test"}},
+					{Type: "bcc", ParticipantIDs: participantIDs[3:4], DisplayNames: []string{"Draft Bcc"}, EmailAddresses: []string{"draft-bcc@example.test"}},
+				},
+				LabelIDs: []int64{oldLabelID},
+				FTS: &store.FTSDoc{
+					Subject:  "Draft subject",
+					Body:     "draftword",
+					FromAddr: "draft-author@example.test",
+					ToAddrs:  "draft-to@example.test",
+					CcAddrs:  "draft-cc@example.test",
+				},
+			}
+		},
+	)
+	require.NoError(err)
+	require.NoError(st.UpsertAttachmentRecord(t.Context(), targetID, store.AttachmentWrite{
+		Filename: "draft.txt", MIMEType: "text/plain", StoragePath: "draft.txt",
+		ContentHash: "draft-hash", Size: 11, SourcePartKey: "mime:part:1",
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceMIMEDisposition,
+	}))
+	require.NoError(st.UpsertAttachmentRecord(t.Context(), targetID, store.AttachmentWrite{
+		Filename: "provider.bin", MIMEType: "application/octet-stream", StoragePath: "provider.bin",
+		ContentHash: "provider-hash", Size: 12, SourceAttachmentID: "provider:attachment:1",
+		SourcePartKey: "provider:part:1", Role: store.AttachmentRoleStandalone,
+		RoleSource: store.AttachmentRoleSourceProviderExplicit,
+	}))
+	require.NoError(st.RecomputeMessageAttachmentStats(targetID))
+	require.NoError(st.SetEmbedGen(t.Context(), []int64{targetID}, 19))
+	syncID, err := st.StartSync(source.ID, "full")
+	require.NoError(err)
+
+	return imapRelocationFixture{
+		Store: st, Scoped: st.ScopedToSync(source.ID, syncID),
+		SourceID: source.ID, ConversationID: conversationID, TargetID: targetID,
+		Guard: store.MessageIdentityGuard{
+			ID: targetID, SourceID: source.ID, SourceMessageID: "Drafts|1",
+		},
+		OldLabelID: oldLabelID, SentLabelID: sentLabelID, SyncID: syncID,
+	}
+}
+
+func relocatedIMAPMessageData(
+	fixture imapRelocationFixture, participantIDs []int64,
+) *store.MessagePersistData {
+	emptyReplacement := []store.AttachmentWrite{}
+	return &store.MessagePersistData{
+		Message: &store.Message{
+			ConversationID:  fixture.ConversationID,
+			SourceID:        fixture.SourceID,
+			SourceMessageID: "Sent|2",
+			RFC822MessageID: sql.NullString{String: "relocation@example.test", Valid: true},
+			MessageType:     "email",
+			SenderID:        sql.NullInt64{Int64: participantIDs[0], Valid: true},
+			Subject:         sql.NullString{String: "Sent subject", Valid: true},
+			Snippet:         sql.NullString{String: "Sent snippet", Valid: true},
+			SizeEstimate:    202,
+		},
+		BodyText: sql.NullString{String: "finalword", Valid: true},
+		BodyHTML: sql.NullString{String: "<p>finalword</p>", Valid: true},
+		RawMIME:  []byte("literal sent MIME"),
+		Recipients: []store.RecipientSet{
+			{Type: "from", ParticipantIDs: participantIDs[0:1], DisplayNames: []string{"Sent Author"}, EmailAddresses: []string{"sent-author@example.test"}},
+			{Type: "to", ParticipantIDs: participantIDs[1:2], DisplayNames: []string{"Sent To"}, EmailAddresses: []string{"sent-to@example.test"}},
+			{Type: "cc", ParticipantIDs: []int64{}, DisplayNames: []string{}, EmailAddresses: []string{}},
+			{Type: "bcc", ParticipantIDs: []int64{}, DisplayNames: []string{}, EmailAddresses: []string{}},
+		},
+		LabelIDs:                  []int64{fixture.SentLabelID},
+		MIMEAttachmentReplacement: &emptyReplacement,
+		FTS: &store.FTSDoc{
+			Subject:  "Sent subject",
+			Body:     "finalword",
+			FromAddr: "sent-author@example.test",
+			ToAddrs:  "sent-to@example.test",
+		},
+	}
+}
+
+func imapRelocationParticipants() []store.ParticipantPersistData {
+	return []store.ParticipantPersistData{
+		{EmailAddress: "sent-author@example.test", DisplayName: "Sent Author", Domain: "example.test"},
+		{EmailAddress: "sent-to@example.test", DisplayName: "Sent To", Domain: "example.test"},
+	}
+}
+
+func TestPersistIMAPRelocationReplacesCompleteSnapshotAtomically(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := seedIMAPRelocationFixture(t)
+
+	gotID, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			return relocatedIMAPMessageData(fixture, participantIDs)
+		}, true,
+	)
+	require.NoError(err)
+	assert.Equal(fixture.Guard.ID, gotID)
+
+	after := readSiblingMessageSnapshot(t, fixture.Store, gotID)
+	assert.Equal("Sent|2", after.SourceMessageID)
+	assert.Equal("Sent subject", after.Subject.String)
+	assert.Equal("Sent snippet", after.Snippet.String)
+	assert.Equal("finalword", after.BodyText.String)
+	assert.Equal("<p>finalword</p>", after.BodyHTML.String)
+	assert.Equal([]byte("literal sent MIME"), after.RawMIME)
+	assert.Equal([]string{"provider.bin"}, attachmentFilenames(after))
+	assert.True(after.HasAttachments)
+	assert.Equal(1, after.AttachmentCount)
+	assert.False(after.EmbedGen.Valid)
+	assert.Equal([]int64{fixture.SentLabelID}, after.LabelIDs)
+	require.Len(after.Recipients, 2)
+	assert.Equal("from", after.Recipients[0].Type)
+	assert.Equal("sent-author@example.test", after.Recipients[0].EnvelopeEmail.String)
+	assert.Equal("to", after.Recipients[1].Type)
+	assert.Equal("sent-to@example.test", after.Recipients[1].EnvelopeEmail.String)
+
+	_, finalHits, err := fixture.Store.SearchMessages("finalword", 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), finalHits)
+	_, draftHits, err := fixture.Store.SearchMessages("draftword", 0, 10)
+	require.NoError(err)
+	assert.Zero(draftHits)
+}
+
+func TestPersistIMAPRelocationRequiresGuardedIMAPSyncScope(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) (imapRelocationFixture, *store.Store, store.MessageIdentityGuard)
+		want  string
+	}{
+		{
+			name: "wrong old source identity",
+			setup: func(t *testing.T) (imapRelocationFixture, *store.Store, store.MessageIdentityGuard) {
+				t.Helper()
+				fixture := seedIMAPRelocationFixture(t)
+				guard := fixture.Guard
+				guard.SourceMessageID = "Drafts|wrong"
+				return fixture, fixture.Scoped, guard
+			},
+			want: "identity guard",
+		},
+		{
+			name: "wrong sync source owner",
+			setup: func(t *testing.T) (imapRelocationFixture, *store.Store, store.MessageIdentityGuard) {
+				t.Helper()
+				fixture := seedIMAPRelocationFixture(t)
+				other, err := fixture.Store.GetOrCreateSource("imap", "other-relocation@example.test")
+				require.NoError(t, err)
+				runID, err := fixture.Store.StartSync(other.ID, "full")
+				require.NoError(t, err)
+				return fixture, fixture.Store.ScopedToSync(other.ID, runID), fixture.Guard
+			},
+			want: "scoped to source",
+		},
+		{
+			name: "unscoped store",
+			setup: func(t *testing.T) (imapRelocationFixture, *store.Store, store.MessageIdentityGuard) {
+				t.Helper()
+				fixture := seedIMAPRelocationFixture(t)
+				return fixture, fixture.Store, fixture.Guard
+			},
+			want: "requires a sync generation",
+		},
+		{
+			name: "non IMAP source",
+			setup: func(t *testing.T) (imapRelocationFixture, *store.Store, store.MessageIdentityGuard) {
+				t.Helper()
+				fixture := seedRelocationFixtureWithSourceType(t, "gmail")
+				return fixture, fixture.Scoped, fixture.Guard
+			},
+			want: "requires an IMAP source",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture, scoped, guard := test.setup(t)
+			before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+			var built atomic.Bool
+			_, err := scoped.PersistIMAPRelocationWithParticipantsContext(
+				t.Context(), guard, imapRelocationParticipants(),
+				func(participantIDs []int64) *store.MessagePersistData {
+					built.Store(true)
+					return relocatedIMAPMessageData(fixture, participantIDs)
+				}, true,
+			)
+			require.ErrorContains(t, err, test.want)
+			assert.False(t, built.Load(), "preflight rejection must precede participant resolution and building")
+			assert.Equal(t, before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+		})
+	}
+}
+
+func TestPersistIMAPRelocationRejectsSupersededSyncGeneration(t *testing.T) {
+	fixture := seedIMAPRelocationFixture(t)
+	require.NoError(t, fixture.Store.CompleteSync(fixture.SyncID, "complete"))
+	var built atomic.Bool
+
+	_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			built.Store(true)
+			return relocatedIMAPMessageData(fixture, participantIDs)
+		}, true,
+	)
+	require.ErrorIs(t, err, store.ErrSyncRunSuperseded)
+	assert.False(t, built.Load())
+}
+
+func TestPersistIMAPRelocationRejectsDifferentRFC822Identity(t *testing.T) {
+	fixture := seedIMAPRelocationFixture(t)
+	before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+
+	_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			data := relocatedIMAPMessageData(fixture, participantIDs)
+			data.Message.RFC822MessageID = sql.NullString{String: "<different@example.test>", Valid: true}
+			return data
+		}, true,
+	)
+	require.ErrorContains(t, err, "RFC822 identity mismatch")
+	assert.Equal(t, before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+}
+
+func TestPersistIMAPRelocationRequiresCompleteSnapshotPayload(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*store.MessagePersistData)
+		want   string
+	}{
+		{
+			name: "snapshot source",
+			mutate: func(data *store.MessagePersistData) {
+				data.Message.SourceID++
+			},
+			want: "snapshot source mismatch",
+		},
+		{
+			name: "new source message ID",
+			mutate: func(data *store.MessagePersistData) {
+				data.Message.SourceMessageID = ""
+			},
+			want: "requires a source message ID",
+		},
+		{
+			name: "changed source message ID",
+			mutate: func(data *store.MessagePersistData) {
+				data.Message.SourceMessageID = "Drafts|1"
+			},
+			want: "must change",
+		},
+		{
+			name: "raw MIME",
+			mutate: func(data *store.MessagePersistData) {
+				data.RawMIME = nil
+			},
+			want: "requires raw MIME",
+		},
+		{
+			name: "FTS",
+			mutate: func(data *store.MessagePersistData) {
+				data.FTS = nil
+			},
+			want: "requires FTS content",
+		},
+		{
+			name: "MIME attachment replacement",
+			mutate: func(data *store.MessagePersistData) {
+				data.MIMEAttachmentReplacement = nil
+			},
+			want: "requires MIME attachment replacement",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := seedIMAPRelocationFixture(t)
+			before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+			_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+				t.Context(), fixture.Guard, imapRelocationParticipants(),
+				func(participantIDs []int64) *store.MessagePersistData {
+					data := relocatedIMAPMessageData(fixture, participantIDs)
+					test.mutate(data)
+					return data
+				}, true,
+			)
+			require.ErrorContains(t, err, test.want)
+			assert.Equal(t, before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+		})
+	}
+}
+
+func TestPersistIMAPRelocationRequiresExactlyOneCompleteRecipientSetPerRole(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*store.MessagePersistData)
+		want   string
+	}{
+		{
+			name: "missing role",
+			mutate: func(data *store.MessagePersistData) {
+				data.Recipients = data.Recipients[:3]
+			},
+			want: "exactly one bcc recipient set",
+		},
+		{
+			name: "duplicate role",
+			mutate: func(data *store.MessagePersistData) {
+				data.Recipients = append(data.Recipients, store.RecipientSet{Type: "from"})
+			},
+			want: "exactly one from recipient set",
+		},
+		{
+			name: "unexpected role",
+			mutate: func(data *store.MessagePersistData) {
+				data.Recipients[3].Type = "reply-to"
+			},
+			want: "unexpected recipient role",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := seedIMAPRelocationFixture(t)
+			before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+			_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+				t.Context(), fixture.Guard, imapRelocationParticipants(),
+				func(participantIDs []int64) *store.MessagePersistData {
+					data := relocatedIMAPMessageData(fixture, participantIDs)
+					test.mutate(data)
+					return data
+				}, true,
+			)
+			require.ErrorContains(t, err, test.want)
+			assert.Equal(t, before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+		})
+	}
+}
+
+func TestPersistIMAPRelocationAppliesLabelPolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		replaceLabels  bool
+		preserveLabels bool
+		want           func(imapRelocationFixture) []int64
+	}{
+		{
+			name: "complete replaces", replaceLabels: true,
+			want: func(fixture imapRelocationFixture) []int64 { return []int64{fixture.SentLabelID} },
+		},
+		{
+			name: "partial merges", replaceLabels: false,
+			want: func(fixture imapRelocationFixture) []int64 {
+				return []int64{fixture.OldLabelID, fixture.SentLabelID}
+			},
+		},
+		{
+			name: "deferred preserves", replaceLabels: true, preserveLabels: true,
+			want: func(fixture imapRelocationFixture) []int64 { return []int64{fixture.OldLabelID} },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := seedIMAPRelocationFixture(t)
+			_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+				t.Context(), fixture.Guard, imapRelocationParticipants(),
+				func(participantIDs []int64) *store.MessagePersistData {
+					data := relocatedIMAPMessageData(fixture, participantIDs)
+					data.PreserveLabels = test.preserveLabels
+					return data
+				}, test.replaceLabels,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, test.want(fixture),
+				readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID).LabelIDs)
+		})
+	}
+}
+
+func TestPersistIMAPRelocationRejectsNewSourceIDCollisionWithoutChangingEitherRow(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := seedIMAPRelocationFixture(t)
+	collisionID, err := fixture.Store.UpsertMessage(&store.Message{
+		ConversationID: fixture.ConversationID, SourceID: fixture.SourceID,
+		SourceMessageID: "Sent|2", MessageType: "email",
+		Subject: sql.NullString{String: "Collision", Valid: true},
+	})
+	require.NoError(err)
+	require.NotEqual(fixture.TargetID, collisionID)
+	beforeTarget := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+
+	_, err = fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			return relocatedIMAPMessageData(fixture, participantIDs)
+		}, true,
+	)
+	require.ErrorContains(err, "rekey IMAP relocation target")
+	assert.Equal(beforeTarget, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID))
+	collisionSourceID, sourceErr := fixture.Store.GetMessageSourceID(collisionID)
+	require.NoError(sourceErr)
+	assert.Equal("Sent|2", collisionSourceID)
+}
+
+func TestPersistIMAPRelocationHonorsCanceledContext(t *testing.T) {
+	fixture := seedIMAPRelocationFixture(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	var built atomic.Bool
+
+	_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		ctx, fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			built.Store(true)
+			return relocatedIMAPMessageData(fixture, participantIDs)
+		}, true,
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, built.Load())
+}
+
+func TestPersistIMAPRelocationRollsBackEveryMutationOnLateLabelFailure(t *testing.T) {
+	fixture := seedIMAPRelocationFixture(t)
+	before := readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID)
+
+	_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, imapRelocationParticipants(),
+		func(participantIDs []int64) *store.MessagePersistData {
+			data := relocatedIMAPMessageData(fixture, participantIDs)
+			data.LabelIDs = []int64{fixture.SentLabelID, 1 << 60}
+			return data
+		}, true,
+	)
+	require.ErrorContains(t, err, "reconcile IMAP relocation labels")
+	assert.Equal(t, before, readSiblingMessageSnapshot(t, fixture.Store, fixture.TargetID),
+		"late label failure must roll back source, content, FTS, recipients, attachments, and labels")
+}
+
+func TestPersistIMAPRelocationDoesNotMutateCallerData(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := seedIMAPRelocationFixture(t)
+	participantIDs := make([]int64, 2)
+	for index, participant := range imapRelocationParticipants() {
+		id, err := fixture.Store.EnsureParticipant(
+			participant.EmailAddress, participant.DisplayName, participant.Domain)
+		require.NoError(err)
+		participantIDs[index] = id
+	}
+	data := relocatedIMAPMessageData(fixture, participantIDs)
+	data.Message.ID = 987654
+	wantMessage := *data.Message
+	wantRaw := slices.Clone(data.RawMIME)
+	wantRecipients := make([]store.RecipientSet, len(data.Recipients))
+	for index, recipient := range data.Recipients {
+		wantRecipients[index] = recipient
+		wantRecipients[index].ParticipantIDs = slices.Clone(recipient.ParticipantIDs)
+		wantRecipients[index].DisplayNames = slices.Clone(recipient.DisplayNames)
+		wantRecipients[index].EmailAddresses = slices.Clone(recipient.EmailAddresses)
+	}
+	wantLabels := slices.Clone(data.LabelIDs)
+	wantAttachments := slices.Clone(*data.MIMEAttachmentReplacement)
+	wantFTS := *data.FTS
+
+	gotID, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, nil,
+		func([]int64) *store.MessagePersistData { return data }, true,
+	)
+	require.NoError(err)
+	assert.Equal(fixture.TargetID, gotID)
+	assert.Equal(wantMessage, *data.Message)
+	assert.Equal(wantRaw, data.RawMIME)
+	assert.Equal(wantRecipients, data.Recipients)
+	assert.Equal(wantLabels, data.LabelIDs)
+	assert.Equal(wantAttachments, *data.MIMEAttachmentReplacement)
+	assert.Equal(wantFTS, *data.FTS)
+}
+
+func TestPersistIMAPRelocationRequiresBuilder(t *testing.T) {
+	fixture := seedIMAPRelocationFixture(t)
+	_, err := fixture.Scoped.PersistIMAPRelocationWithParticipantsContext(
+		t.Context(), fixture.Guard, nil, nil, true)
+	require.ErrorContains(t, err, "requires a participant builder")
+}

--- a/internal/store/message_adoption.go
+++ b/internal/store/message_adoption.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// AdoptMessageSourceIDContext atomically rekeys a message to a new composite
+// source ID and reconciles its labels in one transaction. The rekey is
+// guarded by the expected old source ID under the sync-source fence, so a
+// lost race, a failing label step, or cancellation leaves the previous key,
+// labels, and snapshot untouched and the adoption retryable — the old key is
+// never consumed before every step of the adoption has committed.
+//
+// reconcileLabels false (deferred authoritative reconciliation) performs the
+// guarded rekey alone and leaves labels unchanged: no label step is split
+// into a second transaction. The later label finalizer stays an independent
+// operation — atomicity here covers the rekey itself, not the rekey plus that
+// finalizer. replaceLabels follows ReconcileMessageLabels semantics and only
+// applies when reconcileLabels is true.
+func (s *Store) AdoptMessageSourceIDContext(
+	ctx context.Context,
+	messageID int64,
+	expectedSourceMessageID, newSourceMessageID string,
+	reconcileLabels bool,
+	labelIDs []int64,
+	replaceLabels bool,
+) (bool, error) {
+	if newSourceMessageID == "" || expectedSourceMessageID == "" ||
+		expectedSourceMessageID == newSourceMessageID {
+		return false, errors.New(
+			"adoption requires a changing non-empty source message ID")
+	}
+	var changed bool
+	err := s.withTxContext(ctx, func(tx *loggedTx) error {
+		if err := s.requireSyncMessageSourceTx(tx, messageID); err != nil {
+			return err
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE messages SET source_message_id = ?
+			WHERE id = ? AND source_message_id = ?
+		`, newSourceMessageID, messageID, expectedSourceMessageID)
+		if err != nil {
+			return fmt.Errorf("rekey adopted message source ID: %w", err)
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("inspect adopted message rekey: %w", err)
+		}
+		if affected != 1 {
+			return fmt.Errorf(
+				"adoption identity guard mismatch: message %d no longer has source ID %q",
+				messageID, expectedSourceMessageID)
+		}
+		changed = true
+		if !reconcileLabels {
+			return nil
+		}
+		labelsChanged, err := s.reconcileMessageLabelsTxContext(
+			ctx, tx, messageID, labelIDs, replaceLabels)
+		if err != nil {
+			return fmt.Errorf("reconcile adopted message labels: %w", err)
+		}
+		changed = changed || labelsChanged
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}

--- a/internal/store/message_adoption_test.go
+++ b/internal/store/message_adoption_test.go
@@ -1,0 +1,136 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// adoptionFixture seeds one IMAP message with an old composite key, two
+// labels, and a running sync generation.
+func adoptionFixture(t *testing.T) (*store.Store, int64, []int64) {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	src, err := st.GetOrCreateSource("imap", "adopt-atomic@example.test")
+	require.NoError(t, err)
+	conv, err := st.EnsureConversation(src.ID, "thread", "Adoption")
+	require.NoError(t, err)
+	messageID, err := st.UpsertMessage(&store.Message{
+		SourceID: src.ID, ConversationID: conv,
+		SourceMessageID: "INBOX|7", MessageType: "email",
+	})
+	require.NoError(t, err)
+	labelA, err := st.EnsureLabel(src.ID, "INBOX", "INBOX", "system")
+	require.NoError(t, err)
+	labelB, err := st.EnsureLabel(src.ID, "Archive", "Archive", "user")
+	require.NoError(t, err)
+	for _, labelID := range []int64{labelA, labelB} {
+		_, err = st.DB().Exec(st.Rebind(
+			"INSERT INTO message_labels (message_id, label_id) VALUES (?, ?)"),
+			messageID, labelID)
+		require.NoError(t, err)
+	}
+	run, err := st.StartSync(src.ID, "full")
+	require.NoError(t, err)
+	return st.ScopedToSync(src.ID, run), messageID, []int64{labelA, labelB}
+}
+
+func adoptionLabelNames(t *testing.T, st *store.Store, messageID int64) []string {
+	t.Helper()
+	rows, err := st.DB().Query(st.Rebind(
+		"SELECT l.name FROM message_labels ml JOIN labels l ON ml.label_id = l.id"+
+			" WHERE ml.message_id = ? ORDER BY l.name"), messageID)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		names = append(names, name)
+	}
+	require.NoError(t, rows.Err())
+	return names
+}
+
+// A failing label reconciliation must roll the guarded rekey back with the
+// labels: the old composite key stays put, so the adoption stays retryable.
+// The label write fails through a real constraint — a nonexistent label ID
+// violates the foreign key on both SQLite and PostgreSQL.
+func TestAdoptMessageSourceIDContextRollsBackLabelFailure(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, messageID, labelIDs := adoptionFixture(t)
+
+	changed, err := st.AdoptMessageSourceIDContext(
+		t.Context(), messageID, "INBOX|7", "Archive|9",
+		true, append(append([]int64{}, labelIDs...), 999999), true)
+	require.Error(err)
+	assert.False(changed)
+	var sourceMessageID string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), messageID,
+	).Scan(&sourceMessageID))
+	assert.Equal("INBOX|7", sourceMessageID, "the old composite key must survive a failed label step")
+	assert.ElementsMatch([]string{"Archive", "INBOX"}, adoptionLabelNames(t, st, messageID))
+
+	// The retry after the fault clears adopts key and labels atomically.
+	changed, err = st.AdoptMessageSourceIDContext(
+		t.Context(), messageID, "INBOX|7", "Archive|9", true, labelIDs[:1], true)
+	require.NoError(err)
+	assert.True(changed)
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), messageID,
+	).Scan(&sourceMessageID))
+	assert.Equal("Archive|9", sourceMessageID)
+	assert.ElementsMatch([]string{"INBOX"}, adoptionLabelNames(t, st, messageID))
+}
+
+// Deferred authoritative reconciliation rekeys alone and never touches
+// labels; the command finalizer owns them.
+func TestAdoptMessageSourceIDContextDeferredLabels(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, messageID, labelIDs := adoptionFixture(t)
+
+	changed, err := st.AdoptMessageSourceIDContext(
+		t.Context(), messageID, "INBOX|7", "Trash|3", false, nil, true)
+	require.NoError(err)
+	assert.True(changed)
+	var sourceMessageID string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), messageID,
+	).Scan(&sourceMessageID))
+	assert.Equal("Trash|3", sourceMessageID)
+	assert.ElementsMatch([]string{"Archive", "INBOX"}, adoptionLabelNames(t, st, messageID),
+		"deferred reconciliation leaves labels untouched")
+	assert.NotEmpty(labelIDs)
+}
+
+// The expected-old-source guard must reject a lost race without touching the
+// row, and a canceled context must fail before any write commits.
+func TestAdoptMessageSourceIDContextGuardAndCancellation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	st, messageID, _ := adoptionFixture(t)
+
+	_, err := st.AdoptMessageSourceIDContext(
+		t.Context(), messageID, "INBOX|8", "Trash|3", true, nil, false)
+	require.ErrorContains(err, "identity guard mismatch")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = st.AdoptMessageSourceIDContext(
+		ctx, messageID, "INBOX|7", "Trash|3", true, nil, false)
+	require.Error(err)
+
+	var sourceMessageID string
+	require.NoError(st.DB().QueryRow(st.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), messageID,
+	).Scan(&sourceMessageID))
+	assert.Equal("INBOX|7", sourceMessageID,
+		"a lost race and cancellation must both leave the old key in place")
+}

--- a/internal/sync/imap_content.go
+++ b/internal/sync/imap_content.go
@@ -1,0 +1,63 @@
+package sync
+
+import (
+	"encoding/json/v2"
+	"fmt"
+)
+
+type imapContentOrigin string
+
+const (
+	imapContentSent     imapContentOrigin = "sent"
+	imapContentDrafts   imapContentOrigin = "drafts"
+	imapContentOutgoing imapContentOrigin = "outgoing"
+)
+
+// Content origin belongs to the saved snapshot, not its current mailbox.
+// Location-only adoption leaves this metadata intact, including across runs
+// where the original mailbox no longer appears in LIST.
+type imapMessageMetadata struct {
+	ContentOrigin imapContentOrigin `json:"imap_content_origin"`
+}
+
+func (s *Syncer) imapContentOrigin(sourceMessageID string) imapContentOrigin {
+	if !s.relocationContentAuthorized(sourceMessageID) {
+		return ""
+	}
+	if placement, ok := s.client.(sentPrecedencePlacement); ok {
+		if placement.IsSentPlacementMailbox(sourceMessageID) {
+			return imapContentSent
+		}
+		if placement.IsDraftsPlacementMailbox(sourceMessageID) {
+			return imapContentDrafts
+		}
+	}
+	return imapContentOutgoing
+}
+
+func (s *Syncer) savedIMAPContentOrigin(messageID int64) (imapContentOrigin, error) {
+	metadata, err := s.store.GetMessageMetadata(messageID)
+	if err != nil {
+		return "", fmt.Errorf("get IMAP content origin: %w", err)
+	}
+	var saved imapMessageMetadata
+	if metadata.Valid {
+		if err := json.Unmarshal([]byte(metadata.String), &saved); err != nil {
+			return "", fmt.Errorf("decode IMAP content origin: %w", err)
+		}
+	}
+	return saved.ContentOrigin, nil
+}
+
+func (destination imapContentOrigin) canRefresh(saved imapContentOrigin, canonicalExists bool) bool {
+	if destination == "" || (saved == imapContentSent && destination == imapContentDrafts) {
+		return false
+	}
+	if canonicalExists {
+		// Existing outgoing snapshots only yield to Sent-over-Drafts.
+		return saved == "" || (destination == imapContentSent && saved == imapContentDrafts)
+	}
+	// Once the canonical disappears, equal-priority outgoing survivors can
+	// refresh the snapshot, including Sent-to-Sent and Drafts-to-Drafts.
+	return true
+}

--- a/internal/sync/imap_relocation.go
+++ b/internal/sync/imap_relocation.go
@@ -1,0 +1,177 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/msgvault/internal/export"
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/textutil"
+)
+
+func (s *Syncer) relocateIMAPMessage(
+	ctx context.Context,
+	expected store.MessageIdentityGuard,
+	raw *gmail.RawMessage,
+	threadID string,
+	labelMap map[string]int64,
+	replaceLabels bool,
+	preserveLabels bool,
+) error {
+	prepared, err := s.prepareMessage(expected.SourceID, raw, threadID, true)
+	if err != nil {
+		return err
+	}
+	return s.persistPreparedIMAPRelocation(ctx, expected, prepared, labelMap, replaceLabels, preserveLabels)
+}
+
+func (s *Syncer) relocateIMAPMessageToTarget(
+	ctx context.Context, sourceID int64, target gmail.MessageRelocationTarget,
+	raw *gmail.RawMessage, threadID string, labelMap map[string]int64,
+) error {
+	if target.SourceID != sourceID || target.InternalID <= 0 || target.SourceMessageID == "" ||
+		raw == nil || raw.ID != target.NewSourceMessageID {
+		return errors.New("invalid IMAP relocation target")
+	}
+	if !s.relocationContentAuthorized(target.NewSourceMessageID) {
+		return s.adoptIMAPRelocationLocation(ctx, target, raw, labelMap)
+	}
+	prepared, err := s.prepareMessage(sourceID, raw, threadID, true)
+	if err != nil {
+		return err
+	}
+	expectedID := mime.NormalizeMessageID(target.RFC822MessageID)
+	if expectedID == "" || mime.NormalizeMessageID(prepared.message.RFC822MessageID.String) != expectedID {
+		return fmt.Errorf("IMAP relocation candidate %q changed RFC822 identity", raw.ID)
+	}
+	return s.persistPreparedIMAPRelocation(ctx, store.MessageIdentityGuard{
+		ID: target.InternalID, SourceID: target.SourceID, SourceMessageID: target.SourceMessageID,
+	}, prepared, labelMap, s.labelsSnapshotComplete(), s.defersAuthoritativeLabelReconciliation())
+}
+
+// adoptIMAPRelocationLocation rekeys the guarded row to its surviving
+// location without refreshing the snapshot. The destination carries no
+// trusted outgoing placement — no unambiguous advertised \Sent or \Drafts
+// role and no explicit user configuration — so the fetched bytes, including a
+// forged RFC822 Message-ID, cannot replace archived content; the location is
+// still adopted with the pre-relocation rekey semantics. Identity is checked
+// with the tolerant parser so attacker-controlled MIME cannot strand the run
+// behind a strict-parse failure.
+func (s *Syncer) adoptIMAPRelocationLocation(
+	ctx context.Context,
+	target gmail.MessageRelocationTarget, raw *gmail.RawMessage, labelMap map[string]int64,
+) error {
+	parsed, parseErr := mime.ParseWithRecovery(raw.Raw, "")
+	if parseErr != nil {
+		s.logger.Warn("IMAP relocation identity parse recovered with errors",
+			"id", raw.ID, "error", textutil.FirstLine(parseErr.Error()))
+	}
+	if parsed == nil {
+		return fmt.Errorf("parse IMAP relocation candidate %q", raw.ID)
+	}
+	expectedID := mime.NormalizeMessageID(target.RFC822MessageID)
+	if expectedID == "" || mime.NormalizeMessageID(parsed.MessageID) != expectedID {
+		return fmt.Errorf("IMAP relocation candidate %q changed RFC822 identity", raw.ID)
+	}
+	// One guarded transaction adopts the location and, for clients that do
+	// not defer authoritative labels, reconciles them: a late failure or
+	// cancellation rolls the rekey back with the labels, keeping the old
+	// composite key that the next retry rediscovers the candidate with.
+	_, err := s.store.AdoptMessageSourceIDContext(
+		ctx,
+		target.InternalID, target.SourceMessageID, target.NewSourceMessageID,
+		!s.defersAuthoritativeLabelReconciliation(),
+		labelIDsFor(raw.LabelIDs, labelMap),
+		s.labelsSnapshotComplete(),
+	)
+	if err != nil {
+		return fmt.Errorf("adopt IMAP relocation location: %w", err)
+	}
+	return nil
+}
+
+func (s *Syncer) persistPreparedIMAPRelocation(
+	ctx context.Context, expected store.MessageIdentityGuard, prepared *messageData,
+	labelMap map[string]int64, replaceLabels, preserveLabels bool,
+) error {
+	attachmentWrites, _, err := s.publishMIMEAttachments(ctx, prepared.attachments)
+	if err != nil {
+		return err
+	}
+	participants, participantIndex := preparedMessageParticipants(prepared)
+	labelIDs := labelIDsFor(prepared.gmailLabelIDs, labelMap)
+
+	messageID, err := s.store.PersistIMAPRelocationWithParticipantsContext(
+		ctx,
+		expected,
+		participants,
+		func(participantIDs []int64) *store.MessagePersistData {
+			persist := buildPreparedSnapshot(
+				prepared, participantIndex, participantIDs, attachmentWrites)
+			persist.LabelIDs = labelIDs
+			persist.PreserveLabels = preserveLabels
+			return persist
+		},
+		replaceLabels,
+	)
+	if err != nil {
+		return err
+	}
+	// A relocated snapshot carries the same remote-image archival hook as
+	// ordinary ingest: the refreshed HTML may reference tracked image URLs the
+	// previous location never had. The retained internal ID keeps already
+	// archived images attached, so repeat syncs do not re-download them.
+	if s.opts.RemoteImages != nil && prepared.message.MessageType == store.MessageTypeEmail {
+		archived := s.opts.RemoteImages.Archive(
+			ctx, s.store, s.opts.AttachmentsDir, messageID, prepared.bodyHTML)
+		for _, imageErr := range archived.Errors {
+			s.logger.Warn("failed to archive remote image",
+				"message", messageID, "error", imageErr)
+		}
+	}
+	return nil
+}
+
+func (s *Syncer) publishMIMEAttachments(
+	ctx context.Context,
+	attachments []mime.Attachment,
+) ([]store.AttachmentWrite, map[string]export.DurableAttachmentReceipt, error) {
+	writes := make([]store.AttachmentWrite, 0, len(attachments))
+	created := make(map[string]export.DurableAttachmentReceipt)
+	for i := range attachments {
+		if err := ctx.Err(); err != nil {
+			return nil, created, err
+		}
+		attachment := &attachments[i]
+		if s.opts.AttachmentsDir == "" {
+			return nil, created, fmt.Errorf(
+				"publish attachment %q: attachments directory is required",
+				attachment.Filename,
+			)
+		}
+		receipt, err := export.StoreAttachmentFileDurable(
+			s.opts.AttachmentsDir, attachment)
+		if receipt.Created {
+			created[receipt.StoragePath] = receipt
+		}
+		if err != nil {
+			return nil, created, fmt.Errorf(
+				"publish attachment %q: %w", attachment.Filename, err)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, created, err
+		}
+		role, roleSource := store.AttachmentRoleFromMIME(
+			attachment.Disposition, attachment.IsInline, attachment.ContentID)
+		writes = append(writes, store.AttachmentWrite{
+			Filename: attachment.Filename, MIMEType: attachment.ContentType,
+			StoragePath: receipt.StoragePath, ContentHash: attachment.ContentHash,
+			Size: int64(len(attachment.Content)), Role: role, RoleSource: roleSource,
+			SourcePartKey: attachment.PartKey, ContentID: attachment.ContentID,
+		})
+	}
+	return writes, created, nil
+}

--- a/internal/sync/imap_relocation.go
+++ b/internal/sync/imap_relocation.go
@@ -36,10 +36,15 @@ func (s *Syncer) relocateIMAPMessageToTarget(
 		raw == nil || raw.ID != target.NewSourceMessageID {
 		return errors.New("invalid IMAP relocation target")
 	}
+	savedOrigin, err := s.savedIMAPContentOrigin(target.InternalID)
+	if err != nil {
+		return err
+	}
 	// A surviving Drafts copy may take over the location, but it must not
-	// replace the final snapshot from the lost Sent placement.
-	if !s.relocationContentAuthorized(target.NewSourceMessageID) ||
-		s.relocationSentOverDrafts(target.SourceMessageID, target.NewSourceMessageID) {
+	// replace the final snapshot even if the original Sent mailbox is gone.
+	destinationOrigin := s.imapContentOrigin(target.NewSourceMessageID)
+	canonicalOrigin := s.imapContentOrigin(target.SourceMessageID)
+	if !destinationOrigin.canRefresh(savedOrigin, false) || !destinationOrigin.canRefresh(canonicalOrigin, false) {
 		return s.adoptIMAPRelocationLocation(ctx, target, raw, labelMap)
 	}
 	prepared, err := s.prepareMessage(sourceID, raw, threadID, true)

--- a/internal/sync/imap_relocation.go
+++ b/internal/sync/imap_relocation.go
@@ -36,7 +36,10 @@ func (s *Syncer) relocateIMAPMessageToTarget(
 		raw == nil || raw.ID != target.NewSourceMessageID {
 		return errors.New("invalid IMAP relocation target")
 	}
-	if !s.relocationContentAuthorized(target.NewSourceMessageID) {
+	// A surviving Drafts copy may take over the location, but it must not
+	// replace the final snapshot from the lost Sent placement.
+	if !s.relocationContentAuthorized(target.NewSourceMessageID) ||
+		s.relocationSentOverDrafts(target.SourceMessageID, target.NewSourceMessageID) {
 		return s.adoptIMAPRelocationLocation(ctx, target, raw, labelMap)
 	}
 	prepared, err := s.prepareMessage(sourceID, raw, threadID, true)
@@ -53,10 +56,9 @@ func (s *Syncer) relocateIMAPMessageToTarget(
 }
 
 // adoptIMAPRelocationLocation rekeys the guarded row to its surviving
-// location without refreshing the snapshot. The destination carries no
-// trusted outgoing placement — no unambiguous advertised \Sent or \Drafts
-// role and no explicit user configuration — so the fetched bytes, including a
-// forged RFC822 Message-ID, cannot replace archived content; the location is
+// location without refreshing the snapshot. The destination either lacks
+// trusted outgoing placement or is a Drafts copy superseded by Sent, so its
+// fetched bytes cannot replace archived content; the location is
 // still adopted with the pre-relocation rekey semantics. Identity is checked
 // with the tolerant parser so attacker-controlled MIME cannot strand the run
 // behind a strict-parse failure.

--- a/internal/sync/imap_relocation.go
+++ b/internal/sync/imap_relocation.go
@@ -21,7 +21,7 @@ func (s *Syncer) relocateIMAPMessage(
 	replaceLabels bool,
 	preserveLabels bool,
 ) error {
-	prepared, err := s.prepareMessage(expected.SourceID, raw, threadID, true)
+	prepared, err := s.prepareMessage(expected.SourceID, raw, threadID, false)
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (s *Syncer) relocateIMAPMessageToTarget(
 	if !destinationOrigin.canRefresh(savedOrigin, false) || !destinationOrigin.canRefresh(canonicalOrigin, false) {
 		return s.adoptIMAPRelocationLocation(ctx, target, raw, labelMap)
 	}
-	prepared, err := s.prepareMessage(sourceID, raw, threadID, true)
+	prepared, err := s.prepareMessage(sourceID, raw, threadID, false)
 	if err != nil {
 		return err
 	}

--- a/internal/sync/imap_relocation_guards.go
+++ b/internal/sync/imap_relocation_guards.go
@@ -1,0 +1,106 @@
+package sync
+
+import (
+	"context"
+	"errors"
+
+	"go.kenn.io/msgvault/internal/gmail"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+// failedRelocationGuards is run-scoped protection for forced relocation
+// targets whose adoption failed. A failed target stays a retryable per-item
+// failure so unrelated mail keeps ingesting, but ordinary routing in the same
+// run must not consume the target's discovery provenance: the old composite
+// key is what rediscovers the candidate on the next attempt, and the guarded
+// row keeps its archived snapshot until the relocation succeeds. The guards
+// live only on the scoped Syncer copy a single full() run uses; nothing is
+// persisted, blacklisted, or acknowledged.
+type failedRelocationGuards struct {
+	// byInternalID guards the archived row itself: no dedup adoption may
+	// rekey, relocate, or otherwise mutate it this run.
+	byInternalID map[int64]gmail.MessageRelocationTarget
+	// bySourceMessageID guards the target's composite keys — the expected
+	// old archived key and the failed candidate key — from UID-reuse
+	// invalidation and alias routing.
+	bySourceMessageID map[string]int64
+}
+
+func newFailedRelocationGuards() *failedRelocationGuards {
+	return &failedRelocationGuards{
+		byInternalID:      map[int64]gmail.MessageRelocationTarget{},
+		bySourceMessageID: map[string]int64{},
+	}
+}
+
+func (g *failedRelocationGuards) empty() bool {
+	return len(g.byInternalID) == 0
+}
+
+func (g *failedRelocationGuards) add(target gmail.MessageRelocationTarget) {
+	g.byInternalID[target.InternalID] = target
+	g.bySourceMessageID[target.SourceMessageID] = target.InternalID
+	if target.NewSourceMessageID != "" && target.NewSourceMessageID != target.SourceMessageID {
+		g.bySourceMessageID[target.NewSourceMessageID] = target.InternalID
+	}
+}
+
+// guardFailedRelocation records a failed forced target for this run. The
+// caller has already recorded the per-item error; the guards only keep
+// ordinary routing from destroying the retry provenance.
+func (s *Syncer) guardFailedRelocation(target gmail.MessageRelocationTarget) {
+	if s.failedRelocationGuards == nil {
+		return
+	}
+	s.failedRelocationGuards.add(target)
+}
+
+// relocationGuardsActive reports whether any forced target failed this run.
+func (s *Syncer) relocationGuardsActive() bool {
+	return s.failedRelocationGuards != nil && !s.failedRelocationGuards.empty()
+}
+
+// relocationRowProtected reports whether internalID belongs to a failed
+// relocation target, optionally matching one of its composite keys.
+func (s *Syncer) relocationRowProtected(internalID int64, sourceMessageID string) bool {
+	if s.failedRelocationGuards == nil || internalID <= 0 {
+		return false
+	}
+	if _, guarded := s.failedRelocationGuards.byInternalID[internalID]; guarded {
+		return true
+	}
+	return sourceMessageID != "" &&
+		s.failedRelocationGuards.bySourceMessageID[sourceMessageID] == internalID
+}
+
+// relocationRowProtectedByID reports whether internalID belongs to a failed
+// relocation target regardless of which composite key or RFC822 identity
+// routed to it.
+func (s *Syncer) relocationRowProtectedByID(internalID int64) bool {
+	return s.relocationRowProtected(internalID, "")
+}
+
+// relocationCompositeProtected reports whether sourceMessageID is a composite
+// key held by a failed relocation target, independently of which archived
+// row ordinary routing resolves behind it. Keys stay protected on their own:
+// the old key is the provenance the next retry rediscovers the candidate
+// with, and the failed candidate key must not be adopted by anything else.
+func (s *Syncer) relocationCompositeProtected(sourceMessageID string) bool {
+	if s.failedRelocationGuards == nil || sourceMessageID == "" {
+		return false
+	}
+	_, guarded := s.failedRelocationGuards.bySourceMessageID[sourceMessageID]
+	return guarded
+}
+
+// fatalRelocationError reports whether err must stop the run instead of
+// deferring the relocation target: cancellation and sync-generation fencing
+// invalidate the run itself, so neither the target nor unrelated mail can
+// commit afterwards. Persistence-level SQL failures stay per-item deferrals
+// — the run records them as errors, publishes no topology, and retries —
+// matching the SQL-failure retry contract.
+func fatalRelocationError(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, store.ErrSyncRunSuperseded)
+}

--- a/internal/sync/imap_relocation_test.go
+++ b/internal/sync/imap_relocation_test.go
@@ -1,0 +1,835 @@
+package sync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	imapv2 "github.com/emersion/go-imap/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	imapclient "go.kenn.io/msgvault/internal/imap"
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/remoteimage"
+	"go.kenn.io/msgvault/internal/search"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+	testemail "go.kenn.io/msgvault/internal/testutil/email"
+)
+
+func newDeferredLabelIMAPClient(
+	t *testing.T, addr string, clientOpts ...imapclient.Option,
+) *imapclient.Client {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portString)
+	require.NoError(t, err)
+	client := imapclient.NewClient(&imapclient.Config{
+		Host: host, Port: port, Username: testutil.IMAPTestUsername,
+	}, testutil.IMAPTestPassword, clientOpts...)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func alternativeRelocationRaw(
+	messageID, subject, from, to, cc, textBody, htmlBody string,
+) []byte {
+	return []byte(fmt.Sprintf(
+		"From: %s\r\nTo: %s\r\nCc: %s\r\nSubject: %s\r\n"+
+			"Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n"+
+			"Message-ID: <%s>\r\nMIME-Version: 1.0\r\n"+
+			"Content-Type: multipart/alternative; boundary=alt\r\n\r\n"+
+			"--alt\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n%s\r\n"+
+			"--alt\r\nContent-Type: text/html; charset=utf-8\r\n\r\n%s\r\n"+
+			"--alt--\r\n",
+		from, to, cc, subject, messageID, textBody, htmlBody,
+	))
+}
+
+func TestIMAPRelocationAdoptsEditedSentSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	const messageID = "edited-draft@example.com"
+	draftRaw := testemail.NewMessage().
+		Subject("Draft subject").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").
+		CRLF().
+		Bytes()
+	sentRaw := alternativeRelocationRaw(
+		messageID,
+		"Sent subject",
+		"Final Sender <final-sender@example.com>",
+		"Final Recipient <final-recipient@example.com>",
+		"Final Copy <final-copy@example.com>",
+		"finalword",
+		"<p>htmlfinal</p>",
+	)
+
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{
+			"Brouillons": {imapv2.MailboxAttrDrafts},
+			"Envoyes":    {imapv2.MailboxAttrSent},
+		},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	var initialID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`,
+		"Brouillons|1",
+	).Scan(&initialID))
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", sentRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+	require.NoError(secondClient.Close())
+
+	message, err := env.Store.GetMessage(initialID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Equal("Sent subject", message.Subject)
+	assert.Equal("final-sender@example.com", message.FromEmail)
+	assert.Equal([]string{"Final Recipient <final-recipient@example.com>"}, message.To)
+	assert.Equal([]string{"Final Copy <final-copy@example.com>"}, message.Cc)
+	assert.Contains(message.BodyText, "finalword")
+	assert.NotContains(message.BodyText, "draftword")
+	assert.Contains(message.BodyHTML, "htmlfinal")
+	assert.Empty(message.Snippet)
+	assert.Equal(int64(len(sentRaw)), message.SizeEstimate)
+	assert.ElementsMatch([]string{"Envoyes"}, message.Labels)
+	raw, err := env.Store.GetMessageRaw(initialID)
+	require.NoError(err)
+	assert.Equal(sentRaw, raw)
+	assertMessageCount(t, env.Store, 1)
+	results, total, err := env.Store.SearchMessagesQuery(
+		&search.Query{TextTerms: []string{"finalword"}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(initialID, results[0].ID)
+	_, total, err = env.Store.SearchMessagesQuery(
+		&search.Query{TextTerms: []string{"draftword"}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total)
+
+	thirdClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(thirdClient, env.Store, opts)
+	summary = runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+	})
+	message, err = env.Store.GetMessage(initialID)
+	require.NoError(err)
+	assert.Contains(message.BodyText, "finalword")
+	assertMessageCount(t, env.Store, 1)
+	require.NoError(thirdClient.Close())
+}
+
+func TestIMAPPartialRelocationMergesLabelsAndRefreshesContent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	const messageID = "partial-relocation@example.com"
+	draftRaw := testemail.NewMessage().
+		Subject("Partial draft").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").CRLF().Bytes()
+	finalRaw := testemail.NewMessage().
+		Subject("Partial final").
+		Header("Message-ID", "<"+messageID+">").
+		Body("finalword").CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"Envoyes": {imapv2.MailboxAttrSent}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+	source, err := env.Store.GetSourceByIdentifier(testEmail)
+	require.NoError(err)
+	archiveLabelID, err := env.Store.EnsureLabel(source.ID, "Archive", "Archive", "user")
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(
+		`INSERT INTO message_labels (message_id, label_id) VALUES (?, ?)`,
+		internalID, archiveLabelID)
+	require.NoError(err)
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", finalRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	opts.Limit = 1
+	partialClient := newSyncTestIMAPClient(
+		t, addr,
+		imapclient.WithFolderFilter([]string{"Brouillons", "Envoyes"}, nil),
+	)
+	env.Syncer = New(partialClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
+	})
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Equal("Partial final", message.Subject)
+	assert.Contains(message.BodyText, "finalword")
+	assert.ElementsMatch([]string{"Archive", "Brouillons", "Envoyes"}, message.Labels)
+	require.NoError(partialClient.Close())
+}
+
+func TestIMAPDeferredRelocationPreservesLabelsUntilFinalization(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	const messageID = "deferred-relocation@example.com"
+	draftRaw := testemail.NewMessage().
+		Subject("Deferred draft").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").CRLF().Bytes()
+	finalRaw := testemail.NewMessage().
+		Subject("Deferred final").
+		Header("Message-ID", "<"+messageID+">").
+		Body("finalword").CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"Envoyes": {imapv2.MailboxAttrSent}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newDeferredLabelIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", finalRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	secondClient := newDeferredLabelIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
+	})
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, "finalword")
+	assert.ElementsMatch([]string{"Brouillons"}, message.Labels,
+		"Syncer leaves labels untouched until the command-layer mailbox delta transaction")
+	require.NoError(secondClient.Close())
+}
+
+// Preferred \All adoption rekeys the canonical location but must not replace
+// the archived snapshot: \All placement holds received mail too, so a forged
+// same-Message-ID copy mirrored there carries no provider-authored evidence.
+// The rekey still adopts the stable canonical ID and keeps every attachment.
+func TestIMAPPreferredAllMailAdoptionPreservesSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = filepath.Join(env.TmpDir, "attachments")
+	const messageID = "preferred-relocation@example.com"
+	draftRaw := testemail.NewMessage().
+		Subject("Preferred draft").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").
+		WithAttachment("old.bin", "application/octet-stream", []byte("old bytes")).
+		CRLF().Bytes()
+	finalRaw := testemail.NewMessage().
+		From("Final Sender <final@example.com>").
+		To("Final Recipient <recipient@example.com>").
+		Subject("Preferred final").
+		Header("Message-ID", "<"+messageID+">").
+		Body("finalword").
+		CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"All Mail": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"All Mail": {imapv2.MailboxAttrAll}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "INBOX", draftRaw)
+	firstClient := newSyncTestIMAPClient(
+		t, addr, imapclient.WithFolderFilter([]string{"INBOX"}, nil))
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "INBOX|1",
+	).Scan(&internalID))
+	require.NoError(env.Store.UpsertAttachmentRecord(t.Context(), internalID, store.AttachmentWrite{
+		Filename: "provider.bin", MIMEType: "application/octet-stream",
+		StoragePath: "provider.bin", ContentHash: "provider-hash", Size: 8,
+		SourceAttachmentID: "provider:1", SourcePartKey: "provider:part:1",
+		Role: store.AttachmentRoleStandalone, RoleSource: store.AttachmentRoleSourceProviderExplicit,
+	}))
+	require.NoError(env.Store.RecomputeMessageAttachmentStats(internalID))
+
+	testutil.AppendIMAPRawMessage(t, user, "All Mail", finalRaw)
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
+	})
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("All Mail|1", message.SourceMessageID)
+	assert.Equal("Preferred draft", message.Subject)
+	assert.Contains(message.BodyText, "draftword")
+	assert.NotContains(message.BodyText, "finalword")
+	assert.NotEqual("final@example.com", message.FromEmail)
+	raw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(draftRaw, raw)
+	assert.ElementsMatch([]string{"All Mail", "INBOX"}, message.Labels)
+	require.Len(message.Attachments, 2)
+	filenames := []string{message.Attachments[0].Filename, message.Attachments[1].Filename}
+	assert.ElementsMatch([]string{"old.bin", "provider.bin"}, filenames)
+	assert.True(message.HasAttachments)
+	var providerCount int
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE message_id = ? AND source_attachment_id = ?`,
+		internalID, "provider:1",
+	).Scan(&providerCount))
+	assert.Equal(1, providerCount)
+	results, total, err := env.Store.SearchMessagesQuery(
+		&search.Query{TextTerms: []string{"draftword"}}, 0, 10)
+	require.NoError(err)
+	assert.Equal(int64(1), total)
+	require.Len(results, 1)
+	assert.Equal(internalID, results[0].ID)
+	_, total, err = env.Store.SearchMessagesQuery(
+		&search.Query{TextTerms: []string{"finalword"}}, 0, 10)
+	require.NoError(err)
+	assert.Zero(total, "the unverified copy must not reach the search index")
+	var attachmentCount int
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT attachment_count FROM messages WHERE id = ?`, internalID,
+	).Scan(&attachmentCount))
+	assert.Equal(2, attachmentCount)
+	require.NoError(secondClient.Close())
+}
+
+func TestIMAPRelocationSQLFailureRetainsSnapshotAndRetries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	testutil.SkipIfPostgres(t, "uses a SQLite trigger to inject relocation failure")
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = filepath.Join(env.TmpDir, "attachments")
+	const messageID = "retry-relocation@example.com"
+	draftRaw := testemail.NewMessage().Subject("Retry draft").
+		Header("Message-ID", "<"+messageID+">").Body("draftword").CRLF().Bytes()
+	finalRaw := testemail.NewMessage().Subject("Retry final").
+		Header("Message-ID", "<"+messageID+">").Body("finalword").
+		WithAttachment("retry.bin", "application/octet-stream", []byte("retry bytes")).
+		CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"Envoyes": {imapv2.MailboxAttrSent}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+	before, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	beforeRaw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	parsedFinal, err := mime.Parse(finalRaw)
+	require.NoError(err)
+	require.Len(parsedFinal.Attachments, 1)
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", finalRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	_, err = env.Store.DB().Exec(fmt.Sprintf(`
+		CREATE TRIGGER fail_imap_relocation
+		BEFORE UPDATE ON messages
+		WHEN OLD.id = %d AND NEW.source_message_id = 'Envoyes|1'
+		BEGIN
+			SELECT RAISE(ABORT, 'relocation unavailable');
+		END`, internalID))
+	require.NoError(err)
+	t.Cleanup(func() { _, _ = env.Store.DB().Exec(`DROP TRIGGER IF EXISTS fail_imap_relocation`) })
+
+	acknowledged := make(map[string]imapclient.FolderState)
+	failedClient := newSyncTestIMAPClient(t, addr, imapclient.WithFolderStateSave(
+		func(mailbox string, state imapclient.FolderState) { acknowledged[mailbox] = state },
+	))
+	env.Syncer = New(failedClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{
+		Added: new(int64(0)), Updated: new(int64(0)), Errors: new(int64(1)),
+	})
+	afterFailure, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	afterFailureRaw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(before.SourceMessageID, afterFailure.SourceMessageID)
+	assert.Equal(before.Subject, afterFailure.Subject)
+	assert.Equal(before.BodyText, afterFailure.BodyText)
+	assert.Equal(before.Labels, afterFailure.Labels)
+	assert.Equal(beforeRaw, afterFailureRaw)
+	assert.NotContains(acknowledged, "Envoyes")
+	blobPath := filepath.Join(
+		opts.AttachmentsDir,
+		parsedFinal.Attachments[0].ContentHash[:2],
+		parsedFinal.Attachments[0].ContentHash,
+	)
+	assert.FileExists(blobPath, "failed relocation retains a published CAS blob")
+	require.NoError(failedClient.Close())
+
+	_, err = env.Store.DB().Exec(`DROP TRIGGER fail_imap_relocation`)
+	require.NoError(err)
+	retryClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(retryClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
+	})
+	afterRetry, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", afterRetry.SourceMessageID)
+	assert.Equal("Retry final", afterRetry.Subject)
+	assert.Contains(afterRetry.BodyText, "finalword")
+	require.NoError(retryClient.Close())
+}
+
+func TestIMAPRelocationStrictParseFailurePreservesOldSnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	const messageID = "invalid-relocation@example.com"
+	draftRaw := testemail.NewMessage().Subject("Valid draft").
+		Header("Message-ID", "<"+messageID+">").Body("draftword").CRLF().Bytes()
+	invalidRaw := []byte(
+		"From: invalid-final@example.com\r\nTo: invalid-recipient@example.com\r\n" +
+			"Subject: Invalid final\r\nMessage-ID: <" + messageID + ">\r\n" +
+			"MIME-Version: 1.0\r\nContent-Type: multipart mixed; boundary=outer\r\n\r\n" +
+			"--outer\r\nContent-Type: text/plain\r\n\r\nfinalword\r\n--outer--\r\n")
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"Envoyes": {imapv2.MailboxAttrSent}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+	var participantsBefore int
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM participants`,
+	).Scan(&participantsBefore))
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", invalidRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(0)), Errors: new(int64(1)),
+	})
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Brouillons|1", message.SourceMessageID)
+	assert.Equal("Valid draft", message.Subject)
+	assert.Contains(message.BodyText, "draftword")
+	raw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(draftRaw, raw)
+	var participantsAfter int
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT COUNT(*) FROM participants`,
+	).Scan(&participantsAfter))
+	assert.Equal(participantsBefore, participantsAfter,
+		"strict relocation failure must not resolve prepared participants")
+	require.NoError(secondClient.Close())
+}
+
+func TestIMAPRelocationWithoutAttachmentsDirPreservesSnapshotAndRetries(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = ""
+	const messageID = "attachment-failure-relocation@example.com"
+	draftRaw := testemail.NewMessage().Subject("Attachment draft").
+		Header("Message-ID", "<"+messageID+">").Body("draftword").CRLF().Bytes()
+	finalRaw := testemail.NewMessage().Subject("Attachment final").
+		Header("Message-ID", "<"+messageID+">").Body("finalword").
+		WithAttachment("final.bin", "application/octet-stream", []byte("final bytes")).
+		CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"Envoyes": {imapv2.MailboxAttrSent}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", finalRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	acknowledged := make(map[string]imapclient.FolderState)
+	secondClient := newSyncTestIMAPClient(t, addr, imapclient.WithFolderStateSave(
+		func(mailbox string, state imapclient.FolderState) { acknowledged[mailbox] = state },
+	))
+	env.Syncer = New(secondClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(0)), Errors: new(int64(1)),
+	})
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Brouillons|1", message.SourceMessageID)
+	assert.Equal("Attachment draft", message.Subject)
+	assert.Contains(message.BodyText, "draftword")
+	raw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(draftRaw, raw)
+	assert.NotContains(acknowledged, "Envoyes")
+	require.NoError(secondClient.Close())
+
+	opts.AttachmentsDir = filepath.Join(env.TmpDir, "attachments")
+	retryClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(retryClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
+	})
+	afterRetry, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", afterRetry.SourceMessageID)
+	assert.Equal("Attachment final", afterRetry.Subject)
+	assert.Contains(afterRetry.BodyText, "finalword")
+	require.Len(afterRetry.Attachments, 1)
+	assert.Equal("final.bin", afterRetry.Attachments[0].Filename)
+	afterRetryRaw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(finalRaw, afterRetryRaw)
+	require.NoError(retryClient.Close())
+}
+
+// A relocated snapshot's refreshed HTML must go through the same remote-image
+// archival hook as ordinary ingest, so an edited copy that gains tracked image
+// URLs archives them under the retained internal ID.
+func TestIMAPRelocationArchivesRemoteImages(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nsynthetic"))
+	}))
+	defer upstream.Close()
+	fetcher := remoteimage.NewFetcher()
+	fetcher.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	fetcher.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+	}
+
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = t.TempDir()
+	opts.RemoteImages = fetcher
+
+	const messageID = "remote-image-relocation@example.com"
+	draftRaw := testemail.NewMessage().
+		Subject("Draft subject").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").
+		CRLF().
+		Bytes()
+	sentRaw := alternativeRelocationRaw(
+		messageID,
+		"Sent subject",
+		"Final Sender <final-sender@example.com>",
+		"Final Recipient <final-recipient@example.com>",
+		"Final Copy <final-copy@example.com>",
+		"finalword",
+		"<p>htmlfinal <img src=\"http://images.example/chart\"></p>",
+	)
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"Brouillons": 0, "Envoyes": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{
+			"Brouillons": {imapv2.MailboxAttrDrafts},
+			"Envoyes":    {imapv2.MailboxAttrSent},
+		},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+	refs, err := env.Store.MessageRemoteImages(internalID)
+	require.NoError(err)
+	assert.Empty(refs, "draft without tracked images archives nothing")
+	assert.Zero(requests.Load())
+
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", sentRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(1)),
+	})
+	require.NoError(secondClient.Close())
+
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Contains(message.BodyHTML, "images.example/chart")
+	refs, err = env.Store.MessageRemoteImages(internalID)
+	require.NoError(err)
+	digest := sha256.Sum256([]byte("http://images.example/chart"))
+	key := "remote-image:" + hex.EncodeToString(digest[:])
+	_, archived := refs[key]
+	assert.True(archived, "relocated snapshot archives its remote image")
+	assert.Equal(int64(1), requests.Load())
+
+	thirdClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(thirdClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{
+		Added:   new(int64(0)),
+		Updated: new(int64(0)),
+	})
+	require.NoError(thirdClient.Close())
+	refs, err = env.Store.MessageRemoteImages(internalID)
+	require.NoError(err)
+	assert.Len(refs, 1)
+	assert.Equal(int64(1), requests.Load(), "repeat sync must not refetch the archived image")
+}
+
+// An untrusted destination adopts only the location: the rejected survivor's
+// HTML must not reach the remote-image fetcher, because processing bytes a
+// sender controls would leak requests to sender-chosen servers.
+func TestIMAPRelocationUntrustedDestinationSkipsRemoteImages(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var requests atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("\x89PNG\r\n\x1a\nsynthetic"))
+	}))
+	defer upstream.Close()
+	fetcher := remoteimage.NewFetcher()
+	fetcher.LookupNetIP = func(context.Context, string) ([]netip.Addr, error) {
+		return []netip.Addr{netip.MustParseAddr("93.184.216.34")}, nil
+	}
+	fetcher.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, strings.TrimPrefix(upstream.URL, "http://"))
+	}
+
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = t.TempDir()
+	opts.RemoteImages = fetcher
+
+	const messageID = "untrusted-remote-images@example.com"
+	// No special-use advertisement: the survivor's placement is untrusted.
+	addr, user := testutil.StartIMAPMemServer(t, map[string]int{
+		"Brouillons": 0, "Envoyes": 0, "INBOX": 0,
+	})
+	draftRaw := testemail.NewMessage().
+		Subject("Untrusted draft").
+		Header("Message-ID", "<"+messageID+">").
+		Body("draftword").CRLF().Bytes()
+	testutil.AppendIMAPRawMessage(t, user, "Brouillons", draftRaw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
+	).Scan(&internalID))
+
+	finalRaw := alternativeRelocationRaw(
+		messageID,
+		"Untrusted final",
+		"Final Sender <final-sender@example.com>",
+		"Final Recipient <final-recipient@example.com>",
+		"Final Copy <final-copy@example.com>",
+		"finalword",
+		"<p>htmlfinal <img src=\"http://images.example/chart\"></p>",
+	)
+	testutil.AppendIMAPRawMessage(t, user, "Envoyes", finalRaw)
+	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
+	secondClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(secondClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Errors: new(int64(0))})
+	require.NoError(secondClient.Close())
+
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Contains(message.BodyText, "draftword", "the snapshot is preserved")
+	assert.NotContains(message.BodyText, "finalword")
+	raw, err := env.Store.GetMessageRaw(internalID)
+	require.NoError(err)
+	assert.Equal(draftRaw, raw)
+	refs, err := env.Store.MessageRemoteImages(internalID)
+	require.NoError(err)
+	assert.Empty(refs, "rejected bytes must not reach remote-image processing")
+	assert.Zero(requests.Load())
+}
+
+// A preferred adoption whose label reconciliation fails late must keep the
+// old composite key: the rekey and the label write share one guarded
+// transaction, so a failing or canceled label step rolls the adoption back
+// instead of consuming the key the next retry needs.
+func TestIMAPPreferredAdoptionKeepsOldKeyOnLabelFailure(t *testing.T) {
+	testutil.SkipIfPostgres(t, "uses a SQLite trigger to fail the label write")
+	assert := assert.New(t)
+	require := require.New(t)
+	env := newTestEnv(t)
+	opts := DefaultOptions()
+	opts.SourceType = sourceTypeIMAP
+
+	const messageID = "preferred-atomic@example.com"
+	raw := testemail.NewMessage().
+		Subject("Atomic preferred").
+		Header("Message-ID", "<"+messageID+">").
+		Body("atomicword").CRLF().Bytes()
+	addr, user := testutil.StartIMAPMemServerWithSpecialUse(
+		t,
+		map[string]int{"All Mail": 0, "INBOX": 0},
+		map[string][]imapv2.MailboxAttr{"All Mail": {imapv2.MailboxAttrAll}},
+	)
+	testutil.AppendIMAPRawMessage(t, user, "INBOX", raw)
+	firstClient := newSyncTestIMAPClient(t, addr)
+	env.Syncer = New(firstClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Added: new(int64(1))})
+	require.NoError(firstClient.Close())
+	var internalID int64
+	require.NoError(env.Store.DB().QueryRow(
+		`SELECT id FROM messages WHERE source_message_id = ?`, "INBOX|1",
+	).Scan(&internalID))
+
+	// The immediate-label client runs the preferred adoption's label step in
+	// the same call as the rekey; the trigger fails every label write for the
+	// guarded row.
+	testutil.AppendIMAPRawMessage(t, user, "All Mail", raw)
+	_, triggerErr := env.Store.DB().Exec(fmt.Sprintf(`
+		CREATE TRIGGER fail_preferred_labels_insert
+		BEFORE INSERT ON message_labels
+		WHEN NEW.message_id = %d
+		BEGIN
+			SELECT RAISE(ABORT, 'preferred label write unavailable');
+		END`, internalID))
+	require.NoError(triggerErr)
+	_, triggerErr = env.Store.DB().Exec(fmt.Sprintf(`
+		CREATE TRIGGER fail_preferred_labels_delete
+		BEFORE DELETE ON message_labels
+		WHEN OLD.message_id = %d
+		BEGIN
+			SELECT RAISE(ABORT, 'preferred label write unavailable');
+		END`, internalID))
+	require.NoError(triggerErr)
+	t.Cleanup(func() {
+		_, _ = env.Store.DB().Exec(`DROP TRIGGER IF EXISTS fail_preferred_labels_insert`)
+		_, _ = env.Store.DB().Exec(`DROP TRIGGER IF EXISTS fail_preferred_labels_delete`)
+	})
+
+	immediateClient := &immediateLabelIMAPClient{Client: newSyncTestIMAPClient(t, addr).Client}
+	env.Syncer = New(immediateClient, env.Store, opts)
+	summary := runFullSync(t, env)
+	assertSummary(t, summary, WantSummary{Errors: new(int64(1))})
+
+	message, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("INBOX|1", message.SourceMessageID,
+		"a failed preferred adoption must not consume the old composite key")
+	assert.Equal([]string{"INBOX"}, message.Labels,
+		"a failed preferred adoption must not mutate labels")
+	assert.Contains(message.BodyText, "atomicword")
+
+	// Removing the fault lets the retry adopt key and labels together.
+	_, err = env.Store.DB().Exec(`DROP TRIGGER fail_preferred_labels_insert`)
+	require.NoError(err)
+	_, err = env.Store.DB().Exec(`DROP TRIGGER fail_preferred_labels_delete`)
+	require.NoError(err)
+	retryClient := &immediateLabelIMAPClient{Client: newSyncTestIMAPClient(t, addr).Client}
+	env.Syncer = New(retryClient, env.Store, opts)
+	assertSummary(t, runFullSync(t, env), WantSummary{Errors: new(int64(0))})
+	message, err = env.Store.GetMessage(internalID)
+	require.NoError(err)
+	assert.Equal("All Mail|1", message.SourceMessageID)
+	assert.ElementsMatch([]string{"All Mail", "INBOX"}, message.Labels)
+}

--- a/internal/sync/imap_relocation_test.go
+++ b/internal/sync/imap_relocation_test.go
@@ -448,15 +448,17 @@ func TestIMAPRelocationSQLFailureRetainsSnapshotAndRetries(t *testing.T) {
 	require.NoError(retryClient.Close())
 }
 
-func TestIMAPRelocationStrictParseFailurePreservesOldSnapshot(t *testing.T) {
+func TestIMAPRelocationRecoversMalformedSentSnapshot(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	env := newTestEnv(t)
 	opts := DefaultOptions()
 	opts.SourceType = sourceTypeIMAP
+	opts.AttachmentsDir = filepath.Join(env.TmpDir, "attachments")
 	const messageID = "invalid-relocation@example.com"
 	draftRaw := testemail.NewMessage().Subject("Valid draft").
-		Header("Message-ID", "<"+messageID+">").Body("draftword").CRLF().Bytes()
+		Header("Message-ID", "<"+messageID+">").Body("draftword").
+		WithAttachment("draft.bin", "application/octet-stream", []byte("draft attachment")).CRLF().Bytes()
 	invalidRaw := []byte(
 		"From: invalid-final@example.com\r\nTo: invalid-recipient@example.com\r\n" +
 			"Subject: Invalid final\r\nMessage-ID: <" + messageID + ">\r\n" +
@@ -476,31 +478,26 @@ func TestIMAPRelocationStrictParseFailurePreservesOldSnapshot(t *testing.T) {
 	require.NoError(env.Store.DB().QueryRow(
 		`SELECT id FROM messages WHERE source_message_id = ?`, "Brouillons|1",
 	).Scan(&internalID))
-	var participantsBefore int
-	require.NoError(env.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM participants`,
-	).Scan(&participantsBefore))
+	before, err := env.Store.GetMessage(internalID)
+	require.NoError(err)
+	require.Len(before.Attachments, 1)
 	testutil.AppendIMAPRawMessage(t, user, "Envoyes", invalidRaw)
 	testutil.ExpungeIMAPMessage(t, addr, "Brouillons", imapv2.UID(1))
 	secondClient := newSyncTestIMAPClient(t, addr)
 	env.Syncer = New(secondClient, env.Store, opts)
 	assertSummary(t, runFullSync(t, env), WantSummary{
-		Added: new(int64(0)), Updated: new(int64(0)), Errors: new(int64(1)),
+		Added: new(int64(0)), Updated: new(int64(1)), Errors: new(int64(0)),
 	})
 	message, err := env.Store.GetMessage(internalID)
 	require.NoError(err)
-	assert.Equal("Brouillons|1", message.SourceMessageID)
-	assert.Equal("Valid draft", message.Subject)
-	assert.Contains(message.BodyText, "draftword")
+	assert.Equal("Envoyes|1", message.SourceMessageID)
+	assert.Equal("Invalid final", message.Subject)
+	assert.Contains(message.BodyText, "MIME parsing failed")
+	assert.NotContains(message.BodyText, "draftword")
+	assert.Empty(message.Attachments)
 	raw, err := env.Store.GetMessageRaw(internalID)
 	require.NoError(err)
-	assert.Equal(draftRaw, raw)
-	var participantsAfter int
-	require.NoError(env.Store.DB().QueryRow(
-		`SELECT COUNT(*) FROM participants`,
-	).Scan(&participantsAfter))
-	assert.Equal(participantsBefore, participantsAfter,
-		"strict relocation failure must not resolve prepared participants")
+	assert.Equal(invalidRaw, raw)
 	require.NoError(secondClient.Close())
 }
 

--- a/internal/sync/prepared_snapshot.go
+++ b/internal/sync/prepared_snapshot.go
@@ -1,0 +1,85 @@
+package sync
+
+import (
+	"database/sql"
+	"sort"
+
+	"go.kenn.io/msgvault/internal/mime"
+	"go.kenn.io/msgvault/internal/store"
+)
+
+func preparedMessageParticipants(data *messageData) ([]store.ParticipantPersistData, map[string]int) {
+	byEmail := make(map[string]mime.Address)
+	for _, addresses := range [][]mime.Address{data.from, data.to, data.cc, data.bcc} {
+		for _, address := range addresses {
+			if address.Email != "" {
+				if _, exists := byEmail[address.Email]; !exists {
+					byEmail[address.Email] = address
+				}
+			}
+		}
+	}
+	emails := make([]string, 0, len(byEmail))
+	for email := range byEmail {
+		emails = append(emails, email)
+	}
+	sort.Strings(emails)
+	participants := make([]store.ParticipantPersistData, len(emails))
+	index := make(map[string]int, len(emails))
+	for i, email := range emails {
+		address := byEmail[email]
+		participants[i] = store.ParticipantPersistData{
+			EmailAddress: email, DisplayName: address.Name, Domain: address.Domain,
+		}
+		index[email] = i
+	}
+	return participants, index
+}
+
+func buildPreparedSnapshot(
+	prepared *messageData,
+	participantIndex map[string]int,
+	participantIDs []int64,
+	attachmentWrites []store.AttachmentWrite,
+) *store.MessagePersistData {
+	participantMap := make(map[string]int64, len(participantIndex))
+	for email, index := range participantIndex {
+		participantMap[email] = participantIDs[index]
+	}
+	message := *prepared.message
+	if len(prepared.from) > 0 && prepared.from[0].Email != "" {
+		if senderID, ok := participantMap[prepared.from[0].Email]; ok {
+			message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
+		}
+	}
+
+	return &store.MessagePersistData{
+		Message: &message,
+		Conversation: &store.ConversationPersistData{
+			SourceConversationID: prepared.threadID,
+			ConversationType:     prepared.conversationType,
+			Title:                prepared.conversationTitle,
+		},
+		BodyText: sql.NullString{
+			String: prepared.bodyText, Valid: prepared.bodyText != "",
+		},
+		BodyHTML: sql.NullString{
+			String: prepared.bodyHTML, Valid: prepared.bodyHTML != "",
+		},
+		RawMIME: prepared.rawMIME,
+		Recipients: []store.RecipientSet{
+			buildRecipientSet("from", prepared.from, participantMap),
+			buildRecipientSet("to", prepared.to, participantMap),
+			buildRecipientSet("cc", prepared.cc, participantMap),
+			buildRecipientSet("bcc", prepared.bcc, participantMap),
+		},
+		MIMEAttachmentReplacement: &attachmentWrites,
+		FTS: &store.FTSDoc{
+			Subject:  message.Subject.String,
+			Body:     prepared.bodyText,
+			FromAddr: joinEmails(prepared.from),
+			ToAddrs:  joinEmails(prepared.to),
+			CcAddrs:  joinEmails(prepared.cc),
+		},
+	}
+}

--- a/internal/sync/prepared_snapshot.go
+++ b/internal/sync/prepared_snapshot.go
@@ -54,7 +54,8 @@ func buildPreparedSnapshot(
 	}
 
 	return &store.MessagePersistData{
-		Message: &message,
+		Message:  &message,
+		Metadata: prepared.metadata,
 		Conversation: &store.ConversationPersistData{
 			SourceConversationID: prepared.threadID,
 			ConversationType:     prepared.conversationType,

--- a/internal/sync/repair.go
+++ b/internal/sync/repair.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"sort"
@@ -10,7 +9,6 @@ import (
 
 	"go.kenn.io/msgvault/internal/export"
 	"go.kenn.io/msgvault/internal/gmail"
-	"go.kenn.io/msgvault/internal/mime"
 	"go.kenn.io/msgvault/internal/store"
 )
 
@@ -96,8 +94,7 @@ func (s *Syncer) RepairMessage(ctx context.Context, request RepairRequest) (_ *R
 	if err != nil {
 		return nil, err
 	}
-	attachmentWrites := make([]store.AttachmentWrite, 0, len(prepared.attachments))
-	createdAttachments := make(map[string]export.DurableAttachmentReceipt)
+	var createdAttachments map[string]export.DurableAttachmentReceipt
 	defer func() {
 		if repairErr == nil || len(createdAttachments) == 0 {
 			return
@@ -106,77 +103,23 @@ func (s *Syncer) RepairMessage(ctx context.Context, request RepairRequest) (_ *R
 			repairErr = errors.Join(repairErr, fmt.Errorf("clean up repair attachments: %w", err))
 		}
 	}()
-	for i := range prepared.attachments {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		attachment := &prepared.attachments[i]
-		if s.opts.AttachmentsDir == "" {
-			return nil, fmt.Errorf("publish attachment %q: attachments directory is required", attachment.Filename)
-		}
-		receipt, err := export.StoreAttachmentFileDurable(s.opts.AttachmentsDir, attachment)
-		if receipt.Created {
-			createdAttachments[receipt.StoragePath] = receipt
-		}
-		if err != nil {
-			return nil, fmt.Errorf("publish attachment %q: %w", attachment.Filename, err)
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		role, roleSource := store.AttachmentRoleFromMIME(
-			attachment.Disposition, attachment.IsInline, attachment.ContentID,
-		)
-		attachmentWrites = append(attachmentWrites, store.AttachmentWrite{
-			Filename: attachment.Filename, MIMEType: attachment.ContentType,
-			StoragePath: receipt.StoragePath, ContentHash: attachment.ContentHash,
-			Size: int64(len(attachment.Content)), Role: role, RoleSource: roleSource,
-			SourcePartKey: attachment.PartKey, ContentID: attachment.ContentID,
-		})
+	attachmentWrites, createdAttachments, err := s.publishMIMEAttachments(
+		ctx, prepared.attachments)
+	if err != nil {
+		return nil, err
 	}
 
-	participants, participantIndex := repairParticipants(prepared)
+	participants, participantIndex := preparedMessageParticipants(prepared)
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	guard := target.MessageIdentityGuard
 	messageID, err := s.store.PersistRepairMessageWithParticipantsContext(
 		ctx, guard, participants, func(participantIDs []int64) *store.MessagePersistData {
-			participantMap := make(map[string]int64, len(participantIndex))
-			for email, index := range participantIndex {
-				participantMap[email] = participantIDs[index]
-			}
-			message := *prepared.message
-			if len(prepared.from) > 0 && prepared.from[0].Email != "" {
-				if senderID, ok := participantMap[prepared.from[0].Email]; ok {
-					message.SenderID = sql.NullInt64{Int64: senderID, Valid: true}
-				}
-			}
-			recipients := []store.RecipientSet{
-				buildRecipientSet("from", prepared.from, participantMap),
-				buildRecipientSet("to", prepared.to, participantMap),
-				buildRecipientSet("cc", prepared.cc, participantMap),
-				buildRecipientSet("bcc", prepared.bcc, participantMap),
-			}
-			return &store.MessagePersistData{
-				Message: &message,
-				Conversation: &store.ConversationPersistData{
-					SourceConversationID: prepared.threadID,
-					ConversationType:     prepared.conversationType,
-					Title:                prepared.conversationTitle,
-				},
-				BodyText:                  sql.NullString{String: prepared.bodyText, Valid: prepared.bodyText != ""},
-				BodyHTML:                  sql.NullString{String: prepared.bodyHTML, Valid: prepared.bodyHTML != ""},
-				RawMIME:                   prepared.rawMIME,
-				Recipients:                recipients,
-				LabelRefs:                 labelRefs,
-				MIMEAttachmentReplacement: &attachmentWrites,
-				FTS: &store.FTSDoc{
-					Subject: message.Subject.String, Body: prepared.bodyText,
-					FromAddr: joinEmails(prepared.from), ToAddrs: joinEmails(prepared.to),
-					CcAddrs: joinEmails(prepared.cc),
-				},
-			}
+			persist := buildPreparedSnapshot(
+				prepared, participantIndex, participantIDs, attachmentWrites)
+			persist.LabelRefs = labelRefs
+			return persist
 		},
 	)
 	if err != nil {
@@ -215,34 +158,6 @@ func (s *Syncer) cleanupRepairAttachments(
 		}
 		return cleanupErr
 	})
-}
-
-func repairParticipants(data *messageData) ([]store.ParticipantPersistData, map[string]int) {
-	byEmail := make(map[string]mime.Address)
-	for _, addresses := range [][]mime.Address{data.from, data.to, data.cc, data.bcc} {
-		for _, address := range addresses {
-			if address.Email != "" {
-				if _, exists := byEmail[address.Email]; !exists {
-					byEmail[address.Email] = address
-				}
-			}
-		}
-	}
-	emails := make([]string, 0, len(byEmail))
-	for email := range byEmail {
-		emails = append(emails, email)
-	}
-	sort.Strings(emails)
-	participants := make([]store.ParticipantPersistData, len(emails))
-	index := make(map[string]int, len(emails))
-	for i, email := range emails {
-		address := byEmail[email]
-		participants[i] = store.ParticipantPersistData{
-			EmailAddress: email, DisplayName: address.Name, Domain: address.Domain,
-		}
-		index[email] = i
-	}
-	return participants, index
 }
 
 func repairLabelRefs(messageLabelIDs []string, labels []*gmail.Label) ([]store.MessageLabelRef, error) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -91,6 +91,11 @@ type Syncer struct {
 	opts               *Options
 	successfulHookName string
 	successfulHook     SuccessfulSyncHook
+
+	// failedRelocationGuards holds run-scoped protection for forced
+	// relocation targets that failed this run. It is set only on the scoped
+	// Syncer copy a single full() run uses and never persists.
+	failedRelocationGuards *failedRelocationGuards
 }
 
 // SuccessfulSyncHook runs after the durable sync run is marked complete.
@@ -123,12 +128,73 @@ type sourceMessageMatcher interface {
 	) (matches bool, conclusive bool, err error)
 }
 
+type messageRelocationTargetProvider interface {
+	MessageRelocationTarget(sourceMessageID string) (gmail.MessageRelocationTarget, bool)
+}
+
 type sourceMessageAliaser interface {
 	CanonicalSourceMessageID(sourceMessageID string) (string, bool)
 }
 
 type preferredIMAPSourceID interface {
 	IsPreferredSourceMessageID(messageID string) bool
+}
+
+// trustedOutgoingPlacement is implemented by clients whose production path
+// authenticates outgoing-mailbox placement.
+type trustedOutgoingPlacement interface {
+	// IsTrustedOutgoingMailbox reports whether the mailbox this composite
+	// source ID names is trusted to hold only mail the account itself
+	// authored: an unambiguous \Sent or \Drafts role advertised by the
+	// authenticated LIST response, or an explicit user configuration for
+	// servers without role discovery. RFC 6154 roles advise intent rather
+	// than prove authorship, so this is a scoped trust assumption — but
+	// sender-controlled headers can never produce it.
+	IsTrustedOutgoingMailbox(messageID string) bool
+}
+
+// sentPrecedencePlacement is implemented by clients that can distinguish a
+// Sent placement from a Drafts placement. Both are trusted outgoing
+// placements, but a Sent copy is the account's own final form of a message
+// while a surviving Drafts copy is usually its earlier draft.
+type sentPrecedencePlacement interface {
+	// IsSentPlacementMailbox reports whether the mailbox this composite
+	// source ID names is a Sent placement (unambiguous advertised \Sent or
+	// the explicitly configured Sent folder).
+	IsSentPlacementMailbox(messageID string) bool
+	// IsDraftsPlacementMailbox reports whether the mailbox this composite
+	// source ID names is a Drafts placement and nothing stronger.
+	IsDraftsPlacementMailbox(messageID string) bool
+}
+
+// relocationSentOverDrafts reports whether the fetched copy at
+// destinationSourceMessageID is a Sent placement whose current canonical
+// location is only a Drafts placement. This is the one trusted-over-trusted
+// precedence: an edited Sent copy refreshes a stale archived draft even
+// while the old Drafts copy still exists. It never grants anything to
+// received placements, never lets one Sent placement outrank another, and
+// never lets a Drafts placement outrank anything.
+func (s *Syncer) relocationSentOverDrafts(
+	destinationSourceMessageID, canonicalSourceMessageID string,
+) bool {
+	precedence, ok := s.client.(sentPrecedencePlacement)
+	return ok &&
+		precedence.IsSentPlacementMailbox(destinationSourceMessageID) &&
+		precedence.IsDraftsPlacementMailbox(canonicalSourceMessageID)
+}
+
+// relocationContentAuthorized reports whether replacing an archived snapshot
+// with content fetched from destinationSourceMessageID is backed by trusted
+// outgoing placement. RFC822 Message-ID equality never authorizes replacement
+// on its own: the header is sender-controlled, so an incoming message with a
+// forged Message-ID must only rekey the location and reconcile labels while
+// the canonical snapshot is preserved. Absent, unauthenticated, ambiguous,
+// or non-placement evidence denies the refresh.
+func (s *Syncer) relocationContentAuthorized(
+	destinationSourceMessageID string,
+) bool {
+	placement, ok := s.client.(trustedOutgoingPlacement)
+	return ok && placement.IsTrustedOutgoingMailbox(destinationSourceMessageID)
 }
 
 type fetchedSourceMessageMatcher interface {
@@ -560,7 +626,84 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 	}
 	result.sourceMessageIDs = messageIDs
 
-	// Check which messages already exist
+	result.processed = int64(len(messageIDs))
+
+	// Relocate exact targets before ordinary routing can invalidate a reused
+	// composite ID. A failing target stays a retryable per-item failure whose
+	// old composite key and guarded row survive the run untouched, so ordinary
+	// messages (and later pages) keep flowing while the next attempt
+	// rediscovers the candidate through the retained key.
+	if s.opts.SourceType == sourceTypeIMAP {
+		if provider, ok := s.client.(messageRelocationTargetProvider); ok {
+			var forcedIDs, ordinaryIDs []string
+			targets := make(map[string]gmail.MessageRelocationTarget)
+			for _, id := range messageIDs {
+				if target, selected := provider.MessageRelocationTarget(id); selected {
+					forcedIDs = append(forcedIDs, id)
+					targets[id] = target
+				} else {
+					ordinaryIDs = append(ordinaryIDs, id)
+				}
+			}
+			if len(forcedIDs) > 0 {
+				rawMessages, err := s.getMessagesRawBatchWithDiagnostics(ctx, forcedIDs)
+				if err != nil {
+					for _, id := range forcedIDs {
+						s.recordSyncItem(syncID, id, syncItemPhaseFetch, store.SyncRunItemStatusError, syncItemKindBatchFetchError, err)
+					}
+					checkpoint.ErrorsCount += int64(len(forcedIDs))
+					return nil, fmt.Errorf("fetch IMAP relocation messages: %w", err)
+				}
+				for i, id := range forcedIDs {
+					if err := ctx.Err(); err != nil {
+						return nil, fmt.Errorf("relocate IMAP message %q: %w", id, err)
+					}
+					fetch := gmail.RawMessageBatchResult{Err: errRawBatchMissing}
+					if i < len(rawMessages) {
+						fetch = rawMessages[i]
+					}
+					phase, kind := syncItemPhaseIngest, syncItemKindIngestError
+					err := fetch.Err
+					if err != nil {
+						phase, kind = syncItemPhaseFetch, syncItemKindFetchError
+					} else {
+						err = s.relocateIMAPMessageToTarget(ctx, sourceID, targets[id], fetch.Message, threadIDs[id], labelMap)
+					}
+					if err != nil {
+						if fatalRelocationError(err) {
+							// Cancellation and sync-generation fencing
+							// invalidate the run itself; no further work can
+							// commit, so stop instead of deferring.
+							return nil, fmt.Errorf("relocate IMAP message %q: %w", id, err)
+						}
+						// A failed target stays a retryable per-item failure
+						// so unrelated mail keeps ingesting, but its old
+						// composite key and guarded row must survive this
+						// run untouched: the key is what rediscovers the
+						// candidate next attempt, and the run cannot commit
+						// topology while it reports errors. The target is
+						// not acknowledged.
+						s.recordSyncItem(syncID, id, phase, store.SyncRunItemStatusError, kind, err)
+						checkpoint.ErrorsCount++
+						s.guardFailedRelocation(targets[id])
+						s.logger.Warn("failed to relocate IMAP message; deferring target and continuing",
+							"id", id, "error", err)
+						continue
+					}
+					result.updated++
+					result.acknowledged = append(result.acknowledged, id)
+					summary.BytesDownloaded += int64(len(fetch.Message.Raw))
+				}
+				messageIDs = ordinaryIDs
+			}
+		}
+	}
+	if len(messageIDs) == 0 {
+		return result, nil
+	}
+
+	// Load ordinary metadata after relocation so reused IDs resolve against
+	// the newly committed archive identities.
 	lookupMessageIDs := append([]string(nil), messageIDs...)
 	aliases := make(map[string]string)
 	if s.opts.SourceType == sourceTypeIMAP {
@@ -597,6 +740,19 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 	var existingCount int
 	inconclusiveRefreshes := make(map[string]inconclusiveLabelRefresh)
 	for _, id := range messageIDs {
+		if existing, exists := existingMap[id]; exists &&
+			(s.relocationCompositeProtected(id) ||
+				s.relocationRowProtectedByID(existing.ID)) {
+			// A failed relocation target keeps its keys and row out of
+			// ordinary routing entirely: label refresh, preferred rekey
+			// through a saved alias, UID-reuse invalidation, and dedup-stub
+			// acknowledgement could each consume the old composite key or
+			// mutate the guarded row. Leave the item unacknowledged so the
+			// next attempt rediscovers it.
+			s.logger.Warn("deferring IMAP composite key of a failed relocation target",
+				"id", id)
+			continue
+		}
 		if _, exists := existingMap[id]; !exists {
 			fetchIDs = append(fetchIDs, id)
 			continue
@@ -613,7 +769,6 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 		fetchIDs = append(fetchIDs, id)
 	}
 
-	result.processed = int64(len(messageIDs))
 	result.skipped = int64(existingCount)
 
 	if len(labelRefreshIDs) > 0 {
@@ -704,6 +859,15 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 					continue
 				}
 				if !matches {
+					if s.relocationRowProtected(existing.ID, sourceMessageID) {
+						// The row is a failed relocation target: its old
+						// composite key is the provenance the next retry
+						// rediscovers the candidate with, so this run must not
+						// consume the key. Leave the item unacknowledged.
+						s.logger.Warn("deferring reused IMAP composite key of a failed relocation target",
+							"id", sourceMessageID)
+						continue
+					}
 					err := s.preserveReusedIMAPSource(
 						existing.ID, sourceMessageID)
 					if err != nil {
@@ -767,6 +931,7 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			pendingRefresh, needsRawComparison :=
 				inconclusiveRefreshes[sourceMessageID]
 			raw := fetch.Message
+
 			if raw == nil {
 				if kind, gone := messageGoneKind(fetch.Err); gone {
 					s.logger.Debug("skipping message deleted before fetch", "id", sourceMessageID)
@@ -803,6 +968,13 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 			// dedup skip (e.g. same message in All Mail and Trash).
 			// Distinct from []byte{} which is a genuine empty body.
 			if raw.Raw == nil {
+				if s.relocationCompositeProtected(sourceMessageID) {
+					// Never acknowledge a failed relocation target's key
+					// through a dedup stub.
+					s.logger.Warn("deferring IMAP composite key of a failed relocation target",
+						"id", sourceMessageID)
+					continue
+				}
 				if !alreadyExists {
 					result.skipped++
 				}
@@ -858,6 +1030,13 @@ func (s *Syncer) processBatch(ctx context.Context, syncID, sourceID int64, listR
 					continue
 				}
 
+				if s.relocationRowProtected(existing.ID, sourceMessageID) {
+					// Same protection as the label path: never consume the
+					// old composite key of a failed relocation target.
+					s.logger.Warn("deferring reused IMAP composite key of a failed relocation target",
+						"id", sourceMessageID)
+					continue
+				}
 				if err := s.preserveReusedIMAPSource(
 					existing.ID, sourceMessageID); err != nil {
 					s.logger.Warn("failed to preserve reused IMAP source ID",
@@ -1154,6 +1333,7 @@ func (s *Syncer) full(
 	}
 	scoped := *s
 	scoped.store = s.store.ScopedToSync(source.ID, state.syncID)
+	scoped.failedRelocationGuards = newFailedRelocationGuards()
 	s = &scoped
 	summary.SyncRunID = state.syncID
 	summary.WasResumed = state.wasResumed
@@ -1276,9 +1456,18 @@ func (s *Syncer) full(
 		// Report progress
 		s.progress.OnProgress(state.checkpoint.MessagesProcessed, state.checkpoint.MessagesAdded, result.skipped)
 
-		// Save checkpoint
+		// Save checkpoint. While relocation targets remain failed, the
+		// saved cursor stays empty. The resume query only picks up runs with
+		// a non-empty cursor_before, so the next attempt is a fresh full
+		// replan whose first page carries the forced targets ahead of any
+		// ordinary routing — the run-scoped guards cannot be lost across a
+		// resume boundary because there is none. Production IMAP syncs
+		// disable resume anyway (session-local page offsets).
 		pageToken = listResp.NextPageToken
 		state.checkpoint.PageToken = pageToken
+		if s.relocationGuardsActive() {
+			state.checkpoint.PageToken = ""
+		}
 		if err := s.store.UpdateSyncCheckpoint(state.syncID, state.checkpoint); err != nil {
 			s.logger.Warn("failed to save checkpoint", "error", err)
 		}
@@ -1422,13 +1611,9 @@ type messageData struct {
 	participantMap    map[string]int64
 }
 
-// parseToModel parses a raw Gmail message into a messageData struct.
-func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID string) (*messageData, error) {
-	data, err := s.prepareMessage(sourceID, raw, threadID, false)
-	if err != nil {
-		return nil, err
-	}
-
+// resolvePreparedMessage performs the store-mutating resolution needed by
+// ordinary ingest after pure MIME preparation and deduplication have finished.
+func (s *Syncer) resolvePreparedMessage(data *messageData) (*messageData, error) {
 	allAddresses := make([]mime.Address, 0, len(data.from)+len(data.to)+len(data.cc)+len(data.bcc))
 	allAddresses = append(allAddresses, data.from...)
 	allAddresses = append(allAddresses, data.to...)
@@ -1448,11 +1633,11 @@ func (s *Syncer) parseToModel(sourceID int64, raw *gmail.RawMessage, threadID st
 	var conversationID int64
 	if data.conversationType == conversationTypeChat {
 		conversationID, err = s.store.EnsureConversationWithType(
-			sourceID, data.threadID, data.conversationType, data.conversationTitle,
+			data.message.SourceID, data.threadID, data.conversationType, data.conversationTitle,
 		)
 	} else {
 		conversationID, err = s.store.EnsureConversation(
-			sourceID, data.threadID, data.conversationTitle,
+			data.message.SourceID, data.threadID, data.conversationTitle,
 		)
 	}
 	if err != nil {
@@ -1734,7 +1919,7 @@ func (s *Syncer) ingestMessage(
 	threadID string,
 	labelMap map[string]int64,
 ) (bool, error) {
-	data, err := s.parseToModel(sourceID, raw, threadID)
+	data, err := s.prepareMessage(sourceID, raw, threadID, false)
 	if err != nil {
 		return false, err
 	}
@@ -1764,6 +1949,13 @@ func (s *Syncer) ingestMessage(
 			oldSourceMessageID, err := s.store.GetMessageSourceID(existingID)
 			if err != nil {
 				return false, fmt.Errorf("get dedup source ID: %w", err)
+			}
+			if s.relocationRowProtectedByID(existingID) {
+				// A failed relocation target keeps its snapshot and identity
+				// this run; a duplicate copy reaching it through alias,
+				// composite, or RFC822 routing is deferred unacknowledged
+				// instead of mutating the guarded row.
+				return false, errDeferredIMAPIdentity
 			}
 			matches := false
 			conclusive := true
@@ -1795,6 +1987,54 @@ func (s *Syncer) ingestMessage(
 			}
 			complete := s.labelsSnapshotComplete()
 			if matches {
+				if complete && oldSourceMessageID != data.message.SourceMessageID {
+					if (s.relocationContentAuthorized(data.message.SourceMessageID) &&
+						!s.relocationContentAuthorized(oldSourceMessageID)) ||
+						s.relocationSentOverDrafts(data.message.SourceMessageID, oldSourceMessageID) {
+						// The fetched copy sits in a mailbox trusted to hold only the
+						// account's own outgoing mail, while the current canonical does
+						// not: base rekey semantics redirected it to a mirror or
+						// received copy (for example an untrusted \All adoption that
+						// ran first). Refresh from the outgoing copy so a genuine Sent
+						// edit is not stranded behind it. Separately, an edited Sent
+						// copy outranks a canonical that is only a Drafts placement —
+						// the surviving Drafts copy is the earlier draft the account
+						// already superseded. Every other trusted canonical (Sent or
+						// configured placement) defers to the vanished-source flow, so
+						// Sent never churns against Sent and Drafts never outranks
+						// anything.
+						expected := store.MessageIdentityGuard{
+							ID: existingID, SourceID: sourceID,
+							SourceMessageID: oldSourceMessageID,
+						}
+						err := s.relocateIMAPMessage(
+							ctx, expected, raw, threadID, labelMap,
+							complete, deferLabels,
+						)
+						return dedupMutationResult(
+							true, "refresh relocated IMAP message", err)
+					}
+					if preferred, ok := s.client.(preferredIMAPSourceID); ok &&
+						preferred.IsPreferredSourceMessageID(data.message.SourceMessageID) {
+						// The preferred copy sits where the provider also files
+						// received mail (\All or unadvertised), so its content is
+						// not trusted: adopt the stable canonical ID and keep the
+						// archived snapshot. Rekey and label reconciliation share
+						// one guarded transaction so a late failure or
+						// cancellation cannot consume the old composite key
+						// without the labels the adoption intended.
+						adopted, err := s.store.AdoptMessageSourceIDContext(
+							ctx,
+							existingID, oldSourceMessageID, data.message.SourceMessageID,
+							!deferLabels, labelIDs, complete)
+						if err != nil {
+							return false, fmt.Errorf(
+								"adopt preferred IMAP source ID: %w", err)
+						}
+						return dedupMutationResult(
+							adopted, "adopt preferred IMAP source ID", nil)
+					}
+				}
 				changed := false
 				if !deferLabels {
 					changed, err = s.store.ReconcileMessageLabels(
@@ -1804,26 +2044,25 @@ func (s *Syncer) ingestMessage(
 							"reconcile validated dedup labels: %w", err)
 					}
 				}
-				if complete && oldSourceMessageID != data.message.SourceMessageID {
-					if preferred, ok := s.client.(preferredIMAPSourceID); ok &&
-						preferred.IsPreferredSourceMessageID(data.message.SourceMessageID) {
-						rekeyed, err := s.store.RekeyMessageSourceID(
-							existingID, oldSourceMessageID, data.message.SourceMessageID)
-						if err != nil {
-							return false, fmt.Errorf(
-								"adopt preferred IMAP source ID: %w", err)
-						}
-						if !rekeyed {
-							return false, fmt.Errorf(
-								"preferred IMAP source ID %q changed before adoption",
-								data.message.SourceMessageID)
-						}
-						changed = true
-					}
-				}
 				return dedupMutationResult(
 					changed, "reconcile validated dedup labels", nil)
 			}
+			if s.relocationContentAuthorized(data.message.SourceMessageID) {
+				expected := store.MessageIdentityGuard{
+					ID: existingID, SourceID: sourceID,
+					SourceMessageID: oldSourceMessageID,
+				}
+				err = s.relocateIMAPMessage(
+					ctx, expected, raw, threadID, labelMap,
+					complete, deferLabels,
+				)
+				return dedupMutationResult(
+					true, "refresh relocated IMAP message", err)
+			}
+			// The vanished canonical cannot be tied to this survivor by
+			// provider evidence, so a matching RFC822 Message-ID authorizes
+			// only the location adoption: keep the archived snapshot and
+			// follow the previous rekey and label behavior.
 			if complete {
 				if deferLabels {
 					rekeyed, err := s.store.RekeyMessageSourceID(
@@ -1857,6 +2096,10 @@ func (s *Syncer) ingestMessage(
 		}
 	}
 
+	data, err = s.resolvePreparedMessage(data)
+	if err != nil {
+		return false, err
+	}
 	messageID, err := s.persistMessage(data, labelMap)
 	if err == nil && s.opts.RemoteImages != nil && data.message.MessageType == store.MessageTypeEmail {
 		archived := s.opts.RemoteImages.Archive(ctx, s.store, s.opts.AttachmentsDir, messageID, data.bodyHTML)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1767,8 +1767,8 @@ func (s *Syncer) prepareMessage(
 	}
 
 	var metadata *sql.NullString
-	if s.opts.SourceType == sourceTypeIMAP {
-		encoded, err := json.Marshal(imapMessageMetadata{ContentOrigin: s.imapContentOrigin(raw.ID)})
+	if origin := s.imapContentOrigin(raw.ID); s.opts.SourceType == sourceTypeIMAP && origin != "" {
+		encoded, err := json.Marshal(imapMessageMetadata{ContentOrigin: origin})
 		if err != nil {
 			return nil, fmt.Errorf("encode IMAP content origin: %w", err)
 		}
@@ -1993,18 +1993,29 @@ func (s *Syncer) ingestMessage(
 			if matches {
 				if complete && oldSourceMessageID != data.message.SourceMessageID {
 					if destinationOrigin.canRefresh(savedOrigin, true) && destinationOrigin.canRefresh(canonicalOrigin, true) {
-						// Compare the fetched copy with the saved content's origin:
-						// adopting an All Mail location must not erase Sent priority.
-						expected := store.MessageIdentityGuard{
-							ID: existingID, SourceID: sourceID,
-							SourceMessageID: oldSourceMessageID,
+						storedRaw, err := s.store.GetMessageRaw(existingID)
+						if err != nil && !errors.Is(err, sql.ErrNoRows) && !errors.Is(err, store.ErrInvalidMessageRaw) {
+							return false, fmt.Errorf("read canonical IMAP raw: %w", err)
 						}
-						err := s.relocateIMAPMessage(
-							ctx, expected, raw, threadID, labelMap,
-							complete, deferLabels,
-						)
-						return dedupMutationResult(
-							true, "refresh relocated IMAP message", err)
+						if err != nil || !bytes.Equal(storedRaw, raw.Raw) {
+							// A missing or unreadable snapshot still needs the fetched copy.
+							expected := store.MessageIdentityGuard{
+								ID: existingID, SourceID: sourceID,
+								SourceMessageID: oldSourceMessageID,
+							}
+							err := s.relocateIMAPMessage(
+								ctx, expected, raw, threadID, labelMap,
+								complete, deferLabels,
+							)
+							return dedupMutationResult(
+								true, "refresh relocated IMAP message", err)
+						}
+						// Identical bytes need no content rewrite or relocation. Save
+						// their outgoing origin so later stale Drafts copies still
+						// lose, then apply the normal location and label rules.
+						if err := s.store.SetMessageMetadata(existingID, *data.metadata); err != nil {
+							return false, fmt.Errorf("record identical IMAP content origin: %w", err)
+						}
 					}
 					if preferred, ok := s.client.(preferredIMAPSourceID); ok &&
 						preferred.IsPreferredSourceMessageID(data.message.SourceMessageID) {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -165,22 +166,6 @@ type sentPrecedencePlacement interface {
 	// IsDraftsPlacementMailbox reports whether the mailbox this composite
 	// source ID names is a Drafts placement and nothing stronger.
 	IsDraftsPlacementMailbox(messageID string) bool
-}
-
-// relocationSentOverDrafts reports whether the fetched copy at
-// destinationSourceMessageID is a Sent placement whose current canonical
-// location is only a Drafts placement. This is the one trusted-over-trusted
-// precedence: an edited Sent copy refreshes a stale archived draft even
-// while the old Drafts copy still exists. It never grants anything to
-// received placements, never lets one Sent placement outrank another, and
-// never lets a Drafts placement outrank anything.
-func (s *Syncer) relocationSentOverDrafts(
-	destinationSourceMessageID, canonicalSourceMessageID string,
-) bool {
-	precedence, ok := s.client.(sentPrecedencePlacement)
-	return ok &&
-		precedence.IsSentPlacementMailbox(destinationSourceMessageID) &&
-		precedence.IsDraftsPlacementMailbox(canonicalSourceMessageID)
 }
 
 // relocationContentAuthorized reports whether replacing an archived snapshot
@@ -1595,6 +1580,7 @@ func (s *Syncer) syncLabels(ctx context.Context, sourceID int64) (map[string]int
 
 // messageData holds all parsed data for a message before persistence.
 type messageData struct {
+	metadata          *sql.NullString
 	message           *store.Message
 	threadID          string
 	conversationType  string
@@ -1780,7 +1766,17 @@ func (s *Syncer) prepareMessage(
 		msg.SentAt = sql.NullTime{Time: resolvedDate, Valid: true}
 	}
 
+	var metadata *sql.NullString
+	if s.opts.SourceType == sourceTypeIMAP {
+		encoded, err := json.Marshal(imapMessageMetadata{ContentOrigin: s.imapContentOrigin(raw.ID)})
+		if err != nil {
+			return nil, fmt.Errorf("encode IMAP content origin: %w", err)
+		}
+		metadata = &sql.NullString{String: string(encoded), Valid: true}
+	}
+
 	return &messageData{
+		metadata:          metadata,
 		message:           msg,
 		threadID:          threadID,
 		conversationType:  conversationType,
@@ -1836,6 +1832,7 @@ func (s *Syncer) persistMessage(data *messageData, labelMap map[string]int64) (i
 	// Persist atomically
 	messageID, err := s.store.PersistMessage(&store.MessagePersistData{
 		Message:    data.message,
+		Metadata:   data.metadata,
 		BodyText:   sql.NullString{String: data.bodyText, Valid: data.bodyText != ""},
 		BodyHTML:   sql.NullString{String: data.bodyHTML, Valid: data.bodyHTML != ""},
 		RawMIME:    data.rawMIME,
@@ -1985,24 +1982,19 @@ func (s *Syncer) ingestMessage(
 					errDeferredIMAPIdentity,
 				)
 			}
+			savedOrigin, err := s.savedIMAPContentOrigin(existingID)
+			if err != nil {
+				return false, err
+			}
+			destinationOrigin := s.imapContentOrigin(data.message.SourceMessageID)
+			canonicalOrigin := s.imapContentOrigin(oldSourceMessageID)
+
 			complete := s.labelsSnapshotComplete()
 			if matches {
 				if complete && oldSourceMessageID != data.message.SourceMessageID {
-					if (s.relocationContentAuthorized(data.message.SourceMessageID) &&
-						!s.relocationContentAuthorized(oldSourceMessageID)) ||
-						s.relocationSentOverDrafts(data.message.SourceMessageID, oldSourceMessageID) {
-						// The fetched copy sits in a mailbox trusted to hold only the
-						// account's own outgoing mail, while the current canonical does
-						// not: base rekey semantics redirected it to a mirror or
-						// received copy (for example an untrusted \All adoption that
-						// ran first). Refresh from the outgoing copy so a genuine Sent
-						// edit is not stranded behind it. Separately, an edited Sent
-						// copy outranks a canonical that is only a Drafts placement —
-						// the surviving Drafts copy is the earlier draft the account
-						// already superseded. Every other trusted canonical (Sent or
-						// configured placement) defers to the vanished-source flow, so
-						// Sent never churns against Sent and Drafts never outranks
-						// anything.
+					if destinationOrigin.canRefresh(savedOrigin, true) && destinationOrigin.canRefresh(canonicalOrigin, true) {
+						// Compare the fetched copy with the saved content's origin:
+						// adopting an All Mail location must not erase Sent priority.
 						expected := store.MessageIdentityGuard{
 							ID: existingID, SourceID: sourceID,
 							SourceMessageID: oldSourceMessageID,
@@ -2047,7 +2039,7 @@ func (s *Syncer) ingestMessage(
 				return dedupMutationResult(
 					changed, "reconcile validated dedup labels", nil)
 			}
-			if s.relocationContentAuthorized(data.message.SourceMessageID) {
+			if destinationOrigin.canRefresh(savedOrigin, false) && destinationOrigin.canRefresh(canonicalOrigin, false) {
 				expected := store.MessageIdentityGuard{
 					ID: existingID, SourceID: sourceID,
 					SourceMessageID: oldSourceMessageID,

--- a/internal/testutil/imapmem.go
+++ b/internal/testutil/imapmem.go
@@ -379,6 +379,23 @@ func AppendIMAPMessageWithMessageID(
 	require.NoError(t, err)
 }
 
+// AppendIMAPRawMessage appends caller-supplied RFC822 bytes to a mailbox of an
+// in-memory IMAP test user.
+func AppendIMAPRawMessage(
+	t *testing.T,
+	user *imapmemserver.User,
+	mailbox string,
+	raw []byte,
+) {
+	t.Helper()
+	_, err := user.Append(
+		mailbox,
+		imapLiteral{bytes.NewReader(raw)},
+		&imap.AppendOptions{},
+	)
+	require.NoError(t, err)
+}
+
 // StartIMAPMemServer runs an in-memory IMAP server with the given
 // mailboxes and per-mailbox message counts, returning its listen
 // address and the user handle for later mutation. The server is shut


### PR DESCRIPTION
## What changed

- Refresh the archived snapshot when IMAP adopts an edited copy from a trusted outgoing mailbox, retaining the message ID and updating the body, raw MIME, recipients, attachments, and search index together.
- Refresh from an edited Sent copy while the original Drafts copy still exists, without letting a later stale Drafts copy replace it.
- Recover surviving outgoing copies after the previous location disappears, including incremental syncs where the survivor itself has not changed and full scans where an All Mail mirror is fetched first.
- Preserve archived content when a matching Message-ID comes from an ordinary received-mail folder or All Mail.
- Keep unrelated mail syncing when a relocation target repeatedly fails, preserving the failed message and its retry location until recovery.
- Increase the Windows CLI shard timeout to accommodate its measured suite runtime.

## Why

Sending an edited draft could move the archived message to Sent while leaving its earlier draft text in the archive. A Message-ID match alone cannot authorize replacement because incoming mail can forge that header.

## Usage

Unambiguous server-advertised `\Sent` and `\Drafts` folders are trusted automatically. For a server that does not advertise these roles, configure that account's Sent folder in `config.toml`. Copy the exact `ACCOUNT` value from `msgvault list-accounts`:

```toml
[sync.trusted_imap_sent_mailboxes]
"imaps://user@example.com@imap.example.com:993" = ["Gesendete Elemente"]
```

Trust applies only to the named account. Only configure its Sent folders, and do not include folders that receive incoming mail through filters or filing rules. Advertised Drafts and received-mail roles cannot be overridden by this setting. A folder advertising both Sent and Drafts is ambiguous and remains untrusted. Other relocations preserve the archived snapshot.

This prevents new stale snapshots on supported relocations; it does not repair historical rows that already lost their old location information.

Closes #804.
