### PR TITLE
calendar: support service-account (domain-wide delegation) apps in add-calendar

### DIFF
--- a/cmd/msgvault/cmd/calendar.go
+++ b/cmd/msgvault/cmd/calendar.go
@@ -97,6 +97,22 @@ func newAddCalendarLocalCmd() *cobra.Command {
 			}
 			oauthApp := appDecision.OAuthApp
 
+			// A service-account app authenticates by domain-wide delegation:
+			// there is no per-user token to inspect and no consent screen to
+			// send anyone to, so the whole authorize/escalate dance below does
+			// not apply. buildCalendarClient already mints delegated token
+			// sources for these apps; RegisterCalendars is then the live proof
+			// that the Calendar scope was actually granted.
+			if cfg.OAuth.ServiceAccountKeyFor(oauthApp) != "" {
+				client, err := buildCalendarClient(ctx, email, oauthApp, false)
+				if err != nil {
+					return err
+				}
+				defer func() { _ = client.Close() }()
+				return registerCalendarsAndReport(ctx, cmd.OutOrStdout(), st, client, email, oauthApp,
+					oauthAppExplicit || appDecision.BindingChanged)
+			}
+
 			secretsPath, err := cfg.OAuth.ClientSecretsFor(oauthApp)
 			if err != nil {
 				return err
@@ -175,36 +191,8 @@ func newAddCalendarLocalCmd() *cobra.Command {
 				return err
 			}
 			defer func() { _ = client.Close() }()
-
-			syncer := calsync.New(client, st, calsync.Options{
-				AccountEmail:  email,
-				OAuthApp:      oauthApp,
-				OAuthAppSet:   oauthAppExplicit || appDecision.BindingChanged,
-				Calendars:     calAddCalendars,
-				AllCalendars:  calAddAll,
-				MinAccessRole: calAddMinRole,
-			}).WithLogger(logger)
-
-			// RegisterCalendars enumerates calendars (a live smoke test that the
-			// calendar scope was actually granted) and creates the source rows.
-			cals, err := syncer.RegisterCalendars(ctx)
-			if err != nil {
-				return fmt.Errorf("register calendars (was Calendar access granted?): %w", err)
-			}
-			if len(cals) == 0 {
-				fmt.Println("No calendars matched the filter (try --all-calendars or --calendars).")
-				return nil
-			}
-			fmt.Printf("Registered %d calendar(s) for %s:\n", len(cals), email)
-			for _, c := range cals {
-				fmt.Printf("  - %s (%s)\n", calendarLabel(c), c.AccessRole)
-			}
-			fmt.Printf("\nNext: %s\n", calendarSyncNextCommand(email, oauthApp, calendarSyncNextOptions{
-				AllCalendars:  calAddAll,
-				MinAccessRole: calAddMinRole,
-				Calendars:     calAddCalendars,
-			}))
-			return nil
+			return registerCalendarsAndReport(ctx, cmd.OutOrStdout(), st, client, email, oauthApp,
+				oauthAppExplicit || appDecision.BindingChanged)
 		},
 	}
 	cmd.Flags().StringVar(&calAddOAuthApp, "oauth-app", "", "named OAuth app to use")
@@ -217,6 +205,40 @@ func newAddCalendarLocalCmd() *cobra.Command {
 		panic(err)
 	}
 	return cmd
