### PR TITLE
fix: stabilize header layout and worker renewal test

### DIFF
--- a/internal/vector/visual/worker_test.go
+++ b/internal/vector/visual/worker_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -289,37 +290,67 @@ func TestVisualWorkerRejectsObsoleteFenceAndNonFiniteProviderVector(t *testing.T
 	})
 }
 
-func TestVisualWorkerRenewsClaimsDuringProviderRequestAndCancelsCleanly(t *testing.T) {
+func TestVisualWorkerRenewsClaimsDuringProviderRequest(t *testing.T) {
+	f, _, work := workerFixture(t, 1)
+	// Keep database setup and cleanup outside the bubble. Map its fake clock
+	// onto the fixture's claim timestamps for both SQLite and PostgreSQL.
+	claimStart := time.Now().UTC()
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+		assert := assert.New(t)
+		start := time.Now()
+		now := func() time.Time { return claimStart.Add(time.Since(start)) }
+		const leaseDuration = 100 * time.Millisecond
+		require.NoError(f.Store.RenewVisualWork(t.Context(), work[0].Claim, now(), leaseDuration))
+		providerRelease := make(chan struct{})
+		provider := &fakeVisualProvider{embed: func(ctx context.Context, documents []DocumentInput) ([]EmbeddingResult, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-providerRelease:
+				return []EmbeddingResult{{Owner: documents[0].Owner, Vector: []float32{1, 2}}}, nil
+			}
+		}}
+		worker, err := NewWorker(f.Store, provider, newFakeVisualBackend(), WorkerConfig{
+			Dimension: 2, ProviderTimeout: 50 * time.Millisecond,
+			LeaseDuration: leaseDuration, RenewInterval: 5 * time.Millisecond, Now: now,
+		})
+		require.NoError(err)
+
+		var result WorkerResult
+		var runErr error
+		go func() { result, runErr = worker.Run(t.Context(), work) }()
+		synctest.Wait()
+		// Advance fake time through several renewals while the provider remains
+		// blocked. Real database latency does not consume the provider timeout.
+		synctest.Sleep(30 * time.Millisecond)
+		_, acquired, err := f.Store.ClaimVisualWork(t.Context(), store.VisualClaimRequest{
+			GenerationID: work[0].Claim.GenerationID, Owner: work[0].Candidate.Owner,
+			ProposedRevision: work[0].Document.Revision, LeaseOwner: "successor",
+			Now: claimStart.Add(leaseDuration + time.Millisecond), LeaseDuration: time.Minute,
+			SourceFence: work[0].Claim.SourceFence,
+		})
+		close(providerRelease)
+		synctest.Wait()
+		require.NoError(err)
+		assert.False(acquired, "renewal must keep the claim live beyond its original expiry")
+		require.NoError(runErr)
+		assert.Equal(int64(1), result.Published)
+	})
+}
+
+func TestVisualWorkerCanceledRunReleasesClaims(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	f, _, work := workerFixture(t, 1)
-	provider := &fakeVisualProvider{embed: func(ctx context.Context, documents []DocumentInput) ([]EmbeddingResult, error) {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(30 * time.Millisecond):
-		}
-		return []EmbeddingResult{{Owner: documents[0].Owner, Vector: []float32{1, 2}}}, nil
-	}}
-	worker, err := NewWorker(f.Store, provider, newFakeVisualBackend(), WorkerConfig{
-		Dimension: 2, ProviderTimeout: 50 * time.Millisecond,
-		LeaseDuration: 100 * time.Millisecond, RenewInterval: 5 * time.Millisecond,
-	})
-	require.NoError(err)
-
-	result, err := worker.Run(t.Context(), work)
-	require.NoError(err)
-	assert.Equal(int64(1), result.Published)
-
-	f, _, work = workerFixture(t, 1)
-	provider = &fakeVisualProvider{embed: func(ctx context.Context, _ []DocumentInput) ([]EmbeddingResult, error) {
+	provider := &fakeVisualProvider{embed: func(ctx context.Context, _ []DocumentInput) ([]EmbeddingResult, error) {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}}
-	worker = newTestVisualWorker(t, f, provider, newFakeVisualBackend())
+	worker := newTestVisualWorker(t, f, provider, newFakeVisualBackend())
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	_, err = worker.Run(ctx, work)
+	_, err := worker.Run(ctx, work)
 	require.ErrorIs(err, context.Canceled)
 	_, acquired, err := f.Store.ClaimVisualWork(t.Context(), store.VisualClaimRequest{
 		GenerationID: work[0].Claim.GenerationID, Owner: work[0].Candidate.Owner,

--- a/web/src/lib/components/shell/AppShell.svelte
+++ b/web/src/lib/components/shell/AppShell.svelte
@@ -1101,7 +1101,10 @@
                 : 'Local archive ready'}
           />
         </span>
-        {loader.loading ? 'Searching' : loader.error || loader.unavailable ? 'Attention' : 'Local archive'}
+        <span class="archive-state__label">
+          <span class="archive-state__reserve" aria-hidden="true">Local archive</span>
+          <span>{loader.loading ? 'Searching' : loader.error || loader.unavailable ? 'Attention' : 'Local archive'}</span>
+        </span>
       </span>
     {/snippet}
   </TopBar>
@@ -1446,6 +1449,19 @@
   .appearance-controls {
     display: inline-flex;
     gap: var(--space-2);
+  }
+
+  /* Keep the longest status label's width while searches are in flight. */
+  .archive-state__label {
+    display: inline-grid;
+  }
+
+  .archive-state__label > span {
+    grid-area: 1 / 1;
+  }
+
+  .archive-state__reserve {
+    visibility: hidden;
   }
 
   .files-shell {


### PR DESCRIPTION
Keep the top navigation stationary when opening Everything or running a search. Previously, changing the status from "Local archive" to the shorter "Searching" label shifted the centered tabs. Reserve the longest label's rendered width with an invisible, accessibility-hidden span so the space follows the font size.

Also remove wall-clock timing from the visual worker renewal test that failed in CI. Hold the provider on a channel and advance `testing/synctest`'s fake clock through renewal. Verify that the claim remains valid beyond its original expiry before releasing the provider, and preserve cancellation coverage in a separate test. Worker production behavior is unchanged.
