### PR TITLE
ci: run Windows store tests in four shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,6 @@ jobs:
           go test -timeout 60m -tags "fts5 sqlite_vec" `
             ./internal/api `
             ./internal/importer `
-            ./internal/store `
             ./scripts
 
   test-windows-sharded:
@@ -401,6 +400,9 @@ jobs:
             # executing schema setup (no deadlock; tests kept progressing).
             # Give only this package the larger per-shard budget.
             timeout: 120m
+          - name: store
+            package: ./internal/store
+            timeout: 60m
           - name: sync-vector-embed
             package: ./internal/sync
             package2: ./internal/vector/embed


### PR DESCRIPTION
Windows store tests [hit the one-hour package timeout](https://github.com/kenn-io/msgvault/actions/runs/34608345833/job/103292262017) while still starting tests. Move the store suite into the existing four-shard Windows runner, retaining the one-hour limit per shard.

PR #820 needs this change on `main`: PR checks use `ci.yml@main`, so a workflow change inside that PR cannot affect its own checks. The change only moves the store package between CI jobs.
