### PR TITLE
fix(ci): batch Windows test filters below the command-line limit

### DIFF
--- a/scripts/test-package-shards.ps1
+++ b/scripts/test-package-shards.ps1
@@ -13,6 +13,17 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+# Go accepts compound durations, including fractional units and zero to disable the timeout.
+$units = @{ ns = 1e-9; us = 1e-6; 'µs' = 1e-6; ms = 1e-3; s = 1; m = 60; h = 3600 }
+if ($Timeout -cnotmatch '^[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:ns|us|µs|μs|ms|s|m|h))+$|^[+-]?0$') {
+    throw "Invalid Go test timeout: $Timeout"
+}
+$timeoutSeconds = 0.0
+foreach ($part in [regex]::Matches($Timeout, '(\d+(?:\.\d*)?|\.\d+)(ns|us|µs|μs|ms|s|m|h)')) {
+    $timeoutSeconds += [double]::Parse($part.Groups[1].Value, [cultureinfo]::InvariantCulture) * $units[$part.Groups[2].Value]
+}
+if ($Timeout.StartsWith('-')) { $timeoutSeconds = -$timeoutSeconds }
+
 $goListArgs = @("list", "-f", "{{.Dir}}")
 if ($Tags) {
     $goListArgs += @("-tags", $Tags)
@@ -61,59 +72,87 @@ try {
 
     Write-Host "Running $($testNames.Count) tests from $Package in $activeShards shards"
 
-    $runs = for ($i = 0; $i -lt $activeShards; $i++) {
-        $escapedNames = $shards[$i] | ForEach-Object { [regex]::Escape($_) }
-        $pattern = "^(" + ($escapedNames -join "|") + ")$"
-
-        $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
-        $startInfo.FileName = $testBinary
-        $startInfo.WorkingDirectory = $packageDir
-        $startInfo.UseShellExecute = $false
-        $startInfo.RedirectStandardOutput = $true
-        $startInfo.RedirectStandardError = $true
-        $startInfo.ArgumentList.Add("-test.run=$pattern")
-        $startInfo.ArgumentList.Add("-test.timeout=$Timeout")
-
-        $process = [System.Diagnostics.Process]::new()
-        $process.StartInfo = $startInfo
-        if (-not $process.Start()) {
-            throw "Failed to start test shard $i"
+    # Reserve space for the quoted executable, flags, separators, and terminating NUL.
+    $patternLimit = 32767 - $testBinary.Length - 128
+    $batches = [object[]]::new($activeShards)
+    $spent = [double[]]::new($activeShards)
+    for ($i = 0; $i -lt $activeShards; $i++) {
+        $batches[$i] = [System.Collections.Generic.List[string]]::new()
+        $pattern = '^('
+        foreach ($name in $shards[$i]) {
+            $escaped = [regex]::Escape($name)
+            if ($escaped.Length + 4 -gt $patternLimit) { throw "Test name exceeds the Windows command-line limit: $name" }
+            if ($pattern.Length + $escaped.Length + 3 -gt $patternLimit) {
+                $batches[$i].Add($pattern + ')$')
+                $pattern = '^('
+            }
+            if ($pattern.Length -gt 2) { $pattern += '|' }
+            $pattern += $escaped
         }
-
-        [pscustomobject]@{
-            Index       = $i
-            Count       = $shards[$i].Count
-            Process     = $process
-            StandardOut = $process.StandardOutput.ReadToEndAsync()
-            StandardErr = $process.StandardError.ReadToEndAsync()
-        }
+        $batches[$i].Add($pattern + ')$')
     }
 
     $failed = $false
-    foreach ($run in $runs) {
-        $run.Process.WaitForExit()
-        $elapsed = $run.Process.ExitTime - $run.Process.StartTime
-        $stdout = $run.StandardOut.GetAwaiter().GetResult()
-        $stderr = $run.StandardErr.GetAwaiter().GetResult()
+    $batchCount = ($batches | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
+    for ($batch = 0; $batch -lt $batchCount; $batch++) {
+        $runs = [System.Collections.Generic.List[object]]::new()
+        try {
+            for ($i = 0; $i -lt $activeShards; $i++) {
+                if ($batch -ge $batches[$i].Count) { continue }
+                $batchTimeout = '0'
+                if ($timeoutSeconds -gt 0) {
+                    $remaining = $timeoutSeconds - $spent[$i]
+                    if ($remaining -le 0) {
+                        $failed = $true
+                        Write-Error "shard $($i + 1) exhausted its $Timeout timeout" -ErrorAction Continue
+                        continue
+                    }
+                    $batchTimeout = $remaining.ToString('F9', [cultureinfo]::InvariantCulture) + 's'
+                }
+                $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+                $startInfo.FileName = $testBinary
+                $startInfo.WorkingDirectory = $packageDir
+                $startInfo.UseShellExecute = $false
+                $startInfo.CreateNoWindow = $true
+                $startInfo.RedirectStandardOutput = $true
+                $startInfo.RedirectStandardError = $true
+                $startInfo.ArgumentList.Add("-test.run=$($batches[$i][$batch])")
+                $startInfo.ArgumentList.Add("-test.timeout=$batchTimeout")
 
-        if ($run.Process.ExitCode -eq 0) {
-            Write-Host ("ok shard {0}: {1} tests ({2:N1}s)" -f (
-                $run.Index + 1
-            ), $run.Count, $elapsed.TotalSeconds)
-        } else {
-            $failed = $true
-            Write-Error ("shard {0} failed with exit code {1}" -f (
-                $run.Index + 1
-            ), $run.Process.ExitCode) -ErrorAction Continue
-            if ($stdout) {
-                Write-Output $stdout
+                $process = [System.Diagnostics.Process]::new()
+                $process.StartInfo = $startInfo
+                if (-not $process.Start()) { throw "Failed to start test shard $i" }
+                $runs.Add([pscustomobject]@{
+                    Index       = $i
+                    Process     = $process
+                    StandardOut = $process.StandardOutput.ReadToEndAsync()
+                    StandardErr = $process.StandardError.ReadToEndAsync()
+                })
             }
-            if ($stderr) {
-                Write-Error $stderr -ErrorAction Continue
+
+            foreach ($run in $runs) {
+                $run.Process.WaitForExit()
+                $elapsed = $run.Process.ExitTime - $run.Process.StartTime
+                $spent[$run.Index] += $elapsed.TotalSeconds
+                $stdout = $run.StandardOut.GetAwaiter().GetResult()
+                $stderr = $run.StandardErr.GetAwaiter().GetResult()
+
+                if ($run.Process.ExitCode -eq 0) {
+                    Write-Host ("ok shard {0}, batch {1}/{2} ({3:N1}s)" -f ($run.Index + 1), ($batch + 1), $batches[$run.Index].Count, $elapsed.TotalSeconds)
+                } else {
+                    $failed = $true
+                    Write-Error ("shard {0}, batch {1} failed with exit code {2}" -f ($run.Index + 1), ($batch + 1), $run.Process.ExitCode) -ErrorAction Continue
+                    if ($stdout) { Write-Output $stdout }
+                    if ($stderr) { Write-Error $stderr -ErrorAction Continue }
+                }
+            }
+        } finally {
+            foreach ($run in $runs) {
+                if (-not $run.Process.HasExited) { $run.Process.Kill($true) }
+                $run.Process.WaitForExit()
+                $run.Process.Dispose()
             }
         }
-
-        $run.Process.Dispose()
     }
 
     if ($failed) {

--- a/scripts/test-package-shards.ps1
+++ b/scripts/test-package-shards.ps1
@@ -93,18 +93,43 @@ try {
     }
 
     $failed = $false
-    $batchCount = ($batches | ForEach-Object { $_.Count } | Measure-Object -Maximum).Maximum
-    for ($batch = 0; $batch -lt $batchCount; $batch++) {
-        $runs = [System.Collections.Generic.List[object]]::new()
-        try {
+    $runs = @(for ($i = 0; $i -lt $activeShards; $i++) {
+        [pscustomobject]@{ Batch = 0; Process = $null; StandardOut = $null; StandardErr = $null }
+    })
+    try {
+        do {
+            $active = $false
             for ($i = 0; $i -lt $activeShards; $i++) {
-                if ($batch -ge $batches[$i].Count) { continue }
+                $run = $runs[$i]
+                if ($run.Process) {
+                    if (-not $run.Process.HasExited) {
+                        $active = $true
+                        continue
+                    }
+                    $elapsed = $run.Process.ExitTime - $run.Process.StartTime
+                    $spent[$i] += $elapsed.TotalSeconds
+                    $stdout = $run.StandardOut.GetAwaiter().GetResult()
+                    $stderr = $run.StandardErr.GetAwaiter().GetResult()
+                    if ($run.Process.ExitCode -eq 0) {
+                        Write-Host ("ok shard {0}, batch {1}/{2} ({3:N1}s)" -f ($i + 1), ($run.Batch + 1), $batches[$i].Count, $elapsed.TotalSeconds)
+                    } else {
+                        $failed = $true
+                        Write-Error ("shard {0}, batch {1} failed with exit code {2}" -f ($i + 1), ($run.Batch + 1), $run.Process.ExitCode) -ErrorAction Continue
+                        if ($stdout) { Write-Output $stdout }
+                        if ($stderr) { Write-Error $stderr -ErrorAction Continue }
+                    }
+                    $run.Process.Dispose()
+                    $run.Process = $null
+                    $run.Batch++
+                }
+                if ($run.Batch -ge $batches[$i].Count) { continue }
                 $batchTimeout = '0'
                 if ($timeoutSeconds -gt 0) {
                     $remaining = $timeoutSeconds - $spent[$i]
                     if ($remaining -le 0) {
                         $failed = $true
                         Write-Error "shard $($i + 1) exhausted its $Timeout timeout" -ErrorAction Continue
+                        $run.Batch = $batches[$i].Count
                         continue
                     }
                     $batchTimeout = $remaining.ToString('F9', [cultureinfo]::InvariantCulture) + 's'
@@ -116,45 +141,28 @@ try {
                 $startInfo.CreateNoWindow = $true
                 $startInfo.RedirectStandardOutput = $true
                 $startInfo.RedirectStandardError = $true
-                $startInfo.ArgumentList.Add("-test.run=$($batches[$i][$batch])")
+                $startInfo.ArgumentList.Add("-test.run=$($batches[$i][$run.Batch])")
                 $startInfo.ArgumentList.Add("-test.timeout=$batchTimeout")
 
                 $process = [System.Diagnostics.Process]::new()
                 $process.StartInfo = $startInfo
                 if (-not $process.Start()) { throw "Failed to start test shard $i" }
-                $runs.Add([pscustomobject]@{
-                    Index       = $i
-                    Process     = $process
-                    StandardOut = $process.StandardOutput.ReadToEndAsync()
-                    StandardErr = $process.StandardError.ReadToEndAsync()
-                })
+                $run.Process = $process
+                $run.StandardOut = $process.StandardOutput.ReadToEndAsync()
+                $run.StandardErr = $process.StandardError.ReadToEndAsync()
+                $active = $true
             }
-
-            foreach ($run in $runs) {
-                $run.Process.WaitForExit()
-                $elapsed = $run.Process.ExitTime - $run.Process.StartTime
-                $spent[$run.Index] += $elapsed.TotalSeconds
-                $stdout = $run.StandardOut.GetAwaiter().GetResult()
-                $stderr = $run.StandardErr.GetAwaiter().GetResult()
-
-                if ($run.Process.ExitCode -eq 0) {
-                    Write-Host ("ok shard {0}, batch {1}/{2} ({3:N1}s)" -f ($run.Index + 1), ($batch + 1), $batches[$run.Index].Count, $elapsed.TotalSeconds)
-                } else {
-                    $failed = $true
-                    Write-Error ("shard {0}, batch {1} failed with exit code {2}" -f ($run.Index + 1), ($batch + 1), $run.Process.ExitCode) -ErrorAction Continue
-                    if ($stdout) { Write-Output $stdout }
-                    if ($stderr) { Write-Error $stderr -ErrorAction Continue }
-                }
-            }
-        } finally {
-            foreach ($run in $runs) {
+            if ($active) { Start-Sleep -Milliseconds 100 }
+        } while ($active)
+    } finally {
+        foreach ($run in $runs) {
+            if ($run.Process) {
                 if (-not $run.Process.HasExited) { $run.Process.Kill($true) }
                 $run.Process.WaitForExit()
                 $run.Process.Dispose()
             }
         }
     }
-
     if ($failed) {
         exit 1
     }

--- a/scripts/test_package_shards_windows_test.go
+++ b/scripts/test_package_shards_windows_test.go
@@ -1,0 +1,130 @@
+package scripts
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageShardsWindows(t *testing.T) {
+	r := require.New(t)
+	script, err := filepath.Abs("test-package-shards.ps1")
+	r.NoError(err)
+	pwsh, err := exec.LookPath("pwsh")
+	r.NoError(err)
+	dir := filepath.Join(t.TempDir(), "package with spaces")
+	r.NoError(os.Mkdir(dir, 0o700))
+	r.NoError(os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module shardfixture\n\ngo 1.25\n"), 0o600))
+
+	var source strings.Builder
+	source.WriteString(`package shardfixture
+import ("flag"; "fmt"; "os"; "testing")
+var output *os.File
+func TestMain(m *testing.M) {
+    flag.Parse()
+    code := m.Run()
+    if output != nil { if err := output.Close(); err != nil { panic(err) } }
+    os.Exit(code)
+}
+func record(t *testing.T) {
+    if output == nil {
+        var err error
+        output, err = os.Create(fmt.Sprintf("%s/%d", os.Getenv("SHARD_OUTPUT"), os.Getpid()))
+        if err != nil { panic(err) }
+        if _, err = fmt.Fprintln(output, flag.Lookup("test.timeout").Value); err != nil { panic(err) }
+    }
+    if _, err := fmt.Fprintln(output, t.Name()); err != nil { panic(err) }
+    if t.Name() == os.Getenv("SHARD_FAIL") { panic("shard failure sentinel") }
+}
+`)
+	const count = 1200
+	want := make([]string, count)
+	for i := range want {
+		want[i] = fmt.Sprintf("Test%04d_%s", i, strings.Repeat("long_name_", 13))
+		fmt.Fprintf(&source, "func %s(t *testing.T) { record(t) }\n", want[i])
+	}
+	r.NoError(os.WriteFile(filepath.Join(dir, "fixture_test.go"), []byte(source.String()), 0o600))
+
+	run := func(t *testing.T, timeout, fail string) (string, string, error) {
+		t.Helper()
+		output := t.TempDir()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, pwsh, "-NoProfile", "-File", script, "-Package", ".", "-ShardCount", "4", "-Tags", "fts5 sqlite_vec", "-Timeout", timeout)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "GOWORK=off", "SHARD_OUTPUT="+output, "SHARD_FAIL="+fail)
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+		result, err := cmd.CombinedOutput()
+		return output, string(result), err
+	}
+
+	for _, timeout := range []string{"1m30s", "0"} {
+		t.Run(timeout, func(t *testing.T) {
+			require := require.New(t)
+			output, result, err := run(t, timeout, "")
+			require.NoError(err, result)
+			files, err := os.ReadDir(output)
+			require.NoError(err)
+			require.Greater(len(files), 4, "fixture must exceed one command line per shard")
+			var got []string
+			budgets := make([]map[int]time.Duration, 4)
+			for i := range budgets {
+				budgets[i] = make(map[int]time.Duration)
+			}
+			for _, file := range files {
+				data, err := os.ReadFile(filepath.Join(output, file.Name()))
+				require.NoError(err)
+				lines := strings.Fields(string(data))
+				require.Greater(len(lines), 1)
+				budget, err := time.ParseDuration(lines[0])
+				require.NoError(err)
+				first, err := strconv.Atoi(lines[1][4:8])
+				require.NoError(err)
+				budgets[first%4][first] = budget
+				for _, name := range lines[1:] {
+					index, err := strconv.Atoi(name[4:8])
+					require.NoError(err)
+					require.Equal(first%4, index%4, "batches must retain shard assignments")
+				}
+				got = append(got, lines[1:]...)
+			}
+			sort.Strings(got)
+			require.Equal(want, got, "every test must run exactly once")
+			for _, batches := range budgets {
+				var starts []int
+				for start := range batches {
+					starts = append(starts, start)
+				}
+				sort.Ints(starts)
+				previous := 90 * time.Second
+				for i, start := range starts {
+					if timeout == "0" {
+						require.Zero(batches[start])
+					} else if i == 0 {
+						require.Equal(previous, batches[start])
+					} else {
+						require.Positive(batches[start])
+						require.Less(batches[start], previous)
+					}
+					previous = batches[start]
+				}
+			}
+		})
+	}
+	t.Run("later batch failure", func(t *testing.T) {
+		require := require.New(t)
+		_, result, err := run(t, "1m30s", want[count-1])
+		require.Error(err)
+		require.Contains(result, "shard failure sentinel")
+	})
+}

--- a/scripts/test_package_shards_windows_test.go
+++ b/scripts/test_package_shards_windows_test.go
@@ -28,7 +28,7 @@ func TestPackageShardsWindows(t *testing.T) {
 
 	var source strings.Builder
 	source.WriteString(`package shardfixture
-import ("flag"; "fmt"; "os"; "testing")
+import ("flag"; "fmt"; "os"; "strings"; "testing"; "time")
 var output *os.File
 func TestMain(m *testing.M) {
     flag.Parse()
@@ -37,6 +37,18 @@ func TestMain(m *testing.M) {
     os.Exit(code)
 }
 func record(t *testing.T) {
+    if os.Getenv("SHARD_COORDINATE") != "" {
+        signal := os.Getenv("SHARD_OUTPUT") + "/released"
+        if strings.HasPrefix(t.Name(), "Test1199_") {
+            if err := os.WriteFile(signal, nil, 0600); err != nil { panic(err) }
+        }
+        if strings.HasPrefix(t.Name(), "Test0000_") {
+            for {
+                if _, err := os.Stat(signal); err == nil { break } else if !os.IsNotExist(err) { panic(err) }
+                time.Sleep(10 * time.Millisecond)
+            }
+        }
+    }
     if output == nil {
         var err error
         output, err = os.Create(fmt.Sprintf("%s/%d", os.Getenv("SHARD_OUTPUT"), os.Getpid()))
@@ -121,6 +133,13 @@ func record(t *testing.T) {
 			}
 		})
 	}
+	t.Run("independent shards", func(t *testing.T) {
+		require := require.New(t)
+		t.Setenv("SHARD_COORDINATE", "1")
+		output, result, err := run(t, "30s", "")
+		require.NoError(err, result)
+		require.FileExists(filepath.Join(output, "released"))
+	})
 	t.Run("later batch failure", func(t *testing.T) {
 		require := require.New(t)
 		_, result, err := run(t, "1m30s", want[count-1])


### PR DESCRIPTION
Windows sharded tests now split oversized test filters into batches so large packages can start. The store suite exceeded Windows' 32,767-character command-line limit before any tests ran.

Batches retain the original shard assignments and concurrency cap. Each shard shares its timeout across batches, and any failed batch fails the run.
