### PR TITLE
docs: explain the throughput cost of undersizing max_input_chars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -879,7 +879,7 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `batch_size` | `32` | Embedding inputs per HTTP call. Long messages can contribute multiple chunk inputs. |
 | `timeout` | `30s` | Per-request timeout. |
 | `max_retries` | `3` | Retries per batch on transient failures. |
-| `max_input_chars` | `32768` | Character cap per embedding chunk, counted in characters rather than tokens. Size it to your model's context window: too high and chunks are rejected or silently truncated, too low and each message splits into more chunks and `embeddings build` slows proportionally. For example, `6000` for a 2k-token model such as Ollama's `nomic-embed-text`. See [Matching `max_input_chars` to your embedder's context window](usage/vector-search.md#matching-max_input_chars-to-your-embedders-context-window). |
+| `max_input_chars` | `32768` | Character cap per embedding chunk, counted in characters rather than tokens. Too high and chunks are rejected or silently truncated; too low and long messages split into more chunks, adding embedding overhead. For example, start around `6000` for a 2k-token model such as Ollama's `nomic-embed-text`, then check representative content. See [Matching `max_input_chars` to your embedder's context window](usage/vector-search.md#matching-max_input_chars-to-your-embedders-context-window). |
 | `eta_window` | `10` | Number of recent progress samples used for ETA smoothing. |
 
 ##### Stored provider credentials

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -879,7 +879,7 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `batch_size` | `32` | Embedding inputs per HTTP call. Long messages can contribute multiple chunk inputs. |
 | `timeout` | `30s` | Per-request timeout. |
 | `max_retries` | `3` | Retries per batch on transient failures. |
-| `max_input_chars` | `32768` | Character cap per embedding chunk. Set below your model's context window (e.g., `2000` for Ollama's default `nomic-embed-text`). |
+| `max_input_chars` | `32768` | Character cap per embedding chunk. Set below your model's context window (e.g., `2000` for Ollama's default `nomic-embed-text`), but not far below it: undersizing this splits each message into more chunks and slows `embeddings build` proportionally. See [Matching `max_input_chars` to your embedder's context window](usage/vector-search.md#matching-max_input_chars-to-your-embedders-context-window). |
 | `eta_window` | `10` | Number of recent progress samples used for ETA smoothing. |
 
 ##### Stored provider credentials

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -879,7 +879,7 @@ External OpenAI-compatible embedding endpoint used to convert message text into 
 | `batch_size` | `32` | Embedding inputs per HTTP call. Long messages can contribute multiple chunk inputs. |
 | `timeout` | `30s` | Per-request timeout. |
 | `max_retries` | `3` | Retries per batch on transient failures. |
-| `max_input_chars` | `32768` | Character cap per embedding chunk. Set below your model's context window (e.g., `2000` for Ollama's default `nomic-embed-text`), but not far below it: undersizing this splits each message into more chunks and slows `embeddings build` proportionally. See [Matching `max_input_chars` to your embedder's context window](usage/vector-search.md#matching-max_input_chars-to-your-embedders-context-window). |
+| `max_input_chars` | `32768` | Character cap per embedding chunk, counted in characters rather than tokens. Size it to your model's context window: too high and chunks are rejected or silently truncated, too low and each message splits into more chunks and `embeddings build` slows proportionally. For example, `6000` for a 2k-token model such as Ollama's `nomic-embed-text`. See [Matching `max_input_chars` to your embedder's context window](usage/vector-search.md#matching-max_input_chars-to-your-embedders-context-window). |
 | `eta_window` | `10` | Number of recent progress samples used for ETA smoothing. |
 
 ##### Stored provider credentials

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -225,8 +225,9 @@ with an index built from unprefixed documents.
 
 `max_input_chars` is an upper bound in characters per embedding
 chunk; the embedder converts this to tokens on its own. Set it below
-the embedder's maximum context or individual chunks can fail with
-HTTP 400 during `msgvault embeddings build`.
+the embedder's token limit after conversion, with room for any
+`document_prefix`. Oversized chunks can be rejected or silently truncated
+during `msgvault embeddings build`.
 
 Long post-preprocess messages are split into overlapping chunks
 instead of being truncated to one embedding input. Chunk boundaries
@@ -236,39 +237,44 @@ falling back to a hard rune boundary only when needed.
 Size it to the context window rather than defensively low. The value
 is not only a correctness ceiling — it sets how many chunks each
 message becomes, and every chunk is a separate embedding input. Halving
-`max_input_chars` roughly doubles the chunk count for long messages, and
-`embeddings build` slows in proportion. On a large archive the
-difference between a conservative value and one matched to the model is
-the difference between hours and days, so it is worth confirming the
-real context window before starting a full rebuild.
+`max_input_chars` roughly doubles the chunk count for long messages.
+More chunks add per-input overhead and can slow `embeddings build`; the
+effect on build time depends on the model, batching, and message lengths.
+Confirm the real context window before starting a full rebuild.
 
 Practical guidance:
 
-- **Characters are not tokens.** English prose runs about 4 characters
-  per token; code, markup, and non-Latin scripts run closer to 1–2. The
-  values below assume 3 characters per token, which leaves headroom for
-  mixed content.
+- **Characters are not tokens.** The values below assume 3 characters
+  per token. The ratio varies by tokenizer and content; code, markup,
+  and non-Latin scripts may need a lower cap. Treat these values as
+  starting points and check representative content.
 - **2k-token embedding models:** start around `max_input_chars = 6000`.
 - **8k-token embedding models:** start around `max_input_chars = 24000`.
 - **Self-hosted models:** match the actual context window exposed by
   your server, not just the upstream model card.
 
-To measure the ratio for your own archive, tokenize a representative
-message with your embedder. Ollama's native API reports the token
-count:
+To check a candidate cap, send a representative preprocessed chunk of
+that size, including your `document_prefix`, to your embedder. Ollama's
+[native API](https://docs.ollama.com/api/embed) reports the token count.
+Set `truncate: false` so an oversized input returns an error instead of
+a count for truncated text:
 
 ```bash
-curl -s http://127.0.0.1:11434/api/embed \
-  -d '{"model":"nomic-embed-text","input":"<message text>"}' | jq .prompt_eval_count
+curl -sS http://127.0.0.1:11434/api/embed \
+  -d '{"model":"nomic-embed-text","input":"search_document: <chunk text>","truncate":false}' \
+  | jq '.error // .prompt_eval_count'
 ```
+
+Lower the cap if this reports a context-length error. Repeat with
+representative content before starting a full rebuild.
 
 !!! warning "Ollama truncates instead of rejecting"
     Through its OpenAI-compatible `/v1/embeddings` endpoint, which
-    msgvault uses, Ollama does not return `HTTP 400` for over-limit
-    input. It truncates each input to the smaller of the model's trained
-    context length and `num_ctx`, embeds only the beginning of the
-    chunk, and returns a normal response. Oversizing `max_input_chars`
-    therefore degrades recall silently instead of failing. The trained
+    msgvault uses, Ollama truncates over-limit inputs by default. The
+    ceiling is the smaller of the model's trained context length and
+    `num_ctx`, with room needed for special tokens. Ollama embeds only
+    the beginning of an oversized chunk and returns a normal response,
+    which can silently degrade recall. The trained
     length is the hard ceiling: Ollama's `nomic-embed-text` ships with
     `num_ctx = 8192` but a trained context of 2048 tokens, so raising
     `num_ctx` does not help. Check both with `ollama show <model>`
@@ -278,8 +284,8 @@ If `msgvault embeddings build` logs `HTTP 400`, msgvault includes the
 response body from the embedder when available. Check both the CLI log
 and the embedder's own logs. A body such as `the input length exceeds
 the context length` confirms you need to lower `max_input_chars`.
-Ollama's OpenAI-compatible endpoint does not return this error; see the
-warning above.
+Do not rely on this error to detect oversized inputs through Ollama's
+OpenAI-compatible endpoint; see the warning above.
 
 ## Initial Embedding
 

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -233,6 +233,15 @@ instead of being truncated to one embedding input. Chunk boundaries
 prefer paragraph breaks, then sentence breaks, then word boundaries,
 falling back to a hard rune boundary only when needed.
 
+Size it to the context window rather than defensively low. The value
+is not only a correctness ceiling — it sets how many chunks each
+message becomes, and every chunk is a separate embedding input. Halving
+`max_input_chars` roughly doubles the chunk count for long messages, and
+`embeddings build` slows in proportion. On a large archive the
+difference between a conservative value and one matched to the model is
+the difference between hours and days, so it is worth confirming the
+real context window before starting a full rebuild.
+
 Practical guidance:
 
 - **2k-token embedding models:** start around `max_input_chars = 2000`
@@ -240,6 +249,15 @@ Practical guidance:
 - **8k-token embedding models:** start around `max_input_chars = 24000`.
 - **Self-hosted models:** match the actual context window exposed by
   your server, not just the upstream model card.
+
+!!! warning "Ollama truncates silently"
+    Ollama applies its own context limit (`num_ctx`, 2048 by default for
+    embedding models) and truncates longer inputs instead of returning an
+    error. Raising `max_input_chars` past that limit therefore does not
+    fail loudly — it quietly embeds only the beginning of each chunk and
+    degrades recall. Raise `num_ctx` on the served model first (via a
+    `Modelfile` or the API's `options`), confirm the larger window is
+    actually in effect, and only then raise `max_input_chars`.
 
 If `msgvault embeddings build` logs `HTTP 400`, msgvault now includes
 the response body from the embedder when available. Check both the

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -104,8 +104,15 @@ go build -tags "fts5 sqlite_vec" -o msgvault.exe ./cmd/msgvault
 ## Enable
 
 Use `msgvault setup providers` to select defaults, or add a `[vector]` block
-to `~/.msgvault/config.toml`. This manual example uses an OpenAI-compatible
-endpoint:
+to `~/.msgvault/config.toml`.
+
+Guided Ollama setup uses a conservative `max_input_chars = 2000`, leaving
+more room for token-dense content. To use `6000` as shown below, first
+check representative content with the [sizing guidance](#matching-max_input_chars-to-your-embedders-context-window),
+then change `max_input_chars` under `[vector.embeddings]` in
+`~/.msgvault/config.toml`.
+
+This manual example uses an OpenAI-compatible endpoint:
 
 ```toml
 [vector]
@@ -253,8 +260,10 @@ Practical guidance:
 - **Self-hosted models:** match the actual context window exposed by
   your server, not just the upstream model card.
 
-To check a candidate cap, send a representative preprocessed chunk of
-that size, including your `document_prefix`, to your embedder. Ollama's
+To check a candidate cap, take `max_input_chars` characters of representative
+preprocessed content, then prepend your configured `document_prefix` and
+send the combined input to your embedder. The prefix does not consume the
+chunking budget. Ollama's
 [native API](https://docs.ollama.com/api/embed) reports the token count.
 Set `truncate: false` so an oversized input returns an error instead of
 a count for truncated text:

--- a/docs/usage/vector-search.md
+++ b/docs/usage/vector-search.md
@@ -124,7 +124,7 @@ query_prefix = "search_query: "        # required by nomic-embed-text
 batch_size = 32                          # embeddings per HTTP call
 timeout = "30s"
 max_retries = 3
-max_input_chars = 2000                   # per-chunk cap; see sizing guidance below
+max_input_chars = 6000                   # per-chunk cap; see sizing guidance below
 eta_window = 10                          # progress ETA smoothing window
 
 [vector.preprocess]
@@ -244,25 +244,42 @@ real context window before starting a full rebuild.
 
 Practical guidance:
 
-- **2k-token embedding models:** start around `max_input_chars = 2000`
-  and raise only after confirming the endpoint accepts longer inputs.
+- **Characters are not tokens.** English prose runs about 4 characters
+  per token; code, markup, and non-Latin scripts run closer to 1–2. The
+  values below assume 3 characters per token, which leaves headroom for
+  mixed content.
+- **2k-token embedding models:** start around `max_input_chars = 6000`.
 - **8k-token embedding models:** start around `max_input_chars = 24000`.
 - **Self-hosted models:** match the actual context window exposed by
   your server, not just the upstream model card.
 
-!!! warning "Ollama truncates silently"
-    Ollama applies its own context limit (`num_ctx`, 2048 by default for
-    embedding models) and truncates longer inputs instead of returning an
-    error. Raising `max_input_chars` past that limit therefore does not
-    fail loudly — it quietly embeds only the beginning of each chunk and
-    degrades recall. Raise `num_ctx` on the served model first (via a
-    `Modelfile` or the API's `options`), confirm the larger window is
-    actually in effect, and only then raise `max_input_chars`.
+To measure the ratio for your own archive, tokenize a representative
+message with your embedder. Ollama's native API reports the token
+count:
 
-If `msgvault embeddings build` logs `HTTP 400`, msgvault now includes
-the response body from the embedder when available. Check both the
-CLI log and the embedder's own logs. `the input length exceeds the
-context length` confirms you need to lower `max_input_chars`.
+```bash
+curl -s http://127.0.0.1:11434/api/embed \
+  -d '{"model":"nomic-embed-text","input":"<message text>"}' | jq .prompt_eval_count
+```
+
+!!! warning "Ollama truncates instead of rejecting"
+    Through its OpenAI-compatible `/v1/embeddings` endpoint, which
+    msgvault uses, Ollama does not return `HTTP 400` for over-limit
+    input. It truncates each input to the smaller of the model's trained
+    context length and `num_ctx`, embeds only the beginning of the
+    chunk, and returns a normal response. Oversizing `max_input_chars`
+    therefore degrades recall silently instead of failing. The trained
+    length is the hard ceiling: Ollama's `nomic-embed-text` ships with
+    `num_ctx = 8192` but a trained context of 2048 tokens, so raising
+    `num_ctx` does not help. Check both with `ollama show <model>`
+    before raising `max_input_chars`.
+
+If `msgvault embeddings build` logs `HTTP 400`, msgvault includes the
+response body from the embedder when available. Check both the CLI log
+and the embedder's own logs. A body such as `the input length exceeds
+the context length` confirms you need to lower `max_input_chars`.
+Ollama's OpenAI-compatible endpoint does not return this error; see the
+warning above.
 
 ## Initial Embedding
 


### PR DESCRIPTION
The sizing guide explains how undersizing `max_input_chars` splits long messages into more embedding inputs and adds overhead. It distinguishes characters from tokens and uses consistent starting values for 2k- and 8k-token models, with a check against representative content before rebuilding.

The Ollama warning explains silent truncation and the ceiling imposed by the model's trained context length and `num_ctx`. The native API example disables truncation so readers can detect oversized chunks, including the document prefix. The sample configuration and configuration reference match this guidance. Build time depends on the model, batching, and message lengths.

Documentation only; no runtime behavior changes.
