### PR TITLE
feat(web): add right-side previews and dark email reading

### DIFF
--- a/docs/web-ui.md
+++ b/docs/web-ui.md
@@ -1,5 +1,5 @@
 ---
-last_edited: "2026-09-08"
+last_edited: "2026-09-09"
 title: Web UI
 description: Browse messages and files, maintain people, and monitor archive work from your browser.
 ---
@@ -129,6 +129,21 @@ error, not an empty result, and the query and filters remain available to retry.
 cannot safely honor the selected search mode. Update or rebuild the named
 component, or deliberately select a supported mode. Msgvault does not quietly
 substitute full-text search for either state.
+
+## Read messages
+
+Click an entry in Everything to open its preview below the results. On wide
+windows, choose **Preview position → Right** to read beside the results.
+Drag the divider to resize either layout, or focus it and use the arrow keys.
+Double-click the divider to reset its size. The browser remembers your layout
+choice and each layout's size. Narrow windows use the preview below the results
+and restore your right-side layout when there is room again.
+
+HTML email follows the app's dark theme by replacing sender-defined text,
+background, and border colors. Images keep their original colors. Choose
+**Use original colors** above a message to see its authored colors on a white
+background, or **Use app colors** to return to dark reading. This override
+applies to the open message. Light mode preserves designed email colors.
 
 ## Cache states
 

--- a/web/public/archived-frame.css
+++ b/web/public/archived-frame.css
@@ -4,8 +4,8 @@
  * (style-src 'self') is inherited by sandboxed srcdoc frames and blocks every
  * inline style. Rendering mode and scheme arrive as html[data-mode] /
  * html[data-scheme] attributes:
- *   - canvas: designed mail on its own white, light canvas in both themes
- *   - themed: simple mail rendered transparently with shell inks
+ *   - canvas: original email colors on a white canvas
+ *   - themed: mail rendered transparently with shell inks
  * Themed ink values mirror web/src/styles/theme-light.css / theme-dark.css.
  */
 
