### PR TITLE
fix(carddav): reject unsupported configured providers

### DIFF
--- a/internal/api/carddav_google.go
+++ b/internal/api/carddav_google.go
@@ -28,7 +28,8 @@ func normalizeCardDAVAccountRequest(req CardDAVAccountRequest) CardDAVAccountReq
 }
 
 func cardDAVCredentialMatchesConfig(credential carddav.Credential, cfg config.CardDAVConfig) bool {
-	return credential.Google == (cfg.Provider == "google") && credential.OAuthApp == cfg.OAuthApp
+	return credential.OAuthApp == cfg.OAuthApp &&
+		((cfg.Provider == "" && !credential.Google) || (cfg.Provider == "google" && credential.Google))
 }
 
 func (c *CardDAVController) credentialForRequest(ctx context.Context, req CardDAVAccountRequest) (carddav.Credential, error) {

--- a/internal/api/carddav_test.go
+++ b/internal/api/carddav_test.go
@@ -113,6 +113,22 @@ func TestNewCardDAVControllerLoadsCredentialFromConfiguredDataDir(t *testing.T) 
 	assert.NoFileExists(filepath.Join(home, "tokens", "carddav.json"))
 }
 
+func TestCardDAVUnsupportedProviderDoesNotReuseCredential(t *testing.T) {
+	assertions := assert.New(t)
+	required := require.New(t)
+	cfg, st, _ := savedCardDAVFixture(t)
+	controller, err := NewCardDAVController(cfg, st, slog.New(slog.DiscardHandler))
+	required.NoError(err)
+	required.NotNil(controller.Current())
+
+	cfg.CardDAV.Provider = "googl"
+	controller, err = NewCardDAVController(cfg, st, slog.New(slog.DiscardHandler))
+	required.NoError(err)
+	assertions.Nil(controller.Current())
+	_, err = controller.reusableCredential(t.Context(), cfg.CardDAV.BaseURL, cfg.CardDAV.Username)
+	required.ErrorIs(err, carddav.ErrCredentialNotBound)
+}
+
 type controlledCardDAVCandidate struct {
 	cardDAVListFixture
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -928,6 +928,9 @@ func decodeConfig(cfg *Config, path string, explicit, homeOverride bool, content
 	if err := cfg.Web.Validate(); err != nil {
 		return nil, err
 	}
+	if cfg.CardDAV.Provider != "" && cfg.CardDAV.Provider != "google" {
+		return nil, errors.New("carddav.provider must be empty or \"google\"")
+	}
 	cfg.Integrations.Tasks.ApplyDefaults()
 	if err := cfg.Integrations.Tasks.Validate(); err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -35,6 +36,23 @@ enabled = true
 	var encoded bytes.Buffer
 	require.NoError(toml.NewEncoder(&encoded).Encode(cfg))
 	assert.NotContains(encoded.String(), "password")
+}
+
+func TestCardDAVConfigProvider(t *testing.T) {
+	for _, provider := range []string{"", "google", "googl"} {
+		t.Run(provider, func(t *testing.T) {
+			required := require.New(t)
+			path := filepath.Join(t.TempDir(), "config.toml")
+			required.NoError(os.WriteFile(path, []byte(fmt.Sprintf("[carddav]\nprovider = %q\n", provider)), 0600))
+			cfg, err := Load(path, "")
+			if provider == "googl" {
+				required.ErrorContains(err, "carddav.provider")
+				return
+			}
+			required.NoError(err)
+			assert.Equal(t, provider, cfg.CardDAV.Provider)
+		})
+	}
 }
 
 func TestIMAPDraftConfig(t *testing.T) {


### PR DESCRIPTION
Reject unsupported CardDAV providers in config files. A typo such as `provider = "googl"` previously selected password authentication and could reuse an existing bound credential; only `""` and `"google"` are now accepted, matching the API.

Credential reuse also requires an explicit provider match. Follow-up to #820.
