### PR TITLE
fix(gmail): show copyable scheduler reauthorization commands

### DIFF
--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -3473,9 +3473,9 @@ func runScheduledGmailSync(ctx context.Context, email string, src *store.Source,
 				return nil, fmt.Errorf("get token source: %w (transient network error; will retry on next schedule)", tsErr)
 			}
 			if oauthMgr.HasToken(email) {
-				return nil, fmt.Errorf("get token source: %w (token may be expired; run 'sync %s' or 'verify %s' from an interactive terminal to re-authorize)", tsErr, email, email)
+				return nil, fmt.Errorf("get token source: %w (token may be expired; %s)", tsErr, gmailReauthHint(email, accountIsNarrowed(oauthMgr, email)))
 			}
-			return nil, fmt.Errorf("get token source: %w (run 'add-account %s' first)", tsErr, email)
+			return nil, fmt.Errorf("get token source: %w (run 'msgvault add-account %s' first)", tsErr, email)
 		}
 	}
 

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -2221,17 +2221,19 @@ func TestRunScheduledGmailSync_ReauthGuidance(t *testing.T) {
 		{"readonly", oauth.ScopeGmailReadonly, " --readonly"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
 			// An expired token without a refresh token fails locally, without
 			// contacting Google or opening an authorization flow.
 			_, restore := seedTokenEnv(t, fmt.Sprintf(`{"access_token":"expired","expiry":"2000-01-01T00:00:00Z","scopes":[%q]}`, tc.scope))
 			defer restore()
 			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
-			require.NoError(t, err)
+			require.NoError(err)
 			_, err = runScheduledGmailSync(t.Context(), scopeEscalationAccount, nil, nil,
 				func(string) (*oauth.Manager, error) { return mgr, nil })
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "msgvault add-account user@example.com"+tc.flags+" --force")
-			assert.Contains(t, err.Error(), "msgvault add-account user@example.com"+tc.flags+" --headless")
+			require.Error(err)
+			assert.Contains(err.Error(), "msgvault add-account user@example.com"+tc.flags+" --force")
+			assert.Contains(err.Error(), "msgvault add-account user@example.com"+tc.flags+" --headless")
 		})
 	}
 }

--- a/cmd/msgvault/cmd/serve_test.go
+++ b/cmd/msgvault/cmd/serve_test.go
@@ -2213,6 +2213,29 @@ func TestSetupVectorFeatures_Disabled(t *testing.T) {
 	assert.Nil(t, vf, "setupVectorFeatures should be nil when disabled")
 }
 
+func TestRunScheduledGmailSync_ReauthGuidance(t *testing.T) {
+	for _, tc := range []struct {
+		name, scope, flags string
+	}{
+		{"default", oauth.ScopeGmailModify, ""},
+		{"readonly", oauth.ScopeGmailReadonly, " --readonly"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// An expired token without a refresh token fails locally, without
+			// contacting Google or opening an authorization flow.
+			_, restore := seedTokenEnv(t, fmt.Sprintf(`{"access_token":"expired","expiry":"2000-01-01T00:00:00Z","scopes":[%q]}`, tc.scope))
+			defer restore()
+			mgr, err := oauth.NewManager(cfg.OAuth.ClientSecrets, cfg.TokensDir(), logger)
+			require.NoError(t, err)
+			_, err = runScheduledGmailSync(t.Context(), scopeEscalationAccount, nil, nil,
+				func(string) (*oauth.Manager, error) { return mgr, nil })
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "msgvault add-account user@example.com"+tc.flags+" --force")
+			assert.Contains(t, err.Error(), "msgvault add-account user@example.com"+tc.flags+" --headless")
+		})
+	}
+}
+
 // TestRunScheduledIMAPSync_NoCredentials verifies that the IMAP path
 // in runScheduledSync is reachable — i.e. an IMAP source row makes the
 // dispatcher build an IMAP client and surface a credentials error,


### PR DESCRIPTION
Scheduled Gmail authentication errors shown in the UI omitted the `msgvault` executable from their recovery commands. The message now includes complete `msgvault add-account` commands for browser and headless reauthorization, preserving `--readonly` for narrowed accounts. Missing-token guidance also includes the executable name.