+}
+
+// registerCalendarsAndReport enumerates the account's calendars through client
+// (a live check that Calendar access was actually granted), creates the source
+// rows, and reports what was registered plus the follow-up sync command. It is
+// shared by add-calendar's user-consent and service-account paths.
+func registerCalendarsAndReport(ctx context.Context, out io.Writer, st *store.Store, client gcal.API, email, oauthApp string, oauthAppSet bool) error {
+	syncer := calsync.New(client, st, calsync.Options{
+		AccountEmail:  email,
+		OAuthApp:      oauthApp,
+		OAuthAppSet:   oauthAppSet,
+		Calendars:     calAddCalendars,
+		AllCalendars:  calAddAll,
+		MinAccessRole: calAddMinRole,
+	}).WithLogger(logger)
+
+	cals, err := syncer.RegisterCalendars(ctx)
+	if err != nil {
+		return fmt.Errorf("register calendars (was Calendar access granted?): %w", err)
+	}
+	if len(cals) == 0 {
+		_, _ = fmt.Fprintln(out, "No calendars matched the filter (try --all-calendars or --calendars).")
+		return nil
+	}
+	_, _ = fmt.Fprintf(out, "Registered %d calendar(s) for %s:\n", len(cals), email)
+	for _, c := range cals {
+		_, _ = fmt.Fprintf(out, "  - %s (%s)\n", calendarLabel(c), c.AccessRole)
+	}
+	_, _ = fmt.Fprintf(out, "\nNext: %s\n", calendarSyncNextCommand(email, oauthApp, calendarSyncNextOptions{
+		AllCalendars:  calAddAll,
+		MinAccessRole: calAddMinRole,
+		Calendars:     calAddCalendars,
+	}))
+	return nil
 }
 
 func runAddCalendarHTTP(cmd *cobra.Command, args []string) error {
@@ -592,6 +614,17 @@ func planCLIAddCalendar(
 		return api.CLIAddCalendarPlanResponse{}, err
 	}
 	oauthApp := appDecision.OAuthApp
+
+	// A service-account app has no per-user token to inspect and never needs a
+	// consent or scope-escalation round trip, so report the resolved binding
+	// without reaching for client secrets it does not have.
+	if cfg.OAuth.ServiceAccountKeyFor(oauthApp) != "" {
+		return api.CLIAddCalendarPlanResponse{
+			OAuthApp:         oauthApp,
+			OAuthAppResolved: true,
+			NeedsClientCheck: appDecision.NeedsClientCheck,
+		}, nil
+	}
 
 	secretsPath, err := cfg.OAuth.ClientSecretsFor(oauthApp)
 	if err != nil {

--- a/cmd/msgvault/cmd/calendar_register_test.go
+++ b/cmd/msgvault/cmd/calendar_register_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/api"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/gcal"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+// The service-account path of add-calendar skips consent entirely and relies
+// on registerCalendarsAndReport to enumerate calendars, create the gcal source
+// rows, and report them — so that helper is exercised directly with a mock API.
+func TestRegisterCalendarsAndReport_RegistersSourcesAndReports(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	api := gcal.NewMockAPI()
+	api.Calendars = []gcal.Calendar{
+		{ID: "primary", Summary: "Alice", AccessRole: "owner"},
+		{ID: "team@group.calendar.google.com", Summary: "Team", AccessRole: "writer"},
+		{ID: "holidays", Summary: "Holidays", AccessRole: "reader"}, // excluded by default role filter
+	}
+
+	var out bytes.Buffer
+	err := registerCalendarsAndReport(context.Background(), &out, st, api,
+		"alice@example.com", "acme", true)
+	require.NoError(t, err)
+
+	for _, id := range []string{"alice@example.com/primary", "alice@example.com/team@group.calendar.google.com"} {
+		src, err := st.GetSourceByIdentifier(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, "gcal", src.SourceType)
+	}
+	_, err = st.GetSourceByIdentifier("alice@example.com/holidays")
+	assert.Error(t, err, "reader-only calendar is not registered without --all-calendars")
+
+	assert.Contains(t, out.String(), "Registered 2 calendar(s) for alice@example.com")
+	assert.Contains(t, out.String(), "Next: ")
+}
+
+func TestRegisterCalendarsAndReport_NoMatchIsNotAnError(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	api := gcal.NewMockAPI()
+	api.Calendars = []gcal.Calendar{{ID: "holidays", AccessRole: "reader"}}
+
+	var out bytes.Buffer
+	require.NoError(t, registerCalendarsAndReport(context.Background(), &out, st, api,
+		"alice@example.com", "", false))
+	assert.Contains(t, out.String(), "No calendars matched the filter")
+}
+
+// The daemon-side plan step must not demand client_secrets for a named app
+// configured with a service account: it resolves the binding and reports that
+// no consent/escalation round trip is needed.
+func TestPlanCLIAddCalendar_ServiceAccountAppNeedsNoConsent(t *testing.T) {
+	st := testutil.NewTestStore(t)
+	savedCfg := cfg
+	defer func() { cfg = savedCfg }()
+	cfg = &config.Config{
+		HomeDir: t.TempDir(),
+		OAuth: config.OAuthConfig{
+			Apps: map[string]config.OAuthApp{
+				"sa": {ServiceAccountKey: "/nonexistent/service-account.json"},
+			},
+		},
+	}
+
+	plan, err := planCLIAddCalendar(context.Background(), st, api.CLIAddCalendarPlanRequest{
+		Email: "bob@example.com", OAuthApp: "sa", OAuthAppExplicit: true,
+	})
+	require.NoError(t, err, "service-account apps have no client_secrets and must not be asked for one")
+	assert.Equal(t, "sa", plan.OAuthApp)
+	assert.True(t, plan.OAuthAppResolved)
+	assert.False(t, plan.NeedsScopeEscalation)
+}

--- a/cmd/msgvault/cmd/calendar_register_test.go
+++ b/cmd/msgvault/cmd/calendar_register_test.go
@@ -28,18 +28,20 @@ func TestRegisterCalendarsAndReport_RegistersSourcesAndReports(t *testing.T) {
 	var out bytes.Buffer
 	err := registerCalendarsAndReport(context.Background(), &out, st, api,
 		"alice@example.com", "acme", true)
-	require.NoError(t, err)
+	require := require.New(t)
+	assert := assert.New(t)
+	require.NoError(err)
 
 	for _, id := range []string{"alice@example.com/primary", "alice@example.com/team@group.calendar.google.com"} {
 		src, err := st.GetSourceByIdentifier(id)
-		require.NoError(t, err, id)
-		assert.Equal(t, "gcal", src.SourceType)
+		require.NoError(err, id)
+		assert.Equal("gcal", src.SourceType)
 	}
 	_, err = st.GetSourceByIdentifier("alice@example.com/holidays")
-	assert.Error(t, err, "reader-only calendar is not registered without --all-calendars")
+	require.Error(err, "reader-only calendar is not registered without --all-calendars")
 
-	assert.Contains(t, out.String(), "Registered 2 calendar(s) for alice@example.com")
-	assert.Contains(t, out.String(), "Next: ")
+	assert.Contains(out.String(), "Registered 2 calendar(s) for alice@example.com")
+	assert.Contains(out.String(), "Next: ")
 }
 
 func TestRegisterCalendarsAndReport_NoMatchIsNotAnError(t *testing.T) {
@@ -73,7 +75,8 @@ func TestPlanCLIAddCalendar_ServiceAccountAppNeedsNoConsent(t *testing.T) {
 		Email: "bob@example.com", OAuthApp: "sa", OAuthAppExplicit: true,
 	})
 	require.NoError(t, err, "service-account apps have no client_secrets and must not be asked for one")
-	assert.Equal(t, "sa", plan.OAuthApp)
-	assert.True(t, plan.OAuthAppResolved)
-	assert.False(t, plan.NeedsScopeEscalation)
+	assert := assert.New(t)
+	assert.Equal("sa", plan.OAuthApp)
+	assert.True(plan.OAuthAppResolved)
+	assert.False(plan.NeedsScopeEscalation)
 }

--- a/internal/gcal/client.go
+++ b/internal/gcal/client.go
@@ -142,6 +142,15 @@ func (c *Client) request(ctx context.Context, op gmail.Operation, method, path s
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
+			// A token-source failure (e.g. a service account whose domain-wide
+			// delegation lacks the Calendar scope → 401 unauthorized_client)
+			// surfaces here as a transport error. It is a credential problem,
+			// not a network blip: retrying it would hide the real cause behind
+			// ten minutes of backoff, so fail immediately with Google's message.
+			var rerr *oauth2.RetrieveError
+			if errors.As(err, &rerr) {
+				return nil, fmt.Errorf("oauth token for calendar request: %w", err)
+			}
 			lastErr = fmt.Errorf("http request: %w", err)
 			continue // retry on network errors
 		}
@@ -228,6 +237,11 @@ func isRateLimitError(body []byte) bool {
 		switch e.Reason {
 		case "rateLimitExceeded", "userRateLimitExceeded", "quotaExceeded", "RATE_LIMIT_EXCEEDED":
 			return true
+		case "accessNotConfigured":
+			// Google files "Calendar API is not enabled in this project" under
+			// domain usageLimits too, but it is a configuration error that no
+			// amount of backoff fixes — surface it immediately.
+			return false
 		}
 		if e.Domain == "usageLimits" {
 			return true

--- a/internal/gcal/client.go
+++ b/internal/gcal/client.go
@@ -144,11 +144,13 @@ func (c *Client) request(ctx context.Context, op gmail.Operation, method, path s
 		if err != nil {
 			// A token-source failure (e.g. a service account whose domain-wide
 			// delegation lacks the Calendar scope → 401 unauthorized_client)
-			// surfaces here as a transport error. It is a credential problem,
-			// not a network blip: retrying it would hide the real cause behind
-			// ten minutes of backoff, so fail immediately with Google's message.
+			// surfaces here as a transport error. A credential problem is not
+			// a network blip: retrying it would hide the real cause behind ten
+			// minutes of backoff, so fail immediately with Google's message.
+			// A 429 or 5xx from the token endpoint itself is transient and
+			// keeps the normal retry policy.
 			var rerr *oauth2.RetrieveError
-			if errors.As(err, &rerr) {
+			if errors.As(err, &rerr) && !isTransientTokenError(rerr) {
 				return nil, fmt.Errorf("oauth token for calendar request: %w", err)
 			}
 			lastErr = fmt.Errorf("http request: %w", err)
@@ -212,6 +214,16 @@ func (c *Client) calculateBackoff(attempt int) time.Duration {
 	}
 	jittered := rand.Float64() * base //nolint:gosec // retry spread, not security-sensitive
 	return time.Duration(jittered * float64(time.Second))
+}
+
+// isTransientTokenError reports whether the token endpoint failed with a
+// status worth retrying (429 or 5xx) rather than rejecting the credentials.
+func isTransientTokenError(rerr *oauth2.RetrieveError) bool {
+	if rerr.Response == nil {
+		return false
+	}
+	code := rerr.Response.StatusCode
+	return code == http.StatusTooManyRequests || code >= http.StatusInternalServerError
 }
 
 // isRateLimitError reports whether a 403 body is a quota/rate-limit error

--- a/internal/gcal/client_tokenerror_test.go
+++ b/internal/gcal/client_tokenerror_test.go
@@ -2,7 +2,6 @@ package gcal
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,6 +25,21 @@ func (u *unauthorizedTokenSource) Token() (*oauth2.Token, error) {
 	}
 }
 
+// flakyTokenSource mimics Google's token endpoint answering 503 once before
+// issuing a token: transient, so the request loop must retry it.
+type flakyTokenSource struct{ calls int }
+
+func (f *flakyTokenSource) Token() (*oauth2.Token, error) {
+	f.calls++
+	if f.calls == 1 {
+		return nil, &oauth2.RetrieveError{
+			Response: &http.Response{StatusCode: http.StatusServiceUnavailable},
+			Body:     []byte(`upstream unavailable`),
+		}
+	}
+	return &oauth2.Token{AccessToken: "t"}, nil
+}
+
 // A credential failure must surface immediately with Google's error text —
 // not be retried as a network error for ten minutes of backoff.
 func TestRequest_TokenSourceErrorFailsFast(t *testing.T) {
@@ -42,11 +56,28 @@ func TestRequest_TokenSourceErrorFailsFast(t *testing.T) {
 	_, err := c.ListCalendars(context.Background(), "")
 	require.Error(t, err)
 
+	assert := assert.New(t)
 	var rerr *oauth2.RetrieveError
-	assert.True(t, errors.As(err, &rerr), "the oauth2 RetrieveError must be preserved in the chain")
-	assert.Contains(t, err.Error(), "unauthorized_client")
-	assert.Equal(t, 1, ts.calls, "no retry on a credential error")
-	assert.Less(t, time.Since(start), 2*time.Second, "must not back off")
+	require.ErrorAs(t, err, &rerr, "the oauth2 RetrieveError must be preserved in the chain")
+	assert.Contains(err.Error(), "unauthorized_client")
+	assert.Equal(1, ts.calls, "no retry on a credential error")
+	assert.Less(time.Since(start), 2*time.Second, "must not back off")
+}
+
+// A 5xx from the token endpoint is not a credential problem and must go
+// through the normal retry policy instead of failing fast.
+func TestRequest_TransientTokenErrorIsRetried(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	defer srv.Close()
+
+	ts := &flakyTokenSource{}
+	c := NewClient(ts, WithBaseURL(srv.URL))
+
+	_, err := c.ListCalendars(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, ts.calls, "token fetch retried after a 503")
 }
 
 // "API not enabled in this project" arrives as a 403 in domain usageLimits —
@@ -65,7 +96,8 @@ func TestRequest_AccessNotConfiguredFailsFast(t *testing.T) {
 	start := time.Now()
 	_, err := c.ListCalendars(context.Background(), "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has not been used in project")
-	assert.Equal(t, 1, calls, "no retry on accessNotConfigured")
-	assert.Less(t, time.Since(start), 2*time.Second)
+	assert := assert.New(t)
+	assert.Contains(err.Error(), "has not been used in project")
+	assert.Equal(1, calls, "no retry on accessNotConfigured")
+	assert.Less(time.Since(start), 2*time.Second)
 }

--- a/internal/gcal/client_tokenerror_test.go
+++ b/internal/gcal/client_tokenerror_test.go
@@ -1,0 +1,71 @@
+package gcal
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// unauthorizedTokenSource mimics a service account whose domain-wide
+// delegation does not cover the requested scope: Google answers the token
+// exchange with 401 unauthorized_client before any API request is made.
+type unauthorizedTokenSource struct{ calls int }
+
+func (u *unauthorizedTokenSource) Token() (*oauth2.Token, error) {
+	u.calls++
+	return nil, &oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusUnauthorized},
+		Body:     []byte(`{"error":"unauthorized_client"}`),
+	}
+}
+
+// A credential failure must surface immediately with Google's error text —
+// not be retried as a network error for ten minutes of backoff.
+func TestRequest_TokenSourceErrorFailsFast(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("API must not be reached when the token exchange fails")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ts := &unauthorizedTokenSource{}
+	c := NewClient(ts, WithBaseURL(srv.URL))
+
+	start := time.Now()
+	_, err := c.ListCalendars(context.Background(), "")
+	require.Error(t, err)
+
+	var rerr *oauth2.RetrieveError
+	assert.True(t, errors.As(err, &rerr), "the oauth2 RetrieveError must be preserved in the chain")
+	assert.Contains(t, err.Error(), "unauthorized_client")
+	assert.Equal(t, 1, ts.calls, "no retry on a credential error")
+	assert.Less(t, time.Since(start), 2*time.Second, "must not back off")
+}
+
+// "API not enabled in this project" arrives as a 403 in domain usageLimits —
+// the same domain as real quota errors — but must not be retried.
+func TestRequest_AccessNotConfiguredFailsFast(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":403,"message":"Google Calendar API has not been used in project 123 before or it is disabled.","errors":[{"message":"...","domain":"usageLimits","reason":"accessNotConfigured"}],"status":"PERMISSION_DENIED"}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "t"}))
+	c.baseURL = srv.URL
+	start := time.Now()
+	_, err := c.ListCalendars(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has not been used in project")
+	assert.Equal(t, 1, calls, "no retry on accessNotConfigured")
+	assert.Less(t, time.Since(start), 2*time.Second)
+}


### PR DESCRIPTION
Registering a calendar for an OAuth app configured with `service_account_key` failed before it could do anything: `add-calendar` always resolved `client_secrets` for the app and then walked the user-consent flow, even though `buildCalendarClient` already knows how to mint a delegated token source for that case. On a Workspace domain using domain-wide delegation there is no per-user token to inspect and no consent screen to send anyone to, so there was no way to add calendars at all.

**What changed**

- `add-calendar` short-circuits to registration when the resolved app is a service-account app. `RegisterCalendars` is itself the live proof that the Calendar scope was granted, so nothing is lost by skipping the consent path. The registration tail is factored into a shared `registerCalendarsAndReport` so both paths report identically.
- The daemon-side plan step resolves the binding and reports that no consent/escalation round trip is needed, instead of demanding secrets the app does not have.
- Two calendar misconfigurations no longer burn the full ~10 minute retry budget before surfacing:
  - a token-source failure (a service account whose delegation is missing the Calendar scope answers `401 unauthorized_client`) arrives as a transport error from `httpClient.Do`; it is now detected via `oauth2.RetrieveError` and returned with Google's own message rather than retried.
  - `"Calendar API has not been used in project N"` is filed by Google under domain `usageLimits`, so the rate-limit classifier matched it. Reason `accessNotConfigured` is now excluded — no amount of backoff enables an API.

**Using it**

```toml
[oauth.apps.example]
service_account_key = "/path/to/service-account.json"
```

Grant that service account domain-wide delegation for `https://www.googleapis.com/auth/calendar.readonly`, enable the Calendar API in its GCP project, then `msgvault add-calendar user@example.com --oauth-app example` registers directly with no browser step.

User-consent OAuth apps are unaffected.