### PR TITLE
fix(imap): retire obsolete membership keys without losing archive identity

### DIFF
--- a/internal/store/imap_drafts.go
+++ b/internal/store/imap_drafts.go
@@ -55,16 +55,22 @@ func (s *Store) PersistIMAPDraftContext(
 		if !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("check IMAP draft membership: %w", err)
 		}
-		// A new epoch can reuse an archived UID. Preserve the old message under
-		// sync's invalidated key; sync still owns membership retirement and cursors.
+		// The acknowledged APPEND can reuse an obsolete key while the previous archive row survives.
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE messages SET source_message_id = 'msgvault-invalidated:' || CAST(id AS TEXT)
-			WHERE source_id = ? AND source_message_id = ? AND EXISTS (
+			WHERE source_id = ? AND source_message_id = ? AND (EXISTS (
 				SELECT 1 FROM imap_message_memberships
 				WHERE message_id = messages.id AND source_id = messages.source_id
 				  AND mailbox = ? AND uid = ? AND uidvalidity <> ?
-			)
-		`, receipt.SourceID, IMAPDraftSourceMessageID(receipt), receipt.Mailbox, receipt.UID, receipt.UIDValidity); err != nil {
+			) OR (EXISTS (
+				SELECT 1 FROM imap_folder_state WHERE source_id = messages.source_id AND mailbox = ? AND uidvalidity <> ?
+			) AND NOT EXISTS (
+				SELECT 1 FROM imap_message_memberships WHERE source_id = messages.source_id AND message_id = messages.id AND mailbox = ? AND uid = ?
+			)) OR (deleted_from_source_at IS NOT NULL AND NOT EXISTS (
+				SELECT 1 FROM imap_message_memberships WHERE source_id = messages.source_id AND message_id = messages.id
+			)))
+		`, receipt.SourceID, IMAPDraftSourceMessageID(receipt), receipt.Mailbox, receipt.UID, receipt.UIDValidity,
+			receipt.Mailbox, receipt.UIDValidity, receipt.Mailbox, receipt.UID); err != nil {
 			return fmt.Errorf("invalidate previous IMAP draft source key: %w", err)
 		}
 		err = tx.QueryRowContext(ctx, `

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -558,6 +558,7 @@ func TestIMAPIdentity_OrphanRetirementMailboxBoundary(t *testing.T) {
 	requirements.NoError(err)
 	assertions.Equal(nested+"|1", nestedKey)
 }
+
 func TestIMAPIdentity_MovedCopyMembershipBeforeSync(t *testing.T) {
 	requirements := require.New(t)
 	assertions := assert.New(t)
@@ -596,6 +597,7 @@ func TestIMAPIdentity_MovedCopyMembershipBeforeSync(t *testing.T) {
 	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
 	assertions.Len(states, 2)
 }
+
 func TestIMAPIdentity_SameEpochResetRemovalReleasesSourceKeyForLaterEpoch(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -734,4 +736,26 @@ func TestIMAPIdentity_MovedCopyAppendBeforeSync(t *testing.T) {
 	var archiveID int64
 	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Archive", 30, 7).Scan(&archiveID))
 	assertions.Equal(oldID, archiveID)
+}
+
+func TestIMAPIdentity_DeletedKeyOwnerBesideOldCanonicalMembership(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
+	canonicalID := f.createMessage(t, "canonical", "<canonical@example.com>")
+	delta := store.IMAPMailboxDelta{Mailbox: "Drafts", Reset: true, State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{{UID: 1, SourceMessageID: "Drafts|1", CanonicalSourceMessageID: "canonical"}}}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	requirements.True(messageTombstoned(t, f.store, oldID))
+	var got int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 10, 1).Scan(&got))
+	requirements.Equal(canonicalID, got)
+	newID := f.createMessage(t, "incoming", "<incoming@example.com>")
+	delta.State.UIDValidity = 20
+	delta.Memberships = []store.IMAPMembershipObservation{{UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<incoming@example.com>"}}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 20, 1).Scan(&got))
+	assertions.Equal(newID, got)
+	assertions.True(messageTombstoned(t, f.store, oldID))
 }

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -480,7 +480,7 @@ func TestIMAPIdentity_AmbiguousLiveAppendKeyRefuses(t *testing.T) {
 }
 
 func TestIMAPIdentity_LegacyOrphanIdentity(t *testing.T) {
-	for _, mode := range []string{"unique", "same", "missing", "duplicate", "canonical"} {
+	for _, mode := range []string{"unique", "same", "missing", "duplicate", "canonical", "known-missing", "known-duplicate"} {
 		t.Run(mode, func(t *testing.T) {
 			requirements := require.New(t)
 			assertions := assert.New(t)
@@ -488,28 +488,33 @@ func TestIMAPIdentity_LegacyOrphanIdentity(t *testing.T) {
 			f := newIMAPIdentityFixture(t)
 			oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
 			requirements.NoError(f.store.MarkMessageDeleted(f.source.ID, "Drafts|1"))
+			if mode == "known-missing" || mode == "known-duplicate" {
+				requirements.NoError(f.store.UpsertIMAPFolderStates(f.source.ID, []store.IMAPFolderState{{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}}))
+			}
+			beforeStates, err := f.store.GetIMAPFolderStates(f.source.ID)
+			requirements.NoError(err)
 			newID := f.createMessage(t, "new-source", "<new@example.com>")
 			obs := store.IMAPMembershipObservation{Mailbox: "Drafts", UIDValidity: 20, UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<new@example.com>"}
 			if mode == "same" {
 				obs.RFC822MessageID = "<old@example.com>"
 				newID = oldID
 			}
-			if mode == "missing" {
+			if mode == "missing" || mode == "known-missing" {
 				obs.RFC822MessageID = ""
 			}
-			if mode == "duplicate" || mode == "canonical" {
+			if mode == "duplicate" || mode == "canonical" || mode == "known-duplicate" {
 				f.createMessage(t, "duplicate-source", "<new@example.com>")
 			}
 			if mode == "canonical" {
 				obs.CanonicalSourceMessageID = "new-source"
 			}
-			err := f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{Mailbox: "Drafts", Reset: true, State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{obs}}})
-			if mode == "missing" || mode == "duplicate" {
+			err = f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{Mailbox: "Drafts", Reset: true, State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{obs}}})
+			if mode == "missing" || mode == "duplicate" || mode == "known-missing" || mode == "known-duplicate" {
 				requirements.Error(err)
 				assertions.Zero(membershipCount(t, f.store, f.source.ID))
 				states, stateErr := f.store.GetIMAPFolderStates(f.source.ID)
 				requirements.NoError(stateErr)
-				assertions.Empty(states)
+				assertions.ElementsMatch(beforeStates, states)
 				key, keyErr := f.store.GetMessageSourceID(oldID)
 				requirements.NoError(keyErr)
 				assertions.Equal("Drafts|1", key)
@@ -590,4 +595,143 @@ func TestIMAPIdentity_MovedCopyMembershipBeforeSync(t *testing.T) {
 	assertions.Equal(oldRaw, retainedRaw)
 	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
 	assertions.Len(states, 2)
+}
+func TestIMAPIdentity_SameEpochResetRemovalReleasesSourceKeyForLaterEpoch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts",
+		State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Drafts", UIDValidity: 10, UID: 1, SourceMessageID: "Drafts|1",
+		}},
+	}}))
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts",
+		State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+		Reset:   true,
+	}}))
+
+	receipt := store.IMAPDraftReceipt{
+		SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 20, UID: 1,
+	}
+	newID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil,
+		func([]int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:        f.source.ID,
+					SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+					ConversationID:  f.convID,
+					MessageType:     "email",
+				},
+				BodyText: sql.NullString{String: "new draft", Valid: true},
+				RawMIME:  []byte("From: alice@example.com\r\n\r\nnew draft\r\n"),
+			}
+		})
+	require.NoError(err)
+	assert.NotEqual(oldID, newID)
+	oldSourceMessageID, err := f.store.GetMessageSourceID(oldID)
+	require.NoError(err)
+	assert.Equal(fmt.Sprintf("msgvault-invalidated:%d", oldID), oldSourceMessageID)
+}
+
+func TestIMAPIdentity_RekeysOrphanedSourceDeletedMessage(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "imap://legacy@example.com:143")
+	requirements.NoError(err)
+	conversationID, err := st.EnsureConversation(source.ID, "legacy-draft", "Legacy draft")
+	requirements.NoError(err)
+	oldID, err := st.PersistMessage(&store.MessagePersistData{
+		Message: &store.Message{
+			SourceID: source.ID, SourceMessageID: "Drafts|1",
+			ConversationID: conversationID, MessageType: store.MessageTypeEmail,
+		},
+		BodyText: sql.NullString{String: "old draft", Valid: true},
+		RawMIME:  []byte("Subject: Old draft\r\n\r\nold draft\r\n"),
+	})
+	requirements.NoError(err)
+	requirements.NoError(st.MarkMessageDeleted(source.ID, "Drafts|1"))
+	oldRaw, err := st.GetMessageRaw(oldID)
+	requirements.NoError(err)
+
+	receipt := store.IMAPDraftReceipt{
+		SourceID: source.ID, Mailbox: "Drafts", UIDValidity: 20, UID: 1,
+	}
+	_, err = st.PersistIMAPDraftContext(t.Context(), receipt, nil, func([]int64) *store.MessagePersistData { return nil })
+	requirements.ErrorContains(err, "persist message requires a message")
+	key, err := st.GetMessageSourceID(oldID)
+	requirements.NoError(err)
+	assertions.Equal("Drafts|1", key)
+	assertions.Zero(membershipCount(t, st, source.ID))
+	assertions.True(messageTombstoned(t, st, oldID))
+	newID, err := st.PersistIMAPDraftContext(t.Context(), receipt, nil,
+		func([]int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:        source.ID,
+					SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+					ConversationID:  conversationID,
+					MessageType:     store.MessageTypeEmail,
+				},
+				BodyText: sql.NullString{String: "new draft", Valid: true},
+				RawMIME:  []byte("Subject: New draft\r\n\r\nnew draft\r\n"),
+			}
+		})
+	requirements.NoError(err)
+	assertions.NotEqual(oldID, newID)
+	retainedRaw, err := st.GetMessageRaw(oldID)
+	requirements.NoError(err)
+	assertions.Equal(oldRaw, retainedRaw)
+	oldSourceMessageID, err := st.GetMessageSourceID(oldID)
+	requirements.NoError(err)
+	assertions.Equal(fmt.Sprintf("msgvault-invalidated:%d", oldID), oldSourceMessageID)
+}
+
+func TestIMAPIdentity_MovedCopyAppendBeforeSync(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<moved@example.com>")
+	oldRaw := []byte("Subject: Moved\r\n\r\nold content\r\n")
+	requirements.NoError(f.store.UpsertMessageRaw(oldID, oldRaw))
+	drafts := store.IMAPMailboxDelta{
+		Mailbox: "Drafts", State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "Drafts", UIDValidity: 10, UID: 1, SourceMessageID: "Drafts|1"}},
+	}
+	archive := store.IMAPMailboxDelta{
+		Mailbox: "Archive", State: store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 8},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "Archive", UIDValidity: 30, UID: 7, CanonicalSourceMessageID: "Drafts|1"}},
+	}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	drafts.Reset = true
+	drafts.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	states, err := f.store.GetIMAPFolderStates(f.source.ID)
+	requirements.NoError(err)
+	receipt := store.IMAPDraftReceipt{SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 20, UID: 1}
+	newRaw := []byte("Subject: Replacement\r\n\r\nnew content\r\n")
+	newID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil, func([]int64) *store.MessagePersistData {
+		return &store.MessagePersistData{
+			Message: &store.Message{SourceID: f.source.ID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt), ConversationID: f.convID, MessageType: store.MessageTypeEmail},
+			RawMIME: newRaw,
+		}
+	})
+	requirements.NoError(err)
+	assertions.NotEqual(oldID, newID)
+	retainedRaw, err := f.store.GetMessageRaw(oldID)
+	requirements.NoError(err)
+	assertions.Equal(oldRaw, retainedRaw)
+	retainedStates, err := f.store.GetIMAPFolderStates(f.source.ID)
+	requirements.NoError(err)
+	assertions.ElementsMatch(states, retainedStates)
+	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
+	var archiveID int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Archive", 30, 7).Scan(&archiveID))
+	assertions.Equal(oldID, archiveID)
 }

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -1,0 +1,594 @@
+package store_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/msgvault/internal/store"
+	"go.kenn.io/msgvault/internal/testutil"
+)
+
+func newIMAPIdentityFixture(t *testing.T) imapMembershipFixture {
+	t.Helper()
+	st := testutil.NewTestStore(t)
+	source, err := st.GetOrCreateSource("imap", "imap://identity@example.com:143")
+	require.NoError(t, err)
+	convID, err := st.EnsureConversation(source.ID, "identity-thread", "Identity thread")
+	require.NoError(t, err)
+	return imapMembershipFixture{store: st, source: source, convID: convID}
+}
+
+func TestIMAPIdentity_CanonicalIdentitySkipsRawPriming(t *testing.T) {
+	requirements := require.New(t)
+	f := newIMAPIdentityFixture(t)
+	messageID := f.createMessage(t, "canonical", "")
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 17, UID: 1, SourceMessageID: "canonical",
+		}},
+	}}))
+	_, err := f.store.DB().Exec(f.store.Rebind(`
+		INSERT INTO message_raw (message_id, raw_data, raw_format, compression)
+		VALUES (?, ?, 'mime', 'zlib')
+	`), messageID, []byte("invalid zlib"))
+	requirements.NoError(err)
+
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 17, UID: 1, SourceMessageID: "INBOX|1",
+			CanonicalSourceMessageID: "canonical", RawSHA256: sha256.Sum256([]byte("unused")),
+		}},
+	}}))
+}
+
+func TestIMAPIdentity_ResetSameUIDIdentityMismatchSelectsIncomingMessage(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "INBOX|1", "<old@example.com>")
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 10, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 10, UID: 1,
+			SourceMessageID: "INBOX|1", RFC822MessageID: "<old@example.com>",
+		}},
+	}}))
+	newID := f.createMessage(t, "new-source", "<new@example.com>")
+
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 20, UIDNext: 2},
+		Reset:   true,
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "INBOX", UIDValidity: 20, UID: 1,
+			SourceMessageID: "INBOX|1", RFC822MessageID: "<new@example.com>",
+		}},
+	}}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 20, 1)
+	assertions.Equal(newID, gotMessageID)
+	assertions.Equal(1, membershipCount(t, f.store, f.source.ID))
+	assertions.True(messageTombstoned(t, f.store, oldID))
+
+	var oldSourceID string
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), oldID).Scan(&oldSourceID))
+	assertions.Equal(fmt.Sprintf("msgvault-invalidated:%d", oldID), oldSourceID)
+}
+
+func TestIMAPIdentity_ResetPreservesCanonicalIdentity(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "INBOX|1", "<old@example.com>")
+	initial := []store.IMAPMailboxDelta{
+		{
+			Mailbox: "INBOX",
+			State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 10, UIDNext: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "INBOX", UIDValidity: 10, UID: 1,
+				SourceMessageID: "INBOX|1", RFC822MessageID: "<old@example.com>",
+			}},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Archive", UIDValidity: 30, UID: 1,
+				SourceMessageID: "Archive|1", CanonicalSourceMessageID: "INBOX|1",
+			}},
+		},
+	}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, initial))
+	newID := f.createMessage(t, "new-source", "<new@example.com>")
+
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "INBOX",
+			State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 20, UIDNext: 2},
+			Reset:   true,
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "INBOX", UIDValidity: 20, UID: 1,
+				SourceMessageID: "INBOX|1", RFC822MessageID: "<new@example.com>",
+			}},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Archive", UIDValidity: 30, UID: 1,
+				SourceMessageID: "Archive|1", CanonicalSourceMessageID: "INBOX|1",
+			}},
+		},
+	}))
+
+	gotMessageID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 20, 1)
+	assertions.Equal(newID, gotMessageID)
+	var archiveMessageID int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), f.source.ID, "Archive", 30, 1).Scan(&archiveMessageID))
+	assertions.Equal(oldID, archiveMessageID)
+	assertions.Equal(2, membershipCount(t, f.store, f.source.ID))
+}
+
+func TestIMAPIdentity_RekeysRemovedDraftKeyWithOtherMembership(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<draft-shared@example.com>")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "Drafts",
+			State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Drafts", UIDValidity: 10, UID: 1, SourceMessageID: "Drafts|1",
+			}},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 20, UIDNext: 8},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Archive", UIDValidity: 20, UID: 7, SourceMessageID: "Drafts|1",
+			}},
+		},
+	}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "Drafts",
+			State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 30, UIDNext: 2},
+			Reset:   true,
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 20, UIDNext: 8},
+		},
+	}))
+
+	var sourceMessageID string
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		SELECT source_message_id FROM messages WHERE id = ?
+	`), oldID).Scan(&sourceMessageID))
+	assert.Equal(fmt.Sprintf("msgvault-invalidated:%d", oldID), sourceMessageID)
+
+	newReceipt := store.IMAPDraftReceipt{
+		SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 30, UID: 1,
+	}
+	newID, err := f.store.PersistIMAPDraftContext(t.Context(), newReceipt, nil,
+		func([]int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:        f.source.ID,
+					SourceMessageID: store.IMAPDraftSourceMessageID(newReceipt),
+					ConversationID:  f.convID,
+					MessageType:     "email",
+					RFC822MessageID: sql.NullString{String: "<draft-reused@example.com>", Valid: true},
+				},
+				BodyText: sql.NullString{String: "reused", Valid: true},
+				RawMIME:  []byte("From: alice@example.com\r\n\r\nreused\r\n"),
+			}
+		})
+	require.NoError(err)
+	assert.NotEqual(oldID, newID)
+}
+
+func TestIMAPIdentity_UIDValidityResetRekeysOrphanedDraftBeforeUpsert(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	receipt := store.IMAPDraftReceipt{
+		SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 10, UID: 1,
+	}
+	draftID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil,
+		func([]int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:        f.source.ID,
+					SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+					ConversationID:  f.convID,
+					MessageType:     "email",
+				},
+				BodyText: sql.NullString{String: "old draft", Valid: true},
+				RawMIME:  []byte("Subject: Old draft\r\n\r\nold draft\r\n"),
+			}
+		})
+	require.NoError(err)
+	require.NoError(f.store.UpsertIMAPFolderStates(f.source.ID, []store.IMAPFolderState{{
+		Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2,
+	}}))
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts",
+		State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+		Reset:   true,
+	}}))
+	newID := f.createMessage(t, "new-source", "<new-draft@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts",
+		State:   store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2},
+		Reset:   true,
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Drafts", UIDValidity: 20, UID: 1,
+			SourceMessageID: "Drafts|1", RFC822MessageID: "<new-draft@example.com>",
+		}},
+	}}))
+
+	var gotID int64
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), f.source.ID, "Drafts", 20, 1).Scan(&gotID))
+	assert.Equal(newID, gotID)
+	var sourceMessageID string
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), draftID).Scan(&sourceMessageID))
+	assert.Equal(fmt.Sprintf("msgvault-invalidated:%d", draftID), sourceMessageID)
+}
+
+func TestIMAPIdentity_RetiredMailboxRekeysOrphanedDraftSourceKey(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	receipt := store.IMAPDraftReceipt{
+		SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 10, UID: 1,
+	}
+	draftID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil,
+		func([]int64) *store.MessagePersistData {
+			return &store.MessagePersistData{
+				Message: &store.Message{
+					SourceID:        f.source.ID,
+					SourceMessageID: store.IMAPDraftSourceMessageID(receipt),
+					ConversationID:  f.convID,
+					MessageType:     "email",
+				},
+				BodyText: sql.NullString{String: "old draft", Valid: true},
+				RawMIME:  []byte("Subject: Old draft\r\n\r\nold draft\r\n"),
+			}
+		})
+	require.NoError(err)
+	require.NoError(f.store.UpsertIMAPFolderStates(f.source.ID, []store.IMAPFolderState{{
+		Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2,
+	}}))
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts", Reset: true,
+		State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+	}}))
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "INBOX",
+		State:   store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 30, UIDNext: 1},
+	}}))
+	var sourceMessageID string
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(
+		"SELECT source_message_id FROM messages WHERE id = ?"), draftID).Scan(&sourceMessageID))
+	assert.Equal(fmt.Sprintf("msgvault-invalidated:%d", draftID), sourceMessageID)
+
+	newID := f.createMessage(t, "new-source", "<recreated-draft@example.com>")
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Drafts", Reset: true,
+		State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Drafts", UIDValidity: 20, UID: 1,
+			SourceMessageID: "Drafts|1", RFC822MessageID: "<recreated-draft@example.com>",
+		}},
+	}}))
+	var gotID int64
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), f.source.ID, "Drafts", 20, 1).Scan(&gotID))
+	assert.Equal(newID, gotID)
+}
+
+func TestIMAPIdentity_ResolvesQueuedCanonicalKeyAfterMailboxRetirement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	messageID := f.createMessage(t, "Old|1", "")
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{
+			Mailbox: "Old",
+			State:   store.IMAPFolderState{Mailbox: "Old", UIDValidity: 10, UIDNext: 2},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Old", UIDValidity: 10, UID: 1, SourceMessageID: "Old|1",
+			}},
+		},
+		{
+			Mailbox: "Archive",
+			State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 20, UIDNext: 8},
+			Memberships: []store.IMAPMembershipObservation{{
+				Mailbox: "Archive", UIDValidity: 20, UID: 7, SourceMessageID: "Old|1",
+			}},
+		},
+	}))
+
+	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Archive",
+		State:   store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 20, UIDNext: 8},
+		Memberships: []store.IMAPMembershipObservation{{
+			Mailbox: "Archive", UIDValidity: 20, UID: 7,
+			SourceMessageID: "Archive|7", CanonicalSourceMessageID: "Old|1",
+		}},
+	}}))
+
+	var gotMessageID int64
+	require.NoError(f.store.DB().QueryRow(f.store.Rebind(`
+		SELECT message_id FROM imap_message_memberships
+		WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?
+	`), f.source.ID, "Archive", 20, 7).Scan(&gotMessageID))
+	assert.Equal(messageID, gotMessageID)
+	assert.Equal(1, membershipCount(t, f.store, f.source.ID))
+}
+
+func TestIMAPIdentity_SameEpochOmissionReappears(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	messageID := f.createMessage(t, "INBOX|4", "<stable@example.com>")
+	raw := []byte("Subject: Stable\r\n\r\nretained content\r\n")
+	requirements.NoError(f.store.UpsertMessageRaw(messageID, raw))
+	delta := store.IMAPMailboxDelta{
+		Mailbox: "INBOX", State: store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 10, UIDNext: 5},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "INBOX", UIDValidity: 10, UID: 4, SourceMessageID: "INBOX|4"}},
+	}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	omitted := delta
+	omitted.Reset = true
+	omitted.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{omitted}))
+	requirements.True(messageTombstoned(t, f.store, messageID))
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	gotID, _ := membershipMessageAndFlags(t, f.store, f.source.ID, 10, 4)
+	assertions.Equal(messageID, gotID)
+	assertions.False(messageTombstoned(t, f.store, messageID))
+	gotRaw, err := f.store.GetMessageRaw(messageID)
+	requirements.NoError(err)
+	assertions.Equal(raw, gotRaw)
+}
+
+func TestIMAPIdentity_UnobservedUIDLaterReuse(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	keptID := f.createMessage(t, "Old|1", "<kept@example.com>")
+	oldID := f.createMessage(t, "Old|2", "<old@example.com>")
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+		Mailbox: "Old", State: store.IMAPFolderState{Mailbox: "Old", UIDValidity: 10, UIDNext: 3},
+		Memberships: []store.IMAPMembershipObservation{
+			{Mailbox: "Old", UIDValidity: 10, UID: 1, SourceMessageID: "Old|1", RFC822MessageID: "<kept@example.com>"},
+			{Mailbox: "Old", UIDValidity: 10, UID: 2, SourceMessageID: "Old|2", RFC822MessageID: "<old@example.com>"},
+		},
+	}}))
+	delta := store.IMAPMailboxDelta{
+		Mailbox: "Old", Reset: true, State: store.IMAPFolderState{Mailbox: "Old", UIDValidity: 20, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "Old", UIDValidity: 20, UID: 1, SourceMessageID: "Old|1", RFC822MessageID: "<kept@example.com>"}},
+	}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	newID := f.createMessage(t, "new-source", "<new@example.com>")
+	delta.Reset = false
+	delta.State.UIDNext = 3
+	delta.Memberships = []store.IMAPMembershipObservation{{Mailbox: "Old", UIDValidity: 20, UID: 2, SourceMessageID: "Old|2", RFC822MessageID: "<new@example.com>"}}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{delta}))
+	var actualID int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Old", 20, 2).Scan(&actualID))
+	assertions.Equal(newID, actualID)
+	assertions.True(messageTombstoned(t, f.store, oldID))
+	assertions.False(messageTombstoned(t, f.store, keptID))
+}
+
+func TestIMAPIdentity_NewPublishedCopyKeepsKey(t *testing.T) {
+	for _, mode := range []string{"append", "ingest", "ingest-shared"} {
+		t.Run(mode, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+
+			f := newIMAPIdentityFixture(t)
+			receipt := store.IMAPDraftReceipt{SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 10, UID: 1}
+			build := func([]int64) *store.MessagePersistData {
+				return &store.MessagePersistData{
+					Message: &store.Message{SourceID: f.source.ID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt), ConversationID: f.convID, MessageType: store.MessageTypeEmail, RFC822MessageID: sql.NullString{String: fmt.Sprintf("<generation-%d@example.com>", receipt.UIDValidity), Valid: true}},
+					RawMIME: fmt.Appendf(nil, "Subject: Generation %d\r\n\r\ncontent %d\r\n", receipt.UIDValidity, receipt.UIDValidity),
+				}
+			}
+			oldID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil, build)
+			requirements.NoError(err)
+			oldRaw, err := f.store.GetMessageRaw(oldID)
+			requirements.NoError(err)
+			requirements.NoError(f.store.UpsertIMAPFolderStates(f.source.ID, []store.IMAPFolderState{{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}}))
+			receipt.UIDValidity = 20
+			var newID int64
+			if mode == "append" {
+				newID, err = f.store.PersistIMAPDraftContext(t.Context(), receipt, nil, build)
+			} else {
+				changed, rekeyErr := f.store.RekeyMessageSourceID(oldID, "Drafts|1", fmt.Sprintf("msgvault-invalidated:%d", oldID))
+				requirements.NoError(rekeyErr)
+				requirements.True(changed)
+				newID, err = f.store.PersistMessage(build(nil))
+			}
+			requirements.NoError(err)
+			if mode == "ingest-shared" {
+				requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+					{Mailbox: "Drafts", State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}},
+					{Mailbox: "Archive", State: store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{{UID: 1, CanonicalSourceMessageID: "Drafts|1"}}},
+				}))
+			}
+			requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{
+				Mailbox: "Drafts", Reset: true, State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2},
+				Memberships: []store.IMAPMembershipObservation{{Mailbox: "Drafts", UIDValidity: 20, UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<generation-20@example.com>"}},
+			}}))
+			key, err := f.store.GetMessageSourceID(newID)
+			requirements.NoError(err)
+			assertions.Equal("Drafts|1", key)
+			var currentID int64
+			requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 20, 1).Scan(&currentID))
+			assertions.Equal(newID, currentID)
+			retainedRaw, err := f.store.GetMessageRaw(oldID)
+			requirements.NoError(err)
+			assertions.Equal(oldRaw, retainedRaw)
+		})
+	}
+}
+
+func TestIMAPIdentity_AmbiguousLiveAppendKeyRefuses(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
+	receipt := store.IMAPDraftReceipt{SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 20, UID: 1}
+	_, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil, func([]int64) *store.MessagePersistData {
+		return &store.MessagePersistData{Message: &store.Message{SourceID: f.source.ID, SourceMessageID: "Drafts|1", ConversationID: f.convID, MessageType: store.MessageTypeEmail}}
+	})
+	requirements.ErrorContains(err, "source_key_conflict")
+	key, err := f.store.GetMessageSourceID(oldID)
+	requirements.NoError(err)
+	assertions.Equal("Drafts|1", key)
+	assertions.Zero(membershipCount(t, f.store, f.source.ID))
+}
+
+func TestIMAPIdentity_LegacyOrphanIdentity(t *testing.T) {
+	for _, mode := range []string{"unique", "same", "missing", "duplicate", "canonical"} {
+		t.Run(mode, func(t *testing.T) {
+			requirements := require.New(t)
+			assertions := assert.New(t)
+
+			f := newIMAPIdentityFixture(t)
+			oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
+			requirements.NoError(f.store.MarkMessageDeleted(f.source.ID, "Drafts|1"))
+			newID := f.createMessage(t, "new-source", "<new@example.com>")
+			obs := store.IMAPMembershipObservation{Mailbox: "Drafts", UIDValidity: 20, UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<new@example.com>"}
+			if mode == "same" {
+				obs.RFC822MessageID = "<old@example.com>"
+				newID = oldID
+			}
+			if mode == "missing" {
+				obs.RFC822MessageID = ""
+			}
+			if mode == "duplicate" || mode == "canonical" {
+				f.createMessage(t, "duplicate-source", "<new@example.com>")
+			}
+			if mode == "canonical" {
+				obs.CanonicalSourceMessageID = "new-source"
+			}
+			err := f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{{Mailbox: "Drafts", Reset: true, State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{obs}}})
+			if mode == "missing" || mode == "duplicate" {
+				requirements.Error(err)
+				assertions.Zero(membershipCount(t, f.store, f.source.ID))
+				states, stateErr := f.store.GetIMAPFolderStates(f.source.ID)
+				requirements.NoError(stateErr)
+				assertions.Empty(states)
+				key, keyErr := f.store.GetMessageSourceID(oldID)
+				requirements.NoError(keyErr)
+				assertions.Equal("Drafts|1", key)
+				assertions.True(messageTombstoned(t, f.store, oldID))
+				return
+			}
+			requirements.NoError(err)
+			var currentID int64
+			requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 20, 1).Scan(&currentID))
+			assertions.Equal(newID, currentID)
+			if mode == "same" {
+				assertions.False(messageTombstoned(t, f.store, oldID))
+			}
+		})
+	}
+}
+
+func TestIMAPIdentity_OrphanRetirementMailboxBoundary(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	mailbox := "Drafts%_|box"
+	nested := mailbox + "|nested"
+	oldID := f.createMessage(t, mailbox+"|1", "<old@example.com>")
+	nestedID := f.createMessage(t, nested+"|1", "<nested@example.com>")
+	for _, key := range []string{mailbox + "|1", nested + "|1"} {
+		requirements.NoError(f.store.MarkMessageDeleted(f.source.ID, key))
+	}
+	requirements.NoError(f.store.UpsertIMAPFolderStates(f.source.ID, []store.IMAPFolderState{{Mailbox: mailbox, UIDValidity: 10, UIDNext: 2}, {Mailbox: nested, UIDValidity: 30, UIDNext: 2}}))
+	newID := f.createMessage(t, "new-source", "<new@example.com>")
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{
+		{Mailbox: mailbox, Reset: true, State: store.IMAPFolderState{Mailbox: mailbox, UIDValidity: 20, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{{Mailbox: mailbox, UIDValidity: 20, UID: 1, SourceMessageID: mailbox + "|1", RFC822MessageID: "<new@example.com>"}}},
+		{Mailbox: nested, State: store.IMAPFolderState{Mailbox: nested, UIDValidity: 30, UIDNext: 2}},
+	}))
+	var currentID int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, mailbox, 20, 1).Scan(&currentID))
+	assertions.Equal(newID, currentID)
+	assertions.True(messageTombstoned(t, f.store, oldID))
+	nestedKey, err := f.store.GetMessageSourceID(nestedID)
+	requirements.NoError(err)
+	assertions.Equal(nested+"|1", nestedKey)
+}
+func TestIMAPIdentity_MovedCopyMembershipBeforeSync(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<moved@example.com>")
+	oldRaw := []byte("Subject: Moved\r\n\r\nold content\r\n")
+	requirements.NoError(f.store.UpsertMessageRaw(oldID, oldRaw))
+	drafts := store.IMAPMailboxDelta{
+		Mailbox: "Drafts", State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "Drafts", UIDValidity: 10, UID: 1, SourceMessageID: "Drafts|1"}},
+	}
+	archive := store.IMAPMailboxDelta{
+		Mailbox: "Archive", State: store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 8},
+		Memberships: []store.IMAPMembershipObservation{{Mailbox: "Archive", UIDValidity: 30, UID: 7, CanonicalSourceMessageID: "Drafts|1"}},
+	}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	drafts.Reset = true
+	drafts.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	states, err := f.store.GetIMAPFolderStates(f.source.ID)
+	requirements.NoError(err)
+	newID := f.createMessage(t, "new-source", "<new@example.com>")
+	drafts.State.UIDValidity = 20
+	drafts.Memberships = []store.IMAPMembershipObservation{{Mailbox: "Drafts", UIDValidity: 20, UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<new@example.com>"}}
+	archive.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	var currentID, archiveID int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 20, 1).Scan(&currentID))
+	assertions.Equal(newID, currentID)
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Archive", 30, 7).Scan(&archiveID))
+	assertions.Equal(oldID, archiveID)
+	retainedRaw, err := f.store.GetMessageRaw(oldID)
+	requirements.NoError(err)
+	assertions.Equal(oldRaw, retainedRaw)
+	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
+	assertions.Len(states, 2)
+}

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -1,7 +1,6 @@
 package store_test
 
 import (
-	"context"
 	"crypto/sha256"
 	"database/sql"
 	"fmt"

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -787,3 +787,26 @@ func TestIMAPIdentity_OmittedReplacedKeyAllowsAppend(t *testing.T) {
 	assertions.Equal(raw, retainedRaw)
 	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
 }
+
+func TestIMAPIdentity_LiveKeyOwnerBesideOldCanonicalMembership(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
+	f.createMessage(t, "canonical", "<canonical@example.com>")
+	drafts := store.IMAPMailboxDelta{Mailbox: "Drafts", State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{{UID: 1, CanonicalSourceMessageID: "canonical"}}}
+	archive := store.IMAPMailboxDelta{Mailbox: "Archive", State: store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 8}, Memberships: []store.IMAPMembershipObservation{{UID: 7, CanonicalSourceMessageID: "Drafts|1"}}}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	requirements.False(messageTombstoned(t, f.store, oldID))
+	newID := f.createMessage(t, "incoming", "<incoming@example.com>")
+	drafts.Reset = true
+	drafts.State.UIDValidity = 20
+	drafts.Memberships = []store.IMAPMembershipObservation{{UID: 1, SourceMessageID: "Drafts|1", RFC822MessageID: "<incoming@example.com>"}}
+	archive.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	var got int64
+	requirements.NoError(f.store.DB().QueryRow(f.store.Rebind(`SELECT message_id FROM imap_message_memberships WHERE source_id = ? AND mailbox = ? AND uidvalidity = ? AND uid = ?`), f.source.ID, "Drafts", 20, 1).Scan(&got))
+	assertions.Equal(newID, got)
+	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
+}

