### PR TITLE
feat(mcp): expose running HTTP listeners through status

### DIFF
--- a/cmd/msgvault/cmd/import_gvoice_e2e_test.go
+++ b/cmd/msgvault/cmd/import_gvoice_e2e_test.go
@@ -24,11 +24,19 @@ func TestImportGvoiceStoresVoicemailAudioEndToEnd(t *testing.T) {
 	previousAfter := importGvoiceAfter
 	previousLimit := importGvoiceLimit
 	previousNoDefault := noDefaultIdentityImportGVoice
+	previousCfg, previousLogger := cfg, logger
+	previousCfgFile, previousHomeDir, previousVerbose := cfgFile, homeDir, verbose
+	previousOut, previousErr := rootCmd.OutOrStdout(), rootCmd.ErrOrStderr()
 	t.Cleanup(func() {
 		importGvoiceBefore = previousBefore
 		importGvoiceAfter = previousAfter
 		importGvoiceLimit = previousLimit
 		noDefaultIdentityImportGVoice = previousNoDefault
+		cfg, logger = previousCfg, previousLogger
+		cfgFile, homeDir, verbose = previousCfgFile, previousHomeDir, previousVerbose
+		rootCmd.SetOut(previousOut)
+		rootCmd.SetErr(previousErr)
+		rootCmd.SetArgs(nil)
 	})
 
 	home := t.TempDir()

--- a/cmd/msgvault/cmd/mcp.go
+++ b/cmd/msgvault/cmd/mcp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -43,7 +44,7 @@ Add to Claude Desktop config:
 	    }
 	  }`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		st, _, err := OpenHTTPStore(cmd.Context())
+		st, info, err := OpenHTTPStore(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("open daemon: %w", err)
 		}
@@ -72,9 +73,11 @@ Add to Claude Desktop config:
 				return usageErr(cmd, err)
 			}
 			return serveMCPHTTPWithOptions(ctx, opts, mcpserver.HTTPOptions{
-				Addr:        normalized,
-				APIKey:      cfg.Server.APIKey,
-				AllowWrites: mcpHTTPAllowWrites,
+				Addr:               normalized,
+				DiscoveryDirectory: filepath.Join(cfg.HomeDir, "mcp"),
+				BackendURL:         info.URL,
+				APIKey:             cfg.Server.APIKey,
+				AllowWrites:        mcpHTTPAllowWrites,
 			})
 		}
 		return mcpserver.ServeWithOptions(ctx, opts)
@@ -271,6 +274,7 @@ func (s daemonMCPSimilarSearcher) FindSimilar(
 }
 
 func init() {
+	mcpCmd.AddCommand(newMCPStatusCommand())
 	rootCmd.AddCommand(mcpCmd)
 	mcpCmd.Flags().BoolVar(&mcpForceSQL, "force-sql", false, "Deprecated in 0.17.0: set [analytics].engine = \"sql\" in config.toml")
 	mcpCmd.Flags().BoolVar(&mcpNoSQLiteScanner, "no-sqlite-scanner", false, "Deprecated in 0.17.0: cache engine selection is daemon-managed")

--- a/cmd/msgvault/cmd/mcp_status.go
+++ b/cmd/msgvault/cmd/mcp_status.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"encoding/json/v2"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/msgvault/internal/config"
+	"go.kenn.io/msgvault/internal/mcpdiscovery"
+)
+
+func newMCPStatusCommand() *cobra.Command {
+	var jsonOutput bool
+	command := &cobra.Command{
+		Use:               "status",
+		Short:             "List running HTTP MCP listeners",
+		Args:              cobra.NoArgs,
+		PersistentPreRunE: func(*cobra.Command, []string) error { return nil },
+		RunE: func(command *cobra.Command, _ []string) error {
+			cfg, err := config.Load(cfgFile, homeDir)
+			if err != nil {
+				return err
+			}
+			directory := filepath.Join(cfg.HomeDir, "mcp")
+			endpoints, err := mcpdiscovery.List(directory)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				return json.MarshalWrite(command.OutOrStdout(), endpoints)
+			}
+			if len(endpoints) == 0 {
+				_, err := fmt.Fprintln(command.OutOrStdout(), "No HTTP MCP listeners are running.")
+				if err != nil {
+					return fmt.Errorf("write MCP status: %w", err)
+				}
+				return nil
+			}
+			for _, endpoint := range endpoints {
+				if _, err := fmt.Fprintf(command.OutOrStdout(), "MCP %s (pid %d)\n", endpoint.URL, endpoint.PID); err != nil {
+					return fmt.Errorf("write MCP status: %w", err)
+				}
+			}
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&jsonOutput, "json", false, "Print listener discovery as JSON")
+	return command
+}

--- a/cmd/msgvault/cmd/mcp_status_test.go
+++ b/cmd/msgvault/cmd/mcp_status_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/mcpdiscovery"
+)
+
+func TestMCPStatusJSONReportsPublishedListener(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	home := t.TempDir()
+	t.Setenv("MSGVAULT_HOME", home)
+	cleanup, err := mcpdiscovery.Publish(filepath.Join(home, "mcp"), "127.0.0.1:9876", "", "http://127.0.0.1:4321")
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(cleanup()) })
+	command := newMCPStatusCommand()
+	command.SetArgs([]string{"--json"})
+	var output bytes.Buffer
+	command.SetOut(&output)
+	require.NoError(command.Execute())
+	var rows []mcpdiscovery.Endpoint
+	require.NoError(json.Unmarshal(output.Bytes(), &rows))
+	require.Len(rows, 1)
+	assert.Equal("http://127.0.0.1:9876/mcp", rows[0].URL)
+	assert.Equal("http://127.0.0.1:4321", rows[0].BackendURL)
+}

--- a/cmd/msgvault/cmd/mcp_test.go
+++ b/cmd/msgvault/cmd/mcp_test.go
@@ -101,9 +101,11 @@ func TestMCPCommandForwardsHTTPPolicy(t *testing.T) {
 	}))
 	t.Cleanup(daemon.Close)
 
+	home := t.TempDir()
 	withStoreResolverConfig(t, &config.Config{
-		Data:   config.DataConfig{DataDir: t.TempDir()},
-		Server: config.ServerConfig{APIKey: "mcp-http-key"},
+		HomeDir: home,
+		Data:    config.DataConfig{DataDir: t.TempDir()},
+		Server:  config.ServerConfig{APIKey: "mcp-http-key"},
 		Remote: config.RemoteConfig{
 			URL:           daemon.URL,
 			APIKey:        "daemon-key",
@@ -144,9 +146,11 @@ func TestMCPCommandForwardsHTTPPolicy(t *testing.T) {
 	require.ErrorIs(err, wantErr)
 	assert.True(gotServeOpts.AllowProfileWrites)
 	assert.Equal(mcpserver.HTTPOptions{
-		Addr:        "0.0.0.0:8081",
-		APIKey:      "mcp-http-key",
-		AllowWrites: true,
+		Addr:               "0.0.0.0:8081",
+		DiscoveryDirectory: filepath.Join(home, "mcp"),
+		BackendURL:         daemon.URL,
+		APIKey:             "mcp-http-key",
+		AllowWrites:        true,
 	}, gotHTTPOpts)
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2254,9 +2254,10 @@ from that private file; the status output does not print it.
 
 The listener publishes its actual bound port after startup, including when
 started with port zero, and removes its record on orderly shutdown. Status
-omits records whose process has exited. Stdio sessions are not listening
-endpoints and do not appear. An empty JSON list means no HTTP listeners were
-found in this application's configured data directory.
+omits records whose process has exited or whose process-start identity cannot
+be verified, including when another process reuses the PID. Stdio sessions are
+not listening endpoints and do not appear. An empty JSON list means no HTTP
+listeners were found in this application's configured data directory.
 
 Start the Model Context Protocol server for AI assistant integration.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2244,6 +2244,20 @@ See [SQL Queries](/docs/usage/querying/) for available views and example queries
 
 ## mcp
 
+### Discover running HTTP listeners
+
+Run `msgvault mcp status --json` to list HTTP MCP listeners started by this
+version. The command reads local runtime records without starting a server.
+Each entry includes `transport`, `url`, `pid`, `backend_url` when known,
+and `token_path` when the listener requires a bearer token. Read the token
+from that private file; the status output does not print it.
+
+The listener publishes its actual bound port after startup, including when
+started with port zero, and removes its record on orderly shutdown. Status
+omits records whose process has exited. Stdio sessions are not listening
+endpoints and do not appear. An empty JSON list means no HTTP listeners were
+found in this application's configured data directory.
+
 Start the Model Context Protocol server for AI assistant integration.
 
 ```bash

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,12 +8,15 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"go.kenn.io/msgvault/internal/mcpdiscovery"
+
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.kenn.io/msgvault/internal/peoplebrowser"
 	"go.kenn.io/msgvault/internal/query"
