### PR TITLE
analytics: make the daemon-query DuckDB policy configurable

### DIFF
--- a/cmd/msgvault/cmd/serve.go
+++ b/cmd/msgvault/cmd/serve.go
@@ -1176,6 +1176,9 @@ func openDaemonDuckDBEngine(c *config.Config, s *store.Store) (*query.DuckDBEngi
 			DisableSQLiteScanner: true,
 			TempDirectory:        tempDirectory,
 			OwnTempDirectory:     true,
+			MemoryLimit:          c.Analytics.QueryMemoryLimit,
+			Threads:              c.Analytics.QueryThreads,
+			MaxTempDirectorySize: c.Analytics.QueryTempLimit,
 		},
 	)
 }

--- a/docs/api-server.md
+++ b/docs/api-server.md
@@ -2197,6 +2197,12 @@ All server settings go in the `[server]` section of `config.toml`. Account sched
 | `engine` | `auto` | Aggregate engine for Web UI, TUI, and aggregate HTTP views: `auto`, `sql`, or `duckdb` |
 | `auto_build_cache` | `true` | Build stale or missing Parquet cache files during daemon startup and after scheduled syncs; `false` skips both automatic paths |
 | `min_rebuild_interval` | `0s` | Minimum age of a usable cache before a scheduled sync may rebuild it; zero preserves rebuilding after each sync |
+| `builder_memory_limit` | `2GB` | DuckDB memory limit for cache builds, such as `4GB` or `512MiB` |
+| `builder_threads` | min(CPUs, 2) | DuckDB threads for cache builds; zero keeps the default |
+| `builder_temp_limit` | `32GB` | Maximum spill-to-disk size for cache builds |
+| `query_memory_limit` | `512MB` | DuckDB memory limit for daemon aggregate queries; raise it on a large archive |
+| `query_threads` | min(CPUs, 4) | DuckDB threads for daemon aggregate queries; zero keeps the default |
+| `query_temp_limit` | `2GB` | Maximum spill-to-disk size for daemon aggregate queries; a query that spills past it fails with a DuckDB out-of-memory error |
 
 `engine = "sql"` forces live SQL for aggregate views. `engine = "duckdb"`
 requires a usable Parquet cache and keeps analytics unavailable until it is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -549,6 +549,12 @@ Settings for daemon-side aggregate query behavior. The Web UI, TUI, MCP server, 
 | `engine` | `auto` | Aggregate engine: `auto` starts with live SQL and switches to DuckDB after cache maintenance succeeds; `sql` always uses live SQL; `duckdb` requires a usable Parquet cache |
 | `auto_build_cache` | `true` | Build a stale or missing Parquet cache during daemon startup and after scheduled syncs; `false` skips both automatic paths |
 | `min_rebuild_interval` | `0s` | Minimum age of a usable cache before a scheduled sync may rebuild it; zero preserves rebuilding after each sync |