--- a/internal/store/imap_identity_test.go
+++ b/internal/store/imap_identity_test.go
@@ -759,3 +759,31 @@ func TestIMAPIdentity_DeletedKeyOwnerBesideOldCanonicalMembership(t *testing.T) 
 	assertions.Equal(newID, got)
 	assertions.True(messageTombstoned(t, f.store, oldID))
 }
+
+func TestIMAPIdentity_OmittedReplacedKeyAllowsAppend(t *testing.T) {
+	requirements := require.New(t)
+	assertions := assert.New(t)
+	f := newIMAPIdentityFixture(t)
+	oldID := f.createMessage(t, "Drafts|1", "<old@example.com>")
+	f.createMessage(t, "canonical", "<canonical@example.com>")
+	raw := []byte("Subject: Retained\r\n\r\nold content\r\n")
+	requirements.NoError(f.store.UpsertMessageRaw(oldID, raw))
+	drafts := store.IMAPMailboxDelta{Mailbox: "Drafts", State: store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 10, UIDNext: 2}, Memberships: []store.IMAPMembershipObservation{{UID: 1, CanonicalSourceMessageID: "canonical"}}}
+	archive := store.IMAPMailboxDelta{Mailbox: "Archive", State: store.IMAPFolderState{Mailbox: "Archive", UIDValidity: 30, UIDNext: 8}, Memberships: []store.IMAPMembershipObservation{{UID: 7, CanonicalSourceMessageID: "Drafts|1"}}}
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	drafts.Reset = true
+	drafts.State = store.IMAPFolderState{Mailbox: "Drafts", UIDValidity: 20, UIDNext: 1}
+	drafts.Memberships = nil
+	archive.Memberships = nil
+	requirements.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{drafts, archive}))
+	receipt := store.IMAPDraftReceipt{SourceID: f.source.ID, Mailbox: "Drafts", UIDValidity: 20, UID: 1}
+	newID, err := f.store.PersistIMAPDraftContext(t.Context(), receipt, nil, func([]int64) *store.MessagePersistData {
+		return &store.MessagePersistData{Message: &store.Message{SourceID: f.source.ID, SourceMessageID: store.IMAPDraftSourceMessageID(receipt), ConversationID: f.convID, MessageType: store.MessageTypeEmail}}
+	})
+	requirements.NoError(err)
+	assertions.NotEqual(oldID, newID)
+	retainedRaw, err := f.store.GetMessageRaw(oldID)
+	requirements.NoError(err)
+	assertions.Equal(raw, retainedRaw)
+	assertions.Equal([]string{"Archive"}, messageLabels(t, f.store, oldID))
+}

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -759,7 +759,7 @@ func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint
 			continue
 		}
 		c.uid = uint32(uid)