@@ -52,6 +52,24 @@ html[data-mode='themed'] body {
   max-width: 680px;
   padding: 2px 0;
   background: transparent;
+}
+
+/* In dark reading mode replace sender colors together so dark text never
+ * lands on a dark surface. Keep layout and image pixels intact. Original
+ * colors remain available through the message's color control. */
+html[data-mode='themed'][data-scheme='dark'] :where(body, body *:not([data-archived-image-glyph])) {
+  color: var(--mail-text) !important;
+  background-color: transparent !important;
+  background-image: none !important;
+  border-color: var(--mail-border) !important;
+}
+
+html[data-mode='themed'][data-scheme='dark'] :where(a, a *) {
+  color: var(--mail-link) !important;
+}
+
+html[data-mode='themed'][data-scheme='dark'] :where(blockquote, [data-archived-quote], [data-archived-image-placeholder]) {
+  color: var(--mail-muted) !important;
 }
 
 /* Reading typography as low-specificity defaults: author styles in designed

--- a/web/public/archived-frame.css
+++ b/web/public/archived-frame.css
@@ -64,12 +64,22 @@ html[data-mode='themed'][data-scheme='dark'] :where(body, body *:not([data-archi
   border-color: var(--mail-border) !important;
 }
 
-html[data-mode='themed'][data-scheme='dark'] :where(a, a *) {
-  color: var(--mail-link) !important;
+html[data-mode='themed'][data-scheme='dark'] :where(
+  blockquote, blockquote *, [data-archived-quote], [data-archived-quote] *,
+  [data-archived-quote-toggle] > summary, [data-archived-quote-toggle] > summary *,
+  [data-archived-image-placeholder]
+) {
+  color: var(--mail-muted) !important;
 }
 
-html[data-mode='themed'][data-scheme='dark'] :where(blockquote, [data-archived-quote], [data-archived-image-placeholder]) {
-  color: var(--mail-muted) !important;
+html[data-mode='themed'][data-scheme='dark'] :where(
+  [data-archived-quote-toggle] > summary:hover, [data-archived-quote-toggle] > summary:hover *
+) {
+  color: var(--mail-text) !important;
+}
+
+html[data-mode='themed'][data-scheme='dark'] :where(a, a *) {
+  color: var(--mail-link) !important;
 }
 
 /* Reading typography as low-specificity defaults: author styles in designed

--- a/web/src/lib/components/layout/SplitPane.svelte
+++ b/web/src/lib/components/layout/SplitPane.svelte
@@ -76,9 +76,8 @@
   }
 
   let host = $state<HTMLDivElement>();
-  const storedSize = readStoredSize();
-  let sizedSize = $state(untrack(() => storedSize ?? initialSize));
-  let userSized = storedSize !== undefined;
+  let sizedSize = $state(untrack(() => initialSize));
+  let userSized = false;
   let available = $state(0);
   let resizeStartSize = 0;
 

--- a/web/src/lib/components/layout/SplitPane.svelte
+++ b/web/src/lib/components/layout/SplitPane.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SplitResizeHandle, type SplitResizeEvent } from '@kenn-io/kit-ui';
-  import { onMount, untrack, type Snippet } from 'svelte';
+  import { untrack, type Snippet } from 'svelte';
 
   interface Props {
     ariaLabel: string;
@@ -47,7 +47,7 @@
   }: Props = $props();
 
   const keyboardStep = 24;
-  const vertical = untrack(() => orientation) === 'vertical';
+  const vertical = $derived(orientation === 'vertical');
   const handleThickness = 4;
   const minSized = $derived(vertical ? minSecondary ?? 160 : minPrimary);
   const minOther = $derived(vertical ? minPrimary : minSecondary ?? 320);
@@ -75,7 +75,7 @@
     }
   }
 
-  let host: HTMLDivElement;
+  let host = $state<HTMLDivElement>();
   const storedSize = readStoredSize();
   let sizedSize = $state(untrack(() => storedSize ?? initialSize));
   let userSized = storedSize !== undefined;
@@ -133,7 +133,19 @@
     return vertical ? entry.contentRect.height : entry.contentRect.width;
   }
 
-  onMount(() => {
+  // Reconfigure sizing without remounting either pane's content when the
+  // layout changes. Each orientation can retain its own stored dimensions.
+  $effect(() => {
+    const target = host;
+    void orientation;
+    void storageKey;
+    if (!target) return;
+    untrack(() => {
+      const stored = readStoredSize();
+      userSized = stored !== undefined;
+      sizedSize = stored ?? initialSize;
+      available = 0;
+    });
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
@@ -145,12 +157,12 @@
         setSize(Math.round(available * initialFraction), false);
       } else setSize(sizedSize, false);
     });
-    observer.observe(host);
+    observer.observe(target);
     return () => observer.disconnect();
   });
 </script>
 
-<div class="split-pane" class:split-pane--vertical={vertical} data-split-pane bind:this={host}>
+<div class="split-pane" class:split-pane--vertical={vertical} class:split-pane--collapsed={collapsed} data-split-pane bind:this={host}>
   <section
     class="pane primary"
     data-pane="primary"
@@ -221,6 +233,10 @@
     flex-grow: 0;
     flex-shrink: 0;
     overflow: hidden;
+  }
+
+  .split-pane--collapsed > .primary {
+    flex: 1;
   }
 
   .handle-reset {

--- a/web/src/lib/components/reader/ContentFrame.svelte
+++ b/web/src/lib/components/reader/ContentFrame.svelte
@@ -36,6 +36,7 @@
   let documentState = $state<'building' | 'loading' | 'ready' | 'failed'>('building');
   let remoteImageCount = $state(0);
   let remoteImagesAllowed = $state(false);
+  let originalColors = $state(false);
   let frameHeight = $state(96);
   let nonce = $state(createFrameNonce());
   let colorScheme = $state<FrameColorScheme>(resolvedColorScheme());
@@ -65,6 +66,7 @@
     const identityChanged = nextIdentity !== messageIdentity;
     messageIdentity = nextIdentity;
     if (identityChanged && remoteImagesAllowed) remoteImagesAllowed = false;
+    if (identityChanged && originalColors) originalColors = false;
     // A new message starts from the compact default height; the bridge
     // reports the real content height as soon as the document loads. Reusing
     // the previous message's height would leave a tall empty frame.
@@ -75,7 +77,8 @@
     const buildNonce = createFrameNonce();
     const sanitized = sanitizeArchivedHTML(currentHTML, { messageId: currentMessageID });
     remoteImageCount = sanitized.remoteImages.length;
-    const mode = sanitized.designed ? 'canvas' as const : 'themed' as const;
+    const mode = originalColors || (sanitized.designed && currentScheme === 'light')
+      ? 'canvas' as const : 'themed' as const;
     inlineController = new AbortController();
     const signal = inlineController.signal;
     void resolveArchivedInlineImages({
@@ -193,6 +196,17 @@
 </script>
 
 <section class="content-frame" aria-label={title} bind:this={host}>
+  {#if colorScheme === 'dark'}
+    <div class="color-control">
+      <Button
+        size="sm"
+        surface="soft"
+        label={originalColors ? 'Use app colors' : 'Use original colors'}
+        disabled={documentState !== 'ready'}
+        onclick={() => { originalColors = !originalColors; }}
+      />
+    </div>
+  {/if}
   {#if remoteImageCount > 0 && !remoteImagesAllowed}
     <p class="remote-notice" role="status">
       <span>{remoteImageCount === 1
@@ -241,6 +255,11 @@
     gap: var(--space-2);
   }
 
+  .color-control {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   .remote-notice {
     display: flex;
     align-items: center;
@@ -265,8 +284,7 @@
     background: transparent;
   }
 
-  /* Designed mail keeps the white canvas it was authored for — bounded by a
-   * hairline so it reads as an artifact rather than a hole in dark mode.
+  /* Original colors use the white canvas assumed by authored mail.
    * content-box keeps the styled height equal to the inner viewport, so the
    * hairline never steals bridge-reported content height. */
   iframe.canvas {

--- a/web/src/lib/components/reader/ContentFrame.svelte
+++ b/web/src/lib/components/reader/ContentFrame.svelte
@@ -77,7 +77,7 @@
     const buildNonce = createFrameNonce();
     const sanitized = sanitizeArchivedHTML(currentHTML, { messageId: currentMessageID });
     remoteImageCount = sanitized.remoteImages.length;
-    const mode = originalColors || (sanitized.designed && currentScheme === 'light')
+    const mode = (originalColors && currentScheme === 'dark') || (sanitized.designed && currentScheme === 'light')
       ? 'canvas' as const : 'themed' as const;
     inlineController = new AbortController();
     const signal = inlineController.signal;

--- a/web/src/lib/components/shell/EverythingWorkspace.svelte
+++ b/web/src/lib/components/shell/EverythingWorkspace.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, KbdBadge, SearchInput } from '@kenn-io/kit-ui';
+  import { Button, KbdBadge, SearchInput, SegmentedControl } from '@kenn-io/kit-ui';
   import { onDestroy, untrack } from 'svelte';
 
   import type { APIClient } from '../../api/client';