+| `builder_memory_limit` | `2GB` | DuckDB memory limit for cache builds, such as `4GB` or `512MiB` |
+| `builder_threads` | min(CPUs, 2) | DuckDB threads for cache builds; zero keeps the default |
+| `builder_temp_limit` | `32GB` | Maximum spill-to-disk size for cache builds |
+| `query_memory_limit` | `512MB` | DuckDB memory limit for daemon aggregate queries; raise it on a large archive |
+| `query_threads` | min(CPUs, 4) | DuckDB threads for daemon aggregate queries; zero keeps the default |
+| `query_temp_limit` | `2GB` | Maximum spill-to-disk size for daemon aggregate queries; a query that spills past it fails with a DuckDB out-of-memory error |
 
 The daemon starts HTTP health and API routing before analytics cache
 maintenance. With `engine = "duckdb"`, analytics remain unavailable until a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,9 @@ type AnalyticsConfig struct {
 	BuilderMemoryLimit string        `toml:"builder_memory_limit"` // Optional DuckDB cache-builder memory limit
 	BuilderThreads     int           `toml:"builder_threads"`      // Optional DuckDB cache-builder threads; zero uses the default
 	BuilderTempLimit   string        `toml:"builder_temp_limit"`   // Optional DuckDB cache-builder temp-directory limit
+	QueryMemoryLimit   string        `toml:"query_memory_limit"`   // Optional DuckDB daemon-query memory limit; empty uses the default
+	QueryThreads       int           `toml:"query_threads"`        // Optional DuckDB daemon-query threads; zero uses the default
+	QueryTempLimit     string        `toml:"query_temp_limit"`     // Optional DuckDB daemon-query temp-directory limit; empty uses the default
 }
 
 const (
@@ -163,6 +166,8 @@ func (a *AnalyticsConfig) Validate() error {
 	}{
 		{key: "builder_memory_limit", value: a.BuilderMemoryLimit},
 		{key: "builder_temp_limit", value: a.BuilderTempLimit},
+		{key: "query_memory_limit", value: a.QueryMemoryLimit},
+		{key: "query_temp_limit", value: a.QueryTempLimit},
 	} {
 		if size.value != "" && !duckdbutil.ValidSize(size.value) {
 			return fmt.Errorf("invalid [analytics] %s %q: want a positive integer followed by B, KB, MB, GB, TB, KiB, MiB, GiB, or TiB",
@@ -171,6 +176,9 @@ func (a *AnalyticsConfig) Validate() error {
 	}
 	if a.BuilderThreads < 0 {
 		return fmt.Errorf("invalid [analytics] builder_threads %d: must be zero or positive", a.BuilderThreads)
+	}
+	if a.QueryThreads < 0 {
+		return fmt.Errorf("invalid [analytics] query_threads %d: must be zero or positive", a.QueryThreads)
 	}
 	if a.MinRebuildInterval < 0 {
 		return fmt.Errorf("invalid [analytics] min_rebuild_interval %q: must be zero or positive",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -153,6 +153,28 @@ builder_temp_limit = "12gB"
 	assertions.Equal("12gB", cfg.Analytics.BuilderTempLimit)
 }
 
+// The daemon-query knobs mirror the cache-builder ones: the InteractivePolicy
+// defaults are laptop-sized, and a large archive has to raise them or heavy
+// queries fail once they spill past max_temp_directory_size.
+func TestLoadWithAnalyticsQueryResourceLimits(t *testing.T) {
+	assertions := assert.New(t)
+	requirements := require.New(t)
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+	requirements.NoError(os.WriteFile(configPath, []byte(`
+[analytics]
+query_memory_limit = "8GB"
+query_threads = 6
+query_temp_limit = "40GiB"
+`), 0o600))
+
+	cfg, err := Load(configPath, "")
+	requirements.NoError(err)
+	assertions.Equal("8GB", cfg.Analytics.QueryMemoryLimit)
+	assertions.Equal(6, cfg.Analytics.QueryThreads)
+	assertions.Equal("40GiB", cfg.Analytics.QueryTempLimit)
+}
+
 func TestLoadRejectsInvalidAnalyticsBuilderResourceLimits(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -167,6 +189,10 @@ func TestLoadRejectsInvalidAnalyticsBuilderResourceLimits(t *testing.T) {
 		{name: "negative temp", key: "builder_temp_limit", value: `"-8GB"`},
 		{name: "missing temp number", key: "builder_temp_limit", value: `"GB"`},
 		{name: "negative threads", key: "builder_threads", value: "-1"},
+		{name: "zero query memory", key: "query_memory_limit", value: `"0GB"`},
+		{name: "missing query memory unit", key: "query_memory_limit", value: `"2"`},
+		{name: "negative query temp", key: "query_temp_limit", value: `"-8GB"`},
+		{name: "negative query threads", key: "query_threads", value: "-1"},
 	}
 
 	for _, tt := range tests {

--- a/internal/duckdbutil/connection.go
+++ b/internal/duckdbutil/connection.go
@@ -25,6 +25,17 @@ type Policy struct {
 	MaxTempDirectorySize string
 }
 
+// InteractiveOverrides contains optional interactive/daemon-query policy
+// values. Empty size values and zero threads retain InteractivePolicy
+// defaults, which are sized for a laptop-scale archive: a query that spills
+// past max_temp_directory_size fails outright with a DuckDB out-of-memory
+// error rather than running slowly, so a large archive needs to raise them.
+type InteractiveOverrides struct {
+	MemoryLimit          string
+	Threads              int
+	MaxTempDirectorySize string
+}
+
 // BuilderOverrides contains optional cache-builder policy values. Empty size
 // values and zero threads retain BuilderPolicy defaults.
 type BuilderOverrides struct {
@@ -41,6 +52,22 @@ func InteractivePolicy(tempDirectory string) Policy {
 		TempDirectory:        tempDirectory,
 		MaxTempDirectorySize: "2GB",
 	}
+}
+
+// InteractivePolicyWithOverrides applies non-zero overrides to
+// InteractivePolicy.
+func InteractivePolicyWithOverrides(tempDirectory string, overrides InteractiveOverrides) Policy {
+	policy := InteractivePolicy(tempDirectory)
+	if overrides.MemoryLimit != "" {
+		policy.MemoryLimit = overrides.MemoryLimit
+	}
+	if overrides.Threads != 0 {
+		policy.Threads = overrides.Threads
+	}
+	if overrides.MaxTempDirectorySize != "" {
+		policy.MaxTempDirectorySize = overrides.MaxTempDirectorySize
+	}
+	return policy
 }
 
 // BuilderPolicy returns the bounded policy for cache derivation processes.

--- a/internal/duckdbutil/interactive_overrides_test.go
+++ b/internal/duckdbutil/interactive_overrides_test.go
@@ -1,0 +1,30 @@
+package duckdbutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The interactive defaults are laptop-sized; a large archive must be able to
+// raise them, because a query that spills past max_temp_directory_size fails
+// outright ("Out of Memory Error") instead of running slowly.
+func TestInteractivePolicyWithOverrides(t *testing.T) {
+	base := InteractivePolicy("/tmp/spill")
+	assert.Equal(t, "512MB", base.MemoryLimit)
+	assert.Equal(t, "2GB", base.MaxTempDirectorySize)
+
+	got := InteractivePolicyWithOverrides("/tmp/spill", InteractiveOverrides{
+		MemoryLimit:          "8GB",
+		Threads:              8,
+		MaxTempDirectorySize: "40GB",
+	})
+	assert.Equal(t, "8GB", got.MemoryLimit)
+	assert.Equal(t, 8, got.Threads)
+	assert.Equal(t, "40GB", got.MaxTempDirectorySize)
+	assert.Equal(t, "/tmp/spill", got.TempDirectory)
+
+	// Zero values leave the defaults intact.
+	unchanged := InteractivePolicyWithOverrides("/tmp/spill", InteractiveOverrides{})
+	assert.Equal(t, base, unchanged)
+}

--- a/internal/duckdbutil/interactive_overrides_test.go
+++ b/internal/duckdbutil/interactive_overrides_test.go
@@ -10,21 +10,22 @@ import (
 // raise them, because a query that spills past max_temp_directory_size fails
 // outright ("Out of Memory Error") instead of running slowly.
 func TestInteractivePolicyWithOverrides(t *testing.T) {
+	assertions := assert.New(t)
 	base := InteractivePolicy("/tmp/spill")
-	assert.Equal(t, "512MB", base.MemoryLimit)
-	assert.Equal(t, "2GB", base.MaxTempDirectorySize)
+	assertions.Equal("512MB", base.MemoryLimit)
+	assertions.Equal("2GB", base.MaxTempDirectorySize)
 
 	got := InteractivePolicyWithOverrides("/tmp/spill", InteractiveOverrides{
 		MemoryLimit:          "8GB",
 		Threads:              8,
 		MaxTempDirectorySize: "40GB",
 	})
-	assert.Equal(t, "8GB", got.MemoryLimit)
-	assert.Equal(t, 8, got.Threads)
-	assert.Equal(t, "40GB", got.MaxTempDirectorySize)
-	assert.Equal(t, "/tmp/spill", got.TempDirectory)
+	assertions.Equal("8GB", got.MemoryLimit)
+	assertions.Equal(8, got.Threads)
+	assertions.Equal("40GB", got.MaxTempDirectorySize)
+	assertions.Equal("/tmp/spill", got.TempDirectory)
 
 	// Zero values leave the defaults intact.
 	unchanged := InteractivePolicyWithOverrides("/tmp/spill", InteractiveOverrides{})
-	assert.Equal(t, base, unchanged)
+	assertions.Equal(base, unchanged)
 }

--- a/internal/query/duckdb.go
+++ b/internal/query/duckdb.go
@@ -126,6 +126,13 @@ type DuckDBOptions struct {
 	TempDirectory string
 	// OwnTempDirectory removes TempDirectory after DuckDB closes.
 	OwnTempDirectory bool
+	// MemoryLimit, Threads and MaxTempDirectorySize override the interactive
+	// DuckDB policy. Empty and zero values keep its defaults, which are sized
+	// for a laptop; a large archive must raise them or heavy queries fail with
+	// a DuckDB out-of-memory error once they spill past the cap.
+	MemoryLimit          string
+	Threads              int
+	MaxTempDirectorySize string
 	// DisableLegacyAnalyticalViews skips registration of the Parquet-backed
 	// SQL views. It is a test-only isolation option proving the unfiltered
 	// people/domain/relationship read paths need only the relationship
@@ -162,7 +169,14 @@ func NewDuckDBEngine(analyticsDir string, sqlitePath string, sqliteDB *sql.DB, o
 		ownTempDirectory = true
 	}
 
-	db, err := duckdbutil.Open(context.Background(), duckdbutil.InteractivePolicy(tempDirectory))
+	db, err := duckdbutil.Open(context.Background(), duckdbutil.InteractivePolicyWithOverrides(
+		tempDirectory,
+		duckdbutil.InteractiveOverrides{
+			MemoryLimit:          opt.MemoryLimit,
+			Threads:              opt.Threads,
+			MaxTempDirectorySize: opt.MaxTempDirectorySize,
+		},
+	))
 	if err != nil {
 		if ownTempDirectory {
 			_ = os.RemoveAll(tempDirectory)


### PR DESCRIPTION
`[analytics]` could already bound the cache builder (`builder_memory_limit`, `builder_threads`, `builder_temp_limit`), but the interactive policy the daemon serves queries under was hard-coded at 512MB memory / 2GB temp. Those defaults are sized for a laptop, and DuckDB does not degrade gracefully past them: a query that spills beyond `max_temp_directory_size` fails with `Out of Memory Error` rather than running slowly. On a large archive that made whole classes of aggregate query fail — including MCP tool calls, which surfaced only as HTTP 500 — with no way to tune it.

**What changed**

Adds the symmetric daemon-query knobs, validated the same way as the builder ones and carried through `query.DuckDBOptions` into a new `duckdbutil.InteractivePolicyWithOverrides`.

**Using it**

```toml
[analytics]
query_memory_limit = "8GB"
query_threads = 6
query_temp_limit = "40GB"
```

Empty and zero values keep the current defaults, so behaviour is unchanged unless the knobs are set.