-		if protected || (!old && replaced) {
+		if protected || (!old && replaced && !deleted) {
 			continue
 		}
 		changed := !present || (previous != 0 && previous != delta.uidValidity)

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -193,7 +193,10 @@ func (s *Store) applyIMAPMailboxDeltas(
 			return err
 		}
 		resolver := imapMembershipResolver{tx: tx, sourceID: sourceID}
-		if err := resolver.primeRawIdentities(normalizedDeltas); err != nil {
+		if err := resolver.primeIdentities(normalizedDeltas); err != nil {
+			return err
+		}
+		if err := resolver.retireObsoleteKeys(normalizedDeltas); err != nil {
 			return err
 		}
 
@@ -651,20 +654,161 @@ func captureIMAPMembershipMessageIDs(
 }
 
 type imapMembershipResolver struct {
-	tx          *loggedTx
-	sourceID    int64
-	rawMessages map[int64]map[[32]byte]int64
+	tx                *loggedTx
+	sourceID          int64
+	rawMessages       map[int64]map[[32]byte]int64
+	canonicalMessages map[string]int64
 }
 
-// primeRawIdentities snapshots durable raw candidates before mailbox resets,
-// VANISHED removals, or topology retirement can change which canonical rows
-// still have memberships. Later resolution is therefore independent of delta
-// order within the transaction.
-func (r *imapMembershipResolver) primeRawIdentities(
+func (r *imapMembershipResolver) retireObsoleteKeys(deltas []normalizedIMAPMailboxDelta) error {
+	current := make(map[string]normalizedIMAPMailboxDelta, len(deltas))
+	for _, delta := range deltas {
+		current[delta.mailbox] = delta
+	}
+	rows, err := r.tx.Query(`
+		SELECT mailbox, uidvalidity, true FROM imap_folder_state WHERE source_id = ?
+		UNION SELECT mailbox, uidvalidity, false FROM imap_message_memberships WHERE source_id = ?
+	`, r.sourceID, r.sourceID)
+	if err != nil {
+		return fmt.Errorf("read IMAP key generations: %w", err)
+	}
+	previous := make(map[string]uint32)
+	staleMemberships := make(map[string]bool)
+	for rows.Next() {
+		var mailbox string
+		var generation uint32
+		var folder bool
+		if err := rows.Scan(&mailbox, &generation, &folder); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if folder {
+			previous[mailbox] = generation
+		} else {
+			if _, known := previous[mailbox]; !known {
+				previous[mailbox] = 0
+			}
+			if generation != current[mailbox].uidValidity {
+				staleMemberships[mailbox] = true
+			}
+		}
+	}
+	err = rows.Err()
+	_ = rows.Close()
+	if err != nil {
+		return err
+	}
+	for _, delta := range deltas {
+		if _, ok := previous[delta.mailbox]; !ok {
+			previous[delta.mailbox] = 0
+		}
+	}
+	for mailbox, generation := range previous {
+		delta, present := current[mailbox]
+		if present && generation == delta.uidValidity && !staleMemberships[mailbox] {
+			continue
+		}
+		if err := r.retireMailboxKeys(mailbox, generation, delta, present); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint32, delta normalizedIMAPMailboxDelta, present bool) error {
+	observations := make(map[uint32]IMAPMembershipObservation, len(delta.delta.Memberships))
+	for _, observation := range delta.delta.Memberships {
+		observation.Mailbox, observation.UIDValidity = mailbox, delta.uidValidity
+		observations[observation.UID] = observation
+	}
+	// Escape SQL patterns, then validate the final UID separator to exclude nested mailboxes.
+	pattern := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(mailbox+"|") + "%"
+	rows, err := r.tx.Query(`
+		SELECT messages.id, messages.source_message_id, messages.deleted_from_source_at IS NOT NULL,
+		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id = messages.id),
+		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id = messages.id
+		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity <> ?),
+		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id = messages.id
+		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity = ?),
+		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id <> messages.id
+		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity <> ?)
+		FROM messages WHERE source_id = ? AND source_message_id LIKE ? ESCAPE '\'
+	`, mailbox, delta.uidValidity, mailbox, delta.uidValidity, mailbox, delta.uidValidity, r.sourceID, pattern)
+	if err != nil {
+		return fmt.Errorf("read obsolete IMAP keys for %q: %w", mailbox, err)
+	}
+	type candidate struct {
+		id  int64
+		key string
+		uid uint32
+	}
+	var candidates []candidate
+	for rows.Next() {
+		var c candidate
+		var deleted, memberships, old, protected, replaced bool
+		if err := rows.Scan(&c.id, &c.key, &deleted, &memberships, &old, &protected, &replaced); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		separator := strings.LastIndexByte(c.key, '|')
+		if separator < 0 || c.key[:separator] != mailbox {
+			continue
+		}
+		uid, err := strconv.ParseUint(c.key[separator+1:], 10, 32)
+		if err != nil || uid == 0 || c.key[separator+1:] != strconv.FormatUint(uid, 10) {
+			continue
+		}
+		c.uid = uint32(uid)
+		if protected || (!old && replaced) {
+			continue
+		}
+		changed := !present || (previous != 0 && previous != delta.uidValidity)
+		_, observed := observations[c.uid]
+		if old || (changed && (memberships || deleted)) || (previous == 0 && deleted && !memberships && observed) {
+			candidates = append(candidates, c)
+		}
+	}
+	err = rows.Err()
+	_ = rows.Close()
+	if err != nil {
+		return err
+	}
+	for _, c := range candidates {
+		if observation, ok := observations[c.uid]; ok {
+			id, err := r.resolveIdentity(observation, true)
+			if err != nil {
+				return err
+			}
+			if id == c.id {
+				continue
+			}
+		}
+		if _, err := r.tx.Exec(`UPDATE messages SET source_message_id = 'msgvault-invalidated:' || CAST(id AS TEXT)
+			WHERE source_id = ? AND id = ? AND source_message_id = ?`, r.sourceID, c.id, c.key); err != nil {
+			return fmt.Errorf("retire IMAP source key: %w", err)
+		}
+	}
+	return nil
+}
+
+// Snapshot identity evidence before key retirement and membership changes can invalidate it.
+func (r *imapMembershipResolver) primeIdentities(
 	deltas []normalizedIMAPMailboxDelta,
 ) error {
+	r.canonicalMessages = make(map[string]int64)
 	for _, normalized := range deltas {
 		for _, observation := range normalized.delta.Memberships {
+			if key := observation.CanonicalSourceMessageID; key != "" {
+				if _, loaded := r.canonicalMessages[key]; loaded {
+					continue
+				}
+				var id int64
+				err := r.tx.QueryRow(`SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?`, r.sourceID, key).Scan(&id)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return fmt.Errorf("snapshot canonical IMAP identity: %w", err)
+				}
+				r.canonicalMessages[key] = id
+			}
 			if observation.CanonicalSourceMessageID != "" ||
 				observation.RawSHA256 == ([32]byte{}) {
 				continue
@@ -681,16 +825,14 @@ func (r *imapMembershipResolver) primeRawIdentities(
 }
 
 func (r *imapMembershipResolver) resolve(observation IMAPMembershipObservation) (int64, error) {
+	return r.resolveIdentity(observation, false)
+}
+
+func (r *imapMembershipResolver) resolveIdentity(observation IMAPMembershipObservation, independent bool) (int64, error) {
 	var messageID int64
 	if observation.CanonicalSourceMessageID != "" {
-		err := r.tx.QueryRow(`
-			SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?
-		`, r.sourceID, observation.CanonicalSourceMessageID).Scan(&messageID)
-		if err == nil {
-			return messageID, nil
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return 0, fmt.Errorf("resolve IMAP membership by canonical source message ID: %w", err)
+		if id := r.canonicalMessages[observation.CanonicalSourceMessageID]; id != 0 {
+			return id, nil
 		}
 	}
 	if observation.RawSHA256 != ([32]byte{}) {
@@ -702,7 +844,7 @@ func (r *imapMembershipResolver) resolve(observation IMAPMembershipObservation) 
 			return messageID, nil
 		}
 	}
-	if observation.SourceMessageID != "" {
+	if !independent && observation.SourceMessageID != "" {
 		err := r.tx.QueryRow(`
 			SELECT id FROM messages WHERE source_id = ? AND source_message_id = ?
 		`, r.sourceID, observation.SourceMessageID).Scan(&messageID)
@@ -714,6 +856,20 @@ func (r *imapMembershipResolver) resolve(observation IMAPMembershipObservation) 
 		}
 	}
 	if observation.RFC822MessageID != "" {
+		if independent {
+			ids := make(map[int64]struct{})
+			for _, candidate := range imapRFC822MessageIDCandidates(observation.RFC822MessageID) {
+				if err := captureIMAPMembershipMessageIDs(r.tx, ids, `SELECT id FROM messages WHERE source_id = ? AND rfc822_message_id = ? LIMIT 2`, r.sourceID, candidate); err != nil {
+					return 0, fmt.Errorf("resolve independent IMAP identity: %w", err)
+				}
+			}
+			if len(ids) == 1 {
+				for id := range ids {
+					return id, nil
+				}
+			}
+			return 0, fmt.Errorf("resolve IMAP membership for mailbox %q UID %d: unresolved independent identity", observation.Mailbox, observation.UID)
+		}
 		for _, candidate := range imapRFC822MessageIDCandidates(observation.RFC822MessageID) {
 			err := r.tx.QueryRow(`
 				SELECT id FROM messages

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -729,11 +729,9 @@ func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint
 		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id = messages.id
 		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity <> ?),
 		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id = messages.id
-		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity = ?),
-		  EXISTS (SELECT 1 FROM imap_message_memberships m WHERE m.source_id = messages.source_id AND m.message_id <> messages.id
-		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity <> ?)
+		    AND m.mailbox = ? AND messages.source_message_id = m.mailbox || '|' || CAST(m.uid AS TEXT) AND m.uidvalidity = ?)
 		FROM messages WHERE source_id = ? AND source_message_id LIKE ? ESCAPE '\'
-	`, mailbox, delta.uidValidity, mailbox, delta.uidValidity, mailbox, delta.uidValidity, r.sourceID, pattern)
+	`, mailbox, delta.uidValidity, mailbox, delta.uidValidity, r.sourceID, pattern)
 	if err != nil {
 		return fmt.Errorf("read obsolete IMAP keys for %q: %w", mailbox, err)
 	}
@@ -745,8 +743,8 @@ func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint
 	var candidates []candidate
 	for rows.Next() {
 		var c candidate
-		var deleted, memberships, old, protected, replaced bool
-		if err := rows.Scan(&c.id, &c.key, &deleted, &memberships, &old, &protected, &replaced); err != nil {
+		var deleted, memberships, old, protected bool
+		if err := rows.Scan(&c.id, &c.key, &deleted, &memberships, &old, &protected); err != nil {
 			_ = rows.Close()
 			return err
 		}
@@ -760,7 +758,7 @@ func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint
 		}
 		c.uid = uint32(uid)
 		_, observed := observations[c.uid]
-		if protected || (!old && replaced && !deleted && observed) {
+		if protected {
 			continue
 		}
 		changed := !present || (previous != 0 && previous != delta.uidValidity)

--- a/internal/store/imap_memberships.go
+++ b/internal/store/imap_memberships.go
@@ -759,11 +759,11 @@ func (r *imapMembershipResolver) retireMailboxKeys(mailbox string, previous uint
 			continue
 		}
 		c.uid = uint32(uid)
-		if protected || (!old && replaced && !deleted) {
+		_, observed := observations[c.uid]
+		if protected || (!old && replaced && !deleted && observed) {
 			continue
 		}
 		changed := !present || (previous != 0 && previous != delta.uidValidity)
-		_, observed := observations[c.uid]
 		if old || (changed && (memberships || deleted)) || (previous == 0 && deleted && !memberships && observed) {
 			candidates = append(candidates, c)
 		}

--- a/internal/store/imap_memberships_test.go
+++ b/internal/store/imap_memberships_test.go
@@ -614,6 +614,8 @@ func TestApplyIMAPMailboxDeltas_AmbiguousRawDigestFallsBackToExactSourceID(t *te
 			{UID: 1, SourceMessageID: "[Gmail]/All Mail|1"},
 			{UID: 2, SourceMessageID: "[Gmail]/All Mail|2"},
 		},
+	}, {
+		Mailbox: "INBOX", State: store.IMAPFolderState{Mailbox: "INBOX", UIDValidity: 17, UIDNext: 2},
 	}}))
 
 	require.NoError(f.store.ApplyIMAPMailboxDeltas(f.source.ID, []store.IMAPMailboxDelta{


### PR DESCRIPTION
After a mailbox reset reuses UID 1 for a different message, sync now selects the correct archived content. Acknowledged draft creation can also reuse obsolete IDs while preserving older messages.

On SQLite and PostgreSQL, obsolete mailbox/UID keys could override independently identified messages or block local draft publication. The existing Store transaction now retires those keys while preserving current owners and surviving copies. Ambiguous matches for obsolete keys cause the transaction to roll back.

Part of the outbound submission roadmap below, to allow users to reply and send through the accounts msgvault already syncs.

Refs https://github.com/kenn-io/msgvault/issues/666#issuecomment-5585767456, slice 3(a)

