### PR TITLE
fix(web): settle reduced-motion button colors immediately

### DIFF
--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -99,7 +99,9 @@
   *::before,
   *::after {
     scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
+    /* Even a tiny transition leaves inherited label colors one frame behind
+     * a changed button surface. Apply both colors immediately. */
+    transition-duration: 0s !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
   }

--- a/web/tests/files-toggle-motion.spec.ts
+++ b/web/tests/files-toggle-motion.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { installMixedArchive } from './e2e/fixtures/mixed-archive';
+
+test('Files toggle settles its colors immediately with reduced motion', async ({ page }) => {
+  await installMixedArchive(page);
+  await page.goto('/');
+  await page.getByRole('grid', { name: 'Relationship results' }).getByText('Archive Person').click();
+  const files = page.getByRole('button', { name: 'Files 1' });
+  await files.click();
+  await expect(files).toHaveAttribute('aria-expanded', 'true');
+
+  const colors = await files.evaluate(async (button) => {
+    const label = button.querySelector('.kit-button__label-text')!;
+    const snapshot = () => ({
+      foreground: getComputedStyle(label).color,
+      background: getComputedStyle(button).backgroundColor,
+    });
+    await Promise.all(button.getAnimations().map((animation) => animation.finished));
+    snapshot();
+    button.click();
+    // Flush Svelte's state update within the same frame, before transitions advance.
+    await Promise.resolve();
+    await Promise.resolve();
+    const immediate = snapshot();
+    await Promise.all(button.getAnimations().map((animation) => animation.finished));
+    await new Promise(requestAnimationFrame);
+    return { immediate, settled: snapshot() };
+  });
+  expect(colors.immediate).toEqual(colors.settled);
+});


### PR DESCRIPTION
Apply button color changes immediately when reduced motion is enabled. Closing the Relationships Files pane could briefly leave white text on a light button background and fail the browser accessibility check.

Add a browser regression that checks the Files button’s colors at the state change and after rendering settles.