@@ -95,6 +95,28 @@
   }: Props = $props();
 
   const api = createExploreAPI(untrack(() => client));
+
+  function storedPreviewPosition(): 'below' | 'right' {
+    try {
+      return localStorage.getItem('msgvault.reading-pane.position') === 'right' ? 'right' : 'below';
+    } catch {
+      return 'below';
+    }
+  }
+
+  let previewPosition = $state(storedPreviewPosition());
+  let resultsWidth = $state(0);
+  const canPreviewRight = $derived(resultsWidth >= 960);
+  const previewRight = $derived(canPreviewRight && previewPosition === 'right');
+
+  function setPreviewPosition(value: string): void {
+    previewPosition = value === 'right' ? 'right' : 'below';
+    try {
+      localStorage.setItem('msgvault.reading-pane.position', previewPosition);
+    } catch {
+      // Keep the control usable when browser storage is unavailable.
+    }
+  }
 
   // coverage, coveragePollAttempts/coveragePollKey, visibleLexicalRowKeys,
   // lexicalCountCache/canonicalQueryHashes, and readingGroupDetail/
@@ -500,15 +522,28 @@
     <div>
       <h1>Everything</h1>
     </div>
-    <p class="result-count" aria-live="polite" data-mono>
-      {#if loader.result?.candidatePoolSaturated}
-        {loader.rows.length.toLocaleString()} {loader.rows.length === 1 ? 'result' : 'results'} shown
-      {:else if loader.result?.totalCount !== undefined}
-        {loader.result.totalCount.toLocaleString()} items
-      {:else}
-        Modality-neutral archive
+    <div class="workspace-view-controls">
+      {#if canPreviewRight}
+        <div class="preview-position">
+          <span>Preview position</span>
+          <SegmentedControl
+            ariaLabel="Preview position"
+            options={[{ value: 'below', label: 'Below' }, { value: 'right', label: 'Right' }]}
+            value={previewPosition}
+            onchange={setPreviewPosition}
+          />
+        </div>
       {/if}
-    </p>
+      <p class="result-count" aria-live="polite" data-mono>
+        {#if loader.result?.candidatePoolSaturated}
+          {loader.rows.length.toLocaleString()} {loader.rows.length === 1 ? 'result' : 'results'} shown
+        {:else if loader.result?.totalCount !== undefined}
+          {loader.result.totalCount.toLocaleString()} items
+        {:else}
+          Modality-neutral archive
+        {/if}
+      </p>
+    </div>
   </header>
 
   <form class="search-bar" role="search" aria-label="Search Everything" onsubmit={submitSearch}>
@@ -588,14 +623,14 @@
     <p class="scope-note" role="status">Semantic search covers active messages only.</p>
   {/if}
 
-  <div class="results-split">
+  <div class="results-split" class:results-split--right={previewRight} bind:clientWidth={resultsWidth}>
     <SplitPane
       ariaLabel="Resize reading pane"
-      storageKey="msgvault.reading-pane.size"
-      orientation="vertical"
-      initialFraction={0.55}
-      minPrimary={120}
-      minSecondary={160}
+      storageKey={previewRight ? 'msgvault.reading-pane.right-size' : 'msgvault.reading-pane.size'}
+      orientation={previewRight ? 'horizontal' : 'vertical'}
+      initialFraction={previewRight ? 0.45 : 0.55}
+      minPrimary={previewRight ? 360 : 120}
+      minSecondary={previewRight ? 400 : 160}
       collapsed={!readingTargetKey}
     >
       {#snippet primary()}
@@ -766,6 +801,18 @@
     gap: var(--space-6);
   }
 
+  .workspace-view-controls,
+  .preview-position {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .preview-position {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
   h1 {
     margin: 0;
     font-family: var(--font-sans);
@@ -846,6 +893,16 @@
     border: 1px solid var(--border-default);
     border-top: 0;
     border-radius: 0 0 var(--radius-md) var(--radius-md);
+  }
+
+  .results-split--right :global([data-pane]) {
+    overflow: hidden;
+  }
+
+  .results-split--right :global([data-pane='secondary']) {
+    border-top: 1px solid var(--border-default);
+    border-left: 0;
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
   }
 
   .keyboard-help {

--- a/web/src/lib/content/frame-document.ts
+++ b/web/src/lib/content/frame-document.ts
@@ -19,8 +19,8 @@ export const ARCHIVED_FRAME_STYLE_PATH = '/archived-frame.css';
 export type FrameColorScheme = 'light' | 'dark';
 
 export interface FrameAppearance {
-  /** 'canvas': designed mail on its own white canvas. 'themed': simple mail
-   * rendered transparently on the shell surface with shell inks. */
+  /** 'canvas': original email colors on a white canvas. 'themed': mail
+   * rendered transparently with the shell's reading colors. */
   mode: 'canvas' | 'themed';
   colorScheme: FrameColorScheme;
 }
@@ -94,9 +94,8 @@ export async function buildFrameDocument(options: FrameDocumentOptions): Promise
     "form-action 'none'"
   ].join('; ');
 
-  // Designed mail keeps its assumed white light canvas in both shell themes;
-  // simple mail adopts the shell scheme and renders transparently on the
-  // theme surface. archived-frame.css keys on the data attributes.
+  // Original email colors assume a white canvas; themed mail adopts the
+  // shell scheme. archived-frame.css keys on these data attributes.
   return '<!doctype html>' +
     `<html data-bridge-nonce="${escapeAttribute(options.nonce)}"` +
     ` data-bridge-origin="${escapeAttribute(origin)}"` +

--- a/web/src/lib/content/sanitize.ts
+++ b/web/src/lib/content/sanitize.ts
@@ -23,8 +23,8 @@ export interface SanitizedArchivedHTML {
   remoteImages: string[];
   inlineImages: ArchivedInlineImage[];
   /** True when the sender authored a visual design (backgrounds or
-   * multi-column layout tables). Designed mail renders on its own white
-   * canvas; everything else inherits the shell theme. */
+   * multi-column layout tables). Used to preserve its white canvas in
+   * light mode; dark mode adapts email colors unless the reader opts out. */
   designed: boolean;
 }
 

--- a/web/tests/conversation-content-frame.spec.ts
+++ b/web/tests/conversation-content-frame.spec.ts
@@ -387,7 +387,6 @@ test('opening a message fires no sender-host request until images are enabled', 
 });
 
 test('email colors follow the app theme with an original-colors override', async ({ page }) => {
-  await page.setViewportSize({ width: 1920, height: 1080 });
   await page.addInitScript(() => {
     sessionStorage.setItem('msgvault.appearance.override', JSON.stringify({ theme: 'dark' }));
   });
@@ -404,19 +403,30 @@ test('email colors follow the app theme with an original-colors override', async
       from: 'alice@example.com', to: ['bob@example.com'], sent_at: row.occurred_at,
       snippet: row.preview, labels: [], has_attachments: false, size_bytes: 10,
       body: 'A designed email', attachments: [],
-      body_html: '<table bgcolor="#ffffff"><tr><td style="color: #111111; background-color: #ffffff"><p>Designed email text</p><a href="https://example.com" style="color: #112233">Read more</a><img alt="Embedded image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="></td></tr></table>'
+      body_html: '<table bgcolor="#ffffff"><tr><td style="color: #111111; background-color: #ffffff"><p>Designed email text</p><a href="https://example.com" style="color: #112233">Read more</a><img alt="Embedded image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="></td></tr></table>' +
+        '<blockquote><p style="color: #111111">Quoted paragraph</p><blockquote><div>Nested quote</div><a href="https://example.com"><span>Quoted link</span></a></blockquote></blockquote>' +
+        '<div class="gmail_quote"><div style="color: #111111">Gmail quoted text</div></div>'
     }]
   } }));
   await page.goto(`/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
   await expect(page.locator('html')).toHaveClass(/dark/);
   await page.getByRole('grid', { name: 'Everything results' }).getByText(row.title).click();
-  await page.getByRole('radiogroup', { name: 'Preview position' }).getByRole('radio', { name: 'Right' }).click();
   const content = page.locator('iframe[title="Message body"]').contentFrame();
   await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(242, 243, 245)');
   await expect(content.locator('table')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
   await expect(content.locator('a').filter({ hasText: 'Read more' })).toHaveCSS('color', 'rgb(116, 172, 254)');
   await expect(content.getByRole('img', { name: 'Embedded image' })).toHaveCSS('filter', 'none');
-  await page.screenshot({ path: 'test-results/email-dark-theme.png' });
+  const showQuote = content.getByText('Show quoted text');
+  await expect.soft(showQuote).toHaveCSS('color', 'rgb(164, 168, 175)');
+  await showQuote.hover();
+  await expect.soft(showQuote).toHaveCSS('color', 'rgb(242, 243, 245)');
+  await showQuote.click();
+  await page.mouse.move(0, 0);
+  await expect.soft(content.getByText('Hide quoted text')).toHaveCSS('color', 'rgb(164, 168, 175)');
+  for (const text of ['Quoted paragraph', 'Nested quote', 'Gmail quoted text']) {
+    await expect.soft(content.getByText(text, { exact: true })).toHaveCSS('color', 'rgb(164, 168, 175)');
+  }
+  await expect(content.getByText('Quoted link', { exact: true })).toHaveCSS('color', 'rgb(116, 172, 254)');
   await page.getByRole('button', { name: 'Use original colors' }).click();
   await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(17, 17, 17)');
   await expect(content.locator('table')).toHaveCSS('background-color', 'rgb(255, 255, 255)');
@@ -427,4 +437,36 @@ test('email colors follow the app theme with an original-colors override', async
   await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(17, 17, 17)');
   await setKitTheme(page, 'dark');
   await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(242, 243, 245)');
+});
+
+test('switching to light ignores the original-colors override for simple mail', async ({ page }) => {
+  await page.addInitScript(() => {
+    sessionStorage.setItem('msgvault.appearance.override', JSON.stringify({ theme: 'dark' }));
+  });
+  await page.route('**/api/session', (route) => route.fulfill({ json: {
+    auth_mode: 'loopback', https: false, plain_http_warning: false
+  } }));
+  await page.route('**/api/v1/explore', (route) => route.fulfill({ json: {
+    rows: [row], total_count: 1, cache_revision: 'cache-mail-theme', search_provenance: {}
+  } }));
+  await page.route('**/api/v1/conversations/7**', (route) => route.fulfill({ json: {
+    id: 7, anchor_id: 42, has_before: false, has_after: false, total: 1,
+    messages: [{
+      id: 42, conversation_id: 7, subject: row.title, message_type: 'email',
+      from: 'alice@example.com', to: ['bob@example.com'], sent_at: row.occurred_at,
+      snippet: row.preview, labels: [], has_attachments: false, size_bytes: 10,
+      body: 'Simple reply', body_html: '<p style="color: #112233">Simple reply</p>', attachments: []
+    }]
+  } }));
+  await page.goto(`/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
+  await page.getByRole('grid', { name: 'Everything results' }).getByText(row.title).click();
+  const frame = page.locator('iframe[title="Message body"]');
+  await expect(frame.contentFrame().getByText('Simple reply')).toHaveCSS('color', 'rgb(242, 243, 245)');
+  await page.getByRole('button', { name: 'Use original colors' }).click();
+  await expect(frame).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await expect(frame.contentFrame().getByText('Simple reply')).toHaveCSS('color', 'rgb(17, 34, 51)');
+  await setKitTheme(page, 'light');
+  await expect(page.getByRole('button', { name: 'Use app colors' })).toHaveCount(0);
+  await expect(frame).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(frame.contentFrame().locator('body')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
 });

