### PR TITLE
fix(ci): retry transient uv manifest fetch failures

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install documentation tools
         run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
       - name: Install documentation dependencies
         working-directory: docs


### PR DESCRIPTION
Upgrade `setup-uv` to v10.0.1 so documentation CI retries transient uv manifest fetch failures. The [failed main run](https://github.com/kenn-io/msgvault/actions/runs/34277610785) stopped at `fetch failed` before installing documentation dependencies.

The [upstream fix](https://github.com/astral-sh/setup-uv/pull/1016) makes up to three attempts with bounded delays; persistent failures still fail the job. This PR changes only the pinned action version.
