### PR TITLE
docs: remove rendered README frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-last_edited: "2026-09-08"
----
-
 <p align="center">
   <img src=".github/assets/msgvault-mark.svg" width="160" height="160" alt="msgvault logo">
 </p>


### PR DESCRIPTION
## What changed

- Remove the root README frontmatter so GitHub starts the page with the project logo.

## Why

GitHub renders the `last_edited` metadata as a table above the README header, adding visual noise without helping readers.

## Usage

No usage change.

Closes #830