--- a/web/tests/conversation-content-frame.spec.ts
+++ b/web/tests/conversation-content-frame.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { setKitTheme } from './kit-ui';
 
 const row = {
   key: 'source:1:message:source-1',
@@ -383,4 +384,47 @@ test('opening a message fires no sender-host request until images are enabled', 
   await expect(frame.contentFrame().locator('img[src^="data:image/png;base64,"]')).toHaveCount(1);
   expect(proxiedURLs).toEqual(['https://tracking.example/pixel.gif']);
   expect(sentinelRequests).toEqual([]);
+});
+
+test('email colors follow the app theme with an original-colors override', async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.addInitScript(() => {
+    sessionStorage.setItem('msgvault.appearance.override', JSON.stringify({ theme: 'dark' }));
+  });
+  await page.route('**/api/session', (route) => route.fulfill({ json: {
+    auth_mode: 'loopback', https: false, plain_http_warning: false
+  } }));
+  await page.route('**/api/v1/explore', (route) => route.fulfill({ json: {
+    rows: [row], total_count: 1, cache_revision: 'cache-mail-theme', search_provenance: {}
+  } }));
+  await page.route('**/api/v1/conversations/7**', (route) => route.fulfill({ json: {
+    id: 7, anchor_id: 42, has_before: false, has_after: false, total: 1,
+    messages: [{
+      id: 42, conversation_id: 7, subject: row.title, message_type: 'email',
+      from: 'alice@example.com', to: ['bob@example.com'], sent_at: row.occurred_at,
+      snippet: row.preview, labels: [], has_attachments: false, size_bytes: 10,
+      body: 'A designed email', attachments: [],
+      body_html: '<table bgcolor="#ffffff"><tr><td style="color: #111111; background-color: #ffffff"><p>Designed email text</p><a href="https://example.com" style="color: #112233">Read more</a><img alt="Embedded image" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="></td></tr></table>'
+    }]
+  } }));
+  await page.goto(`/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
+  await expect(page.locator('html')).toHaveClass(/dark/);
+  await page.getByRole('grid', { name: 'Everything results' }).getByText(row.title).click();
+  await page.getByRole('radiogroup', { name: 'Preview position' }).getByRole('radio', { name: 'Right' }).click();
+  const content = page.locator('iframe[title="Message body"]').contentFrame();
+  await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(242, 243, 245)');
+  await expect(content.locator('table')).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(content.locator('a').filter({ hasText: 'Read more' })).toHaveCSS('color', 'rgb(116, 172, 254)');
+  await expect(content.getByRole('img', { name: 'Embedded image' })).toHaveCSS('filter', 'none');
+  await page.screenshot({ path: 'test-results/email-dark-theme.png' });
+  await page.getByRole('button', { name: 'Use original colors' }).click();
+  await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(17, 17, 17)');
+  await expect(content.locator('table')).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await page.getByRole('button', { name: 'Use app colors' }).click();
+  await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(242, 243, 245)');
+  // Change the actual shell theme while the same email remains open.
+  await setKitTheme(page, 'light');
+  await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(17, 17, 17)');
+  await setKitTheme(page, 'dark');
+  await expect(content.getByText('Designed email text')).toHaveCSS('color', 'rgb(242, 243, 245)');
 });

--- a/web/tests/everything-reading-pane.spec.ts
+++ b/web/tests/everything-reading-pane.spec.ts
@@ -204,3 +204,68 @@ test('global command and Escape shortcuts stay suspended in editable controls', 
     await expect(locator).toBeFocused();
   }
 });
+
+test('right preview resizes, restores its width, and falls back below on narrow windows', async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await page.route('**/api/session', (route) =>
+    route.fulfill({ json: { auth_mode: 'loopback', https: false, plain_http_warning: false } })
+  );
+  await page.route('**/api/v1/explore', (route) => route.fulfill({ json: {
+    rows: [entry(1), entry(2)], total_count: 2,
+    cache_revision: 'cache-layout', search_provenance: {}
+  } }));
+  await page.goto(`/?explore=${encodeURIComponent(JSON.stringify({ workspace: 'everything' }))}`);
+  const grid = page.getByRole('grid', { name: 'Everything results' });
+  await grid.getByText('Synthetic subject 1').click();
+  const reading = page.getByRole('complementary', { name: 'Reading pane: Synthetic subject 1' });
+  const resize = page.getByRole('separator', { name: 'Resize reading pane' });
+  const position = page.getByRole('radiogroup', { name: 'Preview position' });
+  await position.getByRole('radio', { name: 'Right', exact: true }).click();
+  await expect(resize).toHaveAttribute('aria-orientation', 'vertical');
+  const primary = page.locator('.results-split > [data-split-pane] > [data-pane="primary"]');
+  const secondary = page.locator('.results-split > [data-split-pane] > [data-pane="secondary"]');
+  const listBox = (await primary.boundingBox())!;
+  const previewBox = (await secondary.boundingBox())!;
+  expect(previewBox.x).toBeGreaterThanOrEqual(listBox.x + listBox.width);
+  expect(previewBox.y).toBe(listBox.y);
+  await expect(reading.getByText('Synthetic excerpt 1')).toBeVisible();
+
+  const handleBox = (await resize.boundingBox())!;
+  await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + 50);
+  await page.mouse.down();
+  await page.mouse.move(handleBox.x + handleBox.width / 2 - 80, handleBox.y + 50);
+  await page.mouse.up();
+  await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(previewBox.width + 80, 0);
+  await resize.press('ArrowLeft');
+  const resizedWidth = previewBox.width + 104;
+  await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(resizedWidth, 0);
+  await page.reload();
+  await expect(reading).toBeVisible();
+  await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(resizedWidth, 0);
+  await page.screenshot({ path: 'test-results/right-preview-desktop.png' });
+
+  await page.setViewportSize({ width: 760, height: 900 });
+  await expect(resize).toHaveAttribute('aria-orientation', 'horizontal');
+  await expect(position).toHaveCount(0);
+  const narrowList = (await primary.boundingBox())!;
+  expect((await secondary.boundingBox())!.y).toBeGreaterThanOrEqual(narrowList.y + narrowList.height);
+  await expect(reading).toBeVisible();
+  await page.screenshot({ path: 'test-results/right-preview-narrow.png' });
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await expect(resize).toHaveAttribute('aria-orientation', 'vertical');
+  await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(resizedWidth, 0);
+  await position.getByRole('radio', { name: 'Below', exact: true }).click();
+  await expect(resize).toHaveAttribute('aria-orientation', 'horizontal');
+  await resize.press('ArrowUp');
+  const bottomHeight = (await secondary.boundingBox())!.height;
+  await position.getByRole('radio', { name: 'Right', exact: true }).click();
+  await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(resizedWidth, 0);
+  await position.getByRole('radio', { name: 'Below', exact: true }).click();
+  await expect.poll(async () => (await secondary.boundingBox())!.height).toBe(bottomHeight);
+  await position.getByRole('radio', { name: 'Right', exact: true }).click();
+  await page.getByRole('button', { name: 'Close reading pane' }).click();
+  await expect(grid).toBeFocused();
+  await expect.poll(async () => (await primary.boundingBox())!.width)
+    .toBeCloseTo((await page.locator('.results-split').boundingBox())!.width, 0);
+});

--- a/web/tests/everything-reading-pane.spec.ts
+++ b/web/tests/everything-reading-pane.spec.ts
@@ -242,7 +242,6 @@ test('right preview resizes, restores its width, and falls back below on narrow 
   await page.reload();
   await expect(reading).toBeVisible();
   await expect.poll(async () => (await secondary.boundingBox())!.width).toBeCloseTo(resizedWidth, 0);
-  await page.screenshot({ path: 'test-results/right-preview-desktop.png' });
 
   await page.setViewportSize({ width: 760, height: 900 });
   await expect(resize).toHaveAttribute('aria-orientation', 'horizontal');
@@ -250,7 +249,6 @@ test('right preview resizes, restores its width, and falls back below on narrow 
   const narrowList = (await primary.boundingBox())!;
   expect((await secondary.boundingBox())!.y).toBeGreaterThanOrEqual(narrowList.y + narrowList.height);
   await expect(reading).toBeVisible();
-  await page.screenshot({ path: 'test-results/right-preview-narrow.png' });
 
   await page.setViewportSize({ width: 1920, height: 1080 });
   await expect(resize).toHaveAttribute('aria-orientation', 'vertical');


### PR DESCRIPTION
Everything now offers a resizable right-side preview on wide windows, alongside the existing bottom layout. The browser remembers the position and each layout's size, falls back below on narrow windows, and supports pointer and keyboard resizing without remounting the results or reader.

HTML emails now use dark reading colors when the app is dark. Previously, designed emails kept a white canvas regardless of the app theme. Images retain their original colors, and a per-message **Use original colors** control restores the authored presentation when needed.