@@ -103,9 +106,11 @@ type ServeOptions struct {
 }
 
 type HTTPOptions struct {
-	Addr        string
-	APIKey      string
-	AllowWrites bool
+	DiscoveryDirectory string
+	BackendURL         string
+	Addr               string
+	APIKey             string
+	AllowWrites        bool
 }
 
 func officialToolHandler(
@@ -263,13 +268,25 @@ func ServeWithOptions(ctx context.Context, opts ServeOptions) error {
 
 // ServeHTTPWithOptions creates an MCP server from opts and serves over
 // StreamableHTTP on the given address.
-func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, httpOpts HTTPOptions) error {
+func ServeHTTPWithOptions(ctx context.Context, opts ServeOptions, httpOpts HTTPOptions) (result error) {
+	listener, err := net.Listen("tcp", httpOpts.Addr)
+	if err != nil {
+		return fmt.Errorf("listen for MCP HTTP: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+	if httpOpts.DiscoveryDirectory != "" {
+		cleanup, err := mcpdiscovery.Publish(httpOpts.DiscoveryDirectory, listener.Addr().String(), httpOpts.APIKey, httpOpts.BackendURL)
+		if err != nil {
+			return err
+		}
+		defer func() { result = errors.Join(result, cleanup()) }()
+	}
 	stdlibServer := newMCPHTTPServer(opts, httpOpts)
 	fmt.Fprintf(os.Stderr, "Starting MCP server on %s\n", httpOpts.Addr)
 
 	errCh := make(chan error, 1)
 	go func() {
-		if err := stdlibServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := stdlibServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 			return
 		}

--- a/internal/mcpdiscovery/discovery.go
+++ b/internal/mcpdiscovery/discovery.go
@@ -1,0 +1,89 @@
+// Package mcpdiscovery publishes the local HTTP MCP listener for CLI clients.
+package mcpdiscovery
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/kit/safefileio"
+)
+
+const service = "msgvault-mcp"
+
+// Endpoint describes an existing listener. TokenPath locates a private file;
+// status output never includes the bearer token itself.
+type Endpoint struct {
+	PID        int    `json:"pid"`
+	Transport  string `json:"transport"`
+	URL        string `json:"url"`
+	BackendURL string `json:"backend_url,omitempty"`
+	TokenPath  string `json:"token_path,omitempty"`
+}
+
+// Publish runs only after bind succeeds. The caller removes discovery state
+// after the listener closes, including shutdown caused by a serving error.
+func Publish(directory, address, token, backendURL string) (func() error, error) {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, fmt.Errorf("MCP discovery: %w", err)
+	}
+	store := daemon.RuntimeStore{Dir: directory, Prefix: "mcp"}
+	rec := daemon.NewRuntimeRecord(service, "", daemon.Endpoint{Network: "tcp", Address: address})
+	rec.Metadata = map[string]string{"url": "http://" + address + "/mcp", "backend_url": backendURL}
+	tokenPath := ""
+	if token != "" {
+		file, err := os.CreateTemp(directory, "mcp-token-*")
+		if err != nil {
+			return nil, fmt.Errorf("MCP discovery: %w", err)
+		}
+		tokenPath = file.Name()
+		_, writeErr := file.WriteString(token)
+		if err := errors.Join(writeErr, file.Close()); err != nil {
+			_ = os.Remove(tokenPath)
+			return nil, fmt.Errorf("MCP discovery: %w", err)
+		}
+		rec.Metadata["token_path"] = tokenPath
+	}
+	recordPath, err := store.Write(rec)
+	if err != nil {
+		if tokenPath != "" {
+			_ = os.Remove(tokenPath)
+		}
+		return nil, fmt.Errorf("MCP discovery: %w", err)
+	}
+	return func() error {
+		recordErr := os.Remove(recordPath)
+		var tokenErr error
+		if tokenPath != "" {
+			tokenErr = os.Remove(tokenPath)
+		}
+		return errors.Join(recordErr, tokenErr)
+	}, nil
+}
+
+// List is observational: it never starts a daemon or prunes another process's
+// records. Dead-process records are omitted, including after an unclean exit.
+func List(directory string) ([]Endpoint, error) {
+	endpoints := []Endpoint{}
+	if _, err := os.Stat(directory); errors.Is(err, os.ErrNotExist) {
+		return endpoints, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("MCP discovery: %w", err)
+	}
+	if err := safefileio.ValidatePrivateDir(directory); err != nil {
+		return nil, fmt.Errorf("MCP discovery: %w", err)
+	}
+	records, err := (daemon.RuntimeStore{Dir: filepath.Clean(directory), Prefix: "mcp"}).List()
+	if err != nil {
+		return nil, fmt.Errorf("read MCP listener status: %w", err)
+	}
+	for _, rec := range records {
+		if rec.Service != service || !daemon.ProcessAlive(rec.PID) {
+			continue
+		}
+		endpoints = append(endpoints, Endpoint{PID: rec.PID, Transport: "http", URL: rec.Metadata["url"], BackendURL: rec.Metadata["backend_url"], TokenPath: rec.Metadata["token_path"]})
+	}
+	return endpoints, nil
+}

--- a/internal/mcpdiscovery/discovery.go
+++ b/internal/mcpdiscovery/discovery.go
@@ -64,7 +64,8 @@ func Publish(directory, address, token, backendURL string) (func() error, error)
 }
 
 // List is observational: it never starts a daemon or prunes another process's
-// records. Dead-process records are omitted, including after an unclean exit.
+// records. Only records matching the live process's creation identity are
+// returned, so PID reuse after an unclean exit cannot revive stale records.
 func List(directory string) ([]Endpoint, error) {
 	endpoints := []Endpoint{}
 	if _, err := os.Stat(directory); errors.Is(err, os.ErrNotExist) {
@@ -81,6 +82,9 @@ func List(directory string) ([]Endpoint, error) {
 	}
 	for _, rec := range records {
 		if rec.Service != service || !daemon.ProcessAlive(rec.PID) {
+			continue
+		}
+		if daemon.CompareRuntimeProcessIdentity(rec) != daemon.ProcessIdentityMatch {
 			continue
 		}
 		endpoints = append(endpoints, Endpoint{PID: rec.PID, Transport: "http", URL: rec.Metadata["url"], BackendURL: rec.Metadata["backend_url"], TokenPath: rec.Metadata["token_path"]})

--- a/internal/mcpdiscovery/discovery_test.go
+++ b/internal/mcpdiscovery/discovery_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
 )
 
 // Listener publication, status, and cleanup are the client discovery contract.
@@ -32,4 +33,48 @@ func TestPublishedListenerStatusAndCleanup(t *testing.T) {
 	rows, err = List(dir)
 	require.NoError(err)
 	assert.Empty(rows)
+}
+
+func TestListOmitsUnverifiedProcessRecords(t *testing.T) {
+	for _, kind := range []string{"mismatched", "missing", "malformed"} {
+		t.Run(kind, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			dir := t.TempDir()
+			require.NoError(os.Chmod(dir, 0o700))
+			cleanup, err := Publish(dir, "127.0.0.1:9876", "test-listener-token", "")
+			require.NoError(err)
+			t.Cleanup(func() { require.NoError(cleanup()) })
+			store := daemon.RuntimeStore{Dir: dir, Prefix: "mcp"}
+			records, err := store.List()
+			require.NoError(err)
+			require.Len(records, 1)
+			rec := records[0]
+			require.Equal(daemon.ProcessIdentityMatch, daemon.CompareRuntimeProcessIdentity(rec))
+			switch kind {
+			case "mismatched":
+				// Change the creation value while retaining its platform encoding.
+				// The PID stays live, as it would after the OS reuses a stale PID.
+				if rec.ProcessIdentityV2 != "" {
+					rec.ProcessIdentityV2 += "0"
+				} else {
+					rec.ProcessIdentity += "0"
+				}
+				require.Equal(daemon.ProcessIdentityMismatch, daemon.CompareRuntimeProcessIdentity(rec))
+			case "missing":
+				rec.ProcessIdentity = ""
+				rec.ProcessIdentityV2 = ""
+			case "malformed":
+				rec.ProcessIdentityV2 = "malformed"
+			}
+			recordPath, err := store.Write(rec)
+			require.NoError(err)
+			rows, err := List(dir)
+			require.NoError(err)
+			assert.Empty(rows)
+			// Status observes records; it must not prune them or their tokens.
+			assert.FileExists(recordPath)
+			assert.FileExists(rec.Metadata["token_path"])
+		})
+	}
 }

--- a/internal/mcpdiscovery/discovery_test.go
+++ b/internal/mcpdiscovery/discovery_test.go
@@ -1,0 +1,35 @@
+package mcpdiscovery
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Listener publication, status, and cleanup are the client discovery contract.
+func TestPublishedListenerStatusAndCleanup(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	require.NoError(os.Chmod(dir, 0o700))
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(listener.Close()) })
+	cleanup, err := Publish(dir, listener.Addr().String(), "test-listener-token", "http://127.0.0.1:4321")
+	require.NoError(err)
+	rows, err := List(dir)
+	require.NoError(err)
+	require.Len(rows, 1)
+	assert.Equal("http://"+listener.Addr().String()+"/mcp", rows[0].URL)
+	assert.Equal("http://127.0.0.1:4321", rows[0].BackendURL)
+	token, err := os.ReadFile(rows[0].TokenPath)
+	require.NoError(err)
+	assert.Equal("test-listener-token", string(token))
+	require.NoError(cleanup())
+	rows, err = List(dir)
+	require.NoError(err)
+	assert.Empty(rows)
+}


### PR DESCRIPTION
`msgvault mcp status --json` reports running HTTP MCP listeners, including their actual bound ports, backend targets, and private token-file paths. Clients can discover an existing listener instead of guessing its port. Status does not start a daemon or print bearer tokens.

Listeners publish after binding and remove their records on orderly shutdown. Status omits dead processes; stdio sessions do not appear in the list.